### PR TITLE
Issue replying to Discussion posts in Preview mode

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.ts
@@ -81,10 +81,6 @@ class ComponentGradingController {
   }
 
   ngOnDestroy() {
-    this.unsubscribeAll();
-  }
-
-  unsubscribeAll() {
     this.annotationSavedToServerSubscription.unsubscribe();
   }
 

--- a/src/assets/wise5/components/componentController.ts
+++ b/src/assets/wise5/components/componentController.ts
@@ -184,10 +184,6 @@ class ComponentController {
   }
 
   ngOnDestroy() {
-    this.unsubscribeAll();
-  }
-
-  unsubscribeAll() {
     this.nodeSubmitClickedSubscription.unsubscribe();
     this.annotationSavedToServerSubscription.unsubscribe();
     this.studentWorkSavedToServerSubscription.unsubscribe();

--- a/src/assets/wise5/components/discussion/discussionController.ts
+++ b/src/assets/wise5/components/discussion/discussionController.ts
@@ -156,7 +156,8 @@ class DiscussionController extends ComponentController {
     this.broadcastDoneRenderingComponent();
   }
 
-  unsubscribeAll() {
+  ngOnDestroy() {
+    super.ngOnDestroy();
     this.studentWorkReceivedSubscription.unsubscribe();
   }
 

--- a/src/assets/wise5/components/embedded/embeddedController.ts
+++ b/src/assets/wise5/components/embedded/embeddedController.ts
@@ -152,11 +152,8 @@ class EmbeddedController extends ComponentController {
 
   ngOnDestroy() {
     super.ngOnDestroy();
-    this.$window.removeEventListener('message', this.messageEventListener);
-  }
-
-  unsubscribeAll() {
     this.siblingComponentStudentDataChangedSubscription.unsubscribe();
+    this.$window.removeEventListener('message', this.messageEventListener);
   }
 
   setWidthAndHeight(width, height) {

--- a/src/assets/wise5/components/graph/graphController.ts
+++ b/src/assets/wise5/components/graph/graphController.ts
@@ -186,10 +186,6 @@ class GraphController extends ComponentController {
 
   ngOnDestroy() {
     super.ngOnDestroy();
-    this.unsubscribeAll();
-  }
-
-  unsubscribeAll() {
     this.deleteKeyPressedSubscription.unsubscribe();
   }
 

--- a/src/assets/wise5/components/label/label-authoring/label-authoring.component.ts
+++ b/src/assets/wise5/components/label/label-authoring/label-authoring.component.ts
@@ -51,10 +51,6 @@ export class LabelAuthoring extends ComponentAuthoring {
 
   ngOnDestroy() {
     super.ngOnDestroy();
-    this.unsubscribeAll();
-  }
-
-  unsubscribeAll() {
     this.numberInputChangeSubscription.unsubscribe();
     this.textInputChangeSubscription.unsubscribe();
   }

--- a/src/assets/wise5/components/match/matchController.ts
+++ b/src/assets/wise5/components/match/matchController.ts
@@ -190,10 +190,7 @@ class MatchController extends ComponentController {
   }
 
   ngOnDestroy() {
-    this.unsubscribeAll();
-  }
-
-  unsubscribeAll() {
+    super.ngOnDestroy();
     if (this.notebookUpdatedSubscription != null) {
       this.notebookUpdatedSubscription.unsubscribe();
     }

--- a/src/assets/wise5/components/table/table-authoring/table-authoring.component.ts
+++ b/src/assets/wise5/components/table/table-authoring/table-authoring.component.ts
@@ -63,10 +63,6 @@ export class TableAuthoring extends ComponentAuthoring {
 
   ngOnDestroy() {
     super.ngOnDestroy();
-    this.unsubscribeAll();
-  }
-
-  unsubscribeAll() {
     this.numColumnsChangeSubscription.unsubscribe();
     this.numRowsChangeSubscription.unsubscribe();
     this.globalCellSizeChangeSubscription.unsubscribe();


### PR DESCRIPTION
Make sure the Discussion duplicate reply bug no longer occurs. Here is how to test it.
1. Preview a project that contains a Discussion component
2. Make a post to the Discussion component
3. Move to a different step
4. Go back to the Discussion component step
5. Make a reply to your previous post
6. Your reply should only show up once. Previously your reply would show up twice.

Make sure ngOnDestroy is called for parent and child for these components
Student Discussion
Student Embedded
Student Graph
Student Match
Authoring Label
Authoring Table

Closes #21