### PR TITLE
Show scrollbar in NotebookNotes if notes content overflows visible area

### DIFF
--- a/src/app/notebook/notebook-notes/notebook-notes.component.scss
+++ b/src/app/notebook/notebook-notes/notebook-notes.component.scss
@@ -27,7 +27,7 @@ $new-note-bottom: 24px;
 
   .notes-wrapper {
     flex: 1 1 0%;
-    overflow: hidden;
+    overflow: auto;
   }
 
   .notes {


### PR DESCRIPTION
To test:
- Run a unit (in preview mode or as a student) that has Notebook notes enabled.
- Add enough notes so that the content starts to overflow the visible area on the screen.
- Verify that a scrollbar appears.

Resolves #43.