### PR TITLE
Changed add step into a wizard

### DIFF
--- a/src/app/teacher-hybrid-angular.module.ts
+++ b/src/app/teacher-hybrid-angular.module.ts
@@ -22,6 +22,8 @@ import { ManageStudentsComponent } from '../assets/wise5/classroomMonitor/manage
 import { AdvancedProjectAuthoringComponent } from '../assets/wise5/authoringTool/advanced/advanced-project-authoring.component';
 import { ChooseNewComponent } from './authoring-tool/add-component/choose-new-component/choose-new-component.component';
 import { ChooseNewComponentLocation } from './authoring-tool/add-component/choose-new-component-location/choose-new-component-location.component';
+import { ChooseNewNode } from '../assets/wise5/authoringTool/addNode/choose-new-node/choose-new-node.component';
+import { ChooseNewNodeLocation } from '../assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component';
 import { ChooseImportStepComponent } from './authoring-tool/import-step/choose-import-step/choose-import-step.component';
 import { ChooseImportStepLocationComponent } from './authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component';
 import { ComponentNewWorkBadgeComponent } from './classroom-monitor/component-new-work-badge/component-new-work-badge.component';
@@ -85,6 +87,8 @@ import { EmbeddedGrading } from '../assets/wise5/components/embedded/embedded-gr
     ChooseImportStepLocationComponent,
     ChooseNewComponent,
     ChooseNewComponentLocation,
+    ChooseNewNode,
+    ChooseNewNodeLocation,
     ComponentNewWorkBadgeComponent,
     ComponentSelectComponent,
     ConceptMapAuthoring,

--- a/src/assets/wise5/authoringTool/addNode/addNodeModule.ts
+++ b/src/assets/wise5/authoringTool/addNode/addNodeModule.ts
@@ -1,0 +1,40 @@
+import * as angular from 'angular';
+import { downgradeComponent } from '@angular/upgrade/static';
+import { ChooseNewNode } from './choose-new-node/choose-new-node.component';
+import { ChooseNewNodeLocation } from './choose-new-node-location/choose-new-node-location.component';
+
+export default angular
+  .module('addNodeModule', ['ui.router'])
+  .directive(
+    'chooseNewNode',
+    downgradeComponent({ component: ChooseNewNode }) as angular.IDirectiveFactory
+  )
+  .directive(
+    'chooseNewNodeLocation',
+    downgradeComponent({ component: ChooseNewNodeLocation }) as angular.IDirectiveFactory
+  )
+  .config([
+    '$stateProvider',
+    ($stateProvider) => {
+      $stateProvider
+        .state('root.at.project.add-node', {
+          url: '/add-node',
+          abstract: true,
+          resolve: {}
+        })
+        .state('root.at.project.add-node.choose-node', {
+          url: '/choose-node',
+          component: 'chooseNewNode',
+          params: {
+            title: ''
+          }
+        })
+        .state('root.at.project.add-node.choose-location', {
+          url: '/choose-location',
+          component: 'chooseNewNodeLocation',
+          params: {
+            title: ''
+          }
+        });
+    }
+  ]);

--- a/src/assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component.html
+++ b/src/assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component.html
@@ -1,0 +1,40 @@
+<h5 i18n>Choose a location for the new step</h5>
+<div style="margin-top: 20px; margin-left: 20px">
+  <div *ngFor="let nodeId of nodeIds"
+     class="project-item"
+     [ngClass]="{'node-select--group': isGroupNode(nodeId), 'node-select--node': !isGroupNode(nodeId)}">
+    <div id="{{nodeId}}"
+       [ngClass]="{'groupHeader': isGroupNode(nodeId), 'stepHeader': !isGroupNode(nodeId), 'branchPathStepHeader': isNodeInAnyBranchPath(nodeId) && !isGroupNode(nodeId)}">
+      <div fxLayout="row" fxLayoutGap="8px" class="projectItemTitleDiv">
+        <div fxLayout="row" fxLayoutAlign="start center">
+          <node-icon [nodeId]="nodeId" size="18"></node-icon>&nbsp;
+          <p style="display:inline; cursor:pointer;">
+            {{getNodePositionById(nodeId)}}: {{getNodeTitleByNodeId(nodeId)}}
+          </p>
+        </div>
+        <button mat-button class="mat-raised-button mat-primary"
+            *ngIf="isGroupNode(nodeId)"
+            matTooltip="Insert As First Step"
+            i18n-matTooltip
+            matTooltipPosition="above"
+            (click)="addNode(nodeId); $event.stopPropagation();">
+          <mat-icon>call_received</mat-icon>
+        </button>
+        <button mat-button class="mat-raised-button mat-primary"
+            *ngIf="!isGroupNode(nodeId)"
+            matTooltip="Insert After"
+            i18n-matTooltip
+            matTooltipPosition="above"
+            (click)="addNode(nodeId); $event.stopPropagation();">
+          <mat-icon>subdirectory_arrow_left</mat-icon>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+<hr>
+<button mat-button
+    class="mat-primary"
+    (click)="cancel()"
+    aria-label="Cancel"
+    i18n>Cancel</button>

--- a/src/assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component.ts
@@ -1,0 +1,88 @@
+import { Component } from '@angular/core';
+import { UpgradeModule } from '@angular/upgrade/static';
+import { TeacherDataService } from '../../../services/teacherDataService';
+import { TeacherProjectService } from '../../../services/teacherProjectService';
+
+@Component({
+  templateUrl: 'choose-new-node-location.component.html'
+})
+export class ChooseNewNodeLocation {
+  nodeIds: string[];
+
+  constructor(
+    private upgrade: UpgradeModule,
+    private TeacherDataService: TeacherDataService,
+    private ProjectService: TeacherProjectService
+  ) {}
+
+  ngOnInit() {
+    this.nodeIds = Object.keys(this.ProjectService.idToOrder);
+    this.nodeIds.shift(); // remove the 'group0' master root node from consideration
+  }
+
+  addNode(nodeId: string) {
+    const newNode = this.ProjectService.createNode(
+      this.upgrade.$injector.get('$stateParams').title
+    );
+    if (this.isGroupNode(nodeId)) {
+      this.ProjectService.createNodeInside(newNode, nodeId);
+    } else {
+      this.ProjectService.createNodeAfter(newNode, nodeId);
+    }
+    this.save(newNode.id).then(() => {
+      this.goToNode(newNode.id);
+    });
+  }
+
+  save(newNodeId: string) {
+    return this.ProjectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
+      this.ProjectService.refreshProject();
+      this.saveEvent('stepCreated', 'Authoring', {
+        nodeId: newNodeId,
+        title: this.ProjectService.getNodePositionAndTitleByNodeId(newNodeId)
+      });
+    });
+  }
+
+  goToNode(nodeId: string) {
+    this.upgrade.$injector.get('$state').go('root.at.project.node', { nodeId: nodeId });
+  }
+
+  isGroupNode(nodeId: string) {
+    return this.ProjectService.isGroupNode(nodeId);
+  }
+
+  getNodeTitleByNodeId(nodeId: string) {
+    return this.ProjectService.getNodeTitleByNodeId(nodeId);
+  }
+
+  getNodePositionById(nodeId: string) {
+    return this.ProjectService.getNodePositionById(nodeId);
+  }
+
+  isNodeInAnyBranchPath(nodeId: string) {
+    return this.ProjectService.isNodeInAnyBranchPath(nodeId);
+  }
+
+  saveEvent(eventName: string, category: string, data: any): any {
+    const context = 'AuthoringTool';
+    const nodeId = null;
+    const componentId = null;
+    const componentType = null;
+    return this.TeacherDataService.saveEvent(
+      context,
+      nodeId,
+      componentId,
+      componentType,
+      category,
+      eventName,
+      data
+    ).then((result) => {
+      return result;
+    });
+  }
+
+  cancel() {
+    this.upgrade.$injector.get('$state').go('root.at.project');
+  }
+}

--- a/src/assets/wise5/authoringTool/addNode/choose-new-node/choose-new-node.component.html
+++ b/src/assets/wise5/authoringTool/addNode/choose-new-node/choose-new-node.component.html
@@ -1,0 +1,17 @@
+<div fxLayout="row wrap" fxLayoutAlign="start center">
+  <mat-form-field>
+    <mat-label i18n>Step Title</mat-label>
+    <input #titleField autofocus matInput type='text' [(ngModel)]='title'>
+  </mat-form-field>
+</div>
+<hr>
+<div fxLayout="row" fxLayoutAlign="end center">
+  <button mat-button class="mat-primary"
+      (click)="cancel()"
+      aria-label="cancel"
+      i18n>Cancel</button>
+  <button mat-button class="mat-raised-button mat-primary"
+      (click)="chooseLocation()"
+      aria-label="next"
+      i18n>Next</button>
+</div>

--- a/src/assets/wise5/authoringTool/addNode/choose-new-node/choose-new-node.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/choose-new-node/choose-new-node.component.ts
@@ -1,0 +1,26 @@
+import { Component, ElementRef, ViewChild } from '@angular/core';
+import { UpgradeModule } from '@angular/upgrade/static';
+
+@Component({
+  templateUrl: 'choose-new-node.component.html'
+})
+export class ChooseNewNode {
+  title: string;
+
+  constructor(private upgrade: UpgradeModule) {}
+
+  @ViewChild('titleField') titleField: ElementRef;
+  ngAfterViewInit() {
+    this.titleField.nativeElement.focus();
+  }
+
+  chooseLocation() {
+    this.upgrade.$injector.get('$state').go('root.at.project.add-node.choose-location', {
+      title: this.title
+    });
+  }
+
+  cancel() {
+    this.upgrade.$injector.get('$state').go('root.at.project');
+  }
+}

--- a/src/assets/wise5/authoringTool/project/projectAuthoring.html
+++ b/src/assets/wise5/authoringTool/project/projectAuthoring.html
@@ -104,7 +104,7 @@
               </md-button>
               <md-button id='createNewStepButton'
                   class='topButton md-raised md-primary'
-                  ng-click='$ctrl.createNewStepClicked()'
+                  ng-click='$ctrl.createNewStep()'
                   ng-disabled='$ctrl.insertGroupMode || $ctrl.insertNodeMode || $ctrl.stepNodeSelected || $ctrl.activityNodeSelected'>
                 <md-icon>add_box</md-icon>
                 <md-tooltip md-direction='top' class='projectButtonTooltip'>
@@ -205,26 +205,6 @@
                 </md-button>
               </div>
             </div>
-            <div ng-if='$ctrl.showCreateNode' layout='row' style='height:50;'>
-              <div layout='row'>
-                <md-input-container style="width: 500px;">
-                  <label translate="stepTitle"></label>
-                  <input id='createNodeTitle'
-                       ng-model='$ctrl.createNodeTitle'
-                       ng-keyup='$event.keyCode == 13 && $ctrl.createNode()'/>
-                </md-input-container>
-              </div>
-              <div layout='row' style='margin-top: 8px;'>
-                <md-button id="createNodeCreateButton" class='createButton md-raised md-primary' ng-click='$ctrl.createNode()'>
-                  <md-icon>check</md-icon>
-                  <md-tooltip md-direction="top" class="projectButtonTooltip">{{ ::"create" | translate }}</md-tooltip>
-                </md-button>
-                <md-button id="createNodeCancelButton" class='createButton md-raised md-primary' ng-click='$ctrl.showProjectView()'>
-                  <md-icon>close</md-icon>
-                  <md-tooltip md-direction="top" class="projectButtonTooltip">{{ ::"CANCEL" | translate }}</md-tooltip>
-                </md-button>
-              </div>
-            </div>
             <div ng-if='$ctrl.insertGroupMode || $ctrl.insertNodeMode' layout='row' style='height:50'>
               <div layout='row'>
                 <h6 translate="chooseNewLocation"></h6>
@@ -252,7 +232,7 @@
                        ng-model='item.checked'
                        ng-change='$ctrl.projectItemClicked(item.$key)'
                        class='check'
-                       ng-disabled='$ctrl.showCreateGroup || $ctrl.showCreateNode || $ctrl.insertNodeMode || $ctrl.insertGroupMode || ($ctrl.isGroupNode(item.$key) && $ctrl.stepNodeSelected) || (!$ctrl.isGroupNode(item.$key) && $ctrl.activityNodeSelected)'
+                       ng-disabled='$ctrl.showCreateGroup || $ctrl.insertNodeMode || $ctrl.insertGroupMode || ($ctrl.isGroupNode(item.$key) && $ctrl.stepNodeSelected) || (!$ctrl.isGroupNode(item.$key) && $ctrl.activityNodeSelected)'
                        aria-label='{{::$ctrl.getNodePositionById(item.$key)}} {{::$ctrl.getNodeTitleByNodeId(item.$key)}}'>
                   </md-checkbox>
                 </div>
@@ -312,7 +292,7 @@
                          ng-model='inactiveNode.checked'
                          ng-change='$ctrl.projectItemClicked(inactiveNode.id)'
                          class='check'
-                         ng-disabled='$ctrl.showCreateGroup || $ctrl.showCreateNode || $ctrl.insertNodeMode || $ctrl.insertGroupMode || $ctrl.stepNodeSelected'
+                         ng-disabled='$ctrl.showCreateGroup || $ctrl.insertNodeMode || $ctrl.insertGroupMode || $ctrl.stepNodeSelected'
                          aria-label='{{::$ctrl.getNodeTitleByNodeId(inactiveNode.id)}}'>
                     </md-checkbox>
                   </div>
@@ -352,7 +332,7 @@
                            ng-model='$ctrl.idToNode[inactiveChildId].checked'
                            ng-change='$ctrl.projectItemClicked(inactiveChildId)'
                            class='check'
-                           ng-disabled='$ctrl.showCreateGroup || $ctrl.showCreateNode || $ctrl.insertNodeMode || $ctrl.insertGroupMode || $ctrl.activityNodeSelected'
+                           ng-disabled='$ctrl.showCreateGroup || $ctrl.insertNodeMode || $ctrl.insertGroupMode || $ctrl.activityNodeSelected'
                            aria-label='{{::$ctrl.getNodeTitleByNodeId(inactiveChildId.id)}}'>
                       </md-checkbox>
                     </div>
@@ -403,7 +383,7 @@
                          ng-model='inactiveNode.checked'
                          ng-change='$ctrl.projectItemClicked(inactiveNode.id)'
                          class='check'
-                         ng-disabled='$ctrl.showCreateGroup || $ctrl.showCreateNode || $ctrl.insertNodeMode || $ctrl.insertGroupMode || $ctrl.activityNodeSelected'
+                         ng-disabled='$ctrl.showCreateGroup || $ctrl.insertNodeMode || $ctrl.insertGroupMode || $ctrl.activityNodeSelected'
                          aria-label='{{::$ctrl.getNodeTitleByNodeId(inactiveNode.id)}}'>
                     </md-checkbox>
                   </div>

--- a/src/assets/wise5/authoringTool/project/projectAuthoringComponent.ts
+++ b/src/assets/wise5/authoringTool/project/projectAuthoringComponent.ts
@@ -18,7 +18,6 @@ class ProjectAuthoringController {
   nodeId: string;
   projectTitle: string;
   showCreateGroup: boolean = false;
-  showCreateNode: boolean = false;
   inactiveGroupNodes: any[];
   inactiveStepNodes: any[];
   inactiveNodes: any[];
@@ -26,7 +25,6 @@ class ProjectAuthoringController {
   insertNodeMode: boolean;
   idToNode: any;
   copyMode: boolean;
-  createNodeTitle: string;
   createMode: boolean;
   nodeToAdd: any;
   projectScriptFilename: string;
@@ -244,14 +242,6 @@ class ProjectAuthoringController {
     this.showCreateGroup = false;
     this.createGroupTitle = '';
     this.insertGroupMode = true;
-    this.createMode = true;
-  }
-
-  createNode() {
-    this.nodeToAdd = this.ProjectService.createNode(this.createNodeTitle);
-    this.showCreateNode = false;
-    this.createNodeTitle = '';
-    this.insertNodeMode = true;
     this.createMode = true;
   }
 
@@ -601,8 +591,8 @@ class ProjectAuthoringController {
   }
 
   creatNewActivityClicked() {
-    this.createGroupTitle = '';
-    this.toggleView('createGroup');
+    this.clearGroupTitle();
+    this.toggleGroupView();
     if (this.showCreateGroup) {
       this.$timeout(() => {
         $('#createGroupTitle').focus();
@@ -610,14 +600,8 @@ class ProjectAuthoringController {
     }
   }
 
-  createNewStepClicked() {
-    this.createNodeTitle = '';
-    this.toggleView('createNode');
-    if (this.showCreateNode) {
-      this.$timeout(() => {
-        $('#createNodeTitle').focus();
-      });
-    }
+  createNewStep() {
+    this.$state.go('root.at.project.add-node.choose-node');
   }
 
   addStructure() {
@@ -701,25 +685,16 @@ class ProjectAuthoringController {
   }
 
   showProjectView() {
-    this.clearNodeAndGroupTitle();
+    this.clearGroupTitle();
     this.showCreateGroup = false;
-    this.showCreateNode = false;
   }
 
-  toggleView(view) {
-    this.clearNodeAndGroupTitle();
-    if (view === 'createGroup') {
-      this.showCreateGroup = !this.showCreateGroup;
-      this.showCreateNode = false;
-    } else if (view === 'createNode') {
-      this.showCreateGroup = false;
-      this.showCreateNode = !this.showCreateNode;
-    }
+  toggleGroupView() {
+    this.showCreateGroup = !this.showCreateGroup;
   }
 
-  clearNodeAndGroupTitle() {
+  clearGroupTitle() {
     this.createGroupTitle = '';
-    this.createNodeTitle = '';
   }
 
   goBackToProjectList() {

--- a/src/assets/wise5/teacher/teacher-angular-js-module.ts
+++ b/src/assets/wise5/teacher/teacher-angular-js-module.ts
@@ -63,6 +63,7 @@ import '../components/graph/graphAuthoringComponentModule';
 import '../components/graph/graphGradingComponentModule';
 import '../components/html/htmlAuthoringComponentModule';
 import '../authoringTool/addComponent/addComponentModule';
+import '../authoringTool/addNode/addNodeModule';
 import '../authoringTool/node/editRubric/editRubricModule';
 import '../authoringTool/importComponent/importComponentModule';
 import '../authoringTool/importStep/importStepModule';
@@ -84,6 +85,7 @@ angular
     'common',
     'angular-inview',
     'addComponentModule',
+    'addNodeModule',
     'editRubricModule',
     'summaryAuthoringComponentModule',
     'animationAuthoringComponentModule',


### PR DESCRIPTION
Adding a step in the AT is now done with a wizard. It will prompt you for a title on the first page, and a location on the next page.

Also cleaned up code related to add step and add group toggle.

## Test
1. Test that you can add a new step to the unit as the first step in an activity, or after an existing step, and you will be taken to the new step authoring view.
2. Test that you can cancel out of the wizard and return to the unit view.
3. Test that adding a new lesson works as before also.

Closes #47