### PR TITLE
Fixed typo preventing (un)locking lessons to work in the CM

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/navItem/navItem.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/navItem/navItem.ts
@@ -267,7 +267,7 @@ class NavItemController {
   toggleLockNode(): void {
     const node = this.ProjectService.getNodeById(this.nodeId);
     const isLocked = this.isLocked();
-    if (this.isLocked) {
+    if (isLocked) {
       this.unlockNode(node);
     } else {
       this.lockNode(node);


### PR DESCRIPTION
Test that you can lock and unlock lessons in the grading tool. Before, nothing happened for teachers and students and there was an error in the js console.

Closes #55 
