### PR TITLE
Export notebook items throws an error and does not generate an export

### DIFF
--- a/src/assets/wise5/services/teacherDataService.ts
+++ b/src/assets/wise5/services/teacherDataService.ts
@@ -188,7 +188,7 @@ export class TeacherDataService extends DataService {
     const params = new HttpParams().set('exportType', exportType);
     const options = { params: params };
     return this.http
-      .get(`/teacher/notebook/run/${this.ConfigService.getRunId()}`, options)
+      .get(this.ConfigService.getConfigParam('notebookURL'), options)
       .toPromise()
       .then((data: any) => {
         return data;


### PR DESCRIPTION
1. Open the Classroom Monitor for a run (that has student notebook data)
2. Go to the Data Export view
3. Try to download the "Export Latest Notebook Items" and "Export All Notebook Items" exports

Closes #71