### PR TITLE
Disable Open Response textarea when all submits are used up

### DIFF
--- a/src/assets/wise5/authoringTool/i18n/i18n_en.json
+++ b/src/assets/wise5/authoringTool/i18n/i18n_en.json
@@ -238,6 +238,7 @@
   "makeThisNodeNotVisitable": "Make this node not visitable",
   "manageAssets": "Manage Assets",
   "maxPathsVisitable": "Max paths visitable",
+  "maxSubmitsNote": "Students will not be able to change their work after using all their submits",
   "merge": "Merge",
   "milestone": "Milestone",
   "milestoneDescription": "Milestone Description",

--- a/src/assets/wise5/components/componentController.ts
+++ b/src/assets/wise5/components/componentController.ts
@@ -665,6 +665,10 @@ class ComponentController {
     return !this.hasMaxSubmitCount() || this.hasSubmitsLeft();
   }
 
+  hasMaxSubmitCountAndNoSubmitsLeft() {
+    return this.hasMaxSubmitCount() && !this.hasSubmitsLeft();
+  }
+
   hasMaxSubmitCount() {
     return this.getMaxSubmitCount() != null;
   }

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
@@ -208,6 +208,10 @@
         ng-model-options='{ debounce: 1000 }'
         ng-change='$ctrl.componentChanged()'/>
 </md-input-container>
+<span style="display: inline;">
+  <md-icon>help</md-icon>
+  <md-tooltip md-direction="right">{{ ::'maxSubmitsNote' | translate }}</md-tooltip>
+</span>
 </div>
 <div layout="column" layout-align="start start">
 <edit-component-max-score [authoring-component-content]="$ctrl.authoringComponentContent"></edit-component-max-score>

--- a/src/assets/wise5/components/openResponse/openResponseController.ts
+++ b/src/assets/wise5/components/openResponse/openResponseController.ts
@@ -190,8 +190,8 @@ class OpenResponseController extends ComponentController {
       this.setStudentWork(componentState);
     }
 
-    if (!this.canSubmit()) {
-      this.isSubmitButtonDisabled = true;
+    if (this.hasMaxSubmitCountAndNoSubmitsLeft()) {
+      this.isDisabled = true;
     }
 
     this.disableComponentIfNecessary();
@@ -257,6 +257,13 @@ class OpenResponseController extends ComponentController {
     }
 
     this.broadcastDoneRenderingComponent();
+  }
+
+  performSubmit(submitTriggeredBy: string): void {
+    super.performSubmit(submitTriggeredBy);
+    if (this.hasMaxSubmitCountAndNoSubmitsLeft()) {
+      this.isDisabled = true;
+    }
   }
 
   handleNodeSubmit() {


### PR DESCRIPTION
Test that the Open Response textarea and save/submit buttons becomes disabled once all the submits are used. Also leave the step and come back and make sure the Open Response is still disabled.

Closes #83