### PR TITLE
Prevent copy pasting images into TinyMCE editor

### DIFF
--- a/src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts
+++ b/src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts
@@ -64,6 +64,7 @@ export class WiseTinymceEditorComponent {
     'nonbreaking',
     'noneditable',
     'pagebreak',
+    'paste',
     'preview',
     'print',
     'quickbars',
@@ -148,7 +149,8 @@ export class WiseTinymceEditorComponent {
           title: $localize`File`,
           items: 'preview wordcount | print'
         }
-      }
+      },
+      paste_block_drop: true
     };
   }
 


### PR DESCRIPTION
- Try copy-pasting an image from a Word document. This should be prevented.
- Try drag-dropping an image from a webpage or local file. This should be prevented.
- Make sure regular copy-paste (for text and other basic html content) still works.
- You can still right click on a webpage image then choosing "Copy image" and then pasting the image into TinyMCE. This will create an image element with the src set to the absolute url to the image on the other website.

Here are the options for the [paste plugin](https://www.tiny.cloud/docs/plugins/opensource/paste) for reference.

Closes #85