### PR TITLE
Refactored handleStudentWorkSavedToServer()

### DIFF
--- a/src/assets/wise5/components/component-student.component.ts
+++ b/src/assets/wise5/components/component-student.component.ts
@@ -144,14 +144,13 @@ export abstract class ComponentStudent {
 
   subscribeToStudentWorkSavedToServer(): void {
     this.subscriptions.add(
-      this.StudentDataService.studentWorkSavedToServer$.subscribe((args: any) => {
-        this.handleStudentWorkSavedToServer(args);
+      this.StudentDataService.studentWorkSavedToServer$.subscribe((componentState: any) => {
+        this.handleStudentWorkSavedToServer(componentState);
       })
     );
   }
 
-  handleStudentWorkSavedToServer(args: any): void {
-    const componentState = args.studentWork;
+  handleStudentWorkSavedToServer(componentState: any): void {
     if (this.isForThisComponent(componentState)) {
       this.setIsDirty(false);
       this.emitComponentDirty(this.getIsDirty());
@@ -172,7 +171,7 @@ export abstract class ComponentStudent {
         this.setSavedMessage(clientSaveTime);
       }
     }
-    this.handleStudentWorkSavedToServerAdditionalProcessing(args);
+    this.handleStudentWorkSavedToServerAdditionalProcessing(componentState);
   }
 
   getIsDirty(): boolean {
@@ -185,7 +184,7 @@ export abstract class ComponentStudent {
     }
   }
 
-  handleStudentWorkSavedToServerAdditionalProcessing(args: any): void {}
+  handleStudentWorkSavedToServerAdditionalProcessing(componentState: any): void {}
 
   subscribeToRequestComponentState(): void {
     this.subscriptions.add(

--- a/src/assets/wise5/components/componentController.ts
+++ b/src/assets/wise5/components/componentController.ts
@@ -245,14 +245,13 @@ class ComponentController {
 
   registerStudentWorkSavedToServerListener() {
     this.subscriptions.add(
-      this.StudentDataService.studentWorkSavedToServer$.subscribe((args: any) => {
-        this.handleStudentWorkSavedToServer(args);
+      this.StudentDataService.studentWorkSavedToServer$.subscribe((componentState: any) => {
+        this.handleStudentWorkSavedToServer(componentState);
       })
     );
   }
 
-  handleStudentWorkSavedToServer(args: any) {
-    const componentState = args.studentWork;
+  handleStudentWorkSavedToServer(componentState: any) {
     if (this.isForThisComponent(componentState)) {
       this.setIsDirty(false);
       this.emitComponentDirty(this.getIsDirty());
@@ -273,10 +272,10 @@ class ComponentController {
         this.setSavedMessage(clientSaveTime);
       }
     }
-    this.handleStudentWorkSavedToServerAdditionalProcessing(args);
+    this.handleStudentWorkSavedToServerAdditionalProcessing(componentState);
   }
 
-  handleStudentWorkSavedToServerAdditionalProcessing(args: any) {}
+  handleStudentWorkSavedToServerAdditionalProcessing(componentState: any) {}
 
   handleNodeSubmit() {
     this.isSubmit = true;

--- a/src/assets/wise5/components/discussion/discussionController.ts
+++ b/src/assets/wise5/components/discussion/discussionController.ts
@@ -208,8 +208,7 @@ class DiscussionController extends ComponentController {
 
   registerStudentWorkSavedToServerListener() {
     this.subscriptions.add(
-      this.StudentDataService.studentWorkSavedToServer$.subscribe((args: any) => {
-        const componentState = args.studentWork;
+      this.StudentDataService.studentWorkSavedToServer$.subscribe((componentState: any) => {
         if (this.isWorkFromThisComponent(componentState)) {
           if (this.isClassmateResponsesGated() && !this.retrievedClassmateResponses) {
             this.getClassmateResponses();

--- a/src/assets/wise5/components/draw/drawController.ts
+++ b/src/assets/wise5/components/draw/drawController.ts
@@ -112,8 +112,7 @@ class DrawController extends ComponentController {
     this.broadcastDoneRenderingComponent();
   }
 
-  handleStudentWorkSavedToServerAdditionalProcessing(args: any) {
-    let componentState = args.studentWork;
+  handleStudentWorkSavedToServerAdditionalProcessing(componentState: any) {
     if (
       this.isForThisComponent(componentState) &&
       this.ProjectService.isConnectedComponent(
@@ -540,8 +539,7 @@ class DrawController extends ComponentController {
   snipButtonClicked($event) {
     if (this.isDirty) {
       const studentWorkSavedToServerSubscription = this.StudentDataService.studentWorkSavedToServer$.subscribe(
-        (args: any) => {
-          const componentState = args.studentWork;
+        (componentState: any) => {
           if (this.isForThisComponent(componentState)) {
             this.snipDrawing($event, componentState.id);
             studentWorkSavedToServerSubscription.unsubscribe();

--- a/src/assets/wise5/components/embedded/embeddedController.ts
+++ b/src/assets/wise5/components/embedded/embeddedController.ts
@@ -288,8 +288,7 @@ class EmbeddedController extends ComponentController {
 
   registerStudentWorkSavedToServerListener() {
     this.subscriptions.add(
-      this.StudentDataService.studentWorkSavedToServer$.subscribe((args: any) => {
-        const componentState = args.studentWork;
+      this.StudentDataService.studentWorkSavedToServer$.subscribe((componentState: any) => {
         if (this.isForThisComponent(componentState)) {
           this.isDirty = false;
           this.StudentDataService.broadcastComponentDirty({

--- a/src/assets/wise5/components/openResponse/openResponseController.ts
+++ b/src/assets/wise5/components/openResponse/openResponseController.ts
@@ -830,8 +830,7 @@ class OpenResponseController extends ComponentController {
   snipButtonClicked($event) {
     if (this.isDirty) {
       const studentWorkSavedToServerSubscription = this.StudentDataService.studentWorkSavedToServer$.subscribe(
-        (args: any) => {
-          const componentState = args.studentWork;
+        (componentState: any) => {
           if (
             componentState &&
             this.nodeId === componentState.nodeId &&

--- a/src/assets/wise5/components/summary/summaryController.ts
+++ b/src/assets/wise5/components/summary/summaryController.ts
@@ -224,7 +224,7 @@ class SummaryController extends ComponentController {
     }
   }
 
-  handleStudentWorkSavedToServerAdditionalProcessing(args: any) {
+  handleStudentWorkSavedToServerAdditionalProcessing(componentState: any) {
     if (this.isStudent) {
       this.isShowDisplay = this.calculateIsShowDisplay();
     }

--- a/src/assets/wise5/components/table/tableController.ts
+++ b/src/assets/wise5/components/table/tableController.ts
@@ -404,8 +404,7 @@ class TableController extends ComponentController {
 
   registerStudentWorkSavedToServerListener() {
     this.subscriptions.add(
-      this.StudentDataService.studentWorkSavedToServer$.subscribe((args: any) => {
-        const componentState = args.studentWork;
+      this.StudentDataService.studentWorkSavedToServer$.subscribe((componentState: any) => {
         if (this.isForThisComponent(componentState)) {
           this.isDirty = false;
           this.StudentDataService.broadcastComponentDirty({

--- a/src/assets/wise5/directives/componentAnnotations/component-annotations.component.ts
+++ b/src/assets/wise5/directives/componentAnnotations/component-annotations.component.ts
@@ -51,8 +51,11 @@ export class ComponentAnnotationsComponent {
   ngOnInit() {
     this.maxScoreDisplay = parseInt(this.maxScore) > 0 ? '/' + this.maxScore : '';
     this.studentWorkSavedToServerSubscription = this.StudentDataService.studentWorkSavedToServer$.subscribe(
-      ({ studentWork }) => {
-        if (studentWork.nodeId === this.nodeId && studentWork.componentId === this.componentId) {
+      (componentState) => {
+        if (
+          componentState.nodeId === this.nodeId &&
+          componentState.componentId === this.componentId
+        ) {
           this.isNew = false;
         }
       }

--- a/src/assets/wise5/directives/summaryDisplay/summaryDisplay.js
+++ b/src/assets/wise5/directives/summaryDisplay/summaryDisplay.js
@@ -123,11 +123,11 @@ class SummaryDisplayController {
       this.renderDisplay();
     };
     this.studentWorkSavedToServerSubscription = this.StudentDataService.studentWorkSavedToServer$
-        .subscribe((args) => {
+        .subscribe((componentState) => {
       if (
         this.doRender &&
-        this.nodeId === args.studentWork.nodeId &&
-        this.componentId === args.studentWork.componentId
+        componentState.nodeId === this.nodeId &&
+        componentState.componentId === this.componentId
       ) {
         this.renderDisplay();
       }

--- a/src/assets/wise5/services/achievementService.ts
+++ b/src/assets/wise5/services/achievementService.ts
@@ -287,12 +287,12 @@ export class AchievementService {
    */
   createStudentWorkSavedListener(projectAchievement) {
     this.debugOutput('registering ' + projectAchievement.id);
-    return this.StudentDataService.studentWorkSavedToServer$.subscribe((args: any) => {
+    return this.StudentDataService.studentWorkSavedToServer$.subscribe((componentState: any) => {
       this.debugOutput(
         'createStudentWorkSavedListener checking ' +
           projectAchievement.id +
           ' completed ' +
-          args.nodeId
+          componentState.nodeId
       );
       if (!this.isStudentAchievementExists(projectAchievement.id)) {
         if (this.isAchievementCompletedByStudent(projectAchievement)) {

--- a/src/assets/wise5/services/studentDataService.ts
+++ b/src/assets/wise5/services/studentDataService.ts
@@ -1005,15 +1005,15 @@ export class StudentDataService extends DataService {
             this.setRemoteServerSaveTimeIntoLocalServerSaveTime(savedStudentWork, localStudentWork);
           }
           this.clearRequestToken(localStudentWork);
-          this.broadcastStudentWorkSavedToServer({ studentWork: localStudentWork });
+          this.broadcastStudentWorkSavedToServer(localStudentWork);
           break;
         }
       }
     }
   }
 
-  broadcastStudentWorkSavedToServer(args: any) {
-    this.studentWorkSavedToServerSource.next(args);
+  broadcastStudentWorkSavedToServer(componentState: any) {
+    this.studentWorkSavedToServerSource.next(componentState);
   }
 
   isMatchingRequestToken(localObj, remoteObj) {


### PR DESCRIPTION
## Changes
- handleStudentWorkSavedToServer() now expects a componentState instead of ```{ studentWork: componentState }```.
- ```StudentService.studentWorkSavedToServer``` observable now also passes componentStates directly instead of wrapping it in an object.
- No new functionality was added.

## Test
Test that saving and loading student work in the student VLE works as before.

Closes #74