### PR TITLE
Fix node scores for workgroups in the Teacher Tools

### DIFF
--- a/src/app/services/annotationService.spec.ts
+++ b/src/app/services/annotationService.spec.ts
@@ -66,9 +66,9 @@ function getTotalScore() {
 }
 
 function getTotalScore_noAnnotationForWorkgroup_return0() {
-  it('should return 0 when no annotations for workgroup', () => {
-    expect(service.getTotalScoreForWorkgroup([], WORKGROUP_1)).toEqual(0);
-    expect(service.getTotalScoreForWorkgroup(annotations, WORKGROUP_3)).toEqual(0);
+  it('should return null when no annotations for workgroup', () => {
+    expect(service.getTotalScoreForWorkgroup([], WORKGROUP_1)).toBeNull();
+    expect(service.getTotalScoreForWorkgroup(annotations, WORKGROUP_3)).toBeNull();
   });
 }
 
@@ -85,7 +85,7 @@ function getTotalScore_omitInActiveNodes() {
       return node.id !== 'node2';
     });
     expect(service.getTotalScoreForWorkgroup(annotations, WORKGROUP_1)).toEqual(2);
-    expect(service.getTotalScoreForWorkgroup(annotations, WORKGROUP_2)).toEqual(0);
+    expect(service.getTotalScoreForWorkgroup(annotations, WORKGROUP_2)).toBeNull();
   });
 }
 

--- a/src/assets/wise5/services/annotationService.ts
+++ b/src/assets/wise5/services/annotationService.ts
@@ -279,6 +279,7 @@ export class AnnotationService {
 
   getTotalScoreForWorkgroup(annotations = [], workgroupId = -1) {
     let totalScore = 0;
+    let hasScore = false;
     const scoresFound = []; // to prevent double counting if teacher scored component multiple times
     for (let i = annotations.length - 1; i >= 0; i--) {
       const annotation = annotations[i];
@@ -293,6 +294,7 @@ export class AnnotationService {
               if (data != null) {
                 const value = data.value;
                 if (typeof value === 'number') {
+                  hasScore = true;
                   totalScore += value;
                   scoresFound.push(scoreFound);
                 }
@@ -302,7 +304,7 @@ export class AnnotationService {
         }
       }
     }
-    return totalScore;
+    return hasScore ? totalScore : null;
   }
 
   isScoreOrAutoScore(annotation: any): boolean {


### PR DESCRIPTION
Show "-" for workgroup step score in the Teacher Tools if they workgroup has not received a score for any component in the step. (We used to show 0 as the score.) This also fixes the node average score that we display in the Grade by Step view for a node.

To test:
- Set up a run that has an autoscored (e.g. c-rater) item in a step and at least one other step that captures student work.
- Add some students to the run and complete the autoscored item and the other step's work for at least one but not all of the students.
- As the teacher, give scores to some but not all of the students in the second step.
- Verify that the student(s) who didn't receive scores are given a "-" instead of a 0 in the Score column (both in the Grade by Team and Grade by Step views).
- In the Grade by Step view, verify that the mean score for each step only takes into account students who have received a score on a component in that step.

Resolves #107.