### PR TITLE
Keep existing style attributes when inserting snip to notebook code

### DIFF
--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -607,7 +607,11 @@ export class ProjectService {
         return matchedString.replace(
           '<img',
           `<img onclick=\\"window.dispatchEvent(new CustomEvent('snip-image', ` +
-            `{ detail: { target: this } }))\\" snip`
+            `{ detail: { target: this } }))\\" ` +
+            `onkeypress=\\"javascript: if (event.key === 'Enter' || event.keyCode === 13 || ` + 
+            `event.which === 13 ) { window.dispatchEvent(new CustomEvent('snip-image', ` +
+            `{ detail: { target: this } } )) }\\" aria-label=\\"Select image to add to notebook\\" ` +
+            `title=\\"Add to notebook\\" tabindex=\\"0\\" snip`
         );
       });
     }

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -607,7 +607,7 @@ export class ProjectService {
         return matchedString.replace(
           '<img',
           `<img onclick=\\"window.dispatchEvent(new CustomEvent('snip-image', ` +
-            `{ detail: { target: this } }))\\" style=\\"cursor: pointer;\\"`
+            `{ detail: { target: this } }))\\" snip`
         );
       });
     }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -8597,35 +8597,35 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Play</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.ts</context>
-          <context context-type="linenumber">187</context>
+          <context context-type="linenumber">190</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3133539296286953705" datatype="html">
         <source>Stop</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.ts</context>
-          <context context-type="linenumber">191</context>
+          <context context-type="linenumber">194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6333335057236774263" datatype="html">
         <source>Saved</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/component-student.component.ts</context>
-          <context context-type="linenumber">455</context>
+          <context context-type="linenumber">457</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6643018309880261465" datatype="html">
         <source>Auto Saved</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/component-student.component.ts</context>
-          <context context-type="linenumber">459</context>
+          <context context-type="linenumber">461</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1612722476211621614" datatype="html">
         <source>Submitted</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/component-student.component.ts</context>
-          <context context-type="linenumber">463</context>
+          <context context-type="linenumber">465</context>
         </context-group>
       </trans-unit>
       <trans-unit id="495b53dee6164e1c3ec7d95ee3527bb23b62a8c2" datatype="html">
@@ -10904,49 +10904,49 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
         <source>Notebook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
-          <context context-type="linenumber">17</context>
+          <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7975589013595125523" datatype="html">
         <source>note</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5946383547512220582" datatype="html">
         <source>notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3177789104763917185" datatype="html">
         <source>Manage Notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1444501656744347415" datatype="html">
         <source>report</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6590475405017990661" datatype="html">
         <source>reports</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
-          <context context-type="linenumber">43</context>
+          <context context-type="linenumber">44</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7008439939460403347" datatype="html">
         <source>Report</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
-          <context context-type="linenumber">44</context>
+          <context context-type="linenumber">45</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2e1aeaf8d183e6846a0463a08c784f472184fcf0" datatype="html">

--- a/src/style/abstracts/_mixins.scss
+++ b/src/style/abstracts/_mixins.scss
@@ -194,6 +194,10 @@
       padding: 4px 8px 4px 0;
     }
   }
+
+  img[snip] {
+    cursor: pointer;
+  }
 }
 
 // Define a custom mixin that takes in the current material theme and colors


### PR DESCRIPTION
Also added keyboard accessibility for clipping images to notebook.

To test:
- Make sure "Enable Clipping" is checked in notebook settings for a unit.
- Add an image to an HTML component.
- Add a custom `style` attribute to the image using either the TinyMCE code view or image settings (e.g. `style="border: 1px solid;"`).
- Preview the unit (or run as student) and verify that your custom styles are retained by the image.
- Make sure that clicking on the image still initiates the new note dialog.
- Also ensure that you can tab to focus on the image using the keyboard and that pressing the Enter key when focused initiates the new note dialog.

Resolves #118. 