### PR TITLE
Extracted duplicate componentTypes declaration

### DIFF
--- a/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.ts
+++ b/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.ts
@@ -1,7 +1,5 @@
 import { Component } from '@angular/core';
 import { UpgradeModule } from '@angular/upgrade/static';
-import { ConfigService } from '../../../../assets/wise5/services/configService';
-import { TeacherDataService } from '../../../../assets/wise5/services/teacherDataService';
 import { UtilService } from '../../../../assets/wise5/services/utilService';
 
 @Component({
@@ -10,34 +8,13 @@ import { UtilService } from '../../../../assets/wise5/services/utilService';
   templateUrl: 'choose-new-component.component.html'
 })
 export class ChooseNewComponent {
-  componentTypes: any;
+  componentTypes: any[];
   selectedComponentType: string;
 
-  constructor(
-    private upgrade: UpgradeModule,
-    private ConfigService: ConfigService,
-    private TeacherDataService: TeacherDataService,
-    private UtilService: UtilService
-  ) {}
+  constructor(private upgrade: UpgradeModule, private UtilService: UtilService) {}
 
   ngOnInit() {
-    this.componentTypes = [
-      { type: 'Animation', name: this.UtilService.getComponentTypeLabel('Animation') },
-      { type: 'AudioOscillator', name: this.UtilService.getComponentTypeLabel('AudioOscillator') },
-      { type: 'ConceptMap', name: this.UtilService.getComponentTypeLabel('ConceptMap') },
-      { type: 'Discussion', name: this.UtilService.getComponentTypeLabel('Discussion') },
-      { type: 'Draw', name: this.UtilService.getComponentTypeLabel('Draw') },
-      { type: 'Embedded', name: this.UtilService.getComponentTypeLabel('Embedded') },
-      { type: 'Graph', name: this.UtilService.getComponentTypeLabel('Graph') },
-      { type: 'Label', name: this.UtilService.getComponentTypeLabel('Label') },
-      { type: 'Match', name: this.UtilService.getComponentTypeLabel('Match') },
-      { type: 'MultipleChoice', name: this.UtilService.getComponentTypeLabel('MultipleChoice') },
-      { type: 'OpenResponse', name: this.UtilService.getComponentTypeLabel('OpenResponse') },
-      { type: 'OutsideURL', name: this.UtilService.getComponentTypeLabel('OutsideURL') },
-      { type: 'HTML', name: this.UtilService.getComponentTypeLabel('HTML') },
-      { type: 'Summary', name: this.UtilService.getComponentTypeLabel('Summary') },
-      { type: 'Table', name: this.UtilService.getComponentTypeLabel('Table') }
-    ];
+    this.componentTypes = this.UtilService.getComponentTypes();
     this.selectedComponentType = this.upgrade.$injector.get('$stateParams').componentType;
   }
 
@@ -53,8 +30,7 @@ export class ChooseNewComponent {
 
   cancel() {
     this.upgrade.$injector.get('$state').go('root.at.project.node', {
-      projectId: this.ConfigService.getProjectId(),
-      nodeId: this.TeacherDataService.getCurrentNodeId()
+      nodeId: this.upgrade.$injector.get('$stateParams').nodeId
     });
   }
 }

--- a/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.ts
@@ -12,25 +12,24 @@ export class AddYourOwnNode {
   addNodeFormGroup: FormGroup = this.fb.group({
     title: new FormControl('', [Validators.required])
   });
-  componentTypes = [
-    { type: 'Animation', name: this.UtilService.getComponentTypeLabel('Animation') },
-    { type: 'AudioOscillator', name: this.UtilService.getComponentTypeLabel('AudioOscillator') },
-    { type: 'ConceptMap', name: this.UtilService.getComponentTypeLabel('ConceptMap') },
-    { type: 'Discussion', name: this.UtilService.getComponentTypeLabel('Discussion') },
-    { type: 'Draw', name: this.UtilService.getComponentTypeLabel('Draw') },
-    { type: 'Embedded', name: this.UtilService.getComponentTypeLabel('Embedded') },
-    { type: 'Graph', name: this.UtilService.getComponentTypeLabel('Graph') },
-    { type: 'Label', name: this.UtilService.getComponentTypeLabel('Label') },
-    { type: 'Match', name: this.UtilService.getComponentTypeLabel('Match') },
-    { type: 'MultipleChoice', name: this.UtilService.getComponentTypeLabel('MultipleChoice') },
-    { type: 'OpenResponse', name: this.UtilService.getComponentTypeLabel('OpenResponse') },
-    { type: 'OutsideURL', name: this.UtilService.getComponentTypeLabel('OutsideURL') },
-    { type: 'HTML', name: this.UtilService.getComponentTypeLabel('HTML') },
-    { type: 'Summary', name: this.UtilService.getComponentTypeLabel('Summary') },
-    { type: 'Table', name: this.UtilService.getComponentTypeLabel('Table') }
-  ];
+  componentTypes: any[];
   initialComponents: string[] = [];
   title: string;
+
+  constructor(
+    private upgrade: UpgradeModule,
+    private UtilService: UtilService,
+    private fb: FormBuilder
+  ) {}
+
+  ngOnInit() {
+    this.componentTypes = this.UtilService.getComponentTypes();
+  }
+
+  @ViewChild('titleField') titleField: ElementRef;
+  ngAfterViewInit() {
+    this.titleField.nativeElement.focus();
+  }
 
   addComponent(componentType: any) {
     this.initialComponents.push(componentType);
@@ -42,17 +41,6 @@ export class AddYourOwnNode {
 
   drop(event: CdkDragDrop<string[]>) {
     moveItemInArray(this.initialComponents, event.previousIndex, event.currentIndex);
-  }
-
-  constructor(
-    private upgrade: UpgradeModule,
-    private UtilService: UtilService,
-    private fb: FormBuilder
-  ) {}
-
-  @ViewChild('titleField') titleField: ElementRef;
-  ngAfterViewInit() {
-    this.titleField.nativeElement.focus();
   }
 
   chooseLocation() {

--- a/src/assets/wise5/services/utilService.ts
+++ b/src/assets/wise5/services/utilService.ts
@@ -383,6 +383,26 @@ export class UtilService {
     return '';
   }
 
+  getComponentTypes(): any[] {
+    return [
+      { type: 'Animation', name: this.getComponentTypeLabel('Animation') },
+      { type: 'AudioOscillator', name: this.getComponentTypeLabel('AudioOscillator') },
+      { type: 'ConceptMap', name: this.getComponentTypeLabel('ConceptMap') },
+      { type: 'Discussion', name: this.getComponentTypeLabel('Discussion') },
+      { type: 'Draw', name: this.getComponentTypeLabel('Draw') },
+      { type: 'Embedded', name: this.getComponentTypeLabel('Embedded') },
+      { type: 'Graph', name: this.getComponentTypeLabel('Graph') },
+      { type: 'Label', name: this.getComponentTypeLabel('Label') },
+      { type: 'Match', name: this.getComponentTypeLabel('Match') },
+      { type: 'MultipleChoice', name: this.getComponentTypeLabel('MultipleChoice') },
+      { type: 'OpenResponse', name: this.getComponentTypeLabel('OpenResponse') },
+      { type: 'OutsideURL', name: this.getComponentTypeLabel('OutsideURL') },
+      { type: 'HTML', name: this.getComponentTypeLabel('HTML') },
+      { type: 'Summary', name: this.getComponentTypeLabel('Summary') },
+      { type: 'Table', name: this.getComponentTypeLabel('Table') }
+    ];
+  }
+
   getComponentTypeLabel(componentType) {
     let label = this.componentTypeToLabel[componentType];
     if (label == null) {


### PR DESCRIPTION
## Changes
- In "add own node"
  - Moved lifecycle funcs at top of file.

- In "choose new component"
  - Removed unnecessary projectId param.
  - Got nodeId from $stateParam.

## Test
- Component listing appears in "add own node" and "choose new component" views in the AT.
- Adding components works as before in those views.
- Canceling choose new component view takes you back to node editing view.

Closes #135