### PR TITLE
Extracted Project Library functions into new service

### DIFF
--- a/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.ts
+++ b/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { ConfigService } from '../../../../assets/wise5/services/configService';
+import { ProjectLibraryService } from '../../../../assets/wise5/services/projectLibraryService';
 import { TeacherProjectService } from '../../../../assets/wise5/services/teacherProjectService';
 
 @Component({
@@ -21,6 +22,7 @@ export class ChooseImportStepComponent {
   constructor(
     private upgrade: UpgradeModule,
     private ConfigService: ConfigService,
+    private ProjectLibraryService: ProjectLibraryService,
     private ProjectService: TeacherProjectService
   ) {
     this.$state = this.upgrade.$injector.get('$state');
@@ -28,8 +30,8 @@ export class ChooseImportStepComponent {
 
   ngOnInit() {
     this.myProjectsList = this.ConfigService.getAuthorableProjects();
-    this.ProjectService.getLibraryProjects().then((libraryProjects) => {
-      this.libraryProjectsList = this.ProjectService.sortAndFilterUniqueLibraryProjects(
+    this.ProjectLibraryService.getLibraryProjects().then((libraryProjects) => {
+      this.libraryProjectsList = this.ProjectLibraryService.sortAndFilterUniqueProjects(
         libraryProjects
       );
     });

--- a/src/app/common-hybrid-angular.module.ts
+++ b/src/app/common-hybrid-angular.module.ts
@@ -6,6 +6,7 @@ import { UpgradeModule } from '@angular/upgrade/static';
 import { UtilService } from '../assets/wise5/services/utilService';
 import { ConfigService } from '../assets/wise5/services/configService';
 import { ProjectService } from '../assets/wise5/services/projectService';
+import { ProjectLibraryService } from '../assets/wise5/services/projectLibraryService';
 import { VLEProjectService } from '../assets/wise5/vle/vleProjectService';
 import { CRaterService } from '../assets/wise5/services/cRaterService';
 import { SessionService } from '../assets/wise5/services/sessionService';
@@ -143,6 +144,7 @@ export class EmptyComponent {}
     NotificationService,
     OutsideURLService,
     OpenResponseService,
+    ProjectLibraryService,
     { provide: ProjectService, useExisting: VLEProjectService },
     SessionService,
     StudentAssetService,

--- a/src/app/services/projectLibraryService.spec.ts
+++ b/src/app/services/projectLibraryService.spec.ts
@@ -1,0 +1,89 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { UpgradeModule } from '@angular/upgrade/static';
+import { ConfigService } from '../../assets/wise5/services/configService';
+import { ProjectLibraryService } from '../../assets/wise5/services/projectLibraryService';
+
+let configService: ConfigService;
+let http: HttpTestingController;
+let service: ProjectLibraryService;
+const getLibraryProjectsURL = '/api/project/library';
+const libraryProjects = [
+  {
+    children: [
+      { id: 3, name: 'three' },
+      { id: 1, name: 'one' }
+    ]
+  },
+  {
+    children: [
+      { id: 2, name: 'two' },
+      { id: 1, name: 'one' }
+    ]
+  }
+];
+
+describe('ProjectLibraryService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, UpgradeModule],
+      providers: [ProjectLibraryService, ConfigService]
+    });
+    http = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(ProjectLibraryService);
+    configService = TestBed.inject(ConfigService);
+  });
+  getLibraryProjects();
+  sortAndFilterUniqueProjects();
+  filterUniqueProjects();
+});
+
+function getLibraryProjects() {
+  describe('getLibraryProjects', () => {
+    it('should get the library projects', () => {
+      spyOnLibraryProjectsURLFromConfig();
+      const result = service.getLibraryProjects();
+      http.expectOne(getLibraryProjectsURL).flush(libraryProjects);
+      result.then((projects) => {
+        expect(projects).toEqual(libraryProjects);
+      });
+    });
+  });
+}
+
+function spyOnLibraryProjectsURLFromConfig() {
+  spyOn(configService, 'getConfigParam').and.callFake((param) => {
+    return getLibraryProjectsURL;
+  });
+}
+
+function sortAndFilterUniqueProjects() {
+  describe('sortAndFilterUniqueProjects', () => {
+    it('should filter and sort unique projects', () => {
+      const result = service.sortAndFilterUniqueProjects(libraryProjects);
+      expect(result).toEqual([
+        { id: 3, name: 'three' },
+        { id: 2, name: 'two' },
+        { id: 1, name: 'one' }
+      ]);
+    });
+  });
+}
+
+function filterUniqueProjects() {
+  describe('filterUniqueProjects', () => {
+    it('should filter unique projects based on id', () => {
+      const nonUniqueProjects = [
+        { id: 3, name: 'three' },
+        { id: 1, name: 'one' },
+        { id: 2, name: 'two' },
+        { id: 1, name: 'one' }
+      ];
+      const uniqueProjects = service.filterUniqueProjects(nonUniqueProjects);
+      expect(uniqueProjects.length).toEqual(3);
+      expect(uniqueProjects[0].id).toEqual(3);
+      expect(uniqueProjects[1].id).toEqual(1);
+      expect(uniqueProjects[2].id).toEqual(2);
+    });
+  });
+}

--- a/src/app/services/teacherProjectService.spec.ts
+++ b/src/app/services/teacherProjectService.spec.ts
@@ -25,21 +25,6 @@ const projectURL = projectBaseURL + 'project.json';
 const registerNewProjectURL = 'http://localhost:8080/wise/project/new';
 const saveProjectURL = 'http://localhost:8080/wise/project/save/' + projectIdDefault;
 const wiseBaseURL = '/wise';
-const getLibraryProjectsURL = '/api/project/library';
-const libraryProjects = [
-  {
-    children: [
-      { id: 3, name: 'three' },
-      { id: 1, name: 'one' }
-    ]
-  },
-  {
-    children: [
-      { id: 2, name: 'two' },
-      { id: 1, name: 'one' }
-    ]
-  }
-];
 
 describe('TeacherProjectService', () => {
   beforeEach(() => {
@@ -47,11 +32,11 @@ describe('TeacherProjectService', () => {
       imports: [HttpClientTestingModule, UpgradeModule],
       providers: [TeacherProjectService, ConfigService, SessionService, UtilService]
     });
-    http = TestBed.get(HttpTestingController);
-    service = TestBed.get(TeacherProjectService);
-    configService = TestBed.get(ConfigService);
-    sessionService = TestBed.get(SessionService);
-    utilService = TestBed.get(UtilService);
+    http = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(TeacherProjectService);
+    configService = TestBed.inject(ConfigService);
+    sessionService = TestBed.inject(SessionService);
+    utilService = TestBed.inject(UtilService);
     spyOn(utilService, 'broadcastEventInRootScope');
     demoProjectJSON = JSON.parse(JSON.stringify(demoProjectJSON_import));
     scootersProjectJSON = JSON.parse(JSON.stringify(scootersProjectJSON_import));
@@ -64,9 +49,6 @@ describe('TeacherProjectService', () => {
   testDeleteTransition();
   testGetNodeIdAfter();
   testCreateNodeAfter();
-  getLibraryProjects();
-  sortAndFilterUniqueLibraryProjects();
-  filterUniqueProjects();
   shouldGetTheNodeIdAndComponentIdObjects();
   shouldGetTheBranchLetter();
   lockNode();
@@ -132,8 +114,6 @@ function createConfigServiceGetConfigParamSpy() {
       return saveProjectURL;
     } else if (param === 'wiseBaseURL') {
       return wiseBaseURL;
-    } else if (param === 'getLibraryProjectsURL') {
-      return getLibraryProjectsURL;
     }
   });
 }
@@ -240,50 +220,6 @@ function testCreateNodeAfter() {
       expect(service.idToNode[newNode.id]).toEqual(newNode);
       expect(newNode.transitionLogic.transitions[0].to).toEqual('node20');
       expect(service.getNodeIdAfter('node19')).toEqual('node1000');
-    });
-  });
-}
-
-function getLibraryProjects() {
-  describe('getLibraryProjects', () => {
-    it('should get the library projects', () => {
-      createConfigServiceGetConfigParamSpy();
-      const result = service.getLibraryProjects();
-      http.expectOne(getLibraryProjectsURL).flush(libraryProjects);
-      result.then((projects) => {
-        expect(projects).toEqual(libraryProjects);
-      });
-    });
-  });
-}
-
-function sortAndFilterUniqueLibraryProjects() {
-  describe('sortAndFilterUniqueLibraryProjects', () => {
-    it('should filter and sort library projects', () => {
-      const result = service.sortAndFilterUniqueLibraryProjects(libraryProjects);
-      expect(result).toEqual([
-        { id: 3, name: 'three' },
-        { id: 2, name: 'two' },
-        { id: 1, name: 'one' }
-      ]);
-    });
-  });
-}
-
-function filterUniqueProjects() {
-  describe('filterUniqueProjects', () => {
-    it('should filter unique projects based on id', () => {
-      const nonUniqueProjects = [
-        { id: 3, name: 'three' },
-        { id: 1, name: 'one' },
-        { id: 2, name: 'two' },
-        { id: 1, name: 'one' }
-      ];
-      const uniqueProjects = service.filterUniqueProjects(nonUniqueProjects);
-      expect(uniqueProjects.length).toEqual(3);
-      expect(uniqueProjects[0].id).toEqual(3);
-      expect(uniqueProjects[1].id).toEqual(1);
-      expect(uniqueProjects[2].id).toEqual(2);
     });
   });
 }

--- a/src/assets/wise5/authoringTool/importComponent/choose-component.component.ts
+++ b/src/assets/wise5/authoringTool/importComponent/choose-component.component.ts
@@ -1,6 +1,7 @@
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { ConfigService } from '../../services/configService';
 import { TeacherDataService } from '../../services/teacherDataService';
+import { ProjectLibraryService } from '../../services/projectLibraryService';
 
 class ChooseComponentController {
   importLibraryProjectId: number;
@@ -12,11 +13,18 @@ class ChooseComponentController {
   libraryProjectsList: any = [];
   myProjectsList: any = [];
 
-  static $inject = ['$state', 'ConfigService', 'ProjectService', 'TeacherDataService'];
+  static $inject = [
+    '$state',
+    'ConfigService',
+    'ProjectLibraryService',
+    'ProjectService',
+    'TeacherDataService'
+  ];
 
   constructor(
     private $state: any,
     private ConfigService: ConfigService,
+    private ProjectLibraryService: ProjectLibraryService,
     private ProjectService: TeacherProjectService,
     private TeacherDataService: TeacherDataService
   ) {}
@@ -29,8 +37,8 @@ class ChooseComponentController {
     this.importProjectId = null;
     this.importProject = null;
     this.myProjectsList = this.ConfigService.getAuthorableProjects();
-    this.ProjectService.getLibraryProjects().then((libraryProjects) => {
-      this.libraryProjectsList = this.ProjectService.sortAndFilterUniqueLibraryProjects(
+    this.ProjectLibraryService.getLibraryProjects().then((libraryProjects) => {
+      this.libraryProjectsList = this.ProjectLibraryService.sortAndFilterUniqueProjects(
         libraryProjects
       );
     });

--- a/src/assets/wise5/services/projectLibraryService.ts
+++ b/src/assets/wise5/services/projectLibraryService.ts
@@ -1,0 +1,43 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { unique } from 'jquery';
+import { ConfigService } from './configService';
+
+@Injectable()
+export class ProjectLibraryService {
+  constructor(protected http: HttpClient, protected ConfigService: ConfigService) {}
+
+  getLibraryProjects() {
+    return this.http
+      .get(this.ConfigService.getConfigParam('getLibraryProjectsURL'))
+      .toPromise()
+      .then((projects) => {
+        return projects;
+      });
+  }
+
+  sortAndFilterUniqueProjects(projects: any) {
+    const flatProjectList = projects
+      .map((grade) => {
+        return grade.children;
+      })
+      .flat();
+    return this.filterUniqueProjects(flatProjectList).sort(this.sortByProjectIdDescending);
+  }
+
+  filterUniqueProjects(projects: any[]): any[] {
+    const uniqueProjects = [];
+    const foundProjects = new Map();
+    for (const project of projects) {
+      if (!foundProjects.has(project.id)) {
+        foundProjects.set(project.id, project);
+        uniqueProjects.push(project);
+      }
+    }
+    return uniqueProjects;
+  }
+
+  sortByProjectIdDescending(project1: any, project2: any) {
+    return project2.id - project1.id;
+  }
+}

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -1212,44 +1212,6 @@ export class TeacherProjectService extends ProjectService {
     return node;
   }
 
-  getLibraryProjects() {
-    return this.http
-      .get(this.ConfigService.getConfigParam('getLibraryProjectsURL'))
-      .toPromise()
-      .then((projects) => {
-        return projects;
-      });
-  }
-
-  sortAndFilterUniqueLibraryProjects(libraryProjects) {
-    const flatProjectList = libraryProjects
-      .map((grade) => {
-        return grade.children;
-      })
-      .flat();
-    return this.filterUniqueProjects(flatProjectList).sort(this.sortByProjectIdDescending);
-  }
-
-  filterUniqueProjects(projects) {
-    const uniqueProjects = [];
-    const filteredProjects = {};
-    for (const project of projects) {
-      if (filteredProjects[project.id] == null) {
-        filteredProjects[project.id] = project;
-        uniqueProjects.push(project);
-      }
-    }
-    return uniqueProjects;
-  }
-
-  sortByProjectIdDescending(project1, project2) {
-    if (project1.id > project2.id) {
-      return -1;
-    } else {
-      return 1;
-    }
-  }
-
   getAutomatedAssessmentProjectId(): number {
     return this.ConfigService.getConfigParam('automatedAssessmentProjectId') || -1;
   }

--- a/src/assets/wise5/teacher/teacher-angular-js-module.ts
+++ b/src/assets/wise5/teacher/teacher-angular-js-module.ts
@@ -5,6 +5,7 @@ import '../common-angular-js-module';
 import { MilestoneService } from '../services/milestoneService';
 import { TeacherProjectService } from '../services/teacherProjectService';
 import { ProjectAssetService } from '../../../app/services/projectAssetService';
+import { ProjectLibraryService } from '../services/projectLibraryService';
 import { SpaceService } from '../services/spaceService';
 import { StudentStatusService } from '../services/studentStatusService';
 import { DataExportService } from '../services/dataExportService';
@@ -127,6 +128,7 @@ angular
   ])
   .service('DataExportService', downgradeInjectable(DataExportService))
   .service('MilestoneService', downgradeInjectable(MilestoneService))
+  .service('ProjectLibraryService', downgradeInjectable(ProjectLibraryService))
   .factory('ProjectService', downgradeInjectable(TeacherProjectService))
   .factory('ProjectAssetService', downgradeInjectable(ProjectAssetService))
   .factory('SpaceService', downgradeInjectable(SpaceService))


### PR DESCRIPTION
## Changes
- Extracted Project Library functions into new service
- Refactored ```filterUniqueProjects``` to use Map instead of javascript object
- Refactored ```sortByProjectIdDescending```
- Renamed ```sortAndFilterUniqueLibraryProjects``` to ```sortAndFilterUniqueProjects```

## Test
- importing steps and components work as before. Library projects should be listed in descending projectId order

Closes #137