### PR TITLE
Change node icon in StepTools when node changes

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/nodeIcon/node-icon.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/nodeIcon/node-icon.component.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import { ProjectService } from '../../../../services/projectService';
-import { Component, Input } from '@angular/core';
+import { Component, Input, SimpleChanges } from '@angular/core';
 
 @Component({
   selector: 'node-icon',
@@ -27,9 +27,9 @@ export class NodeIconComponent {
 
   constructor(private ProjectService: ProjectService) {}
 
-  ngOnChanges() {
+  ngOnChanges(changes: SimpleChanges) {
     this.isGroup = this.ProjectService.isGroupNode(this.nodeId);
-    if (this.icon == null) {
+    if (changes.icon == null) {
       this.icon = this.ProjectService.getNode(this.nodeId).getIcon();
     }
     if (this.size) {


### PR DESCRIPTION
## Changes
- Updated NodeIcon to get icon from ProjectService whenever inputs change and the `icon` input variable is not sent.

Fixes #130.

## Test
- That node icon in the step tools toolbar updates to reflect the current node being viewed (when using both the select drop-down and the navigation arrows).