### PR TITLE
Increase max-height of step tools dropdown select

### DIFF
--- a/src/assets/wise5/common/stepTools/step-tools.component.html
+++ b/src/assets/wise5/common/stepTools/step-tools.component.html
@@ -13,6 +13,7 @@
   <node-icon *ngIf="nodeId" [nodeId]="nodeId" size="18"></node-icon>&nbsp;
   <mat-select id="stepSelectMenu"
       class="mat-button notice-bg-bg"
+      [panelClass]="'select-panel-full-height'"
       aria-label="Select a Step"
       i18n-aria-label
       placeholder="Select a Step"

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -7866,29 +7866,29 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Select a Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/stepTools/step-tools.component.html</context>
-          <context context-type="linenumber">16</context>
+          <context context-type="linenumber">17</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/stepTools/step-tools.component.html</context>
-          <context context-type="linenumber">18</context>
+          <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="336bb34dbee61b667deb8c5d2f94d7b7451e3eb8" datatype="html">
         <source> Select a Step </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/stepTools/step-tools.component.html</context>
-          <context context-type="linenumber">27,28</context>
+          <context context-type="linenumber">28,29</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8b28432b6c78dfa3fb0a921ff13c63faa06457fe" datatype="html">
         <source>Next Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/stepTools/step-tools.component.html</context>
-          <context context-type="linenumber">41</context>
+          <context context-type="linenumber">42</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/stepTools/step-tools.component.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6bc7f2c14cb3141e690735b278591defe07c68fb" datatype="html">

--- a/src/style/abstracts/_mixins.scss
+++ b/src/style/abstracts/_mixins.scss
@@ -189,6 +189,10 @@
     min-height: $toolbar-height;
   }
 
+  .select-panel-full-height {
+    max-height: 80vh;
+  }
+
   td {
     &.mat-cell, &.mat-footer-cell, &.mat-header-cell {
       padding: 4px 8px 4px 0;


### PR DESCRIPTION
## Changes 
Increased the max-height of the step tools dropdown select to 80vh (80% the viewport height). The step select dropdown is no longer limited to 256px height (which is the default for Angular Material) and should be responsive based on window height.

Closes #148.

## Test
- Step select dropdown in AT and CM height increases to show all steps in the unit until it reaches 80vh.
- Step select dropdown is responsive to changes in window height.