### PR TITLE
Support enabling teacher notebook when student notebook is disabled

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorController.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorController.ts
@@ -77,8 +77,10 @@ class ClassroomMonitorController {
     this.projectId = this.ConfigService.getProjectId();
     this.runId = this.ConfigService.getRunId();
     this.runCode = this.ConfigService.getRunCode();
-    this.notebookConfig = this.NotebookService.getTeacherNotebookConfig();
-    this.reportEnabled = this.notebookConfig.enabled;
+    if (this.NotebookService.isNotebookEnabled('teacherNotebook')) {
+      this.notebookConfig = this.NotebookService.getTeacherNotebookConfig();
+      this.reportEnabled = this.notebookConfig.enabled && this.notebookConfig.itemTypes.report.enabled;
+    }
     this.enableProjectAchievements = this.ProjectService.getAchievements().isEnabled;
     this.views = {
       'root.cm.dashboard': {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorController.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorController.ts
@@ -77,10 +77,8 @@ class ClassroomMonitorController {
     this.projectId = this.ConfigService.getProjectId();
     this.runId = this.ConfigService.getRunId();
     this.runCode = this.ConfigService.getRunCode();
-    if (this.NotebookService.isNotebookEnabled()) {
-      this.notebookConfig = this.NotebookService.getTeacherNotebookConfig();
-      this.reportEnabled = this.notebookConfig.enabled;
-    }
+    this.notebookConfig = this.NotebookService.getTeacherNotebookConfig();
+    this.reportEnabled = this.notebookConfig.enabled;
     this.enableProjectAchievements = this.ProjectService.getAchievements().isEnabled;
     this.views = {
       'root.cm.dashboard': {


### PR DESCRIPTION
## Changes
The teacher notebook can now be enabled for a run if the student notebook is disabled.

Closes #155.

## Test
- Disabled student notebook and enable teacher notebook for a run unit in the authoring tool.
- Switch to Teacher Tools and verify that teacher notebook report is visible and functions.
- Try out all the different combinations for turning on and off the teacher and student notebooks and make sure the settings work properly.