### PR TITLE
Match component export cell alignment broken

### DIFF
--- a/src/assets/wise5/classroomMonitor/dataExport/dataExportController.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/dataExportController.ts
@@ -3125,13 +3125,23 @@ class DataExportController {
     );
     for (const bucket of matchComponentState.studentData.buckets) {
       for (const item of bucket.items) {
-        row[columnNameToNumber[item.id]] = bucket.value;
+        row[columnNameToNumber[item.id]] = this.getBucketValueById(component, bucket.id);
         if (this.includeCorrectnessColumns && this.MatchService.hasCorrectAnswer(component)) {
           this.setCorrectnessValue(row, columnNameToNumber, item);
         }
       }
     }
     return row;
+  }
+
+  getBucketValueById(component: any, id: string): string {
+    if (id === '0') {
+      return component.choicesLabel ? component.choicesLabel : 'Choices';
+    }
+    const bucket = component.buckets.find((bucket: any) => {
+      return bucket.id === id;
+    });
+    return bucket ? bucket.value : '';
   }
 
   /**


### PR DESCRIPTION
1. Create a Match component that contains an image tag as a bucket value
2. As a student, save work for the Match component. Make sure to place a choice in the bucket that contains an image.
3. As the teacher, open the Classroom Monitor
4. Go to the "Data Export" view
5. Click "Export Component Data"
6. Find the Match component and click the "Latest" button
7. Open the csv file in Excel. Make sure the cell alignment is correct.

Previously a bucket value image would look like this below in the csv. This should be rendered in a single cell but it gets split up into 3 cells by Excel because of the commas. Below is what is saved in the student data (the onclick and onkeypress probably should not be saved in the student data in the first place and we should fix this in another issue). To fix the problem, I grab the bucket id that the student placed a choice in, and then look up the bucket value in the component content (which does not have the onclick and onkeypress attributes).
```
"<img onclick="window.dispatchEvent(new CustomEvent('snip-image', { detail: { target: this } }))" onkeypress="javascript: if (event.key === 'Enter' || event.keyCode === 13 || event.which === 13 ) { window.dispatchEvent(new CustomEvent('snip-image', { detail: { target: this } } )) }" aria-label="Select image to add to notebook" title="Add to notebook" tabindex="0" snip src="/curriculum/20/assets/wheels-of-didactics.png"/>"
```

Closes #157