### PR TITLE
Only show steps with work in Teacher Tools node select dropdown

### DIFF
--- a/src/assets/wise5/authoringTool/components/shared/toolbar/toolbar.ts
+++ b/src/assets/wise5/authoringTool/components/shared/toolbar/toolbar.ts
@@ -52,7 +52,7 @@ const Toolbar = {
           <md-icon> menu </md-icon>
         </md-button>
         <span class="toolbar__title" ng-if="!$ctrl.showStepTools">{{ $ctrl.viewName }}</span>
-        <step-tools ng-if="$ctrl.showStepTools" show-position="$ctrl.numberProject"></step-tools>
+        <step-tools ng-if="$ctrl.showStepTools"></step-tools>
         <div flex></div>
         <span ng-if="$ctrl.isJSONValid === true" style="color: green; font-size: 16px"><md-icon style="color:green; margin-top: -4px;">done</md-icon><span>{{ ::'jsonValid' | translate }}</span></span>
         <span ng-if="$ctrl.isJSONValid === false" style="color: red; font-size: 16px"><md-icon style="color:red; margin-top: -4px;">clear</md-icon><span>{{ ::'jsonInvalid' | translate }}</span></span>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/toolbar/toolbar.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/toolbar/toolbar.ts
@@ -35,7 +35,7 @@ const Toolbar = {
                     <md-tooltip md-direction="bottom">{{ ::'mainMenu' | translate }}</md-tooltip>
                 </md-button>
                 <span class="toolbar__title" ng-if="$ctrl.showTitle">{{ $ctrl.viewName }}</span>
-                <step-tools ng-if="$ctrl.showStepTools" [show-non-work]="false"></step-tools>
+                <step-tools ng-if="$ctrl.showStepTools" [only-show-steps-with-work]="true"></step-tools>
                 <student-grading-tools ng-if="$ctrl.showTeamTools" workgroup-id="$ctrl.workgroupId"></student-grading-tools>
                 <span flex></span>
                 <period-select ng-if="$ctrl.showPeriodSelect" custom-class="'md-no-underline md-button toolbar__select'"></period-select>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/toolbar/toolbar.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/toolbar/toolbar.ts
@@ -35,7 +35,7 @@ const Toolbar = {
                     <md-tooltip md-direction="bottom">{{ ::'mainMenu' | translate }}</md-tooltip>
                 </md-button>
                 <span class="toolbar__title" ng-if="$ctrl.showTitle">{{ $ctrl.viewName }}</span>
-                <step-tools ng-if="$ctrl.showStepTools" show-position="$ctrl.numberProject"></step-tools>
+                <step-tools ng-if="$ctrl.showStepTools" [show-non-work]="false"></step-tools>
                 <student-grading-tools ng-if="$ctrl.showTeamTools" workgroup-id="$ctrl.workgroupId"></student-grading-tools>
                 <span flex></span>
                 <period-select ng-if="$ctrl.showPeriodSelect" custom-class="'md-no-underline md-button toolbar__select'"></period-select>

--- a/src/assets/wise5/common/stepTools/step-tools.component.ts
+++ b/src/assets/wise5/common/stepTools/step-tools.component.ts
@@ -82,7 +82,7 @@ export class StepToolsComponent {
   }
 
   nodeHasWork(nodeId: string) {
-    return this.isGroupNode(nodeId) ? true : this.ProjectService.nodeHasWork(nodeId);
+    return this.ProjectService.nodeHasWork(nodeId);
   }
 
   isGroupNode(nodeId: string) {

--- a/src/assets/wise5/common/stepTools/step-tools.component.ts
+++ b/src/assets/wise5/common/stepTools/step-tools.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component, Input, ViewEncapsulation } from '@angular/core';
 import { Directionality } from '@angular/cdk/bidi';
 import { Subscription } from 'rxjs';
 import { NodeService } from '../../services/nodeService';
@@ -11,6 +11,9 @@ import { TeacherProjectService } from '../../services/teacherProjectService';
   encapsulation: ViewEncapsulation.None
 })
 export class StepToolsComponent {
+  @Input()
+  showNonWork: boolean = true;
+
   icons: any;
   nextId: any;
   nodeIds: string[];
@@ -47,6 +50,11 @@ export class StepToolsComponent {
 
   calculateNodeIds() {
     this.nodeIds = Object.keys(this.ProjectService.idToOrder);
+    if (!this.showNonWork) {
+      this.nodeIds = this.nodeIds.filter(nodeId => {
+        return this.isGroupNode(nodeId) || this.nodeHasWork(nodeId);
+      })
+    }
     this.nodeIds.shift(); // remove the 'group0' master root node from consideration
   }
 
@@ -71,6 +79,10 @@ export class StepToolsComponent {
 
   getNodePositionAndTitleByNodeId(nodeId: string) {
     return this.ProjectService.getNodePositionAndTitleByNodeId(nodeId);
+  }
+
+  nodeHasWork(nodeId: string) {
+    return this.isGroupNode(nodeId) ? true : this.ProjectService.nodeHasWork(nodeId);
   }
 
   isGroupNode(nodeId: string) {

--- a/src/assets/wise5/common/stepTools/step-tools.component.ts
+++ b/src/assets/wise5/common/stepTools/step-tools.component.ts
@@ -12,7 +12,7 @@ import { TeacherProjectService } from '../../services/teacherProjectService';
 })
 export class StepToolsComponent {
   @Input()
-  showNonWork: boolean = true;
+  onlyShowStepsWithWork: boolean = false;
 
   icons: any;
   nextId: any;
@@ -50,10 +50,10 @@ export class StepToolsComponent {
 
   calculateNodeIds() {
     this.nodeIds = Object.keys(this.ProjectService.idToOrder);
-    if (!this.showNonWork) {
-      this.nodeIds = this.nodeIds.filter(nodeId => {
-        return this.isGroupNode(nodeId) || this.nodeHasWork(nodeId);
-      })
+    if (this.onlyShowStepsWithWork) {
+      this.nodeIds = this.nodeIds.filter((nodeId) => {
+        return this.isGroupNode(nodeId) || this.ProjectService.nodeHasWork(nodeId);
+      });
     }
     this.nodeIds.shift(); // remove the 'group0' master root node from consideration
   }
@@ -79,10 +79,6 @@ export class StepToolsComponent {
 
   getNodePositionAndTitleByNodeId(nodeId: string) {
     return this.ProjectService.getNodePositionAndTitleByNodeId(nodeId);
-  }
-
-  nodeHasWork(nodeId: string) {
-    return this.ProjectService.nodeHasWork(nodeId);
   }
 
   isGroupNode(nodeId: string) {

--- a/src/assets/wise5/services/studentStatusService.ts
+++ b/src/assets/wise5/services/studentStatusService.ts
@@ -255,7 +255,7 @@ export class StudentStatusService {
     }
 
     // generate the percentage number rounded down to the nearest integer
-    let completionPercentage = numTotal > 0 ? Math.floor((100 * numCompleted) / numTotal) : 0;
+    let completionPercentage = numTotal > 0 ? Math.round((100 * numCompleted) / numTotal) : 0;
 
     return {
       completedItems: numCompleted,


### PR DESCRIPTION
## Changes
Added option to filter out steps that don't capture work in the node select dropdown in the StepTools component. Teacher Tools (CM) now only shows steps with work.

Resolves #177.

## Test
- Open the Teacher Tools for a run.
- In Grade by Step, open the node select dropdown from the StepTools in the toolbar. Verify that only steps that capture work are shown.
- Open the Authoring Tool for the run.
- Verify that all steps are shown in the node select dropdown in the toolbar.