### PR TITLE
Extracted notebook module

### DIFF
--- a/src/app/common-hybrid-angular.module.ts
+++ b/src/app/common-hybrid-angular.module.ts
@@ -54,13 +54,6 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MomentModule } from 'ngx-moment';
 import { EditorModule, TINYMCE_SCRIPT_SRC } from '@tinymce/tinymce-angular';
-import { WiseTinymceEditorComponent } from '../assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component';
-import { NotebookParentComponent } from './notebook/notebook-parent/notebook-parent.component';
-import { NotebookItemComponent } from './notebook/notebook-item/notebook-item.component';
-import { NotebookLauncherComponent } from './notebook/notebook-launcher/notebook-launcher.component';
-import { NotebookNotesComponent } from './notebook/notebook-notes/notebook-notes.component';
-import { NotebookReportComponent } from './notebook/notebook-report/notebook-report.component';
-import { NotebookReportAnnotationsComponent } from './notebook/notebook-report-annotations/notebook-report-annotations.component';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
@@ -73,6 +66,7 @@ import { ComponentService } from '../assets/wise5/components/componentService';
 import { WiseLinkService } from './services/wiseLinkService';
 import { DataExportService } from '../assets/wise5/services/dataExportService';
 import { MatChipsModule } from '@angular/material/chips';
+import { NotebookModule } from './notebook/notebook.module';
 
 @Component({ template: `` })
 export class EmptyComponent {}
@@ -83,14 +77,7 @@ export class EmptyComponent {}
     EmptyComponent,
     HelpIconComponent,
     NodeIconComponent,
-    NodeStatusIcon,
-    NotebookParentComponent,
-    NotebookItemComponent,
-    NotebookLauncherComponent,
-    NotebookNotesComponent,
-    NotebookReportComponent,
-    NotebookReportAnnotationsComponent,
-    WiseTinymceEditorComponent
+    NodeStatusIcon
   ],
   imports: [
     UpgradeModule,
@@ -118,6 +105,7 @@ export class EmptyComponent {}
     MatSlideToggleModule,
     MatTooltipModule,
     MomentModule,
+    NotebookModule,
     ReactiveFormsModule,
     RouterModule.forChild([{ path: '**', component: EmptyComponent }])
   ],
@@ -154,7 +142,6 @@ export class EmptyComponent {}
     SummaryService,
     TableService,
     TagService,
-    { provide: TINYMCE_SCRIPT_SRC, useValue: 'tinymce/tinymce.min.js' },
     UtilService,
     VLEProjectService,
     WiseLinkService

--- a/src/app/notebook/notebook-parent/notebook-parent.component.ts
+++ b/src/app/notebook/notebook-parent/notebook-parent.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input } from '@angular/core';
-import { Subscription } from 'rxjs';
 import { ConfigService } from '../../../assets/wise5/services/configService';
 import { NotebookService } from '../../../assets/wise5/services/notebookService';
 import { UtilService } from '../../../assets/wise5/services/utilService';

--- a/src/app/notebook/notebook.module.ts
+++ b/src/app/notebook/notebook.module.ts
@@ -1,0 +1,54 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { EditorModule, TINYMCE_SCRIPT_SRC } from '@tinymce/tinymce-angular';
+import { MomentModule } from 'ngx-moment';
+import { WiseTinymceEditorComponent } from '../../assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component';
+import { NotebookItemComponent } from './notebook-item/notebook-item.component';
+import { NotebookLauncherComponent } from './notebook-launcher/notebook-launcher.component';
+import { NotebookNotesComponent } from './notebook-notes/notebook-notes.component';
+import { NotebookParentComponent } from './notebook-parent/notebook-parent.component';
+import { NotebookReportAnnotationsComponent } from './notebook-report-annotations/notebook-report-annotations.component';
+import { NotebookReportComponent } from './notebook-report/notebook-report.component';
+
+@NgModule({
+  declarations: [
+    NotebookParentComponent,
+    NotebookItemComponent,
+    NotebookLauncherComponent,
+    NotebookNotesComponent,
+    NotebookReportComponent,
+    NotebookReportAnnotationsComponent,
+    WiseTinymceEditorComponent
+  ],
+  imports: [
+    CommonModule,
+    EditorModule,
+    FlexLayoutModule,
+    MatButtonModule,
+    MatCardModule,
+    MatDialogModule,
+    MatDividerModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatSidenavModule,
+    MatTabsModule,
+    MatToolbarModule,
+    MatTooltipModule,
+    MomentModule
+  ],
+  providers: [{ provide: TINYMCE_SCRIPT_SRC, useValue: 'tinymce/tinymce.min.js' }]
+})
+export class NotebookModule {}

--- a/src/assets/wise5/classroomMonitor/classroom-monitor.module.ts
+++ b/src/assets/wise5/classroomMonitor/classroom-monitor.module.ts
@@ -25,7 +25,7 @@ export default angular
     'milestones',
     'nodeGrading',
     'nodeProgress',
-    'notebook',
+    'notebookGrading',
     'studentGrading',
     'studentProgress'
   ])

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/notebook/notebook.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/notebook/notebook.ts
@@ -5,7 +5,7 @@ import NotebookWorkgroupGrading from './notebookWorkgroupGrading/notebookWorkgro
 import * as angular from 'angular';
 
 const Notebook = angular
-  .module('notebook', [])
+  .module('notebookGrading', [])
   .component('notebookItemGrading', NotebookItemGrading)
   .component('notebookWorkgroupGrading', NotebookWorkgroupGrading);
 


### PR DESCRIPTION
## Changes
- Extracted notebook module from common-hybrid-angular.module.ts.
- Renamed notebook grading module from 'notebook' to 'notebookGrading' to avoid conflict.
- Removed unused import in notebook-parent.component.ts.
- No new function was added.

## Test
- Student notebook features work as before
  - add/edit note
  - edit report
- Teacher notebook features work as before
  - edit report
  - view student notes and report
- Teacher can edit HTML using TinyMCE like before

## Other notes
- The step location where the note was added does not appear in the note. This is also true in production, so I wrote this up and we can work on it in a separate issue: #180.

Closes #179