### PR TITLE
Changed retrieveStudentStatuses() to use subscribe().

### DIFF
--- a/src/assets/wise5/services/studentStatusService.ts
+++ b/src/assets/wise5/services/studentStatusService.ts
@@ -19,23 +19,29 @@ export class StudentStatusService {
   ) {}
 
   retrieveStudentStatuses() {
-    this.studentStatuses = [];
     return this.http
       .get(`/api/teacher/run/${this.ConfigService.getRunId()}/student-status`)
-      .toPromise()
-      .then((studentStatuses: any) => {
-        const workgroups = this.ConfigService.getClassmateUserInfos();
-        for (const studentStatus of studentStatuses) {
-          const parsedStatus = JSON.parse(studentStatus.status);
-          if (workgroups.find(workgroup => {
-            return workgroup.workgroupId === studentStatus.workgroupId;
-          })) {
-            parsedStatus.postTimestamp = studentStatus.timestamp;
-            this.studentStatuses.push(parsedStatus);
-          }
-        }
+      .subscribe((studentStatuses: any[]) => {
+        this.studentStatuses = this.parseStudentStatuses(studentStatuses);
         return this.studentStatuses;
       });
+  }
+
+  private parseStudentStatuses(studentStatuses: any[]): any[] {
+    const parsedStatuses = [];
+    const workgroups = this.ConfigService.getClassmateUserInfos();
+    for (const studentStatus of studentStatuses) {
+      if (
+        workgroups.find((workgroup) => {
+          return workgroup.workgroupId === studentStatus.workgroupId;
+        })
+      ) {
+        const parsedStatus = JSON.parse(studentStatus.status);
+        parsedStatus.postTimestamp = studentStatus.timestamp;
+        parsedStatuses.push(parsedStatus);
+      }
+    }
+    return parsedStatuses;
   }
 
   getStudentStatuses() {


### PR DESCRIPTION
## Changes
- Changed retrieveStudentStatuses() to use subscribe().
- Updated test to ensure that old workgroups are properly filtered out, to test work done in #170.
- Also updated test to ensure that studentStatuses field was properly set after http call completes.

## Test
- Code and test are easy to read and understand
- CM loads properly

Closes #182
