### PR TITLE
Authoring Tool can't click Home button and then go back to step previously opened

### DIFF
--- a/src/assets/wise5/authoringTool/node/nodeAuthoringComponent.ts
+++ b/src/assets/wise5/authoringTool/node/nodeAuthoringComponent.ts
@@ -135,6 +135,7 @@ class NodeAuthoringController {
   }
 
   $onDestroy() {
+    this.TeacherDataService.setCurrentNode(null);
     this.subscriptions.unsubscribe();
   }
 

--- a/src/assets/wise5/common/stepTools/step-tools.component.ts
+++ b/src/assets/wise5/common/stepTools/step-tools.component.ts
@@ -43,6 +43,11 @@ export class StepToolsComponent {
         this.updateModel();
       })
     );
+    this.subscriptions.add(
+      this.ProjectService.projectChanged$.subscribe(() => {
+        this.calculateNodeIds();
+      })
+    );
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
1. Open a unit in the Authoring Tool
2. Create a new step and insert it into the unit
3. Click the step drop down and make sure you can see the new step within the drop down. The step used to not show up here.
4. Click the "Unit Home" button on the left side bar
5. Click on the step you just created. You should be taken into the step authoring view. Previously nothing would happen and you would just stay in the unit home view.

Closes #188