### PR TITLE
Updated Node from v10 to v14 for Docker dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM node:10.24-alpine
+FROM node:14.17-alpine
 RUN apk add chromium
 ENV CHROME_BIN='/usr/bin/chromium-browser'
+RUN apk --no-cache add --virtual native-deps \
+    g++ gcc libgcc libstdc++ linux-headers make python3 && \
+    npm install --quiet node-gyp -g
 
 WORKDIR /app
 


### PR DESCRIPTION
## Test
- Change wise-client-dev-image version in docker-compose.yml in WISE-Docker-Dev. Change from v4 to v5:
```wiseberkeley/wise-client-dev:v5```
- Run ```docker-compose up``` and verify that it pulls the wise-client-dev version 5 and starts up wise-client as before.

Closes #208