### PR TITLE
Extracted EditComponentScore and upgraded to Angular

### DIFF
--- a/src/app/teacher-hybrid-angular.module.ts
+++ b/src/app/teacher-hybrid-angular.module.ts
@@ -44,6 +44,7 @@ import { EditComponentMaxScoreComponent } from './authoring-tool/edit-component-
 import { EditComponentPrompt } from './authoring-tool/edit-component-prompt/edit-component-prompt.component';
 import { EditComponentRubricComponent } from './authoring-tool/edit-component-rubric/edit-component-rubric.component';
 import { EditComponentSaveButtonComponent } from './authoring-tool/edit-component-save-button/edit-component-save-button.component';
+import { EditComponentScoreComponent } from '../assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component';
 import { EditComponentSubmitButtonComponent } from './authoring-tool/edit-component-submit-button/edit-component-submit-button.component';
 import { EditComponentTagsComponent } from './authoring-tool/edit-component-tags/edit-component-tags.component';
 import { EditComponentWidthComponent } from './authoring-tool/edit-component-width/edit-component-width.component';
@@ -117,6 +118,7 @@ import { InsertNodesService } from '../assets/wise5/services/insertNodesService'
     EditComponentPrompt,
     EditComponentTagsComponent,
     EditComponentSaveButtonComponent,
+    EditComponentScoreComponent,
     EditComponentSubmitButtonComponent,
     EditComponentWidthComponent,
     EditHTMLAdvancedComponent,

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.html
@@ -1,0 +1,21 @@
+<span fxLayout="row" fxLayoutAlign="start center">
+  <label class="input-label md-no-float annotations--grading__score__label">
+    <span *ngIf="isAutoScore">
+      <span i18n>Auto Score</span>
+      <span *ngIf="!disabled">(<a (click)="focusScoreInput()" i18n>Edit</a>)</span>
+      :
+    </span>
+    <span *ngIf="!isAutoScore && disabled" i18n>Teacher Score:</span>
+    <span *ngIf="!isAutoScore && !disabled" i18n>Item Score:</span>
+  </label>
+  <mat-form-field>
+    <input #scoreInput
+        matInput
+        type="number"
+        min="0"
+        [ngModel]="score"
+        [disabled]="disabled"
+        (ngModelChange)="scoreChanged.next($event)">
+  </mat-form-field>
+</span>
+

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.spec.ts
@@ -1,0 +1,72 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { UpgradeModule } from '@angular/upgrade/static';
+import { configureTestSuite } from 'ng-bullet';
+import { AnnotationService } from '../../../services/annotationService';
+import { EditComponentScoreComponent } from './edit-component-score.component';
+
+class MockAnnotationService {
+  createAnnotation() {}
+  saveAnnotation() {}
+}
+
+let annotationService;
+let component: EditComponentScoreComponent;
+let fixture: ComponentFixture<EditComponentScoreComponent>;
+
+describe('EditComponentScoreComponent', () => {
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, UpgradeModule],
+      declarations: [EditComponentScoreComponent],
+      providers: [{ provide: AnnotationService, useClass: MockAnnotationService }],
+      schemas: [NO_ERRORS_SCHEMA]
+    });
+    annotationService = TestBed.inject(AnnotationService);
+  });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EditComponentScoreComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+  ngOnInit();
+  saveScore();
+});
+
+function ngOnInit() {
+  describe('ngOnInit()', () => {
+    ngOnInit_latestAnnotationNull_SetScoreTo0();
+    ngOnInit_latestAnnotationSet_SetScoreFromAnnotation();
+  });
+}
+
+function ngOnInit_latestAnnotationNull_SetScoreTo0() {
+  it('should set score to 0 when latestAnnotationScore is not set', () => {
+    component.ngOnInit();
+    expect(component.score).toEqual(0);
+  });
+}
+
+function ngOnInit_latestAnnotationSet_SetScoreFromAnnotation() {
+  it('should set score to latestAnnotation.score', () => {
+    component.latestAnnotationScore = { data: { value: 5 } };
+    component.ngOnInit();
+    expect(component.score).toEqual(5);
+  });
+}
+
+function saveScore() {
+  describe('saveScore()', () => {
+    it('should create and save annotation', () => {
+      const createAnnotationSpy = spyOn(
+        annotationService,
+        'createAnnotation'
+      ).and.callFake(() => {});
+      const saveAnnotationSpy = spyOn(annotationService, 'saveAnnotation').and.callFake(() => {});
+      component.saveScore(5);
+      expect(createAnnotationSpy).toHaveBeenCalled();
+      expect(saveAnnotationSpy).toHaveBeenCalled();
+    });
+  });
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.ts
@@ -1,0 +1,65 @@
+import { Component, ElementRef, Input, ViewChild } from '@angular/core';
+import { Subject, Subscription } from 'rxjs';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+import { AnnotationService } from '../../../services/annotationService';
+
+@Component({
+  selector: 'edit-component-score',
+  templateUrl: 'edit-component-score.component.html'
+})
+export class EditComponentScoreComponent {
+  @Input() componentId: string;
+  @Input() componentStateId: string;
+  @Input() disabled: boolean;
+  @Input() fromWorkgroupId: number;
+  @Input() latestAnnotationScore: any;
+  @Input() nodeId: string;
+  @Input() periodId: string;
+  @Input() runId: string;
+  @Input() toWorkgroupId: number;
+  @ViewChild('scoreInput') scoreInputElement: ElementRef;
+
+  isAutoScore: boolean;
+  score: number;
+  scoreChanged: Subject<number> = new Subject<number>();
+  subscriptions: Subscription = new Subscription();
+
+  constructor(private AnnotationService: AnnotationService) {}
+
+  ngOnInit() {
+    this.isAutoScore = this.latestAnnotationScore?.type === 'autoScore';
+    this.score = this.latestAnnotationScore?.data.value ?? 0;
+    this.subscriptions.add(
+      this.scoreChanged.pipe(debounceTime(1000), distinctUntilChanged()).subscribe((newScore) => {
+        this.saveScore(newScore);
+      })
+    );
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
+  }
+
+  saveScore(score: number) {
+    const annotation = this.AnnotationService.createAnnotation(
+      null,
+      this.runId,
+      this.periodId,
+      this.fromWorkgroupId,
+      this.toWorkgroupId,
+      this.nodeId,
+      this.componentId,
+      this.componentStateId,
+      null,
+      null,
+      'score',
+      { value: score },
+      new Date().getTime()
+    );
+    this.AnnotationService.saveAnnotation(annotation);
+  }
+
+  focusScoreInput() {
+    this.scoreInputElement.nativeElement.focus();
+  }
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/grading-edit-component-max-score/grading-edit-component-max-score.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/grading-edit-component-max-score/grading-edit-component-max-score.component.ts
@@ -17,7 +17,6 @@ export class GradingEditComponentMaxScoreComponent {
   @Input()
   disabled: boolean;
 
-  @Input()
   maxScore: number;
 
   maxScoreChanged: Subject<string> = new Subject<string>();

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.html
@@ -1,22 +1,15 @@
 <div ng-if="!$ctrl.showAllAnnotations" class="annotations--grading">
     <div class="annotations--grading__score annotations--grading__item" layout="row" layout-align="start-center">
-        <md-input-container class="md-no-float" layout="row" layout-align="start-center">
-            <label class="input-label md-no-float annotations--grading__score__label">
-                <span ng-if="$ctrl.latestAnnotations.score.type === 'autoScore'">{{ ::'AUTO_SCORE' | translate }}
-                    <span ng-if="!$ctrl.isDisabled">
-                        (<a ng-click="$ctrl.editScore($event)">{{ ::'EDIT' | translate }}</a>)
-                    </span>:</span>
-                <span ng-if="$ctrl.latestAnnotations.score.type !== 'autoScore'">{{ ::'ITEM_SCORE' | translate }}:</span>
-            </label>
-            <input id="{{ 'scoreInput_' + $ctrl.componentId + '_' + $ctrl.toWorkgroupId }}"
-                   type="number"
-                   placeholder="0"
-                   min="0"
-                   ng-model="$ctrl.score"
-                   ng-disabled="$ctrl.isDisabled || !$ctrl.canGradeStudentWork"
-                   ng-change="$ctrl.postAnnotation('score')"
-                   ng-model-options="{ debounce: 1000 }">
-        </md-input-container>
+        <edit-component-score
+            [component-id]="$ctrl.componentId"
+            [component-state-id]="$ctrl.componentStateId"
+            [disabled]="$ctrl.isDisabled || !$ctrl.canGradeStudentWork"
+            [from-workgroup-id]="$ctrl.fromWorkgroupId"
+            [latest-annotation-score]="$ctrl.latestAnnotations.score"
+            [node-id]="$ctrl.nodeId"
+            [period-id]="$ctrl.periodId"
+            [run-id]="$ctrl.runId"
+            [to-workgroup-id]="$ctrl.toWorkgroupId"></edit-component-score>
         <span> / </span>
         <grading-edit-component-max-score [node-id]="$ctrl.nodeId"
             [component-id]="$ctrl.componentId"
@@ -57,14 +50,16 @@
         <div ng-if="$ctrl.latestAnnotations.score"
              class="annotations--grading__item annotations--grading__score"
              layout="row" layout-align="start-center">
-            <md-input-container class="md-no-float" layout="row" layout-align="start-center">
-                <label class="input-label md-no-float annotations--grading__score__label">{{ ::'TEACHER_SCORE' | translate }}:</label>
-                <input type="number"
-                       placeholder="0"
-                       min="0"
-                       ng-model="$ctrl.latestAnnotations.score.data.value"
-                       ng-disabled="true">
-            </md-input-container>
+            <edit-component-score
+                [component-id]="$ctrl.componentId"
+                [component-state-id]="$ctrl.componentStateId"
+                [disabled]="true"
+                [from-workgroup-id]="$ctrl.fromWorkgroupId"
+                [latest-annotation-score]="$ctrl.latestAnnotations.score"
+                [node-id]="$ctrl.nodeId"
+                [period-id]="$ctrl.periodId"
+                [run-id]="$ctrl.runId"
+                [to-workgroup-id]="$ctrl.toWorkgroupId"></edit-component-score>
             <span> / </span>
             <grading-edit-component-max-score [node-id]="$ctrl.nodeId"
                 [component-id]="$ctrl.componentId"
@@ -91,18 +86,20 @@
         <div ng-if="$ctrl.latestAnnotations.autoScore"
              class="annotations--grading__item annotations--grading__score"
              layout="row" layout-align="start-center">
-            <md-input-container class="md-no-float" layout="row" layout-align="start-center">
-                <label class="input-label md-no-float annotations--grading__score__label">{{ ::'AUTO_SCORE' | translate }}:</label>
-                <input type="number"
-                       placeholder="0"
-                       min="0"
-                       ng-model="$ctrl.latestAnnotations.autoScore.data.value"
-                       ng-disabled="true">
-            </md-input-container>
+            <edit-component-score
+                [component-id]="$ctrl.componentId"
+                [component-state-id]="$ctrl.componentStateId"
+                [disabled]="true"
+                [from-workgroup-id]="$ctrl.fromWorkgroupId"
+                [latest-annotation-score]="$ctrl.latestAnnotations.autoScore"
+                [node-id]="$ctrl.nodeId"
+                [period-id]="$ctrl.periodId"
+                [run-id]="$ctrl.runId"
+                [to-workgroup-id]="$ctrl.toWorkgroupId"></edit-component-score>
             <span> / </span>
             <grading-edit-component-max-score [node-id]="$ctrl.nodeId"
-              [component-id]="$ctrl.componentId"
-              [disabled]="true"></grading-edit-component-max-score>
+                [component-id]="$ctrl.componentId"
+                [disabled]="true"></grading-edit-component-max-score>
         </div>
         <div class="annotations--grading__item annotations--grading__auto-comment" ng-if="$ctrl.latestAnnotations.autoComment">
             <div class="heavy md-no-float">{{ ::'AUTO_COMMENT' | translate }}:</div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.ts
@@ -295,16 +295,6 @@ class ComponentGradingController {
       }, 100);
     }
   }
-
-  /**
-   * Focuses the score input when user wants to override an automated score
-   * @param an angular trigger event
-   */
-  editScore($event) {
-    angular
-      .element(document.querySelector('#scoreInput_' + this.componentId + '_' + this.toWorkgroupId))
-      .focus();
-  }
 }
 
 const ComponentGrading = {

--- a/src/assets/wise5/components/component-grading.module.ts
+++ b/src/assets/wise5/components/component-grading.module.ts
@@ -1,5 +1,6 @@
 import { downgradeComponent } from '@angular/upgrade/static';
 import * as angular from 'angular';
+import { EditComponentScoreComponent } from '../classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component';
 import { GradingEditComponentMaxScoreComponent } from '../classroomMonitor/classroomMonitorComponents/grading-edit-component-max-score/grading-edit-component-max-score.component';
 import './animation/animationGradingComponentModule';
 import './audioOscillator/audioOscillatorGradingComponentModule';
@@ -29,6 +30,12 @@ export default angular
     'openResponseGradingComponentModule',
     'tableGradingComponentModule'
   ])
+  .directive(
+    'editComponentScore',
+    downgradeComponent({
+      component: EditComponentScoreComponent
+    }) as angular.IDirectiveFactory
+  )
   .directive(
     'gradingEditComponentMaxScore',
     downgradeComponent({

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -4725,6 +4725,10 @@
           <context context-type="sourcefile">src/app/modules/library/library-project-menu/library-project-menu.component.html</context>
           <context context-type="linenumber">14</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="0bd8b27f60a1f098a53e06328426d818e3508ff9" datatype="html">
         <source>Share</source>
@@ -7903,6 +7907,27 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/rubric/rubric-authoring.component.html</context>
           <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2471906abf7baa724640a079ab3d084a78462ba2" datatype="html">
+        <source>Auto Score</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="f1614a3596f48debea1d7f7c616381868d9741cd" datatype="html">
+        <source>Teacher Score:</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2be79e7197af4e1e057ff5164b6f53fb91126eae" datatype="html">
+        <source>Item Score:</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.html</context>
+          <context context-type="linenumber">9</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f9c52903219e583ddefb23cd102d2057504ac980" datatype="html">


### PR DESCRIPTION
## Changes
- Extracted EditComponentScore and upgraded to Angular
- Also removed @Input from GradingEditComponentMaxScore since it's not an input

## Test
- Items without score should show 0.
- Verify auto-score from c-rater shows with the label "auto score".
- You can edit the auto-score. Doing so will change the label to "item score".
- See past scores in the revisions dialog. All the inputs should be disabled, and the labels should say "teacher score" or "auto score".
- You can remove a score, which will set it to null (and show "0" in the UI).

Closes #211