### PR TITLE
Extracted and upgraded edit component comment to Angular

### DIFF
--- a/src/app/teacher-hybrid-angular.module.ts
+++ b/src/app/teacher-hybrid-angular.module.ts
@@ -38,6 +38,8 @@ import { NodeAdvancedJsonAuthoringComponent } from '../assets/wise5/authoringToo
 import { WorkgroupInfoComponent } from '../assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroupInfo/workgroup-info.component';
 import { NodeAdvancedGeneralAuthoringComponent } from '../assets/wise5/authoringTool/node/advanced/general/node-advanced-general-authoring.component';
 import { WiseAuthoringTinymceEditorComponent } from '../assets/wise5/directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component';
+import { EditComponentCommentComponent } from '../assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component';
+import { EditComponentDefaultFeedback } from './authoring-tool/edit-advanced-component/edit-component-default-feedback/edit-component-default-feedback.component';
 import { EditComponentExcludeFromTotalScoreComponent } from './authoring-tool/edit-component-exclude-from-total-score/edit-component-exclude-from-total-score.component';
 import { EditComponentJsonComponent } from './authoring-tool/edit-component-json/edit-component-json.component';
 import { EditComponentMaxScoreComponent } from './authoring-tool/edit-component-max-score/edit-component-max-score.component';
@@ -87,7 +89,6 @@ import { StepToolsComponent } from '../assets/wise5/common/stepTools/step-tools.
 import { NodeIconChooserDialog } from '../assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component';
 import { CopyNodesService } from '../assets/wise5/services/copyNodesService';
 import { InsertNodesService } from '../assets/wise5/services/insertNodesService';
-import { EditComponentDefaultFeedback } from './authoring-tool/edit-advanced-component/edit-component-default-feedback/edit-component-default-feedback.component';
 
 @NgModule({
   declarations: [
@@ -112,6 +113,7 @@ import { EditComponentDefaultFeedback } from './authoring-tool/edit-advanced-com
     DrawGrading,
     DiscussionAuthoring,
     DiscussionGrading,
+    EditComponentCommentComponent,
     EditComponentDefaultFeedback,
     EditComponentExcludeFromTotalScoreComponent,
     EditComponentRubricComponent,

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.html
@@ -6,7 +6,8 @@
       placeholder="Enter comment here"
       i18n-placeholder
       rows="1"
-      [ngModel]="comment"
+      cdkTextareaAutosize
+      [(ngModel)]="comment"
       [disabled]="disabled"
       (ngModelChange)="commentChanged.next($event)"></textarea>
 </mat-form-field>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.html
@@ -1,0 +1,12 @@
+<mat-form-field class="input-container md-block md-no-float" flex>
+  <mat-label i18n>Teacher Comment:</mat-label>
+  <textarea
+      id="{{ 'commentInput_' + componentId + '_' + toWorkgroupId }}"
+      matInput
+      placeholder="Enter comment here"
+      i18n-placeholder
+      rows="1"
+      [ngModel]="comment"
+      [disabled]="disabled"
+      (ngModelChange)="commentChanged.next($event)"></textarea>
+</mat-form-field>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.spec.ts
@@ -1,0 +1,49 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { UpgradeModule } from '@angular/upgrade/static';
+import { configureTestSuite } from 'ng-bullet';
+import { AnnotationService } from '../../../services/annotationService';
+import { EditComponentCommentComponent } from './edit-component-comment.component';
+
+class MockAnnotationService {
+  createAnnotation() {}
+  saveAnnotation() {}
+}
+
+let annotationService;
+let component: EditComponentCommentComponent;
+let fixture: ComponentFixture<EditComponentCommentComponent>;
+
+describe('EditComponentCommentComponent', () => {
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, UpgradeModule],
+      declarations: [EditComponentCommentComponent],
+      providers: [{ provide: AnnotationService, useClass: MockAnnotationService }],
+      schemas: [NO_ERRORS_SCHEMA]
+    });
+    annotationService = TestBed.inject(AnnotationService);
+  });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EditComponentCommentComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+  saveComment();
+});
+
+function saveComment() {
+  describe('saveComment()', () => {
+    it('should create and save annotation', () => {
+      const createAnnotationSpy = spyOn(
+        annotationService,
+        'createAnnotation'
+      ).and.callFake(() => {});
+      const saveAnnotationSpy = spyOn(annotationService, 'saveAnnotation').and.callFake(() => {});
+      component.saveComment('New comment from teacher');
+      expect(createAnnotationSpy).toHaveBeenCalled();
+      expect(saveAnnotationSpy).toHaveBeenCalled();
+    });
+  });
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.spec.ts
@@ -40,8 +40,10 @@ function saveComment() {
         annotationService,
         'createAnnotation'
       ).and.callFake(() => {});
-      const saveAnnotationSpy = spyOn(annotationService, 'saveAnnotation').and.callFake(() => {});
-      component.saveComment('New comment from teacher');
+      const saveAnnotationSpy = spyOn(annotationService, 'saveAnnotation').and.callFake(() => {
+        return new Promise(() => {});
+      });
+      component.saveComment();
       expect(createAnnotationSpy).toHaveBeenCalled();
       expect(saveAnnotationSpy).toHaveBeenCalled();
     });

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.ts
@@ -1,0 +1,59 @@
+import { Component, Input } from '@angular/core';
+import { Subject, Subscription } from 'rxjs';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+import { AnnotationService } from '../../../services/annotationService';
+
+@Component({
+  selector: 'edit-component-comment',
+  styles: ['.mat-form-field { display: initial }', 'textarea { resize: none }'],
+  templateUrl: 'edit-component-comment.component.html'
+})
+export class EditComponentCommentComponent {
+  @Input() comment: string;
+  @Input() componentId: string;
+  @Input() componentStateId: string;
+  @Input() disabled: boolean;
+  @Input() fromWorkgroupId: number;
+  @Input() nodeId: string;
+  @Input() periodId: string;
+  @Input() runId: string;
+  @Input() toWorkgroupId: number;
+
+  commentChanged: Subject<string> = new Subject<string>();
+  subscriptions: Subscription = new Subscription();
+
+  constructor(private AnnotationService: AnnotationService) {}
+
+  ngOnInit() {
+    this.subscriptions.add(
+      this.commentChanged
+        .pipe(debounceTime(5000), distinctUntilChanged())
+        .subscribe((newComment) => {
+          this.saveComment(newComment);
+        })
+    );
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
+  }
+
+  saveComment(comment: string) {
+    const annotation = this.AnnotationService.createAnnotation(
+      null,
+      this.runId,
+      this.periodId,
+      this.fromWorkgroupId,
+      this.toWorkgroupId,
+      this.nodeId,
+      this.componentId,
+      this.componentStateId,
+      null,
+      null,
+      'comment',
+      { value: comment },
+      new Date().getTime()
+    );
+    this.AnnotationService.saveAnnotation(annotation);
+  }
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.html
@@ -16,23 +16,21 @@
             [disabled]="$ctrl.isDisabled || !$ctrl.canAuthorProject"></grading-edit-component-max-score>
     </div>
     <div ng-show="$ctrl.edit || !$ctrl.showAutoComment()" class="annotations--grading__item">
-        <md-input-container class="input-container md-block md-no-float" flex>
-            <label class="input-label md-no-float" ng-disabled="$ctrl.isDisabled">{{ ::'TEACHER_COMMENT' | translate }}:</label>
-            <div class="input-wrapper">
-                <textarea id="{{ 'commentInput_' + $ctrl.componentId + '_' + $ctrl.toWorkgroupId }}"
-                          md-detect-hidden
-                          placeholder="{{ ::'enterCommentHere' | translate }}"
-                          ng-model="$ctrl.comment"
-                          ng-disabled="$ctrl.isDisabled || !$ctrl.canGradeStudentWork"
-                          ng-change="$ctrl.postAnnotation('comment')"
-                          ng-model-options="{ debounce: 5000 }"></textarea>
-            </div>
-        </md-input-container>
+        <edit-component-comment
+            [comment]="$ctrl.comment"
+            [component-id]="$ctrl.componentId"
+            [component-state-id]="$ctrl.componentStateId"
+            [disabled]="$ctrl.isDisabled || !$ctrl.canGradeStudentWork"
+            [from-workgroup-id]="$ctrl.fromWorkgroupId"
+            [node-id]="$ctrl.nodeId"
+            [period-id]="$ctrl.periodId"
+            [run-id]="$ctrl.runId"
+            [to-workgroup-id]="$ctrl.toWorkgroupId"></edit-component-comment>
     </div>
     <div ng-if="$ctrl.showAutoComment()" class="annotations--grading__item annotations--grading__auto-comment">
         <div class="heavy">
             <span class="md-no-float">{{ ::'AUTO_COMMENT' | translate }}
-                <span ng-if="!$ctrl.isDisabled">(<a ng-click="$ctrl.editComment()">{{ ::'EDIT' | translate }}</a>)</span>:
+                <span ng-if="!$ctrl.isDisabled">(<a ng-click="$ctrl.toggleEditComment()">{{ ::'EDIT' | translate }}</a>)</span>:
             </span>
         </div>
         <div class="annotations--grading__auto-comment__content">
@@ -66,16 +64,16 @@
                 [disabled]="true"></grading-edit-component-max-score>
         </div>
         <div ng-if="$ctrl.latestAnnotations.comment" class="annotations--grading__item">
-            <md-input-container class="input-container md-block md-no-float"
-                                flex>
-                <label class="input-label md-no-float" ng-disabled="true">{{ ::'TEACHER_COMMENT' | translate }}:</label>
-                <div class="input-wrapper">
-                    <textarea md-detect-hidden
-                              placeholder="{{ ::'enterCommentHere' | translate }}"
-                              ng-model="$ctrl.latestAnnotations.comment.data.value"
-                              ng-disabled="true"></textarea>
-                </div>
-            </md-input-container>
+            <edit-component-comment
+                [comment]="$ctrl.latestAnnotations.comment.data.value"
+                [component-id]="$ctrl.componentId"
+                [component-state-id]="$ctrl.componentStateId"
+                [disabled]="true"
+                [from-workgroup-id]="$ctrl.fromWorkgroupId"
+                [node-id]="$ctrl.nodeId"
+                [period-id]="$ctrl.periodId"
+                [run-id]="$ctrl.runId"
+                [to-workgroup-id]="$ctrl.toWorkgroupId"></edit-component-comment>
         </div>
     </div>
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/componentGrading/componentGrading.ts
@@ -3,7 +3,6 @@
 import { AnnotationService } from '../../../../services/annotationService';
 import { ConfigService } from '../../../../services/configService';
 import { TeacherDataService } from '../../../../services/teacherDataService';
-import { UtilService } from '../../../../services/utilService';
 import * as angular from 'angular';
 import { Directive } from '@angular/core';
 import { Subscription } from 'rxjs';
@@ -33,20 +32,16 @@ class ComponentGradingController {
   static $inject = [
     '$filter',
     '$scope',
-    '$timeout',
     'AnnotationService',
     'ConfigService',
-    'TeacherDataService',
-    'UtilService'
+    'TeacherDataService'
   ];
   constructor(
     $filter: any,
     private $scope: any,
-    private $timeout: any,
     private AnnotationService: AnnotationService,
     private ConfigService: ConfigService,
-    private TeacherDataService: TeacherDataService,
-    private UtilService: UtilService
+    private TeacherDataService: TeacherDataService
   ) {
     this.$translate = $filter('translate');
 
@@ -226,73 +221,12 @@ class ComponentGradingController {
     return time;
   }
 
-  /**
-   * Save the annotation to the server
-   * @param type String to indicate which type of annotation to post
-   */
-  postAnnotation(type) {
-    if (
-      this.runId != null &&
-      this.periodId != null &&
-      this.nodeId != null &&
-      this.componentId != null &&
-      this.toWorkgroupId != null &&
-      type
-    ) {
-      let clientSaveTime = new Date().getTime();
-      let fromWorkgroupId = this.ConfigService.getWorkgroupId();
-      let value = null;
-      if (type === 'score') {
-        value = this.score;
-        value = this.UtilService.convertStringToNumber(value);
-      } else if (type === 'comment') {
-        value = this.comment;
-      }
-
-      if (
-        (type === 'comment' && value) ||
-        (type === 'score' && typeof value === 'number' && value >= 0)
-      ) {
-        const data = {
-          value: value
-        };
-        const localNotebookItemId = null; // we're not grading notebook item in this view.
-        const notebookItemId = null; // we're not grading notebook item in this view.
-        const annotation = this.AnnotationService.createAnnotation(
-          this.annotationId,
-          this.runId,
-          this.periodId,
-          this.fromWorkgroupId,
-          this.toWorkgroupId,
-          this.nodeId,
-          this.componentId,
-          this.componentStateId,
-          localNotebookItemId,
-          notebookItemId,
-          type,
-          data,
-          clientSaveTime
-        );
-        this.AnnotationService.saveAnnotation(annotation).then((result) => {});
-      }
-    }
-  }
-
-  /**
-   * Shows (or hides) the teacher comment field when user wants to override an automated comment
-   */
-  editComment() {
+  toggleEditComment() {
     this.edit = !this.edit;
-
     if (this.edit) {
-      let componentId = this.componentId;
-      let toWorkgroupId = this.toWorkgroupId;
-      // if we're showing the comment field, focus it
-      this.$timeout(() => {
-        angular
-          .element(document.querySelector('#commentInput_' + componentId + '_' + toWorkgroupId))
-          .focus();
-      }, 100);
+      angular
+        .element(document.querySelector(`#commentInput_${this.componentId}_${this.toWorkgroupId}`))
+        .focus();
     }
   }
 }

--- a/src/assets/wise5/components/component-grading.module.ts
+++ b/src/assets/wise5/components/component-grading.module.ts
@@ -1,5 +1,6 @@
 import { downgradeComponent } from '@angular/upgrade/static';
 import * as angular from 'angular';
+import { EditComponentCommentComponent } from '../classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component';
 import { EditComponentScoreComponent } from '../classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component';
 import { GradingEditComponentMaxScoreComponent } from '../classroomMonitor/classroomMonitorComponents/grading-edit-component-max-score/grading-edit-component-max-score.component';
 import './animation/animationGradingComponentModule';
@@ -30,6 +31,12 @@ export default angular
     'openResponseGradingComponentModule',
     'tableGradingComponentModule'
   ])
+  .directive(
+    'editComponentComment',
+    downgradeComponent({
+      component: EditComponentCommentComponent
+    }) as angular.IDirectiveFactory
+  )
   .directive(
     'editComponentScore',
     downgradeComponent({

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -7963,6 +7963,20 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">6</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1de4bc95785a34afe2f48becbf8fbb591cf39b5f" datatype="html">
+        <source>Teacher Comment:</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="b197b48f991d6781c56d1948050b437a9d81cb78" datatype="html">
+        <source>Enter comment here</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="2471906abf7baa724640a079ab3d084a78462ba2" datatype="html">
         <source>Auto Score</source>
         <context-group purpose="location">


### PR DESCRIPTION
## Changes
- Renamed editComment() to toggleEditComment, and removed timeout.
- Cleaned up componentGrading.ts.

## Test
- You can save comments
- You can see past comments in the revisions dialog. The comments should be disabled (can't be edited)
- For auto-scored comments, you can toggle the focus to edit comment textarea using the "Edit" link

## Notes
- This will create some duplications with the EditComponentScoreComponent. We can extract the two components to a parent EditComponentAnnotationComponent in a future task.

Closes #213