### PR TITLE
Timeout CRater requests after 40 seconds

### DIFF
--- a/src/app/services/cRaterService.spec.ts
+++ b/src/app/services/cRaterService.spec.ts
@@ -40,7 +40,7 @@ function makeCRaterScoringRequest() {
       const itemId = 'ColdBeverage1Sub';
       const responseId = 1;
       const studentData = 'Hello World.';
-      service.makeCRaterScoringRequest(itemId, responseId, studentData);
+      service.makeCRaterScoringRequest(itemId, responseId, studentData).subscribe();
       http.expectOne({
         url:
           `/c-rater/score?itemId=${itemId}&responseId=${responseId}` +

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.spec.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.spec.ts
@@ -6,6 +6,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { configureTestSuite } from 'ng-bullet';
+import { of } from 'rxjs';
 import { AnnotationService } from '../../../services/annotationService';
 import { AudioRecorderService } from '../../../services/audioRecorderService';
 import { ConfigService } from '../../../services/configService';
@@ -239,9 +240,7 @@ function createComponentStateAdditionalProcessing() {
         spyOn(TestBed.inject(OpenResponseService), 'isCompleted').and.returnValue(true);
         spyOn(component, 'isCRaterScoreOnSubmit').and.returnValue(true);
         spyOn(TestBed.inject(CRaterService), 'makeCRaterScoringRequest').and.returnValue(
-          Promise.resolve({
-            score: 1
-          })
+          of({ score: 1 })
         );
         component.isSubmit = true;
         component.createComponentState('submit').then((componentState: any) => {

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
@@ -384,7 +384,7 @@ export class OpenResponseStudent extends ComponentStudent {
       const cRaterResponseId = new Date().getTime();
       const dialogRef = this.dialog.open(HtmlDialog, {
         data: {
-          content: $localize`Please wait, we are scoring your work...`,
+          content: $localize`We are scoring your work...`,
           isShowCloseButton: false,
           title: $localize`Please Wait`
         }

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { timeout } from 'rxjs/operators';
 import { HtmlDialog } from '../../../directives/html-dialog/html-dialog';
 import { AnnotationService } from '../../../services/annotationService';
 import { AudioRecorderService } from '../../../services/audioRecorderService';
@@ -26,6 +27,7 @@ export class OpenResponseStudent extends ComponentStudent {
   audioRecordingInterval: any;
   audioRecordingMaxTime: number = 60000;
   audioRecordingStartTime: number = 0;
+  cRaterTimeout: number = 40000;
   isPublicSpaceExist: boolean = false;
   isRecordingAudio: boolean = false;
   isRichTextEnabled: boolean = false;
@@ -380,182 +382,124 @@ export class OpenResponseStudent extends ComponentStudent {
     if (performCRaterScoring) {
       const cRaterItemId = this.CRaterService.getCRaterItemId(this.componentContent);
       const cRaterResponseId = new Date().getTime();
-      const studentData = this.studentResponse;
       const dialogRef = this.dialog.open(HtmlDialog, {
         data: {
-          content: $localize`Please wait, we are scoring your work.`,
+          content: $localize`Please wait, we are scoring your work...`,
           isShowCloseButton: false,
           title: $localize`Please Wait`
         }
       });
-
-      // make the CRater request to score the student data
-      this.CRaterService.makeCRaterScoringRequest(cRaterItemId, cRaterResponseId, studentData).then(
-        (data: any) => {
-          /*
-           * annotations we put in the component state will be
-           * removed from the component state and saved separately
-           */
-          componentState.annotations = [];
-
-          // get the CRater score
-          let score = data.score;
-          let concepts = data.concepts;
-          let previousScore = null;
-          if (data.scores != null) {
-            const maxSoFarFunc = (accumulator, currentValue) => {
-              return Math.max(accumulator, currentValue.score);
-            };
-            score = data.scores.reduce(maxSoFarFunc, 0);
-          }
-
-          if (score != null) {
-            const autoScoreAnnotationData: any = {
-              value: score,
-              maxAutoScore: this.ProjectService.getMaxScoreForComponent(
-                this.nodeId,
-                this.componentId
-              ),
-              concepts: concepts,
-              autoGrader: 'cRater'
-            };
+      this.CRaterService.makeCRaterScoringRequest(
+        cRaterItemId,
+        cRaterResponseId,
+        this.studentResponse
+      )
+        .pipe(timeout(this.cRaterTimeout))
+        .subscribe(
+          (data: any) => {
+            /*
+             * annotations we put in the component state will be
+             * removed from the component state and saved separately
+             */
+            componentState.annotations = [];
+            let score = data.score;
+            let concepts = data.concepts;
+            let previousScore = null;
             if (data.scores != null) {
-              autoScoreAnnotationData.scores = data.scores;
+              const maxSoFarFunc = (accumulator, currentValue) => {
+                return Math.max(accumulator, currentValue.score);
+              };
+              score = data.scores.reduce(maxSoFarFunc, 0);
             }
 
-            let autoScoreAnnotation = this.createAutoScoreAnnotation(autoScoreAnnotationData);
-            let annotationGroupForScore = null;
-            const latestAnnotations = this.AnnotationService.getLatestComponentAnnotations(
-              this.nodeId,
-              this.componentId,
-              this.workgroupId
-            );
-
-            if (
-              latestAnnotations != null &&
-              latestAnnotations.score != null &&
-              latestAnnotations.score.data != null
-            ) {
-              previousScore = latestAnnotations.score.data.value;
-            }
-
-            if (
-              this.componentContent.enableGlobalAnnotations &&
-              this.componentContent.globalAnnotationSettings != null
-            ) {
-              let globalAnnotationMaxCount = 0;
-              if (this.componentContent.globalAnnotationSettings.globalAnnotationMaxCount != null) {
-                globalAnnotationMaxCount = this.componentContent.globalAnnotationSettings
-                  .globalAnnotationMaxCount;
+            if (score != null) {
+              const autoScoreAnnotationData: any = {
+                value: score,
+                maxAutoScore: this.ProjectService.getMaxScoreForComponent(
+                  this.nodeId,
+                  this.componentId
+                ),
+                concepts: concepts,
+                autoGrader: 'cRater'
+              };
+              if (data.scores != null) {
+                autoScoreAnnotationData.scores = data.scores;
               }
-              // get the annotation properties for the score that the student got.
-              annotationGroupForScore = this.ProjectService.getGlobalAnnotationGroupByScore(
-                this.componentContent,
-                previousScore,
-                score
+
+              let autoScoreAnnotation = this.createAutoScoreAnnotation(autoScoreAnnotationData);
+              let annotationGroupForScore = null;
+              const latestAnnotations = this.AnnotationService.getLatestComponentAnnotations(
+                this.nodeId,
+                this.componentId,
+                this.workgroupId
               );
 
-              // check if we need to apply this globalAnnotationSetting to this annotation: we don't need to if we've already reached the maxCount
-              if (annotationGroupForScore != null) {
-                let globalAnnotationGroupsByNodeIdAndComponentId = this.AnnotationService.getAllGlobalAnnotationGroups();
-                annotationGroupForScore.annotationGroupCreatedTime =
-                  autoScoreAnnotation.clientSaveTime; // save annotation creation time
-
-                if (
-                  globalAnnotationGroupsByNodeIdAndComponentId.length >= globalAnnotationMaxCount
-                ) {
-                  // we've already applied this annotation properties to maxCount annotations, so we don't need to apply it any more.
-                  annotationGroupForScore = null;
-                }
+              if (
+                latestAnnotations != null &&
+                latestAnnotations.score != null &&
+                latestAnnotations.score.data != null
+              ) {
+                previousScore = latestAnnotations.score.data.value;
               }
 
               if (
-                annotationGroupForScore != null &&
-                annotationGroupForScore.isGlobal &&
-                annotationGroupForScore.unGlobalizeCriteria != null
+                this.componentContent.enableGlobalAnnotations &&
+                this.componentContent.globalAnnotationSettings != null
               ) {
-                // check if this annotation is global and what criteria needs to be met to un-globalize.
-                annotationGroupForScore.unGlobalizeCriteria.map((unGlobalizeCriteria) => {
-                  // if the un-globalize criteria is time-based (e.g. isVisitedAfter, isRevisedAfter, isVisitedAndRevisedAfter, etc), store the timestamp of this annotation in the criteria
-                  // so we can compare it when we check for criteria satisfaction.
-                  if (unGlobalizeCriteria.params != null) {
-                    unGlobalizeCriteria.params.criteriaCreatedTimestamp =
-                      autoScoreAnnotation.clientSaveTime; // save annotation creation time to criteria
-                  }
-                });
-              }
-
-              if (annotationGroupForScore != null) {
-                // copy over the annotation properties into the autoScoreAnnotation's data
-                this.mergeObjects(
-                  autoScoreAnnotation.data,
-                  this.UtilService.makeCopyOfJSONObject(annotationGroupForScore)
+                let globalAnnotationMaxCount = 0;
+                if (
+                  this.componentContent.globalAnnotationSettings.globalAnnotationMaxCount != null
+                ) {
+                  globalAnnotationMaxCount = this.componentContent.globalAnnotationSettings
+                    .globalAnnotationMaxCount;
+                }
+                // get the annotation properties for the score that the student got.
+                annotationGroupForScore = this.ProjectService.getGlobalAnnotationGroupByScore(
+                  this.componentContent,
+                  previousScore,
+                  score
                 );
-              }
-            }
 
-            componentState.annotations.push(autoScoreAnnotation);
-
-            if (this.mode === 'authoring') {
-              if (this.latestAnnotations == null) {
-                this.latestAnnotations = {};
-              }
-
-              /*
-               * we are in the authoring view so we will set the
-               * latest score annotation manually
-               */
-              this.latestAnnotations.score = autoScoreAnnotation;
-            }
-
-            let autoComment = null;
-
-            // get the submit counter
-            const submitCounter = this.submitCounter;
-
-            if (
-              this.componentContent.cRater.enableMultipleAttemptScoringRules &&
-              submitCounter > 1
-            ) {
-              /*
-               * this step has multiple attempt scoring rules and this is
-               * a subsequent submit
-               */
-              // get the feedback based upon the previous score and current score
-              autoComment = this.CRaterService.getMultipleAttemptCRaterFeedbackTextByScore(
-                this.componentContent,
-                previousScore,
-                score
-              );
-            } else {
-              // get the feedback text
-              autoComment = this.CRaterService.getCRaterFeedbackTextByScore(
-                this.componentContent,
-                score
-              );
-            }
-
-            if (autoComment != null) {
-              // create the auto comment annotation
-              const autoCommentAnnotationData: any = {};
-              autoCommentAnnotationData.value = autoComment;
-              autoCommentAnnotationData.concepts = concepts;
-              autoCommentAnnotationData.autoGrader = 'cRater';
-
-              const autoCommentAnnotation = this.createAutoCommentAnnotation(
-                autoCommentAnnotationData
-              );
-
-              if (this.componentContent.enableGlobalAnnotations) {
+                // check if we need to apply this globalAnnotationSetting to this annotation: we don't need to if we've already reached the maxCount
                 if (annotationGroupForScore != null) {
-                  // copy over the annotation properties into the autoCommentAnnotation's data
+                  let globalAnnotationGroupsByNodeIdAndComponentId = this.AnnotationService.getAllGlobalAnnotationGroups();
+                  annotationGroupForScore.annotationGroupCreatedTime =
+                    autoScoreAnnotation.clientSaveTime; // save annotation creation time
+
+                  if (
+                    globalAnnotationGroupsByNodeIdAndComponentId.length >= globalAnnotationMaxCount
+                  ) {
+                    // we've already applied this annotation properties to maxCount annotations, so we don't need to apply it any more.
+                    annotationGroupForScore = null;
+                  }
+                }
+
+                if (
+                  annotationGroupForScore != null &&
+                  annotationGroupForScore.isGlobal &&
+                  annotationGroupForScore.unGlobalizeCriteria != null
+                ) {
+                  // check if this annotation is global and what criteria needs to be met to un-globalize.
+                  annotationGroupForScore.unGlobalizeCriteria.map((unGlobalizeCriteria) => {
+                    // if the un-globalize criteria is time-based (e.g. isVisitedAfter, isRevisedAfter, isVisitedAndRevisedAfter, etc), store the timestamp of this annotation in the criteria
+                    // so we can compare it when we check for criteria satisfaction.
+                    if (unGlobalizeCriteria.params != null) {
+                      unGlobalizeCriteria.params.criteriaCreatedTimestamp =
+                        autoScoreAnnotation.clientSaveTime; // save annotation creation time to criteria
+                    }
+                  });
+                }
+
+                if (annotationGroupForScore != null) {
+                  // copy over the annotation properties into the autoScoreAnnotation's data
                   this.mergeObjects(
                     autoScoreAnnotation.data,
                     this.UtilService.makeCopyOfJSONObject(annotationGroupForScore)
                   );
                 }
               }
-              componentState.annotations.push(autoCommentAnnotation);
+
+              componentState.annotations.push(autoScoreAnnotation);
 
               if (this.mode === 'authoring') {
                 if (this.latestAnnotations == null) {
@@ -564,45 +508,110 @@ export class OpenResponseStudent extends ComponentStudent {
 
                 /*
                  * we are in the authoring view so we will set the
-                 * latest comment annotation manually
+                 * latest score annotation manually
                  */
-                this.latestAnnotations.comment = autoCommentAnnotation;
+                this.latestAnnotations.score = autoScoreAnnotation;
               }
-            }
-            if (
-              this.componentContent.enableNotifications &&
-              this.componentContent.notificationSettings &&
-              this.componentContent.notificationSettings.notifications
-            ) {
-              const notificationForScore: any = this.ProjectService.getNotificationByScore(
-                this.componentContent,
-                previousScore,
-                score
-              );
-              if (notificationForScore != null) {
-                notificationForScore.score = score;
-                notificationForScore.nodeId = this.nodeId;
-                notificationForScore.componentId = this.componentId;
-                this.NotificationService.sendNotificationForScore(notificationForScore);
+
+              let autoComment = null;
+              const submitCounter = this.submitCounter;
+
+              if (
+                this.componentContent.cRater.enableMultipleAttemptScoringRules &&
+                submitCounter > 1
+              ) {
+                /*
+                 * this step has multiple attempt scoring rules and this is
+                 * a subsequent submit
+                 */
+                // get the feedback based upon the previous score and current score
+                autoComment = this.CRaterService.getMultipleAttemptCRaterFeedbackTextByScore(
+                  this.componentContent,
+                  previousScore,
+                  score
+                );
+              } else {
+                autoComment = this.CRaterService.getCRaterFeedbackTextByScore(
+                  this.componentContent,
+                  score
+                );
+              }
+
+              if (autoComment != null) {
+                const autoCommentAnnotationData: any = {};
+                autoCommentAnnotationData.value = autoComment;
+                autoCommentAnnotationData.concepts = concepts;
+                autoCommentAnnotationData.autoGrader = 'cRater';
+
+                const autoCommentAnnotation = this.createAutoCommentAnnotation(
+                  autoCommentAnnotationData
+                );
+
+                if (this.componentContent.enableGlobalAnnotations) {
+                  if (annotationGroupForScore != null) {
+                    // copy over the annotation properties into the autoCommentAnnotation's data
+                    this.mergeObjects(
+                      autoScoreAnnotation.data,
+                      this.UtilService.makeCopyOfJSONObject(annotationGroupForScore)
+                    );
+                  }
+                }
+                componentState.annotations.push(autoCommentAnnotation);
+
+                if (this.mode === 'authoring') {
+                  if (this.latestAnnotations == null) {
+                    this.latestAnnotations = {};
+                  }
+
+                  /*
+                   * we are in the authoring view so we will set the
+                   * latest comment annotation manually
+                   */
+                  this.latestAnnotations.comment = autoCommentAnnotation;
+                }
+              }
+              if (
+                this.componentContent.enableNotifications &&
+                this.componentContent.notificationSettings &&
+                this.componentContent.notificationSettings.notifications
+              ) {
+                const notificationForScore: any = this.ProjectService.getNotificationByScore(
+                  this.componentContent,
+                  previousScore,
+                  score
+                );
+                if (notificationForScore != null) {
+                  notificationForScore.score = score;
+                  notificationForScore.nodeId = this.nodeId;
+                  notificationForScore.componentId = this.componentId;
+                  this.NotificationService.sendNotificationForScore(notificationForScore);
+                }
+              }
+
+              if (
+                this.componentContent.enableGlobalAnnotations &&
+                annotationGroupForScore != null &&
+                annotationGroupForScore.isGlobal &&
+                annotationGroupForScore.isPopup
+              ) {
+                this.AnnotationService.broadcastDisplayGlobalAnnotations();
               }
             }
 
-            if (
-              this.componentContent.enableGlobalAnnotations &&
-              annotationGroupForScore != null &&
-              annotationGroupForScore.isGlobal &&
-              annotationGroupForScore.isPopup
-            ) {
-              this.AnnotationService.broadcastDisplayGlobalAnnotations();
-            }
+            dialogRef.close();
+            deferred.resolve(componentState);
+          },
+          (error) => {
+            alert(
+              $localize`There was an issue scoring your work. Please try again.\nIf this problem continues, let your teacher know and move on to the next activity. Your work will still be saved.`
+            );
+            dialogRef.close();
+            componentState.isSubmit = false;
+            componentState.studentData.submitCounter--;
+            this.submitCounter--;
+            deferred.resolve(componentState);
           }
-
-          dialogRef.close();
-
-          // resolve the promise now that we are done performing additional processing
-          deferred.resolve(componentState);
-        }
-      );
+        );
     } else if (
       this.ProjectService.hasAdditionalProcessingFunctions(this.nodeId, this.componentId)
     ) {

--- a/src/assets/wise5/services/cRaterService.ts
+++ b/src/assets/wise5/services/cRaterService.ts
@@ -3,6 +3,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { ConfigService } from './configService';
+import { Observable } from 'rxjs';
 
 @Injectable()
 export class CRaterService {
@@ -15,7 +16,11 @@ export class CRaterService {
    * @param studentData the student data
    * @returns a promise that returns the result of the CRater request
    */
-  makeCRaterScoringRequest(cRaterItemId: string, cRaterResponseId: number, studentData: any) {
+  makeCRaterScoringRequest(
+    cRaterItemId: string,
+    cRaterResponseId: number,
+    studentData: any
+  ): Observable<any> {
     const url = this.ConfigService.getCRaterRequestURL() + '/score';
     const params = new HttpParams()
       .set('itemId', cRaterItemId)
@@ -24,12 +29,7 @@ export class CRaterService {
     const options = {
       params: params
     };
-    return this.http
-      .get(url, options)
-      .toPromise()
-      .then((response) => {
-        return response;
-      });
+    return this.http.get(url, options);
   }
 
   /**

--- a/src/assets/wise5/vle/node/nodeController.ts
+++ b/src/assets/wise5/vle/node/nodeController.ts
@@ -791,7 +791,7 @@ class NodeController {
     componentState.periodId = this.ConfigService.getPeriodId();
     componentState.workgroupId = this.ConfigService.getWorkgroupId();
     componentState.isAutoSave = isAutoSave === true;
-    componentState.isSubmit = isSubmit === true;
+    componentState.isSubmit ??= isSubmit;
   }
 
   /**

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -11097,8 +11097,8 @@ Are you ready to submit this answer?</source>
           <context context-type="linenumber">272</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7939739394625068310" datatype="html">
-        <source>Please wait, we are scoring your work...</source>
+      <trans-unit id="8936495196157450285" datatype="html">
+        <source>We are scoring your work...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
           <context context-type="linenumber">387</context>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -8840,11 +8840,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">247</context>
+          <context context-type="linenumber">249</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">263</context>
+          <context context-type="linenumber">265</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4965414112249568013" datatype="html">
@@ -9316,7 +9316,7 @@ Are you ready to receive feedback on this answer?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">250</context>
+          <context context-type="linenumber">252</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7123653594948067002" datatype="html">
@@ -11076,7 +11076,7 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">254</context>
+          <context context-type="linenumber">256</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7482125205220618294" datatype="html">
@@ -11085,7 +11085,7 @@ Are you ready to receive feedback on this answer?</source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">266</context>
+          <context context-type="linenumber">268</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6316287012266891697" datatype="html">
@@ -11094,35 +11094,43 @@ Are you ready to receive feedback on this answer?</source>
 Are you ready to submit this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">270</context>
+          <context context-type="linenumber">272</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2175028212589278840" datatype="html">
-        <source>Please wait, we are scoring your work.</source>
+      <trans-unit id="7939739394625068310" datatype="html">
+        <source>Please wait, we are scoring your work...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">386</context>
+          <context context-type="linenumber">387</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2283191014272031538" datatype="html">
         <source>Please Wait</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">388</context>
+          <context context-type="linenumber">389</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8785209093929133444" datatype="html">
+        <source>There was an issue scoring your work. Please try again.
+If this problem continues, let your teacher know and move on to the next activity. Your work will still be saved.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
+          <context context-type="linenumber">606</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5445965000497851580" datatype="html">
         <source>This will replace your existing recording. Is this OK?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">908</context>
+          <context context-type="linenumber">917</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8057349329324626950" datatype="html">
         <source>Are you sure you want to delete your recording?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">952</context>
+          <context context-type="linenumber">961</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2e0e07912515c250498d28841610709033392606" datatype="html">


### PR DESCRIPTION
## Changes
- Added a timeout for CRater requests after 40 seconds
- Changed CRaterRequests to return an observable instead of a promise

## Test
- CRater times out after 40 seconds of no-response from the backend. The student sees a message, and the data is still saved. The data should not be a submit, and the submit counter should remain the same. The student should be able to submit again, or move to the next activity.
- CRater works properly when it responds before 40 seconds.

Closes #233