### PR TITLE
Split teacher-hybrid-angular into AT and CM

### DIFF
--- a/src/app/common-hybrid-angular.module.ts
+++ b/src/app/common-hybrid-angular.module.ts
@@ -68,6 +68,7 @@ import { DataExportService } from '../assets/wise5/services/dataExportService';
 import { MatChipsModule } from '@angular/material/chips';
 import { NotebookModule } from './notebook/notebook.module';
 import { MatSliderModule } from '@angular/material/slider';
+import { setUpLocationSync } from '@angular/router/upgrade';
 
 @Component({ template: `` })
 export class EmptyComponent {}
@@ -184,3 +185,8 @@ export class EmptyComponent {}
   ]
 })
 export class AngularJSModule {}
+
+export function bootstrapAngularJSModule(upgrade: UpgradeModule, moduleType: string) {
+  upgrade.bootstrap(document.body, [moduleType]);
+  setUpLocationSync(upgrade);
+}

--- a/src/app/student-hybrid-angular.module.ts
+++ b/src/app/student-hybrid-angular.module.ts
@@ -1,8 +1,8 @@
 import { NgModule } from '@angular/core';
 
 import { createStudentAngularJSModule } from '../assets/wise5/vle/student-angular-js-module';
+import { bootstrapAngularJSModule } from './common-hybrid-angular.module';
 import { UpgradeModule } from '@angular/upgrade/static';
-import { setUpLocationSync } from '@angular/router/upgrade';
 import { ProjectService } from '../assets/wise5/services/projectService';
 import { VLEProjectService } from '../assets/wise5/vle/vleProjectService';
 import { CommonModule } from '@angular/common';
@@ -63,6 +63,7 @@ export class StudentAngularJSModule {}
 })
 export class StudentVLEAngularJSModule {
   constructor(upgrade: UpgradeModule) {
+    createStudentAngularJSModule('vle');
     bootstrapAngularJSModule(upgrade, 'vle');
   }
 }
@@ -72,12 +73,7 @@ export class StudentVLEAngularJSModule {
 })
 export class PreviewAngularJSModule {
   constructor(upgrade: UpgradeModule) {
+    createStudentAngularJSModule('preview');
     bootstrapAngularJSModule(upgrade, 'preview');
   }
-}
-
-function bootstrapAngularJSModule(upgrade: UpgradeModule, moduleType: string) {
-  createStudentAngularJSModule(moduleType);
-  upgrade.bootstrap(document.body, [moduleType]);
-  setUpLocationSync(upgrade);
 }

--- a/src/app/teacher-hybrid-angular.module.ts
+++ b/src/app/teacher-hybrid-angular.module.ts
@@ -1,13 +1,9 @@
 import { NgModule } from '@angular/core';
-import { RouterModule } from '@angular/router';
 
 import '../assets/wise5/teacher/teacher-angular-js-module';
-import { AlertStatusCornerComponent } from './classroom-monitor/alert-status-corner/alert-status-corner.component';
+import { AngularJSModule, bootstrapAngularJSModule } from './common-hybrid-angular.module';
 import { UpgradeModule } from '@angular/upgrade/static';
-import { setUpLocationSync } from '@angular/router/upgrade';
 import { ProjectService } from '../assets/wise5/services/projectService';
-import { MilestonesComponent } from './classroom-monitor/milestones/milestones.component';
-import { MilestoneReportDataComponent } from './teacher/milestone/milestone-report-data/milestone-report-data.component';
 import { TeacherProjectService } from '../assets/wise5/services/teacherProjectService';
 import { ProjectAssetService } from './services/projectAssetService';
 import { SpaceService } from '../assets/wise5/services/spaceService';
@@ -16,164 +12,15 @@ import { TeacherDataService } from '../assets/wise5/services/teacherDataService'
 import { TeacherWebSocketService } from '../assets/wise5/services/teacherWebSocketService';
 import { DataService } from './services/data.service';
 import { MilestoneService } from '../assets/wise5/services/milestoneService';
-import { WorkgroupNodeScoreComponent } from '../assets/wise5/classroomMonitor/classroomMonitorComponents/shared/workgroupNodeScore/workgroup-node-score.component';
-import { WorkgroupNodeStatusComponent } from './classroom-monitor/workgroup-node-status/workgroup-node-status.component';
-import { NavItemScoreComponent } from '../assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/navItemScore/nav-item-score.component';
-import { ManageStudentsComponent } from '../assets/wise5/classroomMonitor/manageStudents/manage-students-component';
-import { AdvancedProjectAuthoringComponent } from '../assets/wise5/authoringTool/advanced/advanced-project-authoring.component';
-import { ChooseNewComponent } from './authoring-tool/add-component/choose-new-component/choose-new-component.component';
-import { ChooseNewComponentLocation } from './authoring-tool/add-component/choose-new-component-location/choose-new-component-location.component';
-import { AddYourOwnNode } from '../assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component';
-import { ChooseNewNodeLocation } from '../assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component';
-import { ChooseNewNodeTemplate } from '../assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component';
-import { ChooseImportStepComponent } from './authoring-tool/import-step/choose-import-step/choose-import-step.component';
-import { ChooseImportStepLocationComponent } from './authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component';
-import { ComponentNewWorkBadgeComponent } from './classroom-monitor/component-new-work-badge/component-new-work-badge.component';
-import { ComponentSelectComponent } from './classroom-monitor/component-select/component-select.component';
-import { ComponentStateInfoComponent } from '../assets/wise5/classroomMonitor/classroomMonitorComponents/component-state-info/component-state-info.component';
-import { StatusIconComponent } from './classroom-monitor/status-icon/status-icon.component';
-import { StepInfoComponent } from './classroom-monitor/step-info/step-info.component';
-import { AngularJSModule } from './common-hybrid-angular.module';
-import { NodeAdvancedJsonAuthoringComponent } from '../assets/wise5/authoringTool/node/advanced/json/node-advanced-json-authoring.component';
-import { WorkgroupInfoComponent } from '../assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroupInfo/workgroup-info.component';
-import { NodeAdvancedGeneralAuthoringComponent } from '../assets/wise5/authoringTool/node/advanced/general/node-advanced-general-authoring.component';
-import { WiseAuthoringTinymceEditorComponent } from '../assets/wise5/directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component';
-import { EditComponentAnnotationsComponent } from '../assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-annotations/edit-component-annotations.component';
-import { EditComponentCommentComponent } from '../assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component';
-import { EditComponentDefaultFeedback } from './authoring-tool/edit-advanced-component/edit-component-default-feedback/edit-component-default-feedback.component';
-import { EditComponentExcludeFromTotalScoreComponent } from './authoring-tool/edit-component-exclude-from-total-score/edit-component-exclude-from-total-score.component';
-import { EditComponentJsonComponent } from './authoring-tool/edit-component-json/edit-component-json.component';
-import { EditComponentMaxScoreComponent } from './authoring-tool/edit-component-max-score/edit-component-max-score.component';
-import { EditComponentPrompt } from './authoring-tool/edit-component-prompt/edit-component-prompt.component';
-import { EditComponentRubricComponent } from './authoring-tool/edit-component-rubric/edit-component-rubric.component';
-import { EditComponentSaveButtonComponent } from './authoring-tool/edit-component-save-button/edit-component-save-button.component';
-import { EditComponentScoreComponent } from '../assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component';
-import { EditComponentSubmitButtonComponent } from './authoring-tool/edit-component-submit-button/edit-component-submit-button.component';
-import { EditComponentTagsComponent } from './authoring-tool/edit-component-tags/edit-component-tags.component';
-import { EditComponentWidthComponent } from './authoring-tool/edit-component-width/edit-component-width.component';
-import { GradingEditComponentMaxScoreComponent } from '../assets/wise5/classroomMonitor/classroomMonitorComponents/grading-edit-component-max-score/grading-edit-component-max-score.component';
-import { RubricAuthoringComponent } from '../assets/wise5/authoringTool/rubric/rubric-authoring.component';
-import { NavItemProgressComponent } from './classroom-monitor/nav-item-progress/nav-item-progress.component';
-import { WorkgroupSelectDropdownComponent } from './classroom-monitor/workgroup-select/workgroup-select-dropdown/workgroup-select-dropdown.component';
-import { WorkgroupSelectAutocompleteComponent } from './classroom-monitor/workgroup-select/workgroup-select-autocomplete/workgroup-select-autocomplete.component';
-import { EditHTMLAdvancedComponent } from '../assets/wise5/components/html/edit-html-advanced/edit-html-advanced.component';
-import { EditOutsideUrlAdvancedComponent } from '../assets/wise5/components/outsideURL/edit-outside-url-advanced/edit-outside-url-advanced.component';
-import { OpenResponseAuthoring } from '../assets/wise5/components/openResponse/open-response-authoring/open-response-authoring.component';
-import { HtmlAuthoring } from '../assets/wise5/components/html/html-authoring/html-authoring.component';
-import { OutsideUrlAuthoring } from '../assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component';
-import { MultipleChoiceAuthoring } from '../assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component';
-import { ConceptMapAuthoring } from '../assets/wise5/components/conceptMap/concept-map-authoring/concept-map-authoring.component';
-import { DrawAuthoring } from '../assets/wise5/components/draw/draw-authoring/draw-authoring.component';
-import { MatchAuthoring } from '../assets/wise5/components/match/match-authoring/match-authoring.component';
-import { LabelAuthoring } from '../assets/wise5/components/label/label-authoring/label-authoring.component';
-import { TableAuthoring } from '../assets/wise5/components/table/table-authoring/table-authoring.component';
-import { DiscussionAuthoring } from '../assets/wise5/components/discussion/discussion-authoring/discussion-authoring.component';
-import { SummaryAuthoring } from '../assets/wise5/components/summary/summary-authoring/summary-authoring.component';
-import { EmbeddedAuthoring } from '../assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component';
-import { GraphAuthoring } from '../assets/wise5/components/graph/graph-authoring/graph-authoring.component';
-import { AudioOscillatorAuthoring } from '../assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component';
-import { AnimationAuthoring } from '../assets/wise5/components/animation/animation-authoring/animation-authoring.component';
-import { OpenResponseGrading } from '../assets/wise5/components/openResponse/open-response-grading/open-response-grading.component';
-import { MultipleChoiceGrading } from '../assets/wise5/components/multipleChoice/multiple-choice-grading/multiple-choice-grading.component';
-import { MatchGrading } from '../assets/wise5/components/match/match-grading/match-grading.component';
-import { LabelGrading } from '../assets/wise5/components/label/label-grading/label-grading.component';
-import { DrawGrading } from '../assets/wise5/components/draw/draw-grading/draw-grading.component';
-import { AudioOscillatorGrading } from '../assets/wise5/components/audioOscillator/audio-oscillator-grading/audio-oscillator-grading.component';
-import { TableGrading } from '../assets/wise5/components/table/table-grading/table-grading.component';
-import { ConceptMapGrading } from '../assets/wise5/components/conceptMap/concept-map-grading/concept-map-grading.component';
-import { DiscussionGrading } from '../assets/wise5/components/discussion/discussion-grading/discussion-grading.component';
-import { GraphGrading } from '../assets/wise5/components/graph/graph-grading/graph-grading.component';
-import { HighchartsChartModule } from 'highcharts-angular';
-import { AnimationGrading } from '../assets/wise5/components/animation/animation-grading/animation-grading.component';
-import { EmbeddedGrading } from '../assets/wise5/components/embedded/embedded-grading/embedded-grading.component';
-import { StepToolsComponent } from '../assets/wise5/common/stepTools/step-tools.component';
-import { NodeIconChooserDialog } from '../assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component';
 import { CopyNodesService } from '../assets/wise5/services/copyNodesService';
 import { InsertNodesService } from '../assets/wise5/services/insertNodesService';
-import { ViewComponentRevisionsComponent } from '../assets/wise5/classroomMonitor/classroomMonitorComponents/view-component-revisions/view-component-revisions.component';
-import { WorkgroupComponentGradingComponent } from '../assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component';
-import { SelectPeriodComponent } from '../assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component';
+import { AuthoringToolModule } from './teacher/authoring-tool.module';
+import { ClassroomMonitorModule } from './teacher/classroom-monitor.module';
+import { StepToolsComponent } from '../assets/wise5/common/stepTools/step-tools.component';
 
 @NgModule({
-  declarations: [
-    AddYourOwnNode,
-    AdvancedProjectAuthoringComponent,
-    AlertStatusCornerComponent,
-    AnimationAuthoring,
-    AnimationGrading,
-    AudioOscillatorAuthoring,
-    AudioOscillatorGrading,
-    ChooseImportStepComponent,
-    ChooseImportStepLocationComponent,
-    ChooseNewComponent,
-    ChooseNewComponentLocation,
-    ChooseNewNodeLocation,
-    ChooseNewNodeTemplate,
-    ComponentNewWorkBadgeComponent,
-    ComponentSelectComponent,
-    ComponentStateInfoComponent,
-    ConceptMapAuthoring,
-    ConceptMapGrading,
-    DrawAuthoring,
-    DrawGrading,
-    DiscussionAuthoring,
-    DiscussionGrading,
-    EditComponentAnnotationsComponent,
-    EditComponentCommentComponent,
-    EditComponentDefaultFeedback,
-    EditComponentExcludeFromTotalScoreComponent,
-    EditComponentRubricComponent,
-    EditComponentJsonComponent,
-    EditComponentMaxScoreComponent,
-    EditComponentPrompt,
-    EditComponentTagsComponent,
-    EditComponentSaveButtonComponent,
-    EditComponentScoreComponent,
-    EditComponentSubmitButtonComponent,
-    EditComponentWidthComponent,
-    EditHTMLAdvancedComponent,
-    EditOutsideUrlAdvancedComponent,
-    EmbeddedAuthoring,
-    EmbeddedGrading,
-    GradingEditComponentMaxScoreComponent,
-    GraphAuthoring,
-    GraphGrading,
-    HtmlAuthoring,
-    LabelAuthoring,
-    LabelGrading,
-    ManageStudentsComponent,
-    MatchAuthoring,
-    MatchGrading,
-    MilestonesComponent,
-    MilestoneReportDataComponent,
-    MultipleChoiceAuthoring,
-    MultipleChoiceGrading,
-    NavItemProgressComponent,
-    NodeAdvancedGeneralAuthoringComponent,
-    NodeAdvancedJsonAuthoringComponent,
-    NodeIconChooserDialog,
-    OpenResponseGrading,
-    OpenResponseAuthoring,
-    OutsideUrlAuthoring,
-    RubricAuthoringComponent,
-    SelectPeriodComponent,
-    StatusIconComponent,
-    StepInfoComponent,
-    StepToolsComponent,
-    SummaryAuthoring,
-    TableAuthoring,
-    TableGrading,
-    ViewComponentRevisionsComponent,
-    WorkgroupComponentGradingComponent,
-    WorkgroupInfoComponent,
-    WorkgroupNodeScoreComponent,
-    WorkgroupSelectAutocompleteComponent,
-    WorkgroupSelectDropdownComponent,
-    NavItemScoreComponent,
-    WiseAuthoringTinymceEditorComponent,
-    WorkgroupNodeStatusComponent
-  ],
-  imports: [AngularJSModule, HighchartsChartModule, RouterModule],
+  declarations: [StepToolsComponent],
+  imports: [AngularJSModule, AuthoringToolModule, ClassroomMonitorModule],
   providers: [
     CopyNodesService,
     { provide: DataService, useExisting: TeacherDataService },
@@ -192,9 +39,4 @@ export class TeacherAngularJSModule {
   constructor(upgrade: UpgradeModule) {
     bootstrapAngularJSModule(upgrade, 'teacher');
   }
-}
-
-function bootstrapAngularJSModule(upgrade: UpgradeModule, moduleType: string) {
-  upgrade.bootstrap(document.body, [moduleType]);
-  setUpLocationSync(upgrade);
 }

--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -1,0 +1,35 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { AddYourOwnNode } from '../../assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component';
+import { ChooseNewNodeLocation } from '../../assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component';
+import { ChooseNewNodeTemplate } from '../../assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component';
+import { AdvancedProjectAuthoringComponent } from '../../assets/wise5/authoringTool/advanced/advanced-project-authoring.component';
+import { NodeAdvancedGeneralAuthoringComponent } from '../../assets/wise5/authoringTool/node/advanced/general/node-advanced-general-authoring.component';
+import { NodeAdvancedJsonAuthoringComponent } from '../../assets/wise5/authoringTool/node/advanced/json/node-advanced-json-authoring.component';
+import { RubricAuthoringComponent } from '../../assets/wise5/authoringTool/rubric/rubric-authoring.component';
+import { NodeIconChooserDialog } from '../../assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component';
+import { ChooseNewComponentLocation } from '../authoring-tool/add-component/choose-new-component-location/choose-new-component-location.component';
+import { ChooseNewComponent } from '../authoring-tool/add-component/choose-new-component/choose-new-component.component';
+import { ChooseImportStepLocationComponent } from '../authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component';
+import { ChooseImportStepComponent } from '../authoring-tool/import-step/choose-import-step/choose-import-step.component';
+import { AngularJSModule } from '../common-hybrid-angular.module';
+import { ComponentAuthoringModule } from './component-authoring.module';
+
+@NgModule({
+  declarations: [
+    AddYourOwnNode,
+    AdvancedProjectAuthoringComponent,
+    ChooseImportStepComponent,
+    ChooseImportStepLocationComponent,
+    ChooseNewComponent,
+    ChooseNewComponentLocation,
+    ChooseNewNodeLocation,
+    ChooseNewNodeTemplate,
+    NodeAdvancedGeneralAuthoringComponent,
+    NodeAdvancedJsonAuthoringComponent,
+    NodeIconChooserDialog,
+    RubricAuthoringComponent
+  ],
+  imports: [AngularJSModule, ComponentAuthoringModule, RouterModule]
+})
+export class AuthoringToolModule {}

--- a/src/app/teacher/classroom-monitor.module.ts
+++ b/src/app/teacher/classroom-monitor.module.ts
@@ -1,0 +1,56 @@
+import { NgModule } from '@angular/core';
+import { ComponentStateInfoComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/component-state-info/component-state-info.component';
+import { EditComponentAnnotationsComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-annotations/edit-component-annotations.component';
+import { EditComponentCommentComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component';
+import { EditComponentScoreComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component';
+import { GradingEditComponentMaxScoreComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/grading-edit-component-max-score/grading-edit-component-max-score.component';
+import { WorkgroupInfoComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroupInfo/workgroup-info.component';
+import { NavItemScoreComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/navItemScore/nav-item-score.component';
+import { SelectPeriodComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component';
+import { WorkgroupNodeScoreComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/shared/workgroupNodeScore/workgroup-node-score.component';
+import { ViewComponentRevisionsComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/view-component-revisions/view-component-revisions.component';
+import { WorkgroupComponentGradingComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component';
+import { ManageStudentsComponent } from '../../assets/wise5/classroomMonitor/manageStudents/manage-students-component';
+import { AlertStatusCornerComponent } from '../classroom-monitor/alert-status-corner/alert-status-corner.component';
+import { ComponentNewWorkBadgeComponent } from '../classroom-monitor/component-new-work-badge/component-new-work-badge.component';
+import { ComponentSelectComponent } from '../classroom-monitor/component-select/component-select.component';
+import { MilestonesComponent } from '../classroom-monitor/milestones/milestones.component';
+import { NavItemProgressComponent } from '../classroom-monitor/nav-item-progress/nav-item-progress.component';
+import { StatusIconComponent } from '../classroom-monitor/status-icon/status-icon.component';
+import { StepInfoComponent } from '../classroom-monitor/step-info/step-info.component';
+import { WorkgroupNodeStatusComponent } from '../classroom-monitor/workgroup-node-status/workgroup-node-status.component';
+import { WorkgroupSelectAutocompleteComponent } from '../classroom-monitor/workgroup-select/workgroup-select-autocomplete/workgroup-select-autocomplete.component';
+import { WorkgroupSelectDropdownComponent } from '../classroom-monitor/workgroup-select/workgroup-select-dropdown/workgroup-select-dropdown.component';
+import { AngularJSModule } from '../common-hybrid-angular.module';
+import { ComponentGradingModule } from './component-grading.module';
+import { MilestoneReportDataComponent } from './milestone/milestone-report-data/milestone-report-data.component';
+
+@NgModule({
+  declarations: [
+    AlertStatusCornerComponent,
+    ComponentNewWorkBadgeComponent,
+    ComponentSelectComponent,
+    ComponentStateInfoComponent,
+    EditComponentAnnotationsComponent,
+    EditComponentCommentComponent,
+    EditComponentScoreComponent,
+    GradingEditComponentMaxScoreComponent,
+    ManageStudentsComponent,
+    MilestonesComponent,
+    MilestoneReportDataComponent,
+    NavItemProgressComponent,
+    SelectPeriodComponent,
+    StatusIconComponent,
+    StepInfoComponent,
+    ViewComponentRevisionsComponent,
+    WorkgroupComponentGradingComponent,
+    WorkgroupInfoComponent,
+    WorkgroupNodeScoreComponent,
+    WorkgroupSelectAutocompleteComponent,
+    WorkgroupSelectDropdownComponent,
+    NavItemScoreComponent,
+    WorkgroupNodeStatusComponent
+  ],
+  imports: [AngularJSModule, ComponentGradingModule]
+})
+export class ClassroomMonitorModule {}

--- a/src/app/teacher/component-authoring.module.ts
+++ b/src/app/teacher/component-authoring.module.ts
@@ -1,0 +1,95 @@
+import { NgModule } from '@angular/core';
+import { AnimationAuthoring } from '../../assets/wise5/components/animation/animation-authoring/animation-authoring.component';
+import { AudioOscillatorAuthoring } from '../../assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component';
+import { ConceptMapAuthoring } from '../../assets/wise5/components/conceptMap/concept-map-authoring/concept-map-authoring.component';
+import { DiscussionAuthoring } from '../../assets/wise5/components/discussion/discussion-authoring/discussion-authoring.component';
+import { DrawAuthoring } from '../../assets/wise5/components/draw/draw-authoring/draw-authoring.component';
+import { EmbeddedAuthoring } from '../../assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component';
+import { GraphAuthoring } from '../../assets/wise5/components/graph/graph-authoring/graph-authoring.component';
+import { EditHTMLAdvancedComponent } from '../../assets/wise5/components/html/edit-html-advanced/edit-html-advanced.component';
+import { HtmlAuthoring } from '../../assets/wise5/components/html/html-authoring/html-authoring.component';
+import { LabelAuthoring } from '../../assets/wise5/components/label/label-authoring/label-authoring.component';
+import { MatchAuthoring } from '../../assets/wise5/components/match/match-authoring/match-authoring.component';
+import { MultipleChoiceAuthoring } from '../../assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component';
+import { OpenResponseAuthoring } from '../../assets/wise5/components/openResponse/open-response-authoring/open-response-authoring.component';
+import { EditOutsideUrlAdvancedComponent } from '../../assets/wise5/components/outsideURL/edit-outside-url-advanced/edit-outside-url-advanced.component';
+import { OutsideUrlAuthoring } from '../../assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component';
+import { SummaryAuthoring } from '../../assets/wise5/components/summary/summary-authoring/summary-authoring.component';
+import { TableAuthoring } from '../../assets/wise5/components/table/table-authoring/table-authoring.component';
+import { WiseAuthoringTinymceEditorComponent } from '../../assets/wise5/directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component';
+import { EditComponentDefaultFeedback } from '../authoring-tool/edit-advanced-component/edit-component-default-feedback/edit-component-default-feedback.component';
+import { EditComponentExcludeFromTotalScoreComponent } from '../authoring-tool/edit-component-exclude-from-total-score/edit-component-exclude-from-total-score.component';
+import { EditComponentJsonComponent } from '../authoring-tool/edit-component-json/edit-component-json.component';
+import { EditComponentMaxScoreComponent } from '../authoring-tool/edit-component-max-score/edit-component-max-score.component';
+import { EditComponentPrompt } from '../authoring-tool/edit-component-prompt/edit-component-prompt.component';
+import { EditComponentRubricComponent } from '../authoring-tool/edit-component-rubric/edit-component-rubric.component';
+import { EditComponentSaveButtonComponent } from '../authoring-tool/edit-component-save-button/edit-component-save-button.component';
+import { EditComponentSubmitButtonComponent } from '../authoring-tool/edit-component-submit-button/edit-component-submit-button.component';
+import { EditComponentTagsComponent } from '../authoring-tool/edit-component-tags/edit-component-tags.component';
+import { EditComponentWidthComponent } from '../authoring-tool/edit-component-width/edit-component-width.component';
+import { AngularJSModule } from '../common-hybrid-angular.module';
+
+@NgModule({
+  declarations: [
+    AnimationAuthoring,
+    AudioOscillatorAuthoring,
+    ConceptMapAuthoring,
+    DrawAuthoring,
+    DiscussionAuthoring,
+    EditComponentDefaultFeedback,
+    EditComponentExcludeFromTotalScoreComponent,
+    EditComponentJsonComponent,
+    EditComponentMaxScoreComponent,
+    EditComponentPrompt,
+    EditComponentRubricComponent,
+    EditComponentSaveButtonComponent,
+    EditComponentSubmitButtonComponent,
+    EditComponentTagsComponent,
+    EditComponentWidthComponent,
+    EditHTMLAdvancedComponent,
+    EditOutsideUrlAdvancedComponent,
+    EmbeddedAuthoring,
+    GraphAuthoring,
+    HtmlAuthoring,
+    LabelAuthoring,
+    MatchAuthoring,
+    MultipleChoiceAuthoring,
+    OpenResponseAuthoring,
+    OutsideUrlAuthoring,
+    SummaryAuthoring,
+    TableAuthoring,
+    WiseAuthoringTinymceEditorComponent
+  ],
+  imports: [AngularJSModule],
+  exports: [
+    AnimationAuthoring,
+    AudioOscillatorAuthoring,
+    ConceptMapAuthoring,
+    DrawAuthoring,
+    DiscussionAuthoring,
+    EditComponentDefaultFeedback,
+    EditComponentExcludeFromTotalScoreComponent,
+    EditComponentJsonComponent,
+    EditComponentMaxScoreComponent,
+    EditComponentPrompt,
+    EditComponentRubricComponent,
+    EditComponentSaveButtonComponent,
+    EditComponentSubmitButtonComponent,
+    EditComponentTagsComponent,
+    EditComponentWidthComponent,
+    EditHTMLAdvancedComponent,
+    EditOutsideUrlAdvancedComponent,
+    EmbeddedAuthoring,
+    GraphAuthoring,
+    HtmlAuthoring,
+    LabelAuthoring,
+    MatchAuthoring,
+    MultipleChoiceAuthoring,
+    OpenResponseAuthoring,
+    OutsideUrlAuthoring,
+    SummaryAuthoring,
+    TableAuthoring,
+    WiseAuthoringTinymceEditorComponent
+  ]
+})
+export class ComponentAuthoringModule {}

--- a/src/app/teacher/component-grading.module.ts
+++ b/src/app/teacher/component-grading.module.ts
@@ -1,0 +1,48 @@
+import { NgModule } from '@angular/core';
+import { HighchartsChartModule } from 'highcharts-angular';
+import { AnimationGrading } from '../../assets/wise5/components/animation/animation-grading/animation-grading.component';
+import { AudioOscillatorGrading } from '../../assets/wise5/components/audioOscillator/audio-oscillator-grading/audio-oscillator-grading.component';
+import { ConceptMapGrading } from '../../assets/wise5/components/conceptMap/concept-map-grading/concept-map-grading.component';
+import { DiscussionGrading } from '../../assets/wise5/components/discussion/discussion-grading/discussion-grading.component';
+import { DrawGrading } from '../../assets/wise5/components/draw/draw-grading/draw-grading.component';
+import { EmbeddedGrading } from '../../assets/wise5/components/embedded/embedded-grading/embedded-grading.component';
+import { GraphGrading } from '../../assets/wise5/components/graph/graph-grading/graph-grading.component';
+import { LabelGrading } from '../../assets/wise5/components/label/label-grading/label-grading.component';
+import { MatchGrading } from '../../assets/wise5/components/match/match-grading/match-grading.component';
+import { MultipleChoiceGrading } from '../../assets/wise5/components/multipleChoice/multiple-choice-grading/multiple-choice-grading.component';
+import { OpenResponseGrading } from '../../assets/wise5/components/openResponse/open-response-grading/open-response-grading.component';
+import { TableGrading } from '../../assets/wise5/components/table/table-grading/table-grading.component';
+import { AngularJSModule } from '../common-hybrid-angular.module';
+
+@NgModule({
+  declarations: [
+    AnimationGrading,
+    AudioOscillatorGrading,
+    ConceptMapGrading,
+    DrawGrading,
+    DiscussionGrading,
+    EmbeddedGrading,
+    GraphGrading,
+    LabelGrading,
+    MatchGrading,
+    MultipleChoiceGrading,
+    OpenResponseGrading,
+    TableGrading
+  ],
+  imports: [AngularJSModule, HighchartsChartModule],
+  exports: [
+    AnimationGrading,
+    AudioOscillatorGrading,
+    ConceptMapGrading,
+    DrawGrading,
+    DiscussionGrading,
+    EmbeddedGrading,
+    GraphGrading,
+    LabelGrading,
+    MatchGrading,
+    MultipleChoiceGrading,
+    OpenResponseGrading,
+    TableGrading
+  ]
+})
+export class ComponentGradingModule {}


### PR DESCRIPTION
## Changes
- Split teacher-hybrid-angular.module.ts into  authoring-tool.module.ts and classroom-monitor.module.ts
- Split further into component-[grading/authoring].module.ts
- Extracted common bootstrapAngularJSModule()

## Test
- AT and CM load and behave as before

Closes #243