### PR TITLE
Extracted delete/move node and copy project functions

### DIFF
--- a/src/app/services/deleteNodeService.spec.ts
+++ b/src/app/services/deleteNodeService.spec.ts
@@ -1,0 +1,237 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { UpgradeModule } from '@angular/upgrade/static';
+import { ConfigService } from '../../assets/wise5/services/configService';
+import { CopyNodesService } from '../../assets/wise5/services/copyNodesService';
+import { DeleteNodeService } from '../../assets/wise5/services/deleteNodeService';
+import { SessionService } from '../../assets/wise5/services/sessionService';
+import { TeacherProjectService } from '../../assets/wise5/services/teacherProjectService';
+import { UtilService } from '../../assets/wise5/services/utilService';
+import demoProjectJSON_import from './sampleData/curriculum/Demo.project.json';
+
+let demoProjectJSON: any;
+let projectService: TeacherProjectService;
+let service: DeleteNodeService;
+
+describe('DeleteNodeService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, UpgradeModule],
+      providers: [
+        ConfigService,
+        CopyNodesService,
+        DeleteNodeService,
+        SessionService,
+        TeacherProjectService,
+        UtilService
+      ]
+    });
+    demoProjectJSON = JSON.parse(JSON.stringify(demoProjectJSON_import));
+    projectService = TestBed.inject(TeacherProjectService);
+    service = TestBed.inject(DeleteNodeService);
+  });
+  shouldDeleteAStepFromTheProject();
+  shouldDeleteAnInactiveStepFromTheProject();
+  shouldDeleteAStepThatIsTheStartIdOfTheProject();
+  shouldDeleteAStepThatIsTheLastStepOfTheProject();
+  shouldDeleteAStepThatIsTheStartIdOfAnAactivityThatIsNotTheFirstActivity();
+  shouldDeleteTheFirstActivityFromTheProject();
+  shouldDeleteAnActivityInTheMiddleOfTheProject();
+  shouldDeleteTheLastActivityFromTheProject();
+  deleteActivityWithBranching();
+  deleteTheLastStepInAnActivity();
+  deleteAllStepsInAnActivity();
+});
+
+function shouldDeleteAStepFromTheProject() {
+  it('should delete a step from the project', () => {
+    projectService.setProject(demoProjectJSON);
+    expect(projectService.getNodes().length).toEqual(54);
+    expect(projectService.getNodeById('node5')).not.toBeNull();
+    expect(
+      projectService.nodeHasTransitionToNodeId(projectService.getNodeById('node4'), 'node5')
+    ).toBeTruthy();
+    expect(
+      projectService.nodeHasTransitionToNodeId(projectService.getNodeById('node5'), 'node6')
+    ).toBeTruthy();
+    expect(projectService.getNodesWithTransitionToNodeId('node6').length).toEqual(1);
+    service.deleteNode('node5');
+    expect(projectService.getNodes().length).toEqual(53);
+    expect(projectService.getNodeById('node5')).toBeNull();
+    expect(
+      projectService.nodeHasTransitionToNodeId(projectService.getNodeById('node4'), 'node6')
+    ).toBeTruthy();
+    expect(projectService.getNodesWithTransitionToNodeId('node6').length).toEqual(1);
+  });
+}
+
+function shouldDeleteAnInactiveStepFromTheProject() {
+  it('should delete an inactive step from the project', () => {
+    projectService.setProject(demoProjectJSON);
+    expect(projectService.getInactiveNodes().length).toEqual(1);
+    expect(projectService.getNodeById('node789')).not.toBeNull();
+    service.deleteNode('node789');
+    expect(projectService.getInactiveNodes().length).toEqual(0);
+    expect(projectService.getNodeById('node789')).toBeNull();
+  });
+}
+
+function shouldDeleteAStepThatIsTheStartIdOfTheProject() {
+  it('should delete a step that is the start id of the project', () => {
+    projectService.setProject(demoProjectJSON);
+    expect(projectService.getStartNodeId()).toEqual('node1');
+    expect(projectService.getNodesWithTransitionToNodeId('node2').length).toEqual(1);
+    service.deleteNode('node1');
+    expect(projectService.getStartNodeId()).toEqual('node2');
+    expect(projectService.getNodesWithTransitionToNodeId('node2').length).toEqual(0);
+  });
+}
+
+function shouldDeleteAStepThatIsTheLastStepOfTheProject() {
+  it('should delete a step that is the last step of the project', () => {
+    projectService.setProject(demoProjectJSON);
+    expect(projectService.getTransitionsByFromNodeId('node802').length).toEqual(1);
+    expect(
+      projectService.nodeHasTransitionToNodeId(projectService.getNodeById('node802'), 'node803')
+    ).toBeTruthy();
+    service.deleteNode('node803');
+    expect(projectService.getTransitionsByFromNodeId('node802').length).toEqual(0);
+    expect(
+      projectService.nodeHasTransitionToNodeId(projectService.getNodeById('node802'), 'node803')
+    ).toBeFalsy();
+  });
+}
+
+function shouldDeleteAStepThatIsTheStartIdOfAnAactivityThatIsNotTheFirstActivity() {
+  it('should delete a step that is the start id of an activity that is not the first activity', () => {
+    projectService.setProject(demoProjectJSON);
+    expect(projectService.getGroupStartId('group2')).toEqual('node20');
+    expect(
+      projectService.nodeHasTransitionToNodeId(projectService.getNodeById('node19'), 'node20')
+    ).toBeTruthy();
+    expect(
+      projectService.nodeHasTransitionToNodeId(projectService.getNodeById('node20'), 'node21')
+    ).toBeTruthy();
+    service.deleteNode('node20');
+    expect(projectService.getGroupStartId('group2')).toEqual('node21');
+    expect(
+      projectService.nodeHasTransitionToNodeId(projectService.getNodeById('node19'), 'node21')
+    ).toBeTruthy();
+  });
+}
+
+function shouldDeleteTheFirstActivityFromTheProject() {
+  it('should delete the first activity from the project', () => {
+    projectService.setProject(demoProjectJSON);
+    expect(projectService.getGroupStartId('group0')).toEqual('group1');
+    expect(projectService.getStartNodeId()).toEqual('node1');
+    expect(projectService.getNodes().length).toEqual(54);
+    expect(projectService.getNodesWithTransitionToNodeId('node20').length).toEqual(1);
+    service.deleteNode('group1');
+    expect(projectService.getNodeById('group1')).toBeNull();
+    expect(projectService.getGroupStartId('group0')).toEqual('group2');
+    expect(projectService.getStartNodeId()).toEqual('node20');
+    expect(projectService.getNodes().length).toEqual(34);
+    expect(projectService.getNodesWithTransitionToNodeId('node20').length).toEqual(0);
+  });
+}
+
+function shouldDeleteAnActivityInTheMiddleOfTheProject() {
+  it('should delete an activity that is in the middle of the project', () => {
+    projectService.setProject(demoProjectJSON);
+    expect(
+      projectService.nodeHasTransitionToNodeId(projectService.getNodeById('group2'), 'group3')
+    ).toBeTruthy();
+    expect(projectService.getNodes().length).toEqual(54);
+    service.deleteNode('group3');
+    expect(
+      projectService.nodeHasTransitionToNodeId(projectService.getNodeById('group2'), 'group3')
+    ).toBeFalsy();
+    expect(
+      projectService.nodeHasTransitionToNodeId(projectService.getNodeById('group2'), 'group4')
+    ).toBeTruthy();
+    expect(projectService.getNodes().length).toEqual(51);
+  });
+}
+
+function shouldDeleteTheLastActivityFromTheProject() {
+  it('should delete the last activity from the project', () => {
+    projectService.setProject(demoProjectJSON);
+    expect(
+      projectService.nodeHasTransitionToNodeId(projectService.getNodeById('group4'), 'group5')
+    ).toBeTruthy();
+    expect(projectService.getTransitionsByFromNodeId('group4').length).toEqual(1);
+    expect(projectService.getNodes().length).toEqual(54);
+    service.deleteNode('group5');
+    expect(
+      projectService.nodeHasTransitionToNodeId(projectService.getNodeById('group4'), 'group5')
+    ).toBeFalsy();
+    expect(projectService.getTransitionsByFromNodeId('group4').length).toEqual(0);
+    expect(projectService.getNodes().length).toEqual(48);
+  });
+}
+
+function deleteActivityWithBranching() {
+  it(`should delete an activity with branching and is also the first activity in the project
+      and properly set the project start node id`, () => {
+    projectService.setProject(demoProjectJSON);
+    expect(projectService.getStartNodeId()).toEqual('node1');
+    service.deleteNode('group1');
+    expect(projectService.getStartNodeId()).toEqual('node20');
+  });
+
+  it(`should delete an activity in the middle of the project with branching and properly remove
+      transitions from remaining steps`, () => {
+    projectService.setProject(demoProjectJSON);
+    const node19 = projectService.getNodeById('node19');
+    const node19Transitions = node19.transitionLogic.transitions;
+    expect(node19Transitions.length).toEqual(1);
+    expect(node19Transitions[0].to).toEqual('node20');
+    service.deleteNode('group2');
+    expect(node19Transitions.length).toEqual(1);
+    expect(node19Transitions[0].to).toEqual('node790');
+  });
+
+  it(`should delete an activity at the end of the project with branching and properly remove
+      transitions from remaining steps`, () => {
+    projectService.setProject(demoProjectJSON);
+    const node798 = projectService.getNodeById('node798');
+    const node798Transitions = node798.transitionLogic.transitions;
+    expect(node798Transitions.length).toEqual(1);
+    expect(node798Transitions[0].to).toEqual('node799');
+    service.deleteNode('group5');
+    expect(node798Transitions.length).toEqual(0);
+  });
+}
+
+function deleteTheLastStepInAnActivity() {
+  it(`should delete the last step in an activity in the middle of the project and set previous
+      step to transition to the first step of the next activity`, () => {
+    projectService.setProject(demoProjectJSON);
+    const node790Transitions = projectService.getTransitionsByFromNodeId('node790');
+    expect(node790Transitions.length).toEqual(1);
+    expect(
+      projectService.nodeHasTransitionToNodeId(projectService.getNodeById('node790'), 'node791')
+    ).toBeTruthy();
+    service.deleteNode('node791');
+    expect(node790Transitions.length).toEqual(1);
+    expect(
+      projectService.nodeHasTransitionToNodeId(projectService.getNodeById('node790'), 'node792')
+    ).toBeTruthy();
+  });
+}
+
+function deleteAllStepsInAnActivity() {
+  it(`should delete all steps in an activity in the middle of the project and set previous step
+      to transition to activity`, () => {
+    projectService.setProject(demoProjectJSON);
+    const node34 = projectService.getNodeById('node34');
+    const node34Transitions = node34.transitionLogic.transitions;
+    expect(node34Transitions.length).toEqual(1);
+    expect(node34Transitions[0].to).toEqual('node790');
+    service.deleteNode('node790');
+    service.deleteNode('node791');
+    expect(node34Transitions.length).toEqual(1);
+    expect(node34Transitions[0].to).toEqual('group3');
+  });
+}

--- a/src/app/services/projectService.spec.ts
+++ b/src/app/services/projectService.spec.ts
@@ -95,12 +95,9 @@ describe('ProjectService', () => {
   // TODO: add test for service.insertNodeInsideOnlyUpdateTransitions()
   // MARK: Tests for Node and Group Id functions
   // TODO: add test for service.getNodePositionAndTitleByNodeId()
-  // TODO: add test for service.moveNodesInside()
-  // TODO: add test for service.moveNodesAfter()
   // TODO: add test for service.deconsteNode()
   // TODO: add test for service.removeNodeIdFromTransitions()
   // TODO: add test for service.removeNodeIdFromGroups()
-  // TODO: add test for service.removeNodeIdFromNodes()
   // TODO: add test for service.createComponent()
   // TODO: add test for service.addComponentToNode()
   // TODO: add test for service.moveComponentUp()

--- a/src/app/services/teacherProjectService.spec.ts
+++ b/src/app/services/teacherProjectService.spec.ts
@@ -11,7 +11,6 @@ import { SessionService } from '../../assets/wise5/services/sessionService';
 import { CopyNodesService } from '../../assets/wise5/services/copyNodesService';
 let service: TeacherProjectService;
 let configService: ConfigService;
-let sessionService: SessionService;
 let utilService: UtilService;
 let http: HttpTestingController;
 let demoProjectJSON: any;
@@ -42,7 +41,6 @@ describe('TeacherProjectService', () => {
     http = TestBed.inject(HttpTestingController);
     service = TestBed.inject(TeacherProjectService);
     configService = TestBed.inject(ConfigService);
-    sessionService = TestBed.inject(SessionService);
     utilService = TestBed.inject(UtilService);
     spyOn(utilService, 'broadcastEventInRootScope');
     demoProjectJSON = JSON.parse(JSON.stringify(demoProjectJSON_import));
@@ -78,18 +76,7 @@ describe('TeacherProjectService', () => {
   shouldBeAbleToInsertAStepNodeInsideAGroupNode();
   shouldBeAbleToInsertAGroupNodeInsideAGroupNode();
   shouldNotBeAbleToInsertAStepNodeInsideAStepNode();
-  shouldDeleteAStepFromTheProject();
-  shouldDeleteAnInactiveStepFromTheProject();
-  shouldDeleteAStepThatIsTheStartIdOfTheProject();
-  shouldDeleteAStepThatIsTheLastStepOfTheProject();
-  shouldDeleteAStepThatIsTheStartIdOfAnAactivityThatIsNotTheFirstActivity();
-  shouldDeleteTheFirstActivityFromTheProject();
-  shouldDeleteAnActivityInTheMiddleOfTheProject();
-  shouldDeleteTheLastActivityFromTheProject();
   getUniqueAuthors();
-  deleteActivityWithBranching();
-  deleteTheLastStepInAnActivity();
-  deleteAllStepsInAnActivity();
   addCurrentUserToAuthors_CM_shouldAddUserInfo();
   getNodeIds();
   getInactiveNodeIds();
@@ -492,112 +479,6 @@ function shouldNotBeAbleToInsertAStepNodeInsideAStepNode() {
   });
 }
 
-function shouldDeleteAStepFromTheProject() {
-  it('should delete a step from the project', () => {
-    service.setProject(demoProjectJSON);
-    expect(service.getNodes().length).toEqual(54);
-    expect(service.getNodeById('node5')).not.toBeNull();
-    expect(service.nodeHasTransitionToNodeId(service.getNodeById('node4'), 'node5')).toBeTruthy();
-    expect(service.nodeHasTransitionToNodeId(service.getNodeById('node5'), 'node6')).toBeTruthy();
-    expect(service.getNodesWithTransitionToNodeId('node6').length).toEqual(1);
-    service.deleteNode('node5');
-    expect(service.getNodes().length).toEqual(53);
-    expect(service.getNodeById('node5')).toBeNull();
-    expect(service.nodeHasTransitionToNodeId(service.getNodeById('node4'), 'node6')).toBeTruthy();
-    expect(service.getNodesWithTransitionToNodeId('node6').length).toEqual(1);
-  });
-}
-
-function shouldDeleteAnInactiveStepFromTheProject() {
-  it('should delete an inactive step from the project', () => {
-    service.setProject(demoProjectJSON);
-    expect(service.getInactiveNodes().length).toEqual(1);
-    expect(service.getNodeById('node789')).not.toBeNull();
-    service.deleteNode('node789');
-    expect(service.getInactiveNodes().length).toEqual(0);
-    expect(service.getNodeById('node789')).toBeNull();
-  });
-}
-
-function shouldDeleteAStepThatIsTheStartIdOfTheProject() {
-  it('should delete a step that is the start id of the project', () => {
-    service.setProject(demoProjectJSON);
-    expect(service.getStartNodeId()).toEqual('node1');
-    expect(service.getNodesWithTransitionToNodeId('node2').length).toEqual(1);
-    service.deleteNode('node1');
-    expect(service.getStartNodeId()).toEqual('node2');
-    expect(service.getNodesWithTransitionToNodeId('node2').length).toEqual(0);
-  });
-}
-
-function shouldDeleteAStepThatIsTheLastStepOfTheProject() {
-  it('should delete a step that is the last step of the project', () => {
-    service.setProject(demoProjectJSON);
-    expect(service.getTransitionsByFromNodeId('node802').length).toEqual(1);
-    expect(
-      service.nodeHasTransitionToNodeId(service.getNodeById('node802'), 'node803')
-    ).toBeTruthy();
-    service.deleteNode('node803');
-    expect(service.getTransitionsByFromNodeId('node802').length).toEqual(0);
-    expect(
-      service.nodeHasTransitionToNodeId(service.getNodeById('node802'), 'node803')
-    ).toBeFalsy();
-  });
-}
-
-function shouldDeleteAStepThatIsTheStartIdOfAnAactivityThatIsNotTheFirstActivity() {
-  it('should delete a step that is the start id of an activity that is not the first activity', () => {
-    service.setProject(demoProjectJSON);
-    expect(service.getGroupStartId('group2')).toEqual('node20');
-    expect(service.nodeHasTransitionToNodeId(service.getNodeById('node19'), 'node20')).toBeTruthy();
-    expect(service.nodeHasTransitionToNodeId(service.getNodeById('node20'), 'node21')).toBeTruthy();
-    service.deleteNode('node20');
-    expect(service.getGroupStartId('group2')).toEqual('node21');
-    expect(service.nodeHasTransitionToNodeId(service.getNodeById('node19'), 'node21')).toBeTruthy();
-  });
-}
-
-function shouldDeleteTheFirstActivityFromTheProject() {
-  it('should delete the first activity from the project', () => {
-    service.setProject(demoProjectJSON);
-    expect(service.getGroupStartId('group0')).toEqual('group1');
-    expect(service.getStartNodeId()).toEqual('node1');
-    expect(service.getNodes().length).toEqual(54);
-    expect(service.getNodesWithTransitionToNodeId('node20').length).toEqual(1);
-    service.deleteNode('group1');
-    expect(service.getNodeById('group1')).toBeNull();
-    expect(service.getGroupStartId('group0')).toEqual('group2');
-    expect(service.getStartNodeId()).toEqual('node20');
-    expect(service.getNodes().length).toEqual(34);
-    expect(service.getNodesWithTransitionToNodeId('node20').length).toEqual(0);
-  });
-}
-
-function shouldDeleteAnActivityInTheMiddleOfTheProject() {
-  it('should delete an activity that is in the middle of the project', () => {
-    service.setProject(demoProjectJSON);
-    expect(service.nodeHasTransitionToNodeId(service.getNodeById('group2'), 'group3')).toBeTruthy();
-    expect(service.getNodes().length).toEqual(54);
-    service.deleteNode('group3');
-    expect(service.nodeHasTransitionToNodeId(service.getNodeById('group2'), 'group3')).toBeFalsy();
-    expect(service.nodeHasTransitionToNodeId(service.getNodeById('group2'), 'group4')).toBeTruthy();
-    expect(service.getNodes().length).toEqual(51);
-  });
-}
-
-function shouldDeleteTheLastActivityFromTheProject() {
-  it('should delete the last activity from the project', () => {
-    service.setProject(demoProjectJSON);
-    expect(service.nodeHasTransitionToNodeId(service.getNodeById('group4'), 'group5')).toBeTruthy();
-    expect(service.getTransitionsByFromNodeId('group4').length).toEqual(1);
-    expect(service.getNodes().length).toEqual(54);
-    service.deleteNode('group5');
-    expect(service.nodeHasTransitionToNodeId(service.getNodeById('group4'), 'group5')).toBeFalsy();
-    expect(service.getTransitionsByFromNodeId('group4').length).toEqual(0);
-    expect(service.getNodes().length).toEqual(48);
-  });
-}
-
 function insertNodeAfterInTransitions() {
   it('should be able to insert a step node after another step node', () => {
     expectInsertNodeAfterInTransition('node1', 'node2');
@@ -664,71 +545,6 @@ function getUniqueAuthors() {
       expect(uniqueAuthors[2].firstName).toEqual('c');
       expect(uniqueAuthors[2].lastName).toEqual('c');
     });
-  });
-}
-
-function deleteActivityWithBranching() {
-  it(`should delete an activity with branching and is also the first activity in the project
-      and properly set the project start node id`, () => {
-    service.setProject(demoProjectJSON);
-    expect(service.getStartNodeId()).toEqual('node1');
-    service.deleteNode('group1');
-    expect(service.getStartNodeId()).toEqual('node20');
-  });
-
-  it(`should delete an activity in the middle of the project with branching and properly remove
-      transitions from remaining steps`, () => {
-    service.setProject(demoProjectJSON);
-    const node19 = service.getNodeById('node19');
-    const node19Transitions = node19.transitionLogic.transitions;
-    expect(node19Transitions.length).toEqual(1);
-    expect(node19Transitions[0].to).toEqual('node20');
-    service.deleteNode('group2');
-    expect(node19Transitions.length).toEqual(1);
-    expect(node19Transitions[0].to).toEqual('node790');
-  });
-
-  it(`should delete an activity at the end of the project with branching and properly remove
-      transitions from remaining steps`, () => {
-    service.setProject(demoProjectJSON);
-    const node798 = service.getNodeById('node798');
-    const node798Transitions = node798.transitionLogic.transitions;
-    expect(node798Transitions.length).toEqual(1);
-    expect(node798Transitions[0].to).toEqual('node799');
-    service.deleteNode('group5');
-    expect(node798Transitions.length).toEqual(0);
-  });
-}
-
-function deleteTheLastStepInAnActivity() {
-  it(`should delete the last step in an activity in the middle of the project and set previous
-      step to transition to the first step of the next activity`, () => {
-    service.setProject(demoProjectJSON);
-    const node790Transitions = service.getTransitionsByFromNodeId('node790');
-    expect(node790Transitions.length).toEqual(1);
-    expect(
-      service.nodeHasTransitionToNodeId(service.getNodeById('node790'), 'node791')
-    ).toBeTruthy();
-    service.deleteNode('node791');
-    expect(node790Transitions.length).toEqual(1);
-    expect(
-      service.nodeHasTransitionToNodeId(service.getNodeById('node790'), 'node792')
-    ).toBeTruthy();
-  });
-}
-
-function deleteAllStepsInAnActivity() {
-  it(`should delete all steps in an activity in the middle of the project and set previous step
-      to transition to activity`, () => {
-    service.setProject(demoProjectJSON);
-    const node34 = service.getNodeById('node34');
-    const node34Transitions = node34.transitionLogic.transitions;
-    expect(node34Transitions.length).toEqual(1);
-    expect(node34Transitions[0].to).toEqual('node790');
-    service.deleteNode('node790');
-    service.deleteNode('node791');
-    expect(node34Transitions.length).toEqual(1);
-    expect(node34Transitions[0].to).toEqual('group3');
   });
 }
 

--- a/src/app/teacher-hybrid-angular.module.ts
+++ b/src/app/teacher-hybrid-angular.module.ts
@@ -13,7 +13,10 @@ import { TeacherWebSocketService } from '../assets/wise5/services/teacherWebSock
 import { DataService } from './services/data.service';
 import { MilestoneService } from '../assets/wise5/services/milestoneService';
 import { CopyNodesService } from '../assets/wise5/services/copyNodesService';
+import { CopyProjectService } from '../assets/wise5/services/copyProjectService';
+import { DeleteNodeService } from '../assets/wise5/services/deleteNodeService';
 import { InsertNodesService } from '../assets/wise5/services/insertNodesService';
+import { MoveNodesService } from '../assets/wise5/services/moveNodesService';
 import { AuthoringToolModule } from './teacher/authoring-tool.module';
 import { ClassroomMonitorModule } from './teacher/classroom-monitor.module';
 import { StepToolsComponent } from '../assets/wise5/common/stepTools/step-tools.component';
@@ -23,9 +26,12 @@ import { StepToolsComponent } from '../assets/wise5/common/stepTools/step-tools.
   imports: [AngularJSModule, AuthoringToolModule, ClassroomMonitorModule],
   providers: [
     CopyNodesService,
+    CopyProjectService,
     { provide: DataService, useExisting: TeacherDataService },
+    DeleteNodeService,
     InsertNodesService,
     MilestoneService,
+    MoveNodesService,
     ProjectAssetService,
     SpaceService,
     StudentStatusService,

--- a/src/assets/wise5/authoringTool/main/mainAuthoringComponent.ts
+++ b/src/assets/wise5/authoringTool/main/mainAuthoringComponent.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import { ConfigService } from '../../services/configService';
+import { CopyProjectService } from '../../services/copyProjectService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { TeacherDataService } from '../../services/teacherDataService';
 import { UtilService } from '../../services/utilService';
@@ -28,6 +29,7 @@ class MainAuthoringController {
     '$state',
     '$timeout',
     'ConfigService',
+    'CopyProjectService',
     'ProjectService',
     'TeacherDataService',
     'UtilService'
@@ -41,6 +43,7 @@ class MainAuthoringController {
     private $state: any,
     private $timeout: any,
     private ConfigService: ConfigService,
+    private CopyProjectService: CopyProjectService,
     private ProjectService: TeacherProjectService,
     private TeacherDataService: TeacherDataService,
     private UtilService: UtilService
@@ -78,12 +81,18 @@ class MainAuthoringController {
       'areYouSureYouWantToCopyThisProject'
     )}\n\n${projectInfo}`;
     if (confirm(confirmCopyMessage)) {
-      this.ProjectService.copyProject(projectId).then((project: any) => {
-        this.showCopyingProjectMessage();
-        this.saveEvent('projectCopied', 'Authoring', {}, project.id);
-        this.highlightProject(project.id);
-        this.$mdDialog.hide();
-      });
+      this.showCopyingProjectMessage();
+      this.CopyProjectService.copyProject(projectId).subscribe(
+        (project: any) => {
+          this.saveEvent('projectCopied', 'Authoring', {}, project.id);
+          this.highlightProject(project.id);
+          this.$mdDialog.hide();
+        },
+        () => {
+          alert($localize`There was an error copying this project. Please contact WISE staff.`);
+          this.$mdDialog.hide();
+        }
+      );
     }
   }
 

--- a/src/assets/wise5/authoringTool/project/projectAuthoringComponent.ts
+++ b/src/assets/wise5/authoringTool/project/projectAuthoringComponent.ts
@@ -1,7 +1,9 @@
 'use strict';
 
-import { TeacherProjectService } from '../../services/teacherProjectService';
 import { ConfigService } from '../../services/configService';
+import { DeleteNodeService } from '../../services/deleteNodeService';
+import { MoveNodesService } from '../../services/moveNodesService';
+import { TeacherProjectService } from '../../services/teacherProjectService';
 import { TeacherDataService } from '../../services/teacherDataService';
 import { UtilService } from '../../services/utilService';
 import * as angular from 'angular';
@@ -61,6 +63,8 @@ class ProjectAuthoringController {
     '$transitions',
     '$window',
     'ConfigService',
+    'DeleteNodeService',
+    'MoveNodesService',
     'ProjectService',
     'TeacherDataService',
     'UtilService'
@@ -75,6 +79,8 @@ class ProjectAuthoringController {
     private $transitions,
     private $window,
     private ConfigService: ConfigService,
+    private DeleteNodeService: DeleteNodeService,
+    private MoveNodesService: MoveNodesService,
     private ProjectService: TeacherProjectService,
     private TeacherDataService: TeacherDataService,
     private UtilService: UtilService
@@ -311,9 +317,9 @@ class ProjectAuthoringController {
 
       let newNodes = [];
       if (moveTo === 'inside') {
-        newNodes = this.ProjectService.moveNodesInside(selectedNodeIds, nodeId);
+        newNodes = this.MoveNodesService.moveNodesInsideGroup(selectedNodeIds, nodeId);
       } else if (moveTo === 'after') {
-        newNodes = this.ProjectService.moveNodesAfter(selectedNodeIds, nodeId);
+        newNodes = this.MoveNodesService.moveNodesAfter(selectedNodeIds, nodeId);
       } else {
         // an unspecified moveTo was provided
         return;
@@ -481,7 +487,7 @@ class ProjectAuthoringController {
       } else {
         stepsDeleted.push(tempNode);
       }
-      this.ProjectService.deleteNode(nodeId);
+      this.DeleteNodeService.deleteNode(nodeId);
     }
     if (deletedStartNodeId) {
       this.updateStartNodeId();

--- a/src/assets/wise5/services/copyProjectService.ts
+++ b/src/assets/wise5/services/copyProjectService.ts
@@ -1,0 +1,16 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ConfigService } from './configService';
+
+@Injectable()
+export class CopyProjectService {
+  constructor(protected http: HttpClient, protected ConfigService: ConfigService) {}
+
+  copyProject(projectId: number): Observable<any> {
+    return this.http.post(
+      `${this.ConfigService.getConfigParam('copyProjectURL')}/${projectId}`,
+      null
+    );
+  }
+}

--- a/src/assets/wise5/services/deleteNodeService.ts
+++ b/src/assets/wise5/services/deleteNodeService.ts
@@ -1,0 +1,150 @@
+import { Injectable } from '@angular/core';
+import { TeacherProjectService } from './teacherProjectService';
+
+@Injectable()
+export class DeleteNodeService {
+  constructor(protected ProjectService: TeacherProjectService) {}
+
+  /**
+   * Delete a node from the project and update transitions.
+   * If we are deleting the project start node id, we will need to change it to the
+   * next logical node id that will be used as the project start.
+   *
+   * @param nodeId the node id to delete from the project. It can be a step or an activity.
+   */
+  deleteNode(nodeId: string): void {
+    const parentGroup = this.ProjectService.getParentGroup(nodeId);
+    if (parentGroup != null && parentGroup.startId === nodeId) {
+      this.setGroupStartIdToNextChildId(parentGroup);
+    }
+    if (this.isProjectStartNodeIdOrContainsProjectStartNodeId(nodeId)) {
+      this.updateProjectStartNodeIdToNextLogicalNode(nodeId);
+    }
+    if (this.ProjectService.isGroupNode(nodeId)) {
+      this.removeChildNodes(nodeId);
+    }
+    this.ProjectService.removeNodeIdFromTransitions(nodeId);
+    this.ProjectService.removeNodeIdFromGroups(nodeId);
+    this.removeNodeIdFromNodes(nodeId);
+  }
+
+  private setGroupStartIdToNextChildId(group: any): void {
+    let hasSetNewStartId = false;
+    const transitions = this.ProjectService.getTransitionsByFromNodeId(group.startId);
+    if (transitions.length > 0) {
+      const transition = transitions[0];
+      const toNodeId = transition.to;
+      if (this.ProjectService.isNodeInGroup(toNodeId, group.id)) {
+        group.startId = toNodeId;
+        hasSetNewStartId = true;
+      }
+    }
+    if (!hasSetNewStartId) {
+      group.startId = '';
+    }
+  }
+
+  private isProjectStartNodeIdOrContainsProjectStartNodeId(nodeId: string): boolean {
+    return (
+      this.ProjectService.getStartNodeId() === nodeId ||
+      (this.ProjectService.isGroupNode(nodeId) && this.containsStartNodeId(nodeId))
+    );
+  }
+
+  private containsStartNodeId(groupId: string): boolean {
+    const group = this.ProjectService.getNodeById(groupId);
+    const projectStartNodeId = this.ProjectService.getStartNodeId();
+    for (let childId of group.ids) {
+      if (childId === projectStartNodeId) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private updateProjectStartNodeIdToNextLogicalNode(nodeId: string): void {
+    if (this.ProjectService.isGroupNode(nodeId)) {
+      this.updateProjectStartNodeIdToNextLogicalNodeForRemovingGroup(nodeId);
+    } else {
+      this.updateProjectStartNodeIdToNextLogicalNodeForRemovingStep(nodeId);
+    }
+  }
+
+  /**
+   * Set the startNodeId of the specified group to the first node of the next group.
+   * If the next group doesn't have any nodes, startNodeId should point
+   * to the next group.
+   */
+  private updateProjectStartNodeIdToNextLogicalNodeForRemovingGroup(nodeId: string): void {
+    const transitions = this.ProjectService.getTransitionsByFromNodeId(nodeId);
+    if (transitions.length == 0) {
+      this.ProjectService.setStartNodeId('group0');
+    } else {
+      let nextNodeId = transitions[0].to;
+      if (this.ProjectService.isGroupNode(nextNodeId)) {
+        const nextGroupStartId = this.ProjectService.getGroupStartId(nextNodeId);
+        if (nextGroupStartId == null) {
+          this.ProjectService.setStartNodeId(nextNodeId);
+        } else {
+          this.ProjectService.setStartNodeId(nextGroupStartId);
+        }
+      } else {
+        this.ProjectService.setStartNodeId(nextNodeId);
+      }
+    }
+  }
+
+  /**
+   * Set the startNodeId to the next node in the transitions.
+   * If there are no transitions, set it to the parent group of the node.
+   */
+  private updateProjectStartNodeIdToNextLogicalNodeForRemovingStep(nodeId: string): void {
+    const transitions = this.ProjectService.getTransitionsByFromNodeId(nodeId);
+    const parentGroupId = this.ProjectService.getParentGroupId(nodeId);
+    if (transitions.length == 0) {
+      this.ProjectService.setStartNodeId(parentGroupId);
+    } else {
+      let nextNodeId = transitions[0].to;
+      if (this.ProjectService.isNodeInGroup(nextNodeId, parentGroupId)) {
+        this.ProjectService.setStartNodeId(nextNodeId);
+      } else {
+        this.ProjectService.setStartNodeId(this.ProjectService.getParentGroupId(nodeId));
+      }
+    }
+  }
+
+  private removeChildNodes(groupId: string): void {
+    const group = this.ProjectService.getNodeById(groupId);
+    for (let i = 0; i < group.ids.length; i++) {
+      const childId = group.ids[i];
+      this.ProjectService.removeNodeIdFromTransitions(childId);
+      this.ProjectService.removeNodeIdFromGroups(childId);
+      this.removeNodeIdFromNodes(childId);
+      i--; // so it won't skip the next element
+    }
+  }
+
+  private removeNodeIdFromNodes(nodeId: string): void {
+    const nodes = this.ProjectService.project.nodes;
+    for (let n = 0; n < nodes.length; n++) {
+      const node = nodes[n];
+      if (node != null) {
+        if (nodeId === node.id) {
+          nodes.splice(n, 1);
+        }
+      }
+    }
+    const inactiveNodes = this.ProjectService.project.inactiveNodes;
+    if (inactiveNodes != null) {
+      for (let i = 0; i < inactiveNodes.length; i++) {
+        const inactiveNode = inactiveNodes[i];
+        if (inactiveNode != null) {
+          if (nodeId === inactiveNode.id) {
+            inactiveNodes.splice(i, 1);
+          }
+        }
+      }
+    }
+    this.ProjectService.idToNode[nodeId] = null;
+  }
+}

--- a/src/assets/wise5/services/moveNodesService.ts
+++ b/src/assets/wise5/services/moveNodesService.ts
@@ -1,0 +1,108 @@
+import { Injectable } from '@angular/core';
+import { TeacherProjectService } from './teacherProjectService';
+
+@Injectable()
+export class MoveNodesService {
+  constructor(protected ProjectService: TeacherProjectService) {}
+
+  /**
+   * Move nodes inside an active/inactive group node
+   * @param nodeIds the node ids to move
+   * @param groupNodeId the node id of the group we are moving the nodes inside
+   */
+  moveNodesInsideGroup(nodeIds: string[], groupNodeId: string): any[] {
+    const movedNodes = [];
+    for (let n = 0; n < nodeIds.length; n++) {
+      const nodeId = nodeIds[n];
+      const node = this.ProjectService.getNodeById(nodeId);
+      movedNodes.push(node);
+      const movingNodeIsActive = this.ProjectService.isActive(nodeId);
+      const stationaryNodeIsActive = this.ProjectService.isActive(groupNodeId);
+
+      if (movingNodeIsActive && stationaryNodeIsActive) {
+        this.ProjectService.removeNodeIdFromTransitions(nodeId);
+        this.ProjectService.removeNodeIdFromGroups(nodeId);
+
+        if (n == 0) {
+          this.ProjectService.insertNodeInsideOnlyUpdateTransitions(nodeId, groupNodeId);
+          this.ProjectService.insertNodeInsideInGroups(nodeId, groupNodeId);
+        } else {
+          this.ProjectService.insertNodeAfterInTransitions(node, groupNodeId);
+          this.ProjectService.insertNodeAfterInGroups(nodeId, groupNodeId);
+        }
+      } else if (movingNodeIsActive && !stationaryNodeIsActive) {
+        this.ProjectService.removeNodeIdFromTransitions(nodeId);
+        this.ProjectService.removeNodeIdFromGroups(nodeId);
+
+        if (n == 0) {
+          this.ProjectService.moveFromActiveToInactiveInsertInside(node, groupNodeId);
+        } else {
+          this.ProjectService.moveToInactive(node, groupNodeId);
+        }
+      } else if (!movingNodeIsActive && stationaryNodeIsActive) {
+        this.ProjectService.moveToActive(node);
+
+        if (n == 0) {
+          this.ProjectService.insertNodeInsideOnlyUpdateTransitions(nodeId, groupNodeId);
+          this.ProjectService.insertNodeInsideInGroups(nodeId, groupNodeId);
+        } else {
+          this.ProjectService.insertNodeAfterInTransitions(node, groupNodeId);
+          this.ProjectService.insertNodeAfterInGroups(nodeId, groupNodeId);
+        }
+      } else if (!movingNodeIsActive && !stationaryNodeIsActive) {
+        this.ProjectService.removeNodeIdFromTransitions(nodeId);
+        this.ProjectService.removeNodeIdFromGroups(nodeId);
+
+        if (n == 0) {
+          this.ProjectService.moveFromInactiveToInactiveInsertInside(node, groupNodeId);
+        } else {
+          this.moveInactiveNodeToInactiveSection(node, groupNodeId);
+        }
+      }
+      // remember the node id so we can put the next node (if any) after this one
+      groupNodeId = node.id;
+    }
+    return movedNodes;
+  }
+
+  /**
+   * Move nodes after a certain node id
+   * @param nodeIds the node ids to move
+   * @param moveAfterNodeId the node id we will put the moved nodes after
+   */
+  moveNodesAfter(nodeIds: string[], moveAfterNodeId: string): any[] {
+    const movedNodes = [];
+    for (let nodeId of nodeIds) {
+      const node = this.ProjectService.getNodeById(nodeId);
+      movedNodes.push(node);
+      const movingNodeIsActive = this.ProjectService.isActive(nodeId);
+      const stationaryNodeIsActive = this.ProjectService.isActive(moveAfterNodeId);
+      if (movingNodeIsActive && stationaryNodeIsActive) {
+        this.ProjectService.removeNodeIdFromTransitions(nodeId);
+        this.ProjectService.removeNodeIdFromGroups(nodeId);
+        this.ProjectService.insertNodeAfterInGroups(nodeId, moveAfterNodeId);
+        this.ProjectService.insertNodeAfterInTransitions(node, moveAfterNodeId);
+      } else if (movingNodeIsActive && !stationaryNodeIsActive) {
+        this.ProjectService.removeNodeIdFromTransitions(nodeId);
+        this.ProjectService.removeNodeIdFromGroups(nodeId);
+        this.ProjectService.moveToInactive(node, moveAfterNodeId);
+      } else if (!movingNodeIsActive && stationaryNodeIsActive) {
+        this.ProjectService.moveToActive(node);
+        this.ProjectService.insertNodeAfterInGroups(nodeId, moveAfterNodeId);
+        this.ProjectService.insertNodeAfterInTransitions(node, moveAfterNodeId);
+      } else if (!movingNodeIsActive && !stationaryNodeIsActive) {
+        this.ProjectService.removeNodeIdFromTransitions(nodeId);
+        this.ProjectService.removeNodeIdFromGroups(nodeId);
+        this.moveInactiveNodeToInactiveSection(node, moveAfterNodeId);
+      }
+      // remember the node id so we can put the next node (if any) after this one
+      moveAfterNodeId = node.id;
+    }
+    return movedNodes;
+  }
+
+  private moveInactiveNodeToInactiveSection(node: any, nodeIdToInsertAfter: string): void {
+    this.ProjectService.removeNodeFromInactiveNodes(node.id);
+    this.ProjectService.addInactiveNodeInsertAfter(node, nodeIdToInsertAfter);
+  }
+}

--- a/src/assets/wise5/teacher/teacher-angular-js-module.ts
+++ b/src/assets/wise5/teacher/teacher-angular-js-module.ts
@@ -2,7 +2,10 @@ import '../lib/jquery/jquery-global';
 import * as angular from 'angular';
 import { downgradeComponent, downgradeInjectable } from '@angular/upgrade/static';
 import '../common-angular-js-module';
+import { CopyProjectService } from '../services/copyProjectService';
+import { DeleteNodeService } from '../services/deleteNodeService';
 import { MilestoneService } from '../services/milestoneService';
+import { MoveNodesService } from '../services/moveNodesService';
 import { TeacherProjectService } from '../services/teacherProjectService';
 import { SpaceService } from '../services/spaceService';
 import { StudentStatusService } from '../services/studentStatusService';
@@ -15,7 +18,10 @@ import '../authoringTool/authoring-tool.module';
 
 angular
   .module('teacher', ['common', 'angular-inview', 'authoringTool', 'classroomMonitor', 'ngAnimate'])
+  .factory('CopyProjectService', downgradeInjectable(CopyProjectService))
+  .factory('DeleteNodeService', downgradeInjectable(DeleteNodeService))
   .factory('MilestoneService', downgradeInjectable(MilestoneService))
+  .factory('MoveNodesService', downgradeInjectable(MoveNodesService))
   .factory('ProjectService', downgradeInjectable(TeacherProjectService))
   .factory('SpaceService', downgradeInjectable(SpaceService))
   .factory('StudentStatusService', downgradeInjectable(StudentStatusService))

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -7947,6 +7947,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="2544043210306731906" datatype="html">
+        <source>There was an error copying this project. Please contact WISE staff.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/main/mainAuthoringComponent.ts</context>
+          <context context-type="linenumber">92</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="bfab7f41cfc32a926c55987d6a9c3349ae417131" datatype="html">
         <source> Show Save Button </source>
         <context-group purpose="location">


### PR DESCRIPTION
## Changes
- Extracted delete/move node and copy project functions from teacherProjectService to new services
- Added function param types and return values
- Moved CopyProject message dialog to appear before making POST request
- Added CopyProject error handling

## Test
- Delete node(s) works as before
- Move node(s) works as before
- Copy project works as before. If the request fails (debug WISE-API -> make the AuthorAPIController.copyProject function throw error, or stop wise-api docker service before making request), you should see an alert message and the "Copying..." dialog should close.

Closes #247