### PR TITLE
Extract importComponents into its own service

### DIFF
--- a/src/app/teacher-hybrid-angular.module.ts
+++ b/src/app/teacher-hybrid-angular.module.ts
@@ -16,6 +16,7 @@ import { CopyComponentService } from '../assets/wise5/services/copyComponentServ
 import { CopyNodesService } from '../assets/wise5/services/copyNodesService';
 import { CopyProjectService } from '../assets/wise5/services/copyProjectService';
 import { DeleteNodeService } from '../assets/wise5/services/deleteNodeService';
+import { ImportComponentService } from '../assets/wise5/services/importComponentService';
 import { InsertComponentService } from '../assets/wise5/services/insertComponentService';
 import { InsertNodesService } from '../assets/wise5/services/insertNodesService';
 import { MoveNodesService } from '../assets/wise5/services/moveNodesService';
@@ -32,6 +33,7 @@ import { StepToolsComponent } from '../assets/wise5/common/stepTools/step-tools.
     CopyProjectService,
     { provide: DataService, useExisting: TeacherDataService },
     DeleteNodeService,
+    ImportComponentService,
     InsertComponentService,
     InsertNodesService,
     MilestoneService,

--- a/src/assets/wise5/authoringTool/importComponent/choose-component-location.component.ts
+++ b/src/assets/wise5/authoringTool/importComponent/choose-component-location.component.ts
@@ -1,4 +1,5 @@
 import { ConfigService } from '../../services/configService';
+import { ImportComponentService } from '../../services/importComponentService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { TeacherDataService } from '../../services/teacherDataService';
 import { ProjectAssetService } from '../../../../app/services/projectAssetService';
@@ -12,6 +13,7 @@ class ChooseComponentLocationController {
     '$state',
     '$stateParams',
     'ConfigService',
+    'ImportComponentService',
     'ProjectAssetService',
     'ProjectService',
     'TeacherDataService',
@@ -22,6 +24,7 @@ class ChooseComponentLocationController {
     private $state: any,
     private $stateParams: any,
     private ConfigService: ConfigService,
+    private ImportComponentService: ImportComponentService,
     private ProjectAssetService: ProjectAssetService,
     private ProjectService: TeacherProjectService,
     private TeacherDataService: TeacherDataService,
@@ -42,7 +45,13 @@ class ChooseComponentLocationController {
   }
 
   importComponentAfter(insertAfterComponentId: string) {
-    this.importComponents(this.nodeId, insertAfterComponentId).then((newComponents) => {
+    this.ImportComponentService.importComponents(
+      this.$stateParams.selectedComponents,
+      this.$stateParams.importFromProjectId,
+      this.nodeId,
+      insertAfterComponentId
+    ).then((newComponents) => {
+      this.saveImportedComponentsEvent(newComponents);
       this.ProjectService.saveProject();
       // refresh the project assets in case any of the imported components also imported assets
       this.ProjectAssetService.retrieveProjectAssets();
@@ -51,18 +60,6 @@ class ChooseComponentLocationController {
         nodeId: this.nodeId,
         newComponents: newComponents
       });
-    });
-  }
-
-  importComponents(nodeId: string, insertAfterComponentId: string) {
-    return this.ProjectService.importComponents(
-      this.$stateParams.selectedComponents,
-      this.$stateParams.importFromProjectId,
-      nodeId,
-      insertAfterComponentId
-    ).then((newComponents) => {
-      this.saveImportedComponentsEvent(newComponents);
-      return newComponents;
     });
   }
 

--- a/src/assets/wise5/services/importComponentService.ts
+++ b/src/assets/wise5/services/importComponentService.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@angular/core';
+import { ConfigService } from './configService';
+import { CopyNodesService } from './copyNodesService';
+import { InsertComponentService } from './insertComponentService';
+import { TeacherProjectService } from './teacherProjectService';
+import { UtilService } from './utilService';
+
+@Injectable()
+export class ImportComponentService {
+  constructor(
+    protected ConfigService: ConfigService,
+    protected CopyNodesService: CopyNodesService,
+    protected InsertComponentService: InsertComponentService,
+    protected ProjectService: TeacherProjectService,
+    protected UtilService: UtilService
+  ) {}
+
+  /**
+   * Import components from a project. Also import asset files that are
+   * referenced in any of those components.
+   * @param components an array of component objects that we are importing
+   * @param importProjectId the id of the project we are importing from
+   * @param nodeId the node we are adding the components to
+   * @param insertAfterComponentId insert the components after this component id
+   * @return an array of the new components
+   */
+  importComponents(
+    components: any[],
+    importProjectId: number,
+    nodeId: string,
+    insertAfterComponentId: string
+  ) {
+    const newComponents = [];
+    const newComponentIds = [];
+    for (const component of components) {
+      const newComponent = this.UtilService.makeCopyOfJSONObject(component);
+      let newComponentId = newComponent.id;
+      if (this.ProjectService.isComponentIdUsed(newComponentId)) {
+        newComponentId = this.ProjectService.getUnusedComponentId(newComponentIds);
+        newComponent.id = newComponentId;
+      }
+      newComponents.push(newComponent);
+      newComponentIds.push(newComponentId);
+    }
+
+    return this.CopyNodesService.copyNodes(
+      newComponents,
+      importProjectId,
+      this.ConfigService.getConfigParam('projectId')
+    )
+      .toPromise()
+      .then((newComponents: any) => {
+        this.InsertComponentService.insertComponents(newComponents, nodeId, insertAfterComponentId);
+        return newComponents;
+      });
+  }
+}

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -586,52 +586,6 @@ export class TeacherProjectService extends ProjectService {
   }
 
   /**
-   * Import components from a project. Also import asset files that are
-   * referenced in any of those components.
-   * @param components an array of component objects that we are importing
-   * @param importProjectId the id of the project we are importing from
-   * @param nodeId the node we are adding the components to
-   * @param insertAfterComponentId insert the components after this component id
-   * @return an array of the new components
-   */
-  importComponents(components, importProjectId, nodeId, insertAfterComponentId) {
-    const newComponents = [];
-    const newComponentIds = [];
-    for (const component of components) {
-      const newComponent = this.UtilService.makeCopyOfJSONObject(component);
-      let newComponentId = newComponent.id;
-      if (this.isComponentIdUsed(newComponentId)) {
-        newComponentId = this.getUnusedComponentId(newComponentIds);
-        newComponent.id = newComponentId;
-      }
-      newComponents.push(newComponent);
-      newComponentIds.push(newComponentId);
-    }
-
-    return this.CopyNodesService.copyNodes(
-      newComponents,
-      importProjectId,
-      this.ConfigService.getConfigParam('projectId')
-    )
-      .toPromise()
-      .then((newComponents: any) => {
-        const node = this.getNodeById(nodeId);
-        let insertPosition = 0;
-        if (insertAfterComponentId == null) {
-          insertPosition = 0;
-        } else {
-          insertPosition =
-            this.getComponentPositionByNodeIdAndComponentId(nodeId, insertAfterComponentId) + 1;
-        }
-        for (const newComponent of newComponents) {
-          node.components.splice(insertPosition, 0, newComponent);
-          insertPosition += 1;
-        }
-        return newComponents;
-      });
-  }
-
-  /**
    * Delete a component from a node
    * @param nodeId the node id containing the node
    * @param componentId the component id

--- a/src/assets/wise5/teacher/teacher-angular-js-module.ts
+++ b/src/assets/wise5/teacher/teacher-angular-js-module.ts
@@ -5,6 +5,7 @@ import '../common-angular-js-module';
 import { CopyComponentService } from '../services/copyComponentService';
 import { CopyProjectService } from '../services/copyProjectService';
 import { DeleteNodeService } from '../services/deleteNodeService';
+import { ImportComponentService } from '../services/importComponentService';
 import { InsertComponentService } from '../services/insertComponentService';
 import { MilestoneService } from '../services/milestoneService';
 import { MoveNodesService } from '../services/moveNodesService';
@@ -23,6 +24,7 @@ angular
   .factory('CopyComponentService', downgradeInjectable(CopyComponentService))
   .factory('CopyProjectService', downgradeInjectable(CopyProjectService))
   .factory('DeleteNodeService', downgradeInjectable(DeleteNodeService))
+  .factory('ImportComponentService', downgradeInjectable(ImportComponentService))
   .factory('InsertComponentService', downgradeInjectable(InsertComponentService))
   .factory('MilestoneService', downgradeInjectable(MilestoneService))
   .factory('MoveNodesService', downgradeInjectable(MoveNodesService))


### PR DESCRIPTION
## Changes
- Extract importComponents into its own service
- Refactored toPromise code to use InsertComponentService.insertComponents()
- Refactored choose-component-location by removing extra importComponents() function definition

## Test
- Import component (via node editing view) works as before
  - import as first component
  - import after existing component

Closes #253