### PR TITLE
Moved copyNodesInside/After and copyNode functions

### DIFF
--- a/src/app/services/copyNodesService.spec.ts
+++ b/src/app/services/copyNodesService.spec.ts
@@ -1,0 +1,89 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { UpgradeModule } from '@angular/upgrade/static';
+import { ConfigService } from '../../assets/wise5/services/configService';
+import { CopyNodesService } from '../../assets/wise5/services/copyNodesService';
+import { TeacherProjectService } from '../../assets/wise5/services/teacherProjectService';
+import { UtilService } from '../../assets/wise5/services/utilService';
+
+class ConfigServiceStub {}
+
+class ProjectServiceStub {
+  createNodeAfter(node: any, nodeIdAfter: string) {}
+  createNodeInside(node: any, groupId: string) {}
+  getNextAvailableNodeId() {
+    return 'n2';
+  }
+  getNodeById(nodeId: string) {
+    return { id: nodeId, components: [{ id: 'c1' }] };
+  }
+  getUnusedComponentId(componentIds: string[]) {
+    return 'c2';
+  }
+  parseProject() {}
+}
+
+class UtilServiceStub {
+  makeCopyOfJSONObject(obj) {
+    return JSON.parse(JSON.stringify(obj));
+  }
+}
+
+let service: CopyNodesService;
+let projectService: TeacherProjectService;
+let utilService: UtilService;
+let createNodeAfterSpy, createNodeInsideSpy, getUnusedComponentIdSpy, parseProjectSpy;
+
+describe('CopyNodesService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, UpgradeModule],
+      providers: [
+        CopyNodesService,
+        { provide: ConfigService, useClass: ConfigServiceStub },
+        { provide: TeacherProjectService, useClass: ProjectServiceStub },
+        { provide: UtilService, useClass: UtilServiceStub }
+      ]
+    });
+    service = TestBed.inject(CopyNodesService);
+    projectService = TestBed.inject(TeacherProjectService);
+    utilService = TestBed.inject(UtilService);
+    createNodeAfterSpy = spyOn(projectService, 'createNodeAfter');
+    createNodeInsideSpy = spyOn(projectService, 'createNodeInside');
+    getUnusedComponentIdSpy = spyOn(projectService, 'getUnusedComponentId');
+    parseProjectSpy = spyOn(projectService, 'parseProject');
+  });
+  copyNodeInside();
+  copyNodesAfter();
+});
+
+function copyNodeInside() {
+  describe('copyNodeInside()', () => {
+    it('should copy and create node inside specified group id', () => {
+      const newNode = service.copyNodeInside('n1', 'g1');
+      expect(newNode.id).not.toEqual('n1');
+      expectSpiesToHaveBeenCalled(createNodeInsideSpy, getUnusedComponentIdSpy, parseProjectSpy);
+    });
+  });
+}
+
+function copyNodesAfter() {
+  describe('copyNodesAfter', () => {
+    it('should copy and create a node after specified node id', () => {
+      const newNodes = service.copyNodesAfter(['n1'], 'n2');
+      expect(newNodes.length).toEqual(1);
+      expectSpiesToHaveBeenCalled(createNodeAfterSpy, parseProjectSpy);
+    });
+    it('should copy and create nodes after specified node id', () => {
+      const newNodes = service.copyNodesAfter(['n1', 'n2'], 'n1');
+      expect(newNodes.length).toEqual(2);
+      expectSpiesToHaveBeenCalled(createNodeAfterSpy, parseProjectSpy);
+    });
+  });
+}
+
+function expectSpiesToHaveBeenCalled(...spies) {
+  spies.forEach((spy) => {
+    expect(spy).toHaveBeenCalled();
+  });
+}

--- a/src/app/services/teacherProjectService.spec.ts
+++ b/src/app/services/teacherProjectService.spec.ts
@@ -8,7 +8,6 @@ import demoProjectJSON_import from './sampleData/curriculum/Demo.project.json';
 import scootersProjectJSON_import from './sampleData/curriculum/SelfPropelledVehiclesChallenge.project.json';
 import teacherProjctJSON_import from './sampleData/curriculum/TeacherProjectServiceSpec.project.json';
 import { SessionService } from '../../assets/wise5/services/sessionService';
-import { CopyNodesService } from '../../assets/wise5/services/copyNodesService';
 let service: TeacherProjectService;
 let configService: ConfigService;
 let utilService: UtilService;
@@ -30,13 +29,7 @@ describe('TeacherProjectService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, UpgradeModule],
-      providers: [
-        TeacherProjectService,
-        ConfigService,
-        CopyNodesService,
-        SessionService,
-        UtilService
-      ]
+      providers: [TeacherProjectService, ConfigService, SessionService, UtilService]
     });
     http = TestBed.inject(HttpTestingController);
     service = TestBed.inject(TeacherProjectService);

--- a/src/assets/wise5/authoringTool/project/projectAuthoringComponent.ts
+++ b/src/assets/wise5/authoringTool/project/projectAuthoringComponent.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import { ConfigService } from '../../services/configService';
+import { CopyNodesService } from '../../services/copyNodesService';
 import { DeleteNodeService } from '../../services/deleteNodeService';
 import { MoveNodesService } from '../../services/moveNodesService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
@@ -63,6 +64,7 @@ class ProjectAuthoringController {
     '$transitions',
     '$window',
     'ConfigService',
+    'CopyNodesService',
     'DeleteNodeService',
     'MoveNodesService',
     'ProjectService',
@@ -79,6 +81,7 @@ class ProjectAuthoringController {
     private $transitions,
     private $window,
     private ConfigService: ConfigService,
+    private CopyNodesService: CopyNodesService,
     private DeleteNodeService: DeleteNodeService,
     private MoveNodesService: MoveNodesService,
     private ProjectService: TeacherProjectService,
@@ -361,26 +364,27 @@ class ProjectAuthoringController {
    * @param moveTo whether to insert 'inside' or 'after' the nodeId parameter
    */
   handleCopyModeInsert(nodeId, moveTo) {
-    let copiedNodes = [];
     let selectedNodeIds = this.getSelectedNodeIds();
-    for (let selectedNodeId of selectedNodeIds) {
-      let node = {
-        fromNodeId: selectedNodeId,
-        fromTitle: this.ProjectService.getNodePositionAndTitleByNodeId(selectedNodeId)
-      };
-      copiedNodes.push(node);
-    }
-
     let newNodes = [];
     if (moveTo === 'inside') {
-      newNodes = this.ProjectService.copyNodesInside(selectedNodeIds, nodeId);
+      const firstNode: any = this.CopyNodesService.copyNodeInside(selectedNodeIds[0], nodeId);
+      const otherNodes = this.CopyNodesService.copyNodesAfter(
+        selectedNodeIds.slice(1),
+        firstNode.id
+      );
+      newNodes = [firstNode].concat(otherNodes);
     } else if (moveTo === 'after') {
-      newNodes = this.ProjectService.copyNodesAfter(selectedNodeIds, nodeId);
+      newNodes = this.CopyNodesService.copyNodesAfter(selectedNodeIds, nodeId);
     } else {
       // an unspecified moveTo was provided
       return;
     }
-
+    const copiedNodes: any[] = selectedNodeIds.map((selectedNodeId) => {
+      return {
+        fromNodeId: selectedNodeId,
+        fromTitle: this.ProjectService.getNodePositionAndTitleByNodeId(selectedNodeId)
+      };
+    });
     this.copyMode = false;
     this.insertGroupMode = false;
     this.insertNodeMode = false;

--- a/src/assets/wise5/services/copyNodesService.ts
+++ b/src/assets/wise5/services/copyNodesService.ts
@@ -2,10 +2,67 @@ import * as angular from 'angular';
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { ConfigService } from './configService';
+import { TeacherProjectService } from './teacherProjectService';
+import { UtilService } from './utilService';
 
 @Injectable()
 export class CopyNodesService {
-  constructor(protected http: HttpClient, protected ConfigService: ConfigService) {}
+  constructor(
+    protected http: HttpClient,
+    protected ConfigService: ConfigService,
+    protected ProjectService: TeacherProjectService,
+    protected UtilService: UtilService
+  ) {}
+
+  /**
+   * Copy node and put it inside a specified group as first step
+   * @param nodeId the node id to copy
+   * @param groupId the group to insert the copied node as first step
+   */
+  copyNodeInside(nodeId: string, groupId: string): any {
+    const newNode = this.copyNode(nodeId);
+    this.ProjectService.createNodeInside(newNode, groupId);
+    this.ProjectService.parseProject();
+    return newNode;
+  }
+
+  /**
+   * Copy nodes and put them after a certain node id
+   * @param nodeIds the node ids to copy
+   * @param nodeIdAfter the node id we will put the copied nodes after
+   */
+  copyNodesAfter(nodeIds: string[], nodeIdAfter: string): any[] {
+    const newNodes = [];
+    for (const nodeId of nodeIds) {
+      const newNode = this.copyNode(nodeId);
+      this.ProjectService.createNodeAfter(newNode, nodeIdAfter);
+      nodeIdAfter = newNode.id;
+      this.ProjectService.parseProject();
+      newNodes.push(newNode);
+    }
+    return newNodes;
+  }
+
+  /**
+   * Copy the node with the specified nodeId
+   * @param nodeId the node id to copy
+   * @return copied node
+   */
+  private copyNode(nodeId: string): any {
+    const node = this.ProjectService.getNodeById(nodeId);
+    const nodeCopy = this.UtilService.makeCopyOfJSONObject(node);
+    nodeCopy.id = this.ProjectService.getNextAvailableNodeId();
+    nodeCopy.transitionLogic = {};
+    nodeCopy.constraints = [];
+
+    const newComponentIds = [];
+    for (const component of nodeCopy.components) {
+      const newComponentId = this.ProjectService.getUnusedComponentId(newComponentIds);
+      newComponentIds.push(newComponentId);
+      component.id = newComponentId;
+    }
+    return nodeCopy;
+  }
 
   /**
    * Get a copy of nodes from the fromProject. This will copy the asset files

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -9,7 +9,6 @@ import { UpgradeModule } from '@angular/upgrade/static';
 import { HttpClient } from '@angular/common/http';
 import { Observable, Subject } from 'rxjs';
 import { SessionService } from './sessionService';
-import { CopyNodesService } from './copyNodesService';
 
 @Injectable()
 export class TeacherProjectService extends ProjectService {
@@ -36,7 +35,6 @@ export class TeacherProjectService extends ProjectService {
     protected upgrade: UpgradeModule,
     protected http: HttpClient,
     protected ConfigService: ConfigService,
-    protected CopyNodesService: CopyNodesService,
     protected SessionService: SessionService,
     protected UtilService: UtilService
   ) {
@@ -281,28 +279,6 @@ export class TeacherProjectService extends ProjectService {
     };
   }
 
-  /**
-   * Copy nodes and put them after a certain node id
-   * @param nodeIds the node ids to copy
-   * @param nodeId the node id we will put the copied nodes after
-   */
-  copyNodesInside(nodeIds, nodeId) {
-    const newNodes = [];
-    for (let n = 0; n < nodeIds.length; n++) {
-      const newNode = this.copyNode(nodeIds[n]);
-      const newNodeId = newNode.id;
-      if (n == 0) {
-        this.createNodeInside(newNode, nodeId);
-      } else {
-        this.createNodeAfter(newNode, nodeId);
-      }
-      nodeId = newNodeId;
-      this.parseProject();
-      newNodes.push(newNode);
-    }
-    return newNodes;
-  }
-
   getNodesWithNewIds(nodes: any[]): any[] {
     const oldToNewIds = this.getOldToNewIds(nodes);
     return nodes.map((node: any) => {
@@ -378,24 +354,6 @@ export class TeacherProjectService extends ProjectService {
       this.insertNodeAfterInGroups(newNode.id, nodeId);
       this.insertNodeAfterInTransitions(newNode, nodeId);
     }
-  }
-
-  /**
-   * Copy nodes and put them after a certain node id
-   * @param nodeIds the node ids to copy
-   * @param nodeId the node id we will put the copied nodes after
-   */
-  copyNodesAfter(nodeIds, nodeId) {
-    const newNodes = [];
-    for (const nodeIdToCopy of nodeIds) {
-      const newNode = this.copyNode(nodeIdToCopy);
-      const newNodeId = newNode.id;
-      this.createNodeAfter(newNode, nodeId);
-      nodeId = newNodeId; // remember the node id so we can put the next node (if any) after this one
-      this.parseProject();
-      newNodes.push(newNode);
-    }
-    return newNodes;
   }
 
   isInactive(nodeId) {
@@ -1502,27 +1460,6 @@ export class TeacherProjectService extends ProjectService {
     return this.project.inactiveNodes.map((node) => {
       return node.id;
     });
-  }
-
-  /**
-   * Copy the node with the specified nodeId
-   * @param nodeId the node id to copy
-   * @return copied node
-   */
-  copyNode(nodeId) {
-    const node = this.getNodeById(nodeId);
-    const nodeCopy = this.UtilService.makeCopyOfJSONObject(node);
-    nodeCopy.id = this.getNextAvailableNodeId();
-    nodeCopy.transitionLogic = {}; // clear transition logic
-    nodeCopy.constraints = []; // clear constraints
-
-    const newComponentIds = [];
-    for (let component of nodeCopy.components) {
-      const newComponentId = this.getUnusedComponentId(newComponentIds);
-      newComponentIds.push(newComponentId);
-      component.id = newComponentId;
-    }
-    return nodeCopy;
   }
 
   /**

--- a/src/assets/wise5/teacher/teacher-angular-js-module.ts
+++ b/src/assets/wise5/teacher/teacher-angular-js-module.ts
@@ -3,6 +3,7 @@ import * as angular from 'angular';
 import { downgradeComponent, downgradeInjectable } from '@angular/upgrade/static';
 import '../common-angular-js-module';
 import { CopyComponentService } from '../services/copyComponentService';
+import { CopyNodesService } from '../services/copyNodesService';
 import { CopyProjectService } from '../services/copyProjectService';
 import { DeleteNodeService } from '../services/deleteNodeService';
 import { ImportComponentService } from '../services/importComponentService';
@@ -22,6 +23,7 @@ import '../authoringTool/authoring-tool.module';
 angular
   .module('teacher', ['common', 'angular-inview', 'authoringTool', 'classroomMonitor', 'ngAnimate'])
   .factory('CopyComponentService', downgradeInjectable(CopyComponentService))
+  .factory('CopyNodesService', downgradeInjectable(CopyNodesService))
   .factory('CopyProjectService', downgradeInjectable(CopyProjectService))
   .factory('DeleteNodeService', downgradeInjectable(DeleteNodeService))
   .factory('ImportComponentService', downgradeInjectable(ImportComponentService))


### PR DESCRIPTION
## Changes
- Moved copyNodesInside/After and copyNode functions
- Refactored code to remove duplicates in copyNodesInside/After
- Added unit tests to copyNodesService

## Test
- In project authoring view, copy node(s)
  - at the beginning of a lesson
  - after a node

Closes #257