### PR TITLE
ManageStudentsRewrite: implemented change period dialog

### DIFF
--- a/src/app/teacher/classroom-monitor.module.ts
+++ b/src/app/teacher/classroom-monitor.module.ts
@@ -28,10 +28,12 @@ import { WorkgroupSelectDropdownComponent } from '../classroom-monitor/workgroup
 import { AngularJSModule } from '../common-hybrid-angular.module';
 import { ComponentGradingModule } from './component-grading.module';
 import { MilestoneReportDataComponent } from './milestone/milestone-report-data/milestone-report-data.component';
+import { ChangeTeamPeriodDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component';
 
 @NgModule({
   declarations: [
     AlertStatusCornerComponent,
+    ChangeTeamPeriodDialogComponent,
     ComponentNewWorkBadgeComponent,
     ComponentSelectComponent,
     ComponentStateInfoComponent,

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html
@@ -1,0 +1,23 @@
+<h1 mat-dialog-title i18n>Change Period</h1>
+<div mat-dialog-content class="info-block">
+  <div i18n>Select a new period for team {{team.workgroupId}} - {{team.username.replace(":", ", ")}}</div>
+  <br/>
+  <form [formGroup]="selectPeriodForm">
+    <mat-form-field appearance="fill" class="change-team-period-form-field">
+      <mat-label i18n>Choose Period</mat-label>
+      <mat-select formControlName="period" [(value)]="selectedPeriod">
+        <mat-option *ngFor="let period of periods" [value]="period">{{period.periodName}}</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </form>
+</div>
+<div mat-dialog-actions fxLayoutAlign="end" fxLayoutGap="8px">
+  <button mat-button mat-dialog-close [disabled]="isChangingPeriod" i18n>Cancel</button>
+  <button mat-flat-button
+          color="primary"
+          (click)="changePeriod()"
+          [disabled]="selectPeriodForm.invalid || isChangingPeriod">
+    <mat-progress-bar *ngIf="isChangingPeriod" mode="indeterminate"></mat-progress-bar>
+    <ng-container i18n>Confirm</ng-container>
+  </button>
+</div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html
@@ -5,6 +5,13 @@
     <span *ngIf="canViewStudentNames" class="studentNames">
        - {{team.username.replace(":", ", ")}}
     </span>
+    <span *ngIf="!canViewStudentNames" class="studentNames">
+      <span *ngFor="let user of team.users; last as isLast; first as isFirst">
+        <span *ngIf="isFirst"> - </span>
+        <span i18n>Student {{user.id}}</span>
+        <span *ngIf="!isLast">, </span>
+      </span>
+    </span>
   </div>
   <br/>
   <form [formGroup]="selectPeriodForm">

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html
@@ -1,6 +1,11 @@
 <h1 mat-dialog-title i18n>Change Period</h1>
 <div mat-dialog-content class="info-block">
-  <div i18n>Select a new period for team {{team.workgroupId}} - {{team.username.replace(":", ", ")}}</div>
+  <div>
+    <span i18n>Select a new period for team {{team.workgroupId}}</span>
+    <span *ngIf="canViewStudentNames" class="studentNames">
+       - {{team.username.replace(":", ", ")}}
+    </span>
+  </div>
   <br/>
   <form [formGroup]="selectPeriodForm">
     <mat-form-field appearance="fill" class="change-team-period-form-field">

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.scss
@@ -1,0 +1,5 @@
+.change-team-period-form-field {
+  .mat-form-field-underline {
+    display: none;
+  }
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.spec.ts
@@ -1,0 +1,72 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ConfigService } from '../../../../services/configService';
+
+import { ChangeTeamPeriodDialogComponent } from './change-team-period-dialog.component';
+
+class ConfigServiceStub {
+  getPeriods() {
+    return [{ periodId: -1 }, { periodId: 1 }, { periodId: 2 }];
+  }
+  getRunId() {
+    return 123;
+  }
+}
+
+const team = {
+  periodId: 1,
+  username: 'Oski Bear (oskib0101)',
+  workgroupId: 10
+};
+
+let component: ChangeTeamPeriodDialogComponent;
+let http: HttpTestingController;
+describe('ChangeTeamPeriodDialogComponent', () => {
+  let fixture: ComponentFixture<ChangeTeamPeriodDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ChangeTeamPeriodDialogComponent],
+      imports: [HttpClientTestingModule, MatDialogModule],
+      providers: [
+        { provide: ConfigService, useClass: ConfigServiceStub },
+        { provide: MAT_DIALOG_DATA, useValue: team }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  });
+  beforeEach(() => {
+    http = TestBed.inject(HttpTestingController);
+    fixture = TestBed.createComponent(ChangeTeamPeriodDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+  ngOnInit_filterPeriods();
+  changePeriod_makeRequestToChangePeriod();
+});
+
+function ngOnInit_filterPeriods() {
+  describe('ngOnInit()', () => {
+    it('should create and filter periods', () => {
+      expect(component).toBeTruthy();
+      expect(component.periods.length).toEqual(1);
+      expect(component.periods[0].periodId).toEqual(2);
+    });
+  });
+}
+
+function changePeriod_makeRequestToChangePeriod() {
+  describe('changePeriod()', () => {
+    it('should make request to change the period and then to retrieve config', () => {
+      component.selectedPeriod = { periodId: 2 };
+      component.changePeriod();
+      const req = http.expectOne(`/api/teacher/run/123/team/10/change-period`);
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body).toEqual(2);
+      req.flush({});
+      http.verify();
+    });
+  });
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { By } from '@angular/platform-browser';
 import { ConfigService } from '../../../../services/configService';
 
 import { ChangeTeamPeriodDialogComponent } from './change-team-period-dialog.component';
@@ -9,6 +10,9 @@ import { ChangeTeamPeriodDialogComponent } from './change-team-period-dialog.com
 class ConfigServiceStub {
   getPeriods() {
     return [{ periodId: -1 }, { periodId: 1 }, { periodId: 2 }];
+  }
+  getPermissions() {
+    return { canViewStudentNames: true };
   }
   getRunId() {
     return 123;
@@ -22,10 +26,9 @@ const team = {
 };
 
 let component: ChangeTeamPeriodDialogComponent;
+let fixture: ComponentFixture<ChangeTeamPeriodDialogComponent>;
 let http: HttpTestingController;
 describe('ChangeTeamPeriodDialogComponent', () => {
-  let fixture: ComponentFixture<ChangeTeamPeriodDialogComponent>;
-
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ChangeTeamPeriodDialogComponent],
@@ -45,6 +48,7 @@ describe('ChangeTeamPeriodDialogComponent', () => {
   });
   ngOnInit_filterPeriods();
   changePeriod_makeRequestToChangePeriod();
+  showStudentNames();
 });
 
 function ngOnInit_filterPeriods() {
@@ -69,4 +73,23 @@ function changePeriod_makeRequestToChangePeriod() {
       http.verify();
     });
   });
+}
+
+function showStudentNames() {
+  describe('student names', () => {
+    it('should be displayed if user has canViewStudentNames permission', () => {
+      component.canViewStudentNames = true;
+      fixture.detectChanges();
+      expect(getStudentNamesElement()).toBeTruthy();
+    });
+    it('should not be displayed if user does not have canViewStudentNames permission', () => {
+      component.canViewStudentNames = false;
+      fixture.detectChanges();
+      expect(getStudentNamesElement()).toBeFalsy();
+    });
+  });
+}
+
+function getStudentNamesElement() {
+  return fixture.debugElement.query(By.css('.studentNames'));
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.spec.ts
@@ -22,6 +22,7 @@ class ConfigServiceStub {
 const team = {
   periodId: 1,
   username: 'Oski Bear (oskib0101)',
+  users: [{ id: 500 }],
   workgroupId: 10
 };
 
@@ -77,19 +78,19 @@ function changePeriod_makeRequestToChangePeriod() {
 
 function showStudentNames() {
   describe('student names', () => {
-    it('should be displayed if user has canViewStudentNames permission', () => {
+    it('should display usernames if user has canViewStudentNames permission', () => {
       component.canViewStudentNames = true;
       fixture.detectChanges();
-      expect(getStudentNamesElement()).toBeTruthy();
+      expect(getStudentNames()).toContain('Oski Bear (oskib0101)');
     });
-    it('should not be displayed if user does not have canViewStudentNames permission', () => {
+    it('should display Student Id if user does not have canViewStudentNames permission', () => {
       component.canViewStudentNames = false;
       fixture.detectChanges();
-      expect(getStudentNamesElement()).toBeFalsy();
+      expect(getStudentNames()).toContain('Student 500');
     });
   });
 }
 
-function getStudentNamesElement() {
-  return fixture.debugElement.query(By.css('.studentNames'));
+function getStudentNames() {
+  return fixture.debugElement.query(By.css('.studentNames')).nativeElement.textContent;
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.ts
@@ -11,6 +11,7 @@ import { ConfigService } from '../../../../services/configService';
   encapsulation: ViewEncapsulation.None
 })
 export class ChangeTeamPeriodDialogComponent {
+  canViewStudentNames: boolean;
   selectPeriodForm: FormGroup = new FormGroup({
     period: new FormControl('', Validators.required)
   });
@@ -26,6 +27,7 @@ export class ChangeTeamPeriodDialogComponent {
   ) {}
 
   ngOnInit(): void {
+    this.canViewStudentNames = this.ConfigService.getPermissions().canViewStudentNames;
     this.periods = this.ConfigService.getPeriods().filter((period) => {
       return period.periodId != -1 && period.periodId != this.team.periodId;
     });

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.ts
@@ -1,0 +1,51 @@
+import { HttpClient } from '@angular/common/http';
+import { Component, Inject, ViewEncapsulation } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ConfigService } from '../../../../services/configService';
+
+@Component({
+  selector: 'change-team-period-dialog',
+  templateUrl: './change-team-period-dialog.component.html',
+  styleUrls: ['./change-team-period-dialog.component.scss'],
+  encapsulation: ViewEncapsulation.None
+})
+export class ChangeTeamPeriodDialogComponent {
+  selectPeriodForm: FormGroup = new FormGroup({
+    period: new FormControl('', Validators.required)
+  });
+  isChangingPeriod: boolean;
+  periods: any[];
+  selectedPeriod: any;
+
+  constructor(
+    protected dialog: MatDialog,
+    @Inject(MAT_DIALOG_DATA) public team: any,
+    protected http: HttpClient,
+    protected ConfigService: ConfigService
+  ) {}
+
+  ngOnInit(): void {
+    this.periods = this.ConfigService.getPeriods().filter((period) => {
+      return period.periodId != -1 && period.periodId != this.team.periodId;
+    });
+  }
+
+  changePeriod() {
+    this.isChangingPeriod = true;
+    this.http
+      .post(
+        `/api/teacher/run/${this.ConfigService.getRunId()}/team/${
+          this.team.workgroupId
+        }/change-period`,
+        this.selectedPeriod.periodId
+      )
+      .subscribe(() => {
+        this.isChangingPeriod = false;
+        this.ConfigService.retrieveConfig(
+          `/api/config/classroomMonitor/${this.ConfigService.getRunId()}`
+        );
+        this.dialog.closeAll();
+      });
+  }
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.html
@@ -1,7 +1,7 @@
 <div class="content-head accent-1">
-  <h2 class="content-head__item" i18n>
-    Period {{period.periodName}}
-    <span class="md-subhead">Students: {{students.size}} | Teams: {{teams.size}}</span>
+  <h2 class="content-head__item">
+    <span i18n>Period {{period.periodName}}</span>
+    <span class="md-subhead" i18n>Students: {{students.size}} | Teams: {{teams.size}}</span>
   </h2>
 </div>
 <ul class="teams" fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="8px">

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { ConfigService } from '../../../../services/configService';
 
 @Component({
@@ -10,11 +11,28 @@ export class ManagePeriodComponent {
   @Input() period: any;
 
   students: Set<any> = new Set();
+  subscriptions: Subscription = new Subscription();
   teams: Set<any> = new Set();
 
   constructor(private ConfigService: ConfigService) {}
 
   ngOnChanges() {
+    this.initialize();
+  }
+
+  ngOnInit() {
+    this.subscriptions.add(
+      this.ConfigService.configRetrieved$.subscribe(() => {
+        this.initialize();
+      })
+    );
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
+  }
+
+  initialize() {
     this.initializeTeams();
     this.initializeStudents();
   }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html
@@ -1,7 +1,7 @@
 <span fxLayout="row">
   <span class="name" i18n>Team {{team.workgroupId}}</span>
   <span fxFlex></span>
-  <a class="changePeriodLink" (click)="changePeriod()" i18n>Change Period</a>
+  <a *ngIf="canChangePeriod" class="changePeriodLink" (click)="changePeriod()" i18n>Change Period</a>
 </span>
 <ul class="users" fxLayout="column" fxLayoutGap="8px">
   <li class="user" *ngFor="let user of team.users" i18n>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html
@@ -1,4 +1,8 @@
-<span class="name" i18n>Team {{team.workgroupId}}</span>
+<span fxLayout="row">
+  <span class="name" i18n>Team {{team.workgroupId}}</span>
+  <span fxFlex></span>
+  <a class="changePeriodLink" (click)="changePeriod()" i18n>Change Period</a>
+</span>
 <ul class="users" fxLayout="column" fxLayoutGap="8px">
   <li class="user" *ngFor="let user of team.users" i18n>
     <manage-user [user]="user"></manage-user>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.spec.ts
@@ -1,0 +1,60 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { By } from '@angular/platform-browser';
+import { configureTestSuite } from 'ng-bullet';
+import { ConfigService } from '../../../../services/configService';
+import { ManageTeamComponent } from './manage-team.component';
+
+class ConfigServiceStub {
+  getPermissions() {}
+}
+
+let configService: ConfigService;
+let fixture: ComponentFixture<ManageTeamComponent>;
+let component: ManageTeamComponent;
+
+describe('ManageTeamComponent', () => {
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [ManageTeamComponent],
+      providers: [
+        { provide: ConfigService, useClass: ConfigServiceStub },
+        { provide: MatDialog, useValue: {} }
+      ]
+    });
+    configService = TestBed.inject(ConfigService);
+  });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ManageTeamComponent);
+    component = fixture.componentInstance;
+    component.team = { workgroupId: 3 };
+  });
+  changePeriodLinkVisible();
+});
+
+function changePeriodLinkVisible() {
+  describe('change period link', () => {
+    it('should appear when user has GradeStudentWork permission', () => {
+      spyOnCanGradeStudentWork(true);
+      fixture.detectChanges();
+      expect(getChangePeriodLink()).toBeTruthy();
+    });
+    it('should not appear when user does not have GradeStudentWork permission', () => {
+      spyOnCanGradeStudentWork(false);
+      fixture.detectChanges();
+      expect(getChangePeriodLink()).toBeFalsy();
+    });
+  });
+}
+
+function spyOnCanGradeStudentWork(canGrade: boolean) {
+  spyOn(configService, 'getPermissions').and.returnValue({
+    canGradeStudentWork: canGrade,
+    canViewStudentNames: true,
+    canAuthorProject: true
+  });
+}
+
+function getChangePeriodLink() {
+  return fixture.debugElement.query(By.css('.changePeriodLink'));
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
@@ -1,4 +1,6 @@
 import { Component, Input } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { ChangeTeamPeriodDialogComponent } from '../change-team-period-dialog/change-team-period-dialog.component';
 
 @Component({
   selector: 'manage-team',
@@ -7,4 +9,13 @@ import { Component, Input } from '@angular/core';
 })
 export class ManageTeamComponent {
   @Input() team: any;
+
+  constructor(private dialog: MatDialog) {}
+
+  changePeriod() {
+    this.dialog.open(ChangeTeamPeriodDialogComponent, {
+      data: this.team,
+      panelClass: 'mat-dialog--md'
+    });
+  }
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { ConfigService } from '../../../../services/configService';
 import { ChangeTeamPeriodDialogComponent } from '../change-team-period-dialog/change-team-period-dialog.component';
 
 @Component({
@@ -10,7 +11,13 @@ import { ChangeTeamPeriodDialogComponent } from '../change-team-period-dialog/ch
 export class ManageTeamComponent {
   @Input() team: any;
 
-  constructor(private dialog: MatDialog) {}
+  canChangePeriod: boolean;
+
+  constructor(private dialog: MatDialog, private ConfigService: ConfigService) {}
+
+  ngOnInit() {
+    this.canChangePeriod = this.ConfigService.getPermissions().canGradeStudentWork;
+  }
 
   changePeriod() {
     this.dialog.open(ChangeTeamPeriodDialogComponent, {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html
@@ -1,1 +1,2 @@
-<span i18n>User: {{user.name}} ({{user.username}})</span>
+<span class="username" *ngIf="canViewStudentNames">{{user.name}} ({{user.username}})</span>
+<span class="username" *ngIf="!canViewStudentNames" i18n>Student {{user.id}}</span>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.spec.ts
@@ -1,0 +1,56 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { configureTestSuite } from 'ng-bullet';
+import { ConfigService } from '../../../../services/configService';
+import { ManageUserComponent } from './manage-user.component';
+
+class ConfigServiceStub {
+  getPermissions() {}
+}
+
+let configService: ConfigService;
+let fixture: ComponentFixture<ManageUserComponent>;
+let component: ManageUserComponent;
+
+describe('ManageUserComponent', () => {
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [ManageUserComponent],
+      providers: [{ provide: ConfigService, useClass: ConfigServiceStub }]
+    });
+    configService = TestBed.inject(ConfigService);
+  });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ManageUserComponent);
+    component = fixture.componentInstance;
+    component.user = { id: 1, name: 'oski bear', username: 'oskib0101' };
+  });
+  userNameDisplay();
+});
+
+function userNameDisplay() {
+  describe('user name', () => {
+    it('should show username when user has ViewStudentNames permission', () => {
+      spyOnCanViewStudentNames(true);
+      fixture.detectChanges();
+      expect(getUsername()).toEqual('oski bear (oskib0101)');
+    });
+    it('should show user id when user does not have ViewStudentNames permission', () => {
+      spyOnCanViewStudentNames(false);
+      fixture.detectChanges();
+      expect(getUsername()).toEqual('Student 1');
+    });
+  });
+}
+
+function spyOnCanViewStudentNames(canView: boolean) {
+  spyOn(configService, 'getPermissions').and.returnValue({
+    canGradeStudentWork: true,
+    canViewStudentNames: canView,
+    canAuthorProject: true
+  });
+}
+
+function getUsername(): string {
+  return fixture.debugElement.query(By.css('.username')).nativeElement.textContent;
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core';
+import { ConfigService } from '../../../../services/configService';
 
 @Component({
   selector: 'manage-user',
@@ -6,4 +7,12 @@ import { Component, Input } from '@angular/core';
 })
 export class ManageUserComponent {
   @Input() user: any;
+
+  canViewStudentNames: boolean;
+
+  constructor(private ConfigService: ConfigService) {}
+
+  ngOnInit() {
+    this.canViewStudentNames = this.ConfigService.getPermissions().canViewStudentNames;
+  }
 }

--- a/src/assets/wise5/services/configService.ts
+++ b/src/assets/wise5/services/configService.ts
@@ -3,10 +3,13 @@
 import { Injectable } from '@angular/core';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { HttpClient } from '@angular/common/http';
+import { Observable, Subject } from 'rxjs';
 
 @Injectable()
 export class ConfigService {
   public config: any = null;
+  private configRetrievedSource: Subject<any> = new Subject<any>();
+  public configRetrieved$: Observable<any> = this.configRetrievedSource.asObservable();
 
   constructor(private upgrade: UpgradeModule, private http: HttpClient) {}
 
@@ -64,7 +67,7 @@ export class ConfigService {
             myUserInfo.workgroupId = Math.floor(100 * Math.random()) + 1;
           }
         }
-
+        this.configRetrievedSource.next(configJSON);
         return configJSON;
       });
   }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -8110,11 +8110,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">8</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="eb9bd705cf6d767d3b534606e6cab396c2456b47" datatype="html">
-        <source>User: <x id="INTERPOLATION" equiv-text="{{user.name}}"/> (<x id="INTERPOLATION_1" equiv-text="{{user.username}}"/>)</source>
+      <trans-unit id="cc098b5c45cb0a9a41f75986d8ba37564302cf50" datatype="html">
+        <source>Student <x id="INTERPOLATION" equiv-text="{{user.id}}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html</context>
-          <context context-type="linenumber">1</context>
+          <context context-type="linenumber">2</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f9c52903219e583ddefb23cd102d2057504ac980" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -405,7 +405,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">27</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.html</context>
@@ -6565,7 +6565,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f6755cff4957d5c3c89bafce5651f1b6fa2b1fd9" datatype="html">
@@ -8068,11 +8068,22 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="cc098b5c45cb0a9a41f75986d8ba37564302cf50" datatype="html">
+        <source>Student <x id="INTERPOLATION" equiv-text="{{user.id}}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="68e710782ccb5398b3acb8844caf0b199da2c3da" datatype="html">
         <source>Confirm</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3ee7b8fcc267b39c4ec8d3dd9cb8075134ae032c" datatype="html">
@@ -8108,13 +8119,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html</context>
           <context context-type="linenumber">8</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="cc098b5c45cb0a9a41f75986d8ba37564302cf50" datatype="html">
-        <source>Student <x id="INTERPOLATION" equiv-text="{{user.id}}"/></source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html</context>
-          <context context-type="linenumber">2</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f9c52903219e583ddefb23cd102d2057504ac980" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -405,7 +405,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="linenumber">20</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.html</context>
@@ -6565,7 +6565,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html</context>
-          <context context-type="linenumber">7</context>
+          <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f6755cff4957d5c3c89bafce5651f1b6fa2b1fd9" datatype="html">
@@ -8061,18 +8061,18 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="b35fc680cd21a9d7521afb7757c0ca81d0931726" datatype="html">
-        <source>Select a new period for team <x id="INTERPOLATION" equiv-text="{{team.workgroupId}}"/> - <x id="INTERPOLATION_1" equiv-text="{{team.username.replace(&quot;:&quot;, &quot;, &quot;)}}"/></source>
+      <trans-unit id="4693296a32d61d8ff2306dc5915b3626ed7206c9" datatype="html">
+        <source>Select a new period for team <x id="INTERPOLATION" equiv-text="{{team.workgroupId}}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html</context>
-          <context context-type="linenumber">3</context>
+          <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
       <trans-unit id="68e710782ccb5398b3acb8844caf0b199da2c3da" datatype="html">
         <source>Confirm</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html</context>
-          <context context-type="linenumber">21</context>
+          <context context-type="linenumber">26</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3ee7b8fcc267b39c4ec8d3dd9cb8075134ae032c" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -404,6 +404,10 @@
           <context context-type="linenumber">19</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.html</context>
           <context context-type="linenumber">83</context>
         </context-group>
@@ -6559,6 +6563,10 @@
           <context context-type="sourcefile">src/app/student/add-project-dialog/add-project-dialog.component.html</context>
           <context context-type="linenumber">15</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="f6755cff4957d5c3c89bafce5651f1b6fa2b1fd9" datatype="html">
         <source>Add</source>
@@ -8042,11 +8050,43 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">9</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="ce93f96b96d28611b56bf06f5e248bd195cafd42" datatype="html">
-        <source> Period <x id="INTERPOLATION" equiv-text="{{period.periodName}}"/> <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;md-subhead&quot;&gt;"/>Students: <x id="INTERPOLATION_1" equiv-text="{{students.size}}"/> | Teams: <x id="INTERPOLATION_2" equiv-text="{{teams.size}}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></source>
+      <trans-unit id="4333d62731dc124644ca59e02aabfaa86e730714" datatype="html">
+        <source>Change Period</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="b35fc680cd21a9d7521afb7757c0ca81d0931726" datatype="html">
+        <source>Select a new period for team <x id="INTERPOLATION" equiv-text="{{team.workgroupId}}"/> - <x id="INTERPOLATION_1" equiv-text="{{team.username.replace(&quot;:&quot;, &quot;, &quot;)}}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="68e710782ccb5398b3acb8844caf0b199da2c3da" datatype="html">
+        <source>Confirm</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3ee7b8fcc267b39c4ec8d3dd9cb8075134ae032c" datatype="html">
+        <source>Period <x id="INTERPOLATION" equiv-text="{{period.periodName}}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.html</context>
-          <context context-type="linenumber">2,4</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6a2db88ef87383c0408204b7e000a4b550bde2eb" datatype="html">
+        <source>Students: <x id="INTERPOLATION" equiv-text="{{students.size}}"/> | Teams: <x id="INTERPOLATION_1" equiv-text="{{teams.size}}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.html</context>
+          <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
       <trans-unit id="aaea40b48d6391b2d7d409e743652d5015b3fbc6" datatype="html">
@@ -8060,14 +8100,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Team <x id="INTERPOLATION" equiv-text="{{team.workgroupId}}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html</context>
-          <context context-type="linenumber">1</context>
+          <context context-type="linenumber">2</context>
         </context-group>
       </trans-unit>
       <trans-unit id="20331dea6d1730722706722bf72ab5f033021c1c" datatype="html">
         <source><x id="START_TAG_MANAGE_USER" ctype="x-manage_user" equiv-text="&lt;manage-user [user]=&quot;user&quot;&gt;"/><x id="CLOSE_TAG_MANAGE_USER" ctype="x-manage_user" equiv-text="&lt;/manage-user&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html</context>
-          <context context-type="linenumber">4</context>
+          <context context-type="linenumber">8</context>
         </context-group>
       </trans-unit>
       <trans-unit id="eb9bd705cf6d767d3b534606e6cab396c2456b47" datatype="html">


### PR DESCRIPTION
## Changes
- Implemented change period dialog from the new ManageStudents page
- Added observable to ConfigService for alerting when config has been retrieved
- Broke up i18n in ManagePeriod template heading

## Test
- First test API changes: https://github.com/WISE-Community/WISE-API/pull/19. This code will make a request to the new api endpoint
- Clicking on "change period" link in the ManageWorkgroup component should open a Change Period dialog
- Period select dropdown should show only the periods that the workgroup can move to. It should hide All Periods and current period options.
- Changing the period should close the dialog and move the workgroup to the new period
- You can cancel out of changing the workgroup's period.

## Notes
- The period drop down in the upper-right corner of the CM does not update the team count properly. This is an existing bug and will be fixed separately.

Closes #246