### PR TITLE
TAP report show before after responses

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneGradingView/milestoneGradingView.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneGradingView/milestoneGradingView.html
@@ -29,7 +29,8 @@
             arrow_drop_up
           </md-icon>
         </md-button>
-        <md-button class="table--list__thead__link" flex="30"
+        <md-button ng-if="$ctrl.milestone.report.locations.length == 1"
+                   class="table--list__thead__link" flex="30"
                    layout="row" layout-align="center center" ng-click="$ctrl.setSort('status')"
                    aria-label="{{::'sortByCompletion' | translate}}">
           <span translate="status"></span>
@@ -91,7 +92,6 @@
     <milestone-workgroup-item ng-repeat="workgroup in $ctrl.workgroupsById | toArray | orderBy:$ctrl.getOrderBy()"
         ng-if="$ctrl.isWorkgroupShown(workgroup)"
         expand="$ctrl.workVisibilityById[workgroup.$key]"
-        max-score="$ctrl.maxScore"
         show-score="true"
         locations="$ctrl.milestone.report.locations"
         workgroup-id="::workgroup.workgroupId"

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneGradingView/milestoneGradingView.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneGradingView/milestoneGradingView.html
@@ -53,8 +53,9 @@
         <md-button ng-if="$ctrl.milestone.report.locations.length > 1"
           class="table--list__thead__link" flex="10" layout="row"
           layout-align="center center" ng-click="$ctrl.setSort('initialScore')"
-          aria-label="{{::'sortByInital' | translate}}">
-          <span translate="initial"></span>
+          aria-label="{{::'sortByNodeScoreTooltip' | translate: { nodePosition: $ctrl.firstNodePosition } }}">
+          <md-tooltip md-direction="top">{{::'sortByNodeScoreTooltip' | translate: { nodePosition: $ctrl.firstNodePosition } }}</md-tooltip>
+          <span>{{$ctrl.firstNodePosition}}</span>
           <md-icon ng-if="$ctrl.sort === 'initialScore' || $ctrl.sort === '-initialScore'"
                     class="text-light table--list__thead__sort" md-theme="default"
                     ng-class="{'table--list__thead__sort--reverse': $ctrl.sort === '-initialScore'}">
@@ -64,8 +65,9 @@
         <md-button ng-if="$ctrl.milestone.report.locations.length > 1"
           class="table--list__thead__link" flex="10" layout="row"
           layout-align="center center" ng-click="$ctrl.setSort('score')"
-          aria-label="{{::'sortByRevised' | translate}}">
-          <span translate="revised"></span>
+          aria-label="{{::'sortByNodeScoreTooltip' | translate: { nodePosition: $ctrl.lastNodePosition } }}">
+          <md-tooltip md-direction="top">{{::'sortByNodeScoreTooltip' | translate: { nodePosition: $ctrl.lastNodePosition } }}</md-tooltip>
+          <span>{{$ctrl.lastNodePosition}}</span>
           <md-icon ng-if="$ctrl.sort === 'score' || $ctrl.sort === '-score'"
                     class="text-light table--list__thead__sort" md-theme="default"
                     ng-class="{'table--list__thead__sort--reverse': $ctrl.sort === '-score'}">
@@ -76,6 +78,7 @@
           class="table--list__thead__link" flex="10" layout="row"
           layout-align="center center" ng-click="$ctrl.setSort('changeInScore')"
           aria-label="{{::'sortByChangeInScore' | translate}}">
+          <md-tooltip md-direction="top">{{::'sortByChangeInScore' | translate }}</md-tooltip>
           <span translate="changeInScore"></span>
           <md-icon ng-if="$ctrl.sort === 'changeInScore' || $ctrl.sort === '-changeInScore'"
                     class="text-light table--list__thead__sort" md-theme="default"

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneGradingView/milestoneGradingView.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneGradingView/milestoneGradingView.ts
@@ -67,6 +67,20 @@ class MilestoneGradingViewController extends NodeGradingViewController {
     this.getNodePositions();
   }
 
+  subscribeToEvents() {
+    super.subscribeToEvents();
+    if (this.milestone.report.locations.length > 1) {
+      this.subscriptions.add(
+        this.AnnotationService.annotationReceived$.subscribe(({ annotation }) => {
+          const workgroupId = annotation.toWorkgroupId;
+          if (annotation.nodeId === this.firstNodeId && this.workgroupsById[workgroupId]) {
+            this.updateWorkgroup(workgroupId);
+          }
+        })
+      );
+    }
+  }
+
   retrieveStudentData() {
     const firstNode = this.ProjectService.getNode(this.firstNodeId);
     super.retrieveStudentData(firstNode);

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneGradingView/milestoneGradingView.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneGradingView/milestoneGradingView.ts
@@ -12,7 +12,9 @@ import * as angular from 'angular';
 
 @Directive()
 class MilestoneGradingViewController extends NodeGradingViewController {
+  firstNodeId: string;
   firstNodePosition: string;
+  lastNodeId: string;
   lastNodePosition: string;
   milestone: any;
   nodeId: string;
@@ -52,22 +54,32 @@ class MilestoneGradingViewController extends NodeGradingViewController {
   $onInit() {
     this.nodeId = this.milestone.nodeId;
     this.node = this.ProjectService.getNode(this.nodeId);
+    if (this.milestone.report.locations.length > 1) {
+      this.firstNodeId = this.milestone.report.locations[0].nodeId;
+      this.lastNodeId = this.milestone.report.locations[
+        this.milestone.report.locations.length - 1
+      ].nodeId;
+    }
     this.componentId = this.milestone.componentId;
-    this.maxScore = this.getMaxScore();
     this.retrieveStudentData();
     this.subscribeToEvents();
     this.saveNodeGradingViewDisplayedEvent();
     this.getNodePositions();
   }
 
+  retrieveStudentData() {
+    const firstNode = this.ProjectService.getNode(this.firstNodeId);
+    super.retrieveStudentData(firstNode);
+    if (this.milestone.report.locations.length > 1) {
+      const lastNode = this.ProjectService.getNode(this.lastNodeId);
+      super.retrieveStudentData(lastNode);
+    }
+  }
+
   private getNodePositions() {
     if (this.milestone.report.locations.length > 1) {
-      this.firstNodePosition = this.ProjectService.getNodePositionById(
-        this.milestone.report.locations[0].nodeId
-      );
-      this.lastNodePosition = this.ProjectService.getNodePositionById(
-        this.milestone.report.locations[1].nodeId
-      );
+      this.firstNodePosition = this.ProjectService.getNodePositionById(this.firstNodeId);
+      this.lastNodePosition = this.ProjectService.getNodePositionById(this.lastNodeId);
     }
   }
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneGradingView/milestoneGradingView.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneGradingView/milestoneGradingView.ts
@@ -12,6 +12,8 @@ import * as angular from 'angular';
 
 @Directive()
 class MilestoneGradingViewController extends NodeGradingViewController {
+  firstNodePosition: string;
+  lastNodePosition: string;
   milestone: any;
   nodeId: string;
   componentId: string;
@@ -55,6 +57,18 @@ class MilestoneGradingViewController extends NodeGradingViewController {
     this.retrieveStudentData();
     this.subscribeToEvents();
     this.saveNodeGradingViewDisplayedEvent();
+    this.getNodePositions();
+  }
+
+  private getNodePositions() {
+    if (this.milestone.report.locations.length > 1) {
+      this.firstNodePosition = this.ProjectService.getNodePositionById(
+        this.milestone.report.locations[0].nodeId
+      );
+      this.lastNodePosition = this.ProjectService.getNodePositionById(
+        this.milestone.report.locations[1].nodeId
+      );
+    }
   }
 
   getScoreByWorkgroupId(

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneWorkgroupItem/milestoneWorkgroupItem.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneWorkgroupItem/milestoneWorkgroupItem.html
@@ -30,7 +30,7 @@
   </md-subheader>
   <md-list-item ng-if="$ctrl.expand && !$ctrl.disabled" class="grading__item-container">
       <div class="grading__item" style="width:100%">
-        <div id="component_{{::$ctrl.firstComponentId}}_{{::$ctrl.workgroupId}}" class="component component--grading">
+        <div ng-if="$ctrl.locations.length > 1" id="component_{{::$ctrl.firstComponentId}}_{{::$ctrl.workgroupId}}" class="component component--grading">
           <div>
             <h3 class="accent-1 md-body-2 gray-lightest-bg component__header">
               {{ ::"STEP_POSITION_DISPLAY" | translate: { position: $ctrl.getNodePosition($ctrl.firstNodeId) } }} ({{ $ctrl.getComponentTypeLabel($ctrl.firstComponent.type) }})&nbsp;
@@ -43,7 +43,7 @@
                 [node-id]="$ctrl.firstNodeId"></workgroup-component-grading>
           </div>
         </div>
-        <div ng-if="$ctrl.locations.length > 1" id="component_{{::$ctrl.lastComponentId}}_{{::$ctrl.workgroupId}}" class="component component--grading">
+        <div id="component_{{::$ctrl.lastComponentId}}_{{::$ctrl.workgroupId}}" class="component component--grading">
           <div>
             <h3 class="accent-1 md-body-2 gray-lightest-bg component__header">
               {{ ::"STEP_POSITION_DISPLAY" | translate: { position: $ctrl.getNodePosition($ctrl.lastNodeId) } }} ({{ $ctrl.getComponentTypeLabel($ctrl.lastComponent.type) }})&nbsp;

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneWorkgroupItem/milestoneWorkgroupItem.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneWorkgroupItem/milestoneWorkgroupItem.html
@@ -11,14 +11,14 @@
               <div flex layout="row" layout-align="start center">
                   <workgroup-info [has-alert]="$ctrl.hasAlert" [has-new-alert]="$ctrl.hasNewAlert" [has-new-work]="$ctrl.hasNewWork" [usernames]="$ctrl.workgroupData.displayNames" [workgroup-id]="$ctrl.workgroupId"></workgroup-info>
               </div>
-              <div flex="30" layout="row" layout-align="center center">
+              <div ng-if="$ctrl.locations.length == 1" flex="30" layout="row" layout-align="center center">
                   <workgroup-node-status [status-text]="$ctrl.statusText" [status-class]="$ctrl.statusClass"></workgroup-node-status>
               </div>
               <div ng-if="$ctrl.showScore && $ctrl.locations.length > 1" flex="10" layout="row" layout-align="center center">
-                <workgroup-node-score [score]="$ctrl.initialScore" [max-score]="$ctrl.maxScore"></workgroup-node-score>
+                <workgroup-node-score [score]="$ctrl.initialScore" [max-score]="$ctrl.firstComponentMaxScore"></workgroup-node-score>
               </div>
               <div ng-if="$ctrl.showScore" flex="{{$ctrl.locations.length > 1 ? 10 : 20}}" layout="row" layout-align="center center">
-                <workgroup-node-score [score]="$ctrl.score" [max-score]="$ctrl.maxScore"></workgroup-node-score>
+                <workgroup-node-score [score]="$ctrl.score" [max-score]="$ctrl.lastComponentMaxScore"></workgroup-node-score>
               </div>
               <div ng-if="$ctrl.showScore && $ctrl.locations.length > 1" flex="10" layout="row" layout-align="center center">
                 <span class="md-display-1" ng-class="{'success': $ctrl.changeInScore > 0, 'warn': $ctrl.changeInScore < 0}">
@@ -33,7 +33,7 @@
         <div id="component_{{::$ctrl.firstComponentId}}_{{::$ctrl.workgroupId}}" class="component component--grading">
           <div>
             <h3 class="accent-1 md-body-2 gray-lightest-bg component__header">
-              {{ $ctrl.getComponentTypeLabel($ctrl.firstComponent.type) }}&nbsp;
+              {{ ::"STEP_POSITION_DISPLAY" | translate: { position: $ctrl.getNodePosition($ctrl.firstNodeId) } }} ({{ $ctrl.getComponentTypeLabel($ctrl.firstComponent.type) }})&nbsp;
               <component-new-work-badge [component-id]="$ctrl.firstComponentId"
                                         [workgroup-id]="$ctrl.workgroupId"
                                         [node-id]="$ctrl.firstNodeId"></component-new-work-badge>
@@ -41,6 +41,19 @@
             <workgroup-component-grading [component-id]="$ctrl.firstComponentId"
                 [workgroup-id]="$ctrl.workgroupId"
                 [node-id]="$ctrl.firstNodeId"></workgroup-component-grading>
+          </div>
+        </div>
+        <div ng-if="$ctrl.locations.length > 1" id="component_{{::$ctrl.lastComponentId}}_{{::$ctrl.workgroupId}}" class="component component--grading">
+          <div>
+            <h3 class="accent-1 md-body-2 gray-lightest-bg component__header">
+              {{ ::"STEP_POSITION_DISPLAY" | translate: { position: $ctrl.getNodePosition($ctrl.lastNodeId) } }} ({{ $ctrl.getComponentTypeLabel($ctrl.lastComponent.type) }})&nbsp;
+              <component-new-work-badge [component-id]="$ctrl.lastComponentId"
+                                        [workgroup-id]="$ctrl.workgroupId"
+                                        [node-id]="$ctrl.lastNodeId"></component-new-work-badge>
+            </h3>
+            <workgroup-component-grading [component-id]="$ctrl.lastComponentId"
+                [workgroup-id]="$ctrl.workgroupId"
+                [node-id]="$ctrl.lastNodeId"></workgroup-component-grading>
           </div>
         </div>
       </div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneWorkgroupItem/milestoneWorkgroupItem.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneWorkgroupItem/milestoneWorkgroupItem.html
@@ -30,17 +30,17 @@
   </md-subheader>
   <md-list-item ng-if="$ctrl.expand && !$ctrl.disabled" class="grading__item-container">
       <div class="grading__item" style="width:100%">
-        <div id="component_{{::component.id}}_{{::$ctrl.workgroupId}}" class="component component--grading" ng-repeat='component in $ctrl.components'>
-          <div ng-show="$ctrl.isComponentVisible(component.id)">
+        <div id="component_{{::$ctrl.firstComponentId}}_{{::$ctrl.workgroupId}}" class="component component--grading">
+          <div>
             <h3 class="accent-1 md-body-2 gray-lightest-bg component__header">
-              {{ $index+1 + '. ' + $ctrl.getComponentTypeLabel(component.type) }}&nbsp;
-              <component-new-work-badge [component-id]="component.id"
+              {{ $ctrl.getComponentTypeLabel($ctrl.firstComponent.type) }}&nbsp;
+              <component-new-work-badge [component-id]="$ctrl.firstComponentId"
                                         [workgroup-id]="$ctrl.workgroupId"
-                                        [node-id]="$ctrl.nodeId"></component-new-work-badge>
+                                        [node-id]="$ctrl.firstNodeId"></component-new-work-badge>
             </h3>
-            <workgroup-component-grading [component-id]="$ctrl.componentId"
+            <workgroup-component-grading [component-id]="$ctrl.firstComponentId"
                 [workgroup-id]="$ctrl.workgroupId"
-                [node-id]="$ctrl.nodeId"></workgroup-component-grading>
+                [node-id]="$ctrl.firstNodeId"></workgroup-component-grading>
           </div>
         </div>
       </div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneWorkgroupItem/milestoneWorkgroupItem.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneWorkgroupItem/milestoneWorkgroupItem.ts
@@ -33,6 +33,7 @@ class MilestoneWorkgroupItemController extends WorkgroupItemController {
   statusText: string;
   subscriptions: Subscription = new Subscription();
   workgroupId: number;
+
   static $inject = ['$filter', 'ProjectService', 'UtilService'];
 
   constructor(
@@ -46,6 +47,14 @@ class MilestoneWorkgroupItemController extends WorkgroupItemController {
   $onInit() {
     this.statusText = '';
     this.update();
+    this.initLastLocation();
+    if (this.locations.length > 1) {
+      this.initFirstLocation();
+    }
+    this.subscribeToEvents();
+  }
+
+  private initLastLocation() {
     const lastLocation = this.locations[this.locations.length - 1];
     this.lastNodeId = lastLocation.nodeId;
     this.lastComponentId = lastLocation.componentId;
@@ -57,20 +66,20 @@ class MilestoneWorkgroupItemController extends WorkgroupItemController {
       this.lastNodeId,
       this.lastComponentId
     );
-    if (this.locations.length > 1) {
-      const firstLocation = this.locations[0];
-      this.firstComponentId = firstLocation.componentId;
-      this.firstNodeId = firstLocation.nodeId;
-      this.firstComponent = this.ProjectService.getComponentByNodeIdAndComponentId(
-        this.firstNodeId,
-        this.firstComponentId
-      );
-      this.firstComponentMaxScore = this.ProjectService.getMaxScoreForComponent(
-        this.firstNodeId,
-        this.firstComponentId
-      );
-    }
-    this.subscribeToEvents();
+  }
+
+  private initFirstLocation() {
+    const firstLocation = this.locations[0];
+    this.firstComponentId = firstLocation.componentId;
+    this.firstNodeId = firstLocation.nodeId;
+    this.firstComponent = this.ProjectService.getComponentByNodeIdAndComponentId(
+      this.firstNodeId,
+      this.firstComponentId
+    );
+    this.firstComponentMaxScore = this.ProjectService.getMaxScoreForComponent(
+      this.firstNodeId,
+      this.firstComponentId
+    );
   }
 
   subscribeToEvents() {
@@ -103,8 +112,11 @@ class MilestoneWorkgroupItemController extends WorkgroupItemController {
           ? workgroupData.score - workgroupData.initialScore
           : '-';
     }
-
     this.update();
+  }
+
+  $onDestroy() {
+    this.subscriptions.unsubscribe();
   }
 
   getComponentTypeLabel(componentType) {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneWorkgroupItem/milestoneWorkgroupItem.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneWorkgroupItem/milestoneWorkgroupItem.ts
@@ -9,16 +9,19 @@ class MilestoneWorkgroupItemController extends WorkgroupItemController {
   $translate: any;
   locations: any[];
   changeInScore: any;
-  componentId: string;
   components: any[] = [];
   disabled: any;
   expand: any;
+  firstComponent: any;
+  firstComponentId: string;
+  firstNodeId: string;
   hasAlert: boolean;
   hasNewAlert: boolean;
-  hiddenComponents: string[] = [];
   initialScore: any;
+  lastComponent: any;
+  lastComponentId: string;
+  lastNodeId: string;
   maxScore: number;
-  nodeId: string;
   onUpdateExpand: any;
   score: any;
   showScore: boolean;
@@ -39,14 +42,21 @@ class MilestoneWorkgroupItemController extends WorkgroupItemController {
   $onInit() {
     this.statusText = '';
     this.update();
-    this.componentId = this.locations[this.locations.length - 1].componentId;
-    this.nodeId = this.locations[this.locations.length - 1].nodeId;
-    this.hiddenComponents = [];
-    const component = this.ProjectService.getComponentByNodeIdAndComponentId(
-      this.nodeId,
-      this.componentId
+    this.firstComponentId = this.locations[0].componentId;
+    this.firstNodeId = this.locations[0].nodeId;
+    this.firstComponent = this.ProjectService.getComponentByNodeIdAndComponentId(
+      this.firstNodeId,
+      this.firstComponentId
     );
-    this.components.push(component);
+    if (this.locations.length > 1) {
+      const lastLocation = this.locations[this.locations.length - 1];
+      this.lastNodeId = lastLocation.nodeId;
+      this.lastComponentId = lastLocation.componentId;
+      this.lastComponent = this.ProjectService.getComponentByNodeIdAndComponentId(
+        this.lastNodeId,
+        this.lastComponentId
+      );
+    }
   }
 
   $onChanges(changesObj) {
@@ -69,10 +79,6 @@ class MilestoneWorkgroupItemController extends WorkgroupItemController {
     }
 
     this.update();
-  }
-
-  isComponentVisible(componentId: string): boolean {
-    return !this.hiddenComponents.includes(componentId);
   }
 
   getComponentTypeLabel(componentType) {
@@ -126,7 +132,6 @@ const MilestoneWorkgroupItem = {
     showScore: '<',
     workgroupId: '<',
     workgroupData: '<',
-    hiddenComponents: '<',
     onUpdateExpand: '&'
   },
   controller: MilestoneWorkgroupItemController,

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneWorkgroupItem/milestoneWorkgroupItem.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneWorkgroupItem/milestoneWorkgroupItem.ts
@@ -15,12 +15,14 @@ class MilestoneWorkgroupItemController extends WorkgroupItemController {
   firstComponent: any;
   firstComponentId: string;
   firstNodeId: string;
+  firstComponentMaxScore: number;
   hasAlert: boolean;
   hasNewAlert: boolean;
   initialScore: any;
   lastComponent: any;
   lastComponentId: string;
   lastNodeId: string;
+  lastComponentMaxScore: number;
   maxScore: number;
   onUpdateExpand: any;
   score: any;
@@ -48,6 +50,10 @@ class MilestoneWorkgroupItemController extends WorkgroupItemController {
       this.firstNodeId,
       this.firstComponentId
     );
+    this.firstComponentMaxScore = this.ProjectService.getMaxScoreForComponent(
+      this.firstNodeId,
+      this.firstComponentId
+    );
     if (this.locations.length > 1) {
       const lastLocation = this.locations[this.locations.length - 1];
       this.lastNodeId = lastLocation.nodeId;
@@ -56,6 +62,12 @@ class MilestoneWorkgroupItemController extends WorkgroupItemController {
         this.lastNodeId,
         this.lastComponentId
       );
+      this.lastComponentMaxScore = this.ProjectService.getMaxScoreForComponent(
+        this.lastNodeId,
+        this.lastComponentId
+      );
+    } else {
+      this.lastComponentMaxScore = this.firstComponentMaxScore;
     }
   }
 
@@ -83,6 +95,10 @@ class MilestoneWorkgroupItemController extends WorkgroupItemController {
 
   getComponentTypeLabel(componentType) {
     return this.UtilService.getComponentTypeLabel(componentType);
+  }
+
+  getNodePosition(nodeId: string): string {
+    return this.ProjectService.getNodePositionById(nodeId);
   }
 
   update() {
@@ -127,7 +143,6 @@ class MilestoneWorkgroupItemController extends WorkgroupItemController {
 const MilestoneWorkgroupItem = {
   bindings: {
     expand: '<',
-    maxScore: '<',
     locations: '<',
     showScore: '<',
     workgroupId: '<',

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/nodeGradingView/nodeGradingView.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/nodeGradingView/nodeGradingView.ts
@@ -130,13 +130,13 @@ export class NodeGradingViewController {
     );
   }
 
-  retrieveStudentData() {
-    this.TeacherDataService.retrieveStudentDataForNode(this.node).then(() => {
+  retrieveStudentData(node = this.node) {
+    this.TeacherDataService.retrieveStudentDataForNode(node).then(() => {
       this.teacherWorkgroupId = this.ConfigService.getWorkgroupId();
       this.workgroups = this.ConfigService.getClassmateUserInfos();
       this.canViewStudentNames = this.ConfigService.getPermissions().canViewStudentNames;
       this.setWorkgroupsById();
-      this.numRubrics = this.ProjectService.getNumberOfRubricsByNodeId(this.nodeId);
+      this.numRubrics = this.ProjectService.getNumberOfRubricsByNodeId(node.id);
       document.body.scrollTop = document.documentElement.scrollTop = 0;
     });
   }
@@ -160,8 +160,8 @@ export class NodeGradingViewController {
     );
   }
 
-  getMaxScore() {
-    return this.ProjectService.getMaxScoreForNode(this.nodeId);
+  getMaxScore(nodeId = this.nodeId) {
+    return this.ProjectService.getMaxScoreForNode(nodeId);
   }
 
   setWorkgroupsById() {

--- a/src/assets/wise5/classroomMonitor/i18n/i18n_en.json
+++ b/src/assets/wise5/classroomMonitor/i18n/i18n_en.json
@@ -205,6 +205,7 @@
   "sortByChangeInScore": "Sort by change in score",
   "sortByCompletion": "Sort by completion",
   "sortByLocation": "Sort by location",
+  "sortByNodeScoreTooltip": "Sort by score on Step {{nodePosition}}",
   "sortByNumberOfNotes": "Sort by number of notes",
   "sortByReportStatus": "Sort by report status",
   "sortByRevised": "Sort by revised score",

--- a/src/assets/wise5/i18n/i18n_en.json
+++ b/src/assets/wise5/i18n/i18n_en.json
@@ -124,6 +124,7 @@
   "SIGN_OUT": "Sign Out",
   "STEP_HAS_RUBRICS_TIPS": "Step has rubrics/teaching tips",
   "STEP_INFO": "Step Info",
+  "STEP_POSITION_DISPLAY": "Step {{position}}",
   "STUDENT_DATA_SERVICE_SAVE_COMPONENT_EVENT_COMPONENT_CATEGORY_EVENT_ERROR": "StudentDataService.saveComponentEvent: component, category, event args must not be null",
   "STUDENT_DATA_SERVICE_SAVE_COMPONENT_EVENT_NODE_ID_COMPONENT_ID_COMPONENT_TYPE_ERROR": "StudentDataService.saveComponentEvent: nodeId, componentId, componentType must not be null",
   "STUDENT_DATA_SERVICE_SAVE_VLE_EVENT_CATEGORY_EVENT_ERROR": "StudentDataService.saveVLEEvent: category and event args must not be null",


### PR DESCRIPTION
## Changes
- When showing before/after (2 locations) in the TAP report:
  - Update sort field text to show step numbers
  - Show the "before" response, followed by the "after" response
  - Show corresponding maxScore for before/after scores
  - Status column becomes hidden
- Show step number above response

## Test
- TAP report for 1 location
  - shows status column
- TAP report for 2 locations
  - status column is hidden
  - scores and max scores appear correctly
  - responses appear for before and after
- General
  - sorting works as before
  - scoring/commenting works as before

Closes #265