### PR TITLE
Manage students move members

### DIFF
--- a/src/app/services/getWorkgroupService.ts
+++ b/src/app/services/getWorkgroupService.ts
@@ -1,0 +1,14 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { ConfigService } from '../../assets/wise5/services/configService';
+
+@Injectable()
+export class GetWorkgroupService {
+  constructor(private ConfigService: ConfigService, private http: HttpClient) {}
+
+  getAllWorkgroupsInPeriod(periodId: number) {
+    return this.http.get(
+      `/api/teacher/run/${this.ConfigService.getRunId()}/period/${periodId}/workgroups`
+    );
+  }
+}

--- a/src/app/services/updateWorkgroupService.ts
+++ b/src/app/services/updateWorkgroupService.ts
@@ -1,0 +1,18 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { ConfigService } from '../../assets/wise5/services/configService';
+
+@Injectable()
+export class UpdateWorkgroupService {
+  constructor(private ConfigService: ConfigService, private http: HttpClient) {}
+
+  moveMember(userId: string, workgroupIdFrom, workgroupIdTo) {
+    return this.http.post(
+      `/api/teacher/run/${this.ConfigService.getRunId()}/workgroup/move-user/${userId}`,
+      {
+        workgroupIdFrom: workgroupIdFrom,
+        workgroupIdTo: workgroupIdTo
+      }
+    );
+  }
+}

--- a/src/app/services/updateWorkgroupService.ts
+++ b/src/app/services/updateWorkgroupService.ts
@@ -6,7 +6,7 @@ import { ConfigService } from '../../assets/wise5/services/configService';
 export class UpdateWorkgroupService {
   constructor(private ConfigService: ConfigService, private http: HttpClient) {}
 
-  moveMember(userId: string, workgroupIdFrom, workgroupIdTo) {
+  moveMember(userId: number, workgroupIdFrom: number, workgroupIdTo: number) {
     return this.http.post(
       `/api/teacher/run/${this.ConfigService.getRunId()}/workgroup/move-user/${userId}`,
       {

--- a/src/app/teacher-hybrid-angular.module.ts
+++ b/src/app/teacher-hybrid-angular.module.ts
@@ -18,6 +18,7 @@ import { AuthoringToolModule } from './teacher/authoring-tool.module';
 import { ClassroomMonitorModule } from './teacher/classroom-monitor.module';
 import { StepToolsComponent } from '../assets/wise5/common/stepTools/step-tools.component';
 import { UpdateWorkgroupService } from './services/updateWorkgroupService';
+import { GetWorkgroupService } from './services/getWorkgroupService';
 
 @NgModule({
   declarations: [StepToolsComponent],
@@ -25,6 +26,7 @@ import { UpdateWorkgroupService } from './services/updateWorkgroupService';
   providers: [
     CopyNodesService,
     { provide: DataService, useExisting: TeacherDataService },
+    GetWorkgroupService,
     InsertNodesService,
     MilestoneService,
     ProjectAssetService,

--- a/src/app/teacher-hybrid-angular.module.ts
+++ b/src/app/teacher-hybrid-angular.module.ts
@@ -17,6 +17,7 @@ import { InsertNodesService } from '../assets/wise5/services/insertNodesService'
 import { AuthoringToolModule } from './teacher/authoring-tool.module';
 import { ClassroomMonitorModule } from './teacher/classroom-monitor.module';
 import { StepToolsComponent } from '../assets/wise5/common/stepTools/step-tools.component';
+import { UpdateWorkgroupService } from './services/updateWorkgroupService';
 
 @NgModule({
   declarations: [StepToolsComponent],
@@ -32,7 +33,8 @@ import { StepToolsComponent } from '../assets/wise5/common/stepTools/step-tools.
     { provide: ProjectService, useExisting: TeacherProjectService },
     TeacherDataService,
     TeacherProjectService,
-    TeacherWebSocketService
+    TeacherWebSocketService,
+    UpdateWorkgroupService
   ]
 })
 export class TeacherAngularJSModule {

--- a/src/app/teacher/classroom-monitor.module.ts
+++ b/src/app/teacher/classroom-monitor.module.ts
@@ -9,6 +9,7 @@ import { ManageStudentsComponent } from '../../assets/wise5/classroomMonitor/cla
 import { ManageStudentsLegacyComponent } from '../../assets/wise5/classroomMonitor/manageStudents/manage-students-legacy.component';
 import { ManageTeamComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component';
 import { ManageUserComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component';
+import { MoveUserConfirmDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/move-user-confirm-dialog/move-user-confirm-dialog.component';
 import { WorkgroupInfoComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroupInfo/workgroup-info.component';
 import { NavItemScoreComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/navItemScore/nav-item-score.component';
 import { SelectPeriodComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component';
@@ -48,6 +49,7 @@ import { ChangeTeamPeriodDialogComponent } from '../../assets/wise5/classroomMon
     ManageUserComponent,
     MilestonesComponent,
     MilestoneReportDataComponent,
+    MoveUserConfirmDialogComponent,
     NavItemProgressComponent,
     SelectPeriodComponent,
     StatusIconComponent,

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.html
@@ -4,7 +4,7 @@
     <span class="md-subhead" i18n>Students: {{students.size}} | Teams: {{teams.size}}</span>
   </h2>
 </div>
-<ul class="teams" fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="8px">
+<ul class="teams" fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="8px" cdkDropListGroup>
   <li class="team" *ngFor="let team of teams">
     <manage-team [team]="team"></manage-team>
   </li>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.html
@@ -5,7 +5,7 @@
   </h2>
 </div>
 <ul class="teams" fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="8px" cdkDropListGroup>
-  <li class="team" *ngFor="let team of teams">
+  <li class="team" *ngFor="let team of teams.values()">
     <manage-team [team]="team"></manage-team>
   </li>
 </ul>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.spec.ts
@@ -2,6 +2,8 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { configureTestSuite } from 'ng-bullet';
+import { of } from 'rxjs';
+import { GetWorkgroupService } from '../../../../../../app/services/getWorkgroupService';
 import { ConfigService } from '../../../../services/configService';
 import { ManagePeriodComponent } from './manage-period.component';
 
@@ -23,7 +25,7 @@ describe('ManagePeriod', () => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       declarations: [ManagePeriodComponent],
-      providers: [ConfigService, UpgradeModule]
+      providers: [ConfigService, GetWorkgroupService, UpgradeModule]
     });
     configService = TestBed.inject(ConfigService);
   });
@@ -36,29 +38,37 @@ describe('ManagePeriod', () => {
     };
     fixture.detectChanges();
   });
-  initializeTeams();
-  initializeStudents();
+  initTeams();
+  initStudents();
 });
 
-function initializeTeams() {
-  describe('initializeTeams', () => {
-    it('should initialize teams that are in this period', () => {
+function initTeams() {
+  describe('initTeams', () => {
+    it('should initialize teams that are in this period including empty teams', () => {
       spyOn(configService, 'getClassmateUserInfos').and.returnValue(classmateUserInfos);
       spyOn(configService, 'getDisplayUsernamesByWorkgroupId').and.returnValue('student one');
-      component.initializeTeams();
-      expect(component.teams.size).toEqual(2);
-      const teamsArray = Array.from(component.teams);
+      const allWorkgroupsInPeriodSpy = spyOn(
+        TestBed.inject(GetWorkgroupService),
+        'getAllWorkgroupsInPeriod'
+      ).and.callFake((periodId: number) => {
+        return of([{ id: 5 }, { id: 7 }, { id: 8 }]);
+      });
+      component.initTeams();
+      expect(component.teams.size).toEqual(3);
+      const teamsArray = Array.from(component.teams.values());
       expect(teamsArray[0].workgroupId).toEqual(5);
       expect(teamsArray[1].workgroupId).toEqual(7);
+      expect(teamsArray[2].workgroupId).toEqual(8);
+      expect(allWorkgroupsInPeriodSpy).toHaveBeenCalled();
     });
   });
 }
 
-function initializeStudents() {
-  describe('initializeStudents', () => {
+function initStudents() {
+  describe('initStudents', () => {
     it('should initialize students that are in this period', () => {
       spyOn(configService, 'getClassmateUserInfos').and.returnValue(classmateUserInfos);
-      component.initializeStudents();
+      component.initStudents();
       expect(component.students.size).toEqual(3);
     });
   });

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html
@@ -3,8 +3,20 @@
   <span fxFlex></span>
   <a *ngIf="canChangePeriod" class="changePeriodLink" (click)="changePeriod()" i18n>Change Period</a>
 </span>
-<ul class="users" fxLayout="column" fxLayoutGap="8px">
-  <li class="user" *ngFor="let user of team.users" i18n>
+<ul cdkDropList
+    [cdkDropListData]="team.users"
+    [cdkDropListEnterPredicate]="canDrop"
+    (cdkDropListDropped)="drop($event)"
+    class="users"
+    fxLayout="column"
+    fxLayoutGap="8px">
+  <li cdkDrag
+      [cdkDragData]="team.workgroupId"
+      (cdkDragEntered)="dragEnter($event)"
+      (cdkDragExited)="dragExit($event)"
+      class="user"
+      *ngFor="let user of team.users"
+      i18n>
     <manage-user [user]="user"></manage-user>
   </li>
 </ul>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.scss
@@ -6,8 +6,14 @@
   border: 1px dotted red;
   padding: 4px;
   list-style-type: none;
+  cursor: move;
 }
 
 .users {
+  min-height: 30px;
   padding-left: 0px;
+}
+
+.cdk-drag-placeholder {
+  opacity: .4;
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.spec.ts
@@ -2,12 +2,15 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialog } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
 import { configureTestSuite } from 'ng-bullet';
+import { UpdateWorkgroupService } from '../../../../../../app/services/updateWorkgroupService';
 import { ConfigService } from '../../../../services/configService';
 import { ManageTeamComponent } from './manage-team.component';
 
 class ConfigServiceStub {
   getPermissions() {}
 }
+
+class UpdateWorkgroupServiceStub {}
 
 let configService: ConfigService;
 let fixture: ComponentFixture<ManageTeamComponent>;
@@ -19,6 +22,7 @@ describe('ManageTeamComponent', () => {
       declarations: [ManageTeamComponent],
       providers: [
         { provide: ConfigService, useClass: ConfigServiceStub },
+        { provide: UpdateWorkgroupService, useClass: UpdateWorkgroupServiceStub },
         { provide: MatDialog, useValue: {} }
       ]
     });

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
@@ -48,6 +48,10 @@ export class ManageTeamComponent {
     event.container.element.nativeElement.classList.remove('primary-bg');
   }
 
+  canDrop(drag: CdkDrag, drop: CdkDropList): boolean {
+    return drop.data.length < 3;
+  }
+
   drop(event: CdkDragDrop<string[]>) {
     if (event.previousContainer !== event.container) {
       this.dialog
@@ -60,10 +64,6 @@ export class ManageTeamComponent {
           event.container.element.nativeElement.classList.remove('primary-bg');
         });
     }
-  }
-
-  canDrop(drag: CdkDrag, drop: CdkDropList) {
-    return drop.data.length < 3;
   }
 
   private moveUser(event: CdkDragDrop<string[]>) {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
@@ -1,7 +1,17 @@
 import { Component, Input } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ConfigService } from '../../../../services/configService';
+import { UpdateWorkgroupService } from '../../../../../../app/services/updateWorkgroupService';
 import { ChangeTeamPeriodDialogComponent } from '../change-team-period-dialog/change-team-period-dialog.component';
+import {
+  CdkDrag,
+  CdkDragDrop,
+  CdkDragEnter,
+  CdkDragExit,
+  CdkDropList,
+  transferArrayItem
+} from '@angular/cdk/drag-drop';
+import { MoveUserConfirmDialogComponent } from '../move-user-confirm-dialog/move-user-confirm-dialog.component';
 
 @Component({
   selector: 'manage-team',
@@ -13,7 +23,11 @@ export class ManageTeamComponent {
 
   canChangePeriod: boolean;
 
-  constructor(private dialog: MatDialog, private ConfigService: ConfigService) {}
+  constructor(
+    private dialog: MatDialog,
+    private ConfigService: ConfigService,
+    private UpdateWorkgroupService: UpdateWorkgroupService
+  ) {}
 
   ngOnInit() {
     this.canChangePeriod = this.ConfigService.getPermissions().canGradeStudentWork;
@@ -23,6 +37,48 @@ export class ManageTeamComponent {
     this.dialog.open(ChangeTeamPeriodDialogComponent, {
       data: this.team,
       panelClass: 'mat-dialog--md'
+    });
+  }
+
+  dragEnter(event: CdkDragEnter) {
+    event.container.element.nativeElement.classList.add('primary-bg');
+  }
+
+  dragExit(event: CdkDragExit) {
+    event.container.element.nativeElement.classList.remove('primary-bg');
+  }
+
+  drop(event: CdkDragDrop<string[]>) {
+    if (event.previousContainer !== event.container) {
+      this.dialog
+        .open(MoveUserConfirmDialogComponent)
+        .afterClosed()
+        .subscribe((doMoveUser: boolean) => {
+          if (doMoveUser) {
+            this.moveUser(event);
+          }
+          event.container.element.nativeElement.classList.remove('primary-bg');
+        });
+    }
+  }
+
+  canDrop(drag: CdkDrag, drop: CdkDropList) {
+    return drop.data.length < 3;
+  }
+
+  private moveUser(event: CdkDragDrop<string[]>) {
+    const user: any = event.previousContainer.data[event.previousIndex];
+    this.UpdateWorkgroupService.moveMember(
+      user.id,
+      event.item.data,
+      this.team.workgroupId
+    ).subscribe(() => {
+      transferArrayItem(
+        event.previousContainer.data,
+        event.container.data,
+        event.previousIndex,
+        event.currentIndex
+      );
     });
   }
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
@@ -79,6 +79,9 @@ export class ManageTeamComponent {
         event.previousIndex,
         event.currentIndex
       );
+      this.ConfigService.retrieveConfig(
+        `/api/config/classroomMonitor/${this.ConfigService.getRunId()}`
+      );
     });
   }
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manageStudentsModule.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manageStudentsModule.ts
@@ -1,12 +1,17 @@
 import * as angular from 'angular';
 import { downgradeComponent } from '@angular/upgrade/static';
 import { ManageStudentsComponent } from './manage-students/manage-students.component';
+import { ManageStudentsLegacyComponent } from '../../manageStudents/manage-students-legacy.component';
 
 angular
   .module('manageStudents', [])
   .directive(
     'manageStudentsComponent',
     downgradeComponent({ component: ManageStudentsComponent }) as angular.IDirectiveFactory
+  )
+  .directive(
+    'manageStudentsLegacyComponent',
+    downgradeComponent({ component: ManageStudentsLegacyComponent }) as angular.IDirectiveFactory
   )
   .config([
     '$stateProvider',

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manageStudentsModule.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manageStudentsModule.ts
@@ -1,32 +1,12 @@
 import * as angular from 'angular';
 import { downgradeComponent } from '@angular/upgrade/static';
 import { ManageStudentsComponent } from './manage-students/manage-students.component';
-import { ManageStudentsLegacyComponent } from '../../manageStudents/manage-students-legacy.component';
-import { ManagePeriodComponent } from './manage-period/manage-period.component';
-import { ManageTeamComponent } from './manage-team/manage-team.component';
-import { ManageUserComponent } from './manage-user/manage-user.component';
 
 angular
   .module('manageStudents', [])
   .directive(
     'manageStudentsComponent',
     downgradeComponent({ component: ManageStudentsComponent }) as angular.IDirectiveFactory
-  )
-  .directive(
-    'manageStudentsLegacyComponent',
-    downgradeComponent({ component: ManageStudentsLegacyComponent }) as angular.IDirectiveFactory
-  )
-  .directive(
-    'managePeriodComponent',
-    downgradeComponent({ component: ManagePeriodComponent }) as angular.IDirectiveFactory
-  )
-  .directive(
-    'manageTeamComponent',
-    downgradeComponent({ component: ManageTeamComponent }) as angular.IDirectiveFactory
-  )
-  .directive(
-    'manageUserComponent',
-    downgradeComponent({ component: ManageUserComponent }) as angular.IDirectiveFactory
   )
   .config([
     '$stateProvider',

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/move-user-confirm-dialog/move-user-confirm-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/move-user-confirm-dialog/move-user-confirm-dialog.component.html
@@ -1,0 +1,10 @@
+<h1 mat-dialog-title i18n>Move Student</h1>
+<mat-dialog-content aria-label="Move Student" cdkFocusRegionStart>
+  <p i18n>Warning: removing a student from a team will result in the student losing all the work they completed with that team.</p>
+  <p i18n>If you are moving a student to a new team, they will adopt the work of the new team.</p>
+  <p i18n>Are you sure you want to continue?</p>
+</mat-dialog-content>
+<mat-dialog-actions fxLayoutAlign="end" fxLayoutGap="8px">
+  <button mat-button [mat-dialog-close]="false" i18n>Cancel</button>
+  <button mat-button mat-primary color="primary" [mat-dialog-close]="true" i18n>Confirm</button>
+</mat-dialog-actions>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/move-user-confirm-dialog/move-user-confirm-dialog.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/move-user-confirm-dialog/move-user-confirm-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MoveUserConfirmDialogComponent } from './move-user-confirm-dialog.component';
+
+describe('MoveUserConfirmDialogComponent', () => {
+  let component: MoveUserConfirmDialogComponent;
+  let fixture: ComponentFixture<MoveUserConfirmDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MoveUserConfirmDialogComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MoveUserConfirmDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/move-user-confirm-dialog/move-user-confirm-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/move-user-confirm-dialog/move-user-confirm-dialog.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-move-user-confirm-dialog',
+  templateUrl: './move-user-confirm-dialog.component.html'
+})
+export class MoveUserConfirmDialogComponent {}


### PR DESCRIPTION
## Changes
- Teacher can move members between existing groups
- Manage students page shows empty teams

## Test
- First review [changes in WISE-API to fetch all workgroups in the period and update workgroup membership (WISE-API #22)](https://github.com/WISE-Community/WISE-API/pull/22)
- Move member to non-empty workgroup
- Move member to empty workgroup
- Should not be able to move to a workgroup that already has 3 members
