### PR TITLE
Fixed manage students period select dropdown updating issues

### DIFF
--- a/src/app/services/sampleData/sample_classmateUserInfos.json
+++ b/src/app/services/sampleData/sample_classmateUserInfos.json
@@ -1,0 +1,12 @@
+[
+  {
+    "workgroupId": 7,
+    "periodId": 1,
+    "users": [
+      { "username": "student0103" },
+      { "username": "student0104" }
+    ]
+  },
+  { "workgroupId": 6, "periodId": 2, "users": [{ "username": "student0102" }] },
+  { "workgroupId": 5, "periodId": 1, "users": [{ "username": "student0101" }] }
+]

--- a/src/app/services/workgroup.service.spec.ts
+++ b/src/app/services/workgroup.service.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from '@angular/core/testing';
+import { ConfigService } from '../../assets/wise5/services/configService';
+import { WorkgroupService } from './workgroup.service';
+import classmateUserInfos from './sampleData/sample_classmateUserInfos.json';
+
+let workgroupService: WorkgroupService;
+
+class ConfigServiceStub {
+  getClassmateUserInfos() {
+    return classmateUserInfos;
+  }
+  getDisplayUsernamesByWorkgroupId(workgroupId: number) {
+    return `Workgroup ${workgroupId}`;
+  }
+}
+
+describe('WorkgroupService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: ConfigService, useClass: ConfigServiceStub }, WorkgroupService]
+    });
+    workgroupService = TestBed.inject(WorkgroupService);
+  });
+  getWorkgroupsInPeriod();
+});
+
+function getWorkgroupsInPeriod() {
+  describe('getWorkgroupsInPeriod()', () => {
+    it('should return only workgroups in period with display names', () => {
+      const workgroups = workgroupService.getWorkgroupsInPeriod(1);
+      expect(workgroups.size).toEqual(2);
+      expect(workgroups.get(5).displayNames).toEqual('Workgroup 5');
+      expect(workgroups.get(7).displayNames).toEqual('Workgroup 7');
+    });
+  });
+}

--- a/src/app/services/workgroup.service.ts
+++ b/src/app/services/workgroup.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { ConfigService } from '../../assets/wise5/services/configService';
+
+@Injectable()
+export class WorkgroupService {
+  constructor(private ConfigService: ConfigService) {}
+  getWorkgroupsInPeriod(periodId: number): Map<number, any> {
+    const workgroups = new Map();
+    for (const workgroup of this.getWorkgroupsSortedById()) {
+      if (workgroup.periodId === periodId) {
+        workgroup.displayNames = this.ConfigService.getDisplayUsernamesByWorkgroupId(
+          workgroup.workgroupId
+        );
+        workgroups.set(workgroup.workgroupId, workgroup);
+      }
+    }
+    return workgroups;
+  }
+
+  private getWorkgroupsSortedById() {
+    return this.ConfigService.getClassmateUserInfos().sort((a, b) => {
+      return a.workgroupId - b.workgroupId;
+    });
+  }
+}

--- a/src/app/teacher-hybrid-angular.module.ts
+++ b/src/app/teacher-hybrid-angular.module.ts
@@ -19,6 +19,7 @@ import { ClassroomMonitorModule } from './teacher/classroom-monitor.module';
 import { StepToolsComponent } from '../assets/wise5/common/stepTools/step-tools.component';
 import { UpdateWorkgroupService } from './services/updateWorkgroupService';
 import { GetWorkgroupService } from './services/getWorkgroupService';
+import { WorkgroupService } from './services/workgroup.service';
 
 @NgModule({
   declarations: [StepToolsComponent],
@@ -36,7 +37,8 @@ import { GetWorkgroupService } from './services/getWorkgroupService';
     TeacherDataService,
     TeacherProjectService,
     TeacherWebSocketService,
-    UpdateWorkgroupService
+    UpdateWorkgroupService,
+    WorkgroupService
   ]
 })
 export class TeacherAngularJSModule {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.html
@@ -9,3 +9,8 @@
     <manage-team [team]="team"></manage-team>
   </li>
 </ul>
+<ul class="teams" fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="8px" cdkDropListGroup>
+  <li class="team" *ngFor="let team of emptyTeams.values()">
+    <manage-team [team]="team"></manage-team>
+  </li>
+</ul>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.html
@@ -4,13 +4,15 @@
     <span class="md-subhead" i18n>Students: {{students.size}} | Teams: {{teams.size}}</span>
   </h2>
 </div>
-<ul class="teams" fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="8px" cdkDropListGroup>
-  <li class="team" *ngFor="let team of teams.values()">
-    <manage-team [team]="team"></manage-team>
-  </li>
-</ul>
-<ul class="teams" fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="8px" cdkDropListGroup>
-  <li class="team" *ngFor="let team of emptyTeams.values()">
-    <manage-team [team]="team"></manage-team>
-  </li>
-</ul>
+<div cdkDropListGroup>
+  <ul class="teams" fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="8px">
+    <li class="team" *ngFor="let team of teams.values()">
+      <manage-team [team]="team"></manage-team>
+    </li>
+  </ul>
+  <ul class="teams" fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="8px">
+    <li class="team" *ngFor="let team of emptyTeams.values()">
+      <manage-team [team]="team"></manage-team>
+    </li>
+  </ul>
+</div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.spec.ts
@@ -4,30 +4,32 @@ import { UpgradeModule } from '@angular/upgrade/static';
 import { configureTestSuite } from 'ng-bullet';
 import { of } from 'rxjs';
 import { GetWorkgroupService } from '../../../../../../app/services/getWorkgroupService';
+import { WorkgroupService } from '../../../../../../app/services/workgroup.service';
 import { ConfigService } from '../../../../services/configService';
 import { ManagePeriodComponent } from './manage-period.component';
+import classmateUserInfos from '../../../../../../app/services/sampleData/sample_classmateUserInfos.json';
 
 let fixture: ComponentFixture<ManagePeriodComponent>;
 let component: ManagePeriodComponent;
 let configService: ConfigService;
-const classmateUserInfos = [
-  {
-    workgroupId: 7,
-    periodId: 1,
-    users: [{ username: 'student0103' }, { username: 'student0104' }]
-  },
-  { workgroupId: 6, periodId: 2, users: [{ username: 'student0102' }] },
-  { workgroupId: 5, periodId: 1, users: [{ username: 'student0101' }] }
-];
+let workgroupService: WorkgroupService;
+const workgroupsInPeriod = new Map<number, any>();
+workgroupsInPeriod.set(5, { workgroupId: 5, periodId: 1, users: [{ username: 'student0101' }] });
+workgroupsInPeriod.set(7, {
+  workgroupId: 7,
+  periodId: 1,
+  users: [{ username: 'student0103' }, { username: 'student0104' }]
+});
 
 describe('ManagePeriod', () => {
   configureTestSuite(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       declarations: [ManagePeriodComponent],
-      providers: [ConfigService, GetWorkgroupService, UpgradeModule]
+      providers: [ConfigService, GetWorkgroupService, UpgradeModule, WorkgroupService]
     });
     configService = TestBed.inject(ConfigService);
+    workgroupService = TestBed.inject(WorkgroupService);
   });
   beforeEach(() => {
     fixture = TestBed.createComponent(ManagePeriodComponent);
@@ -45,8 +47,7 @@ describe('ManagePeriod', () => {
 function initTeams() {
   describe('initTeams', () => {
     it('should initialize teams that are in this period including empty teams', () => {
-      spyOn(configService, 'getClassmateUserInfos').and.returnValue(classmateUserInfos);
-      spyOn(configService, 'getDisplayUsernamesByWorkgroupId').and.returnValue('student one');
+      spyOn(workgroupService, 'getWorkgroupsInPeriod').and.returnValue(workgroupsInPeriod);
       const allWorkgroupsInPeriodSpy = spyOn(
         TestBed.inject(GetWorkgroupService),
         'getAllWorkgroupsInPeriod'
@@ -54,11 +55,13 @@ function initTeams() {
         return of([{ id: 5 }, { id: 7 }, { id: 8 }]);
       });
       component.initTeams();
-      expect(component.teams.size).toEqual(3);
+      expect(component.teams.size).toEqual(2);
       const teamsArray = Array.from(component.teams.values());
       expect(teamsArray[0].workgroupId).toEqual(5);
       expect(teamsArray[1].workgroupId).toEqual(7);
-      expect(teamsArray[2].workgroupId).toEqual(8);
+      expect(component.emptyTeams.size).toEqual(1);
+      const emptyTeamsArray = Array.from(component.emptyTeams.values());
+      expect(emptyTeamsArray[0].workgroupId).toEqual(8);
       expect(allWorkgroupsInPeriodSpy).toHaveBeenCalled();
     });
   });

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { Subscription } from 'rxjs';
+import { WorkgroupService } from '../../../../../../app/services/workgroup.service';
 import { ConfigService } from '../../../../services/configService';
 import { GetWorkgroupService } from '../../../../../../app/services/getWorkgroupService';
 
@@ -13,11 +14,13 @@ export class ManagePeriodComponent {
 
   students: Set<any> = new Set();
   subscriptions: Subscription = new Subscription();
+  emptyTeams: Map<number, any> = new Map();
   teams: Map<number, any> = new Map();
 
   constructor(
     private ConfigService: ConfigService,
-    private GetWorkgroupService: GetWorkgroupService
+    private GetWorkgroupService: GetWorkgroupService,
+    private WorkgroupService: WorkgroupService
   ) {}
 
   ngOnChanges() {
@@ -42,22 +45,8 @@ export class ManagePeriodComponent {
   }
 
   initTeams() {
-    this.teams.clear();
-    for (const workgroup of this.getWorkgroupsSortedById()) {
-      if (workgroup.periodId === this.period.periodId) {
-        workgroup.displayNames = this.ConfigService.getDisplayUsernamesByWorkgroupId(
-          workgroup.workgroupId
-        );
-        this.teams.set(workgroup.workgroupId, workgroup);
-      }
-    }
+    this.teams = this.WorkgroupService.getWorkgroupsInPeriod(this.period.periodId);
     this.initEmptyTeams();
-  }
-
-  private getWorkgroupsSortedById() {
-    return this.ConfigService.getClassmateUserInfos().sort((a, b) => {
-      return a.workgroupId - b.workgroupId;
-    });
   }
 
   private initEmptyTeams() {
@@ -67,7 +56,7 @@ export class ManagePeriodComponent {
           if (!this.teams.has(workgroup.id)) {
             workgroup.workgroupId = workgroup.id;
             workgroup.users = [];
-            this.teams.set(workgroup.id, workgroup);
+            this.emptyTeams.set(workgroup.id, workgroup);
           }
         }
       }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.ts
@@ -50,6 +50,7 @@ export class ManagePeriodComponent {
   }
 
   private initEmptyTeams() {
+    this.emptyTeams.clear();
     this.GetWorkgroupService.getAllWorkgroupsInPeriod(this.period.periodId).subscribe(
       (workgroups: any[]) => {
         for (const workgroup of workgroups) {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html
@@ -1,7 +1,10 @@
 <span fxLayout="row">
   <span class="name" i18n>Team {{team.workgroupId}}</span>
   <span fxFlex></span>
-  <a *ngIf="canChangePeriod" class="changePeriodLink" (click)="changePeriod()" i18n>Change Period</a>
+  <a *ngIf="canChangePeriod && team.users.length > 0"
+      class="changePeriodLink"
+      (click)="changePeriod()"
+      i18n>Change Period</a>
 </span>
 <ul cdkDropList
     [cdkDropListData]="team.users"

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.spec.ts
@@ -31,7 +31,7 @@ describe('ManageTeamComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ManageTeamComponent);
     component = fixture.componentInstance;
-    component.team = { workgroupId: 3 };
+    component.team = { workgroupId: 3, users: [{ id: 1 }] };
   });
   changePeriodLinkVisible();
 });
@@ -45,6 +45,12 @@ function changePeriodLinkVisible() {
     });
     it('should not appear when user does not have GradeStudentWork permission', () => {
       spyOnCanGradeStudentWork(false);
+      fixture.detectChanges();
+      expect(getChangePeriodLink()).toBeFalsy();
+    });
+    it('should not appear when there are no members', () => {
+      component.team.users = [];
+      spyOnCanGradeStudentWork(true);
       fixture.detectChanges();
       expect(getChangePeriodLink()).toBeFalsy();
     });

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component.html
@@ -2,9 +2,7 @@
   <mat-select [(value)]="selectedPeriodId"
     (selectionChange)="currentPeriodChanged()">
     <mat-select-trigger>{{selectedPeriodText}}</mat-select-trigger>
-    <mat-option *ngFor="let period of periods"
-        [value]="period.periodId"
-        [disabled]="!period.numWorkgroupsInPeriod">
+    <mat-option *ngFor="let period of periods" [value]="period.periodId">
       <span *ngIf="period.periodId === -1" i18n>All Periods</span>
       <span *ngIf="period.periodId != -1" i18n>Period: {{period.periodName}}</span>
       <span class="text-secondary">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -8062,7 +8062,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html</context>
-          <context context-type="linenumber">4</context>
+          <context context-type="linenumber">7</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4693296a32d61d8ff2306dc5915b3626ed7206c9" datatype="html">
@@ -8126,7 +8126,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source><x id="START_TAG_MANAGE_USER" ctype="x-manage_user" equiv-text="&lt;manage-user [user]=&quot;user&quot;&gt;"/><x id="CLOSE_TAG_MANAGE_USER" ctype="x-manage_user" equiv-text="&lt;/manage-user&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">23</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8e728195d4eb16b80063b74eecea8f498762d1ef" datatype="html">
@@ -8168,35 +8168,35 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>All Periods</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component.html</context>
-          <context context-type="linenumber">8</context>
+          <context context-type="linenumber">6</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cdfc3eab890fa0d259f52a903ff9233f6fbef716" datatype="html">
         <source>Period: <x id="INTERPOLATION" equiv-text="{{period.periodName}}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component.html</context>
-          <context context-type="linenumber">9</context>
+          <context context-type="linenumber">7</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8696bee691864cb6fa43175d75ed7e91b1e980ae" datatype="html">
         <source>0 teams</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component.html</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">10</context>
         </context-group>
       </trans-unit>
       <trans-unit id="183d5532753330e0aa0e6492f2595d24ec36b254" datatype="html">
         <source>1 team</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component.html</context>
-          <context context-type="linenumber">13</context>
+          <context context-type="linenumber">11</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6b8e9026aa61cc49d6342e833d13fee9f468c19c" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{period.numWorkgroupsInPeriod}}"/> teams</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component.html</context>
-          <context context-type="linenumber">14</context>
+          <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1775311053456611668" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -408,6 +408,10 @@
           <context context-type="linenumber">27</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/move-user-confirm-dialog/move-user-confirm-dialog.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.html</context>
           <context context-type="linenumber">83</context>
         </context-group>
@@ -8085,6 +8089,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html</context>
           <context context-type="linenumber">33</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/move-user-confirm-dialog/move-user-confirm-dialog.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="3ee7b8fcc267b39c4ec8d3dd9cb8075134ae032c" datatype="html">
         <source>Period <x id="INTERPOLATION" equiv-text="{{period.periodName}}"/></source>
@@ -8118,7 +8126,35 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source><x id="START_TAG_MANAGE_USER" ctype="x-manage_user" equiv-text="&lt;manage-user [user]=&quot;user&quot;&gt;"/><x id="CLOSE_TAG_MANAGE_USER" ctype="x-manage_user" equiv-text="&lt;/manage-user&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html</context>
-          <context context-type="linenumber">8</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8e728195d4eb16b80063b74eecea8f498762d1ef" datatype="html">
+        <source>Move Student</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/move-user-confirm-dialog/move-user-confirm-dialog.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="599f5341af259f02b18c2669a41e0bc9e57faf84" datatype="html">
+        <source>Warning: removing a student from a team will result in the student losing all the work they completed with that team.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/move-user-confirm-dialog/move-user-confirm-dialog.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="03be49ff81ed4b15c1e93acab253dbb3efc2c6cf" datatype="html">
+        <source>If you are moving a student to a new team, they will adopt the work of the new team.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/move-user-confirm-dialog/move-user-confirm-dialog.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7d1dcf2a9146caac0581329acf94806ec69a89a5" datatype="html">
+        <source>Are you sure you want to continue?</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/move-user-confirm-dialog/move-user-confirm-dialog.component.html</context>
+          <context context-type="linenumber">5</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f9c52903219e583ddefb23cd102d2057504ac980" datatype="html">
@@ -8167,14 +8203,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>All Periods</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component.ts</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">83</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6933068701447776492" datatype="html">
         <source>Period: <x id="PH" equiv-text="this.currentPeriod.periodName"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component.ts</context>
-          <context context-type="linenumber">75</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6c372513ec53879a9eeffbd96670484f6cc52269" datatype="html">


### PR DESCRIPTION
## Changes
- Period select correctly updates number of teams
- Can view team that is moved to an empty period
- Moved empty teams to bottom of manage periods view
- Cleaned up code

## Test
- Move a team to another period. The period select should update the number of teams in each period.
- Move a team to another period that has no teams. You should be able to go to that period and see the team.

Closes #271