### PR TITLE
Manage student show info

### DIFF
--- a/src/app/teacher/classroom-monitor.module.ts
+++ b/src/app/teacher/classroom-monitor.module.ts
@@ -29,6 +29,7 @@ import { AngularJSModule } from '../common-hybrid-angular.module';
 import { ComponentGradingModule } from './component-grading.module';
 import { MilestoneReportDataComponent } from './milestone/milestone-report-data/milestone-report-data.component';
 import { ChangeTeamPeriodDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component';
+import { ManageShowStudentInfo } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component';
 
 @NgModule({
   declarations: [
@@ -42,6 +43,7 @@ import { ChangeTeamPeriodDialogComponent } from '../../assets/wise5/classroomMon
     EditComponentScoreComponent,
     GradingEditComponentMaxScoreComponent,
     ManagePeriodComponent,
+    ManageShowStudentInfo,
     ManageStudentsComponent,
     ManageStudentsLegacyComponent,
     ManageTeamComponent,

--- a/src/app/teacher/classroom-monitor.module.ts
+++ b/src/app/teacher/classroom-monitor.module.ts
@@ -29,7 +29,7 @@ import { AngularJSModule } from '../common-hybrid-angular.module';
 import { ComponentGradingModule } from './component-grading.module';
 import { MilestoneReportDataComponent } from './milestone/milestone-report-data/milestone-report-data.component';
 import { ChangeTeamPeriodDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component';
-import { ManageShowStudentInfo } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component';
+import { ManageShowStudentInfoComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component';
 
 @NgModule({
   declarations: [
@@ -43,7 +43,7 @@ import { ManageShowStudentInfo } from '../../assets/wise5/classroomMonitor/class
     EditComponentScoreComponent,
     GradingEditComponentMaxScoreComponent,
     ManagePeriodComponent,
-    ManageShowStudentInfo,
+    ManageShowStudentInfoComponent,
     ManageStudentsComponent,
     ManageStudentsLegacyComponent,
     ManageTeamComponent,

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html
@@ -1,31 +1,33 @@
 <h1 class="mat-dialog-title">
-  <span class="md-subhead" *ngIf="canViewStudentNames">{{user.name}}</span>
-  <span class="md-subhead" *ngIf="!canViewStudentNames" i18n>Student {{user.id}}</span>
+  <span class="username" *ngIf="canViewStudentNames">{{user.name}}</span>
+  <span *ngIf="!canViewStudentNames" i18n>Student {{user.id}}</span>
 </h1>
-<div mat-dialog-content class="info-block">
-  <table style="width: 100%">
-    <tr>
-      <td class="key" i18n>Student ID</td>
-      <td>{{user.id}}</td>
-    </tr>
-    <tr *ngIf="canViewStudentNames">
-      <td class="key" i18n>Username</td>
-      <td>{{user.username}}</td>
-    </tr>
-    <tr>
-      <td class="key" i18n>Most Recent Login</td>
-      <td>{{ user.lastLoginTime | amDateFormat:'ddd, MMM D YYYY, h:mm a' }}</td>
-    </tr>
-    <tr>
-      <td class="key" i18n>Registration Date</td>
-      <td>{{ user.signUpTime | amDateFormat:'ddd, MMM D YYYY, h:mm a' }}</td>
-    </tr>
-    <tr>
-      <td class="key" i18n>Number of Logins</td>
-      <td>{{user.numberOfLogins}}</td>
-    </tr>
-  </table>
-</div>
-<div mat-dialog-actions fxLayoutAlign="end" fxLayoutGap="8px">
+<div mat-dialog-content>
+  <div class="info-block">
+    <table style="width: 100%">
+      <tr>
+        <strong i18n>Student ID</strong>
+        <td>{{user.id}}</td>
+      </tr>
+      <tr class="username" *ngIf="canViewStudentNames">
+        <strong>Username</strong>
+        <td>{{user.username}}</td>
+      </tr>
+      <tr>
+        <strong i18n>Most Recent Login</strong>
+        <td>{{ user.lastLoginTime | amDateFormat:'ddd, MMM D YYYY, h:mm a' }}</td>
+      </tr>
+      <tr>
+        <strong i18n>Registration Date</strong>
+        <td>{{ user.signUpTime | amDateFormat:'ddd, MMM D YYYY, h:mm a' }}</td>
+      </tr>
+      <tr>
+        <strong i18n>Number of Logins</strong>
+        <td>{{user.numberOfLogins}}</td>
+      </tr>
+    </table>
+    </div>
+  </div>
+<div mat-dialog-actions fxLayoutAlign="end">
   <button mat-button mat-dialog-close i18n>Close</button>
 </div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html
@@ -1,31 +1,31 @@
-<h1 class="mat-dialog-title" i18n>
-    <span>Student Information</span>
-    <span class="md-subhead"> {{user.name}}</span>
+<h1 class="mat-dialog-title">
+  <span i18n>Student Information</span>
+  <span class="md-subhead" *ngIf="canViewStudentNames">({{user.name}})</span>
 </h1>
 <div mat-dialog-content class="info-block">
-    <table style="width: 100%">
-        <tr>
-            <td>Student ID:</td>
-            <td>{{user.id}}</td>
-        </tr>
-        <tr *ngIf="canViewStudentNames">
-            <td>Username:</td>
-            <td>{{user.username}}</td>
-        </tr>
-        <tr>
-            <td>Recently logged in:</td>
-        </tr>
-        <tr>
-            <td>Registered date:</td>
-        </tr>
-        <tr>
-            <td>Logins:</td>
-        </tr>
-
-    </table>
-        
-        <span *ngIf="canViewStudentNames" class="studentNames"></span>
-    </div>
+  <table style="width: 100%">
+    <tr>
+      <td class="key" i18n>Student ID</td>
+      <td>{{user.id}}</td>
+    </tr>
+    <tr *ngIf="canViewStudentNames">
+      <td class="key" i18n>Username</td>
+      <td>{{user.username}}</td>
+    </tr>
+    <tr>
+      <td class="key" i18n>Most Recent Login</td>
+      <td>{{ user.lastLoginTime | amDateFormat:'ddd, MMM D YYYY, h:mm a' }}</td>
+    </tr>
+    <tr>
+      <td class="key" i18n>Registration Date</td>
+      <td>{{ user.signUpTime | amDateFormat:'ddd, MMM D YYYY, h:mm a' }}</td>
+    </tr>
+    <tr>
+      <td class="key" i18n>Number of Logins</td>
+      <td>{{user.numberOfLogins}}</td>
+    </tr>
+  </table>
+</div>
 <div mat-dialog-actions fxLayoutAlign="end" fxLayoutGap="8px">
-    <button mat-button mat-dialog-close i18n>Cancel</button>
+  <button mat-button mat-dialog-close i18n>Cancel</button>
 </div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html
@@ -1,6 +1,6 @@
 <h1 class="mat-dialog-title">
-  <span i18n>Student Information</span>
-  <span class="md-subhead" *ngIf="canViewStudentNames">({{user.name}})</span>
+  <span class="md-subhead" *ngIf="canViewStudentNames">{{user.name}}</span>
+  <span class="md-subhead" *ngIf="!canViewStudentNames" i18n>Student {{user.id}}</span>
 </h1>
 <div mat-dialog-content class="info-block">
   <table style="width: 100%">
@@ -27,5 +27,5 @@
   </table>
 </div>
 <div mat-dialog-actions fxLayoutAlign="end" fxLayoutGap="8px">
-  <button mat-button mat-dialog-close i18n>Cancel</button>
+  <button mat-button mat-dialog-close i18n>Close</button>
 </div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html
@@ -1,0 +1,31 @@
+<h1 class="mat-dialog-title" i18n>
+    <span>Student Information</span>
+    <span class="md-subhead"> {{user.name}}</span>
+</h1>
+<div mat-dialog-content class="info-block">
+    <table style="width: 100%">
+        <tr>
+            <td>Student ID:</td>
+            <td>{{user.id}}</td>
+        </tr>
+        <tr *ngIf="canViewStudentNames">
+            <td>Username:</td>
+            <td>{{user.username}}</td>
+        </tr>
+        <tr>
+            <td>Recently logged in:</td>
+        </tr>
+        <tr>
+            <td>Registered date:</td>
+        </tr>
+        <tr>
+            <td>Logins:</td>
+        </tr>
+
+    </table>
+        
+        <span *ngIf="canViewStudentNames" class="studentNames"></span>
+    </div>
+<div mat-dialog-actions fxLayoutAlign="end" fxLayoutGap="8px">
+    <button mat-button mat-dialog-close i18n>Cancel</button>
+</div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.scss
@@ -1,0 +1,3 @@
+.key {
+  font-weight: bold;
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.scss
@@ -1,3 +1,0 @@
-.key {
-  font-weight: bold;
-}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.spec.ts
@@ -1,0 +1,65 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MomentModule } from 'ngx-moment';
+import { By } from '@angular/platform-browser';
+import { configureTestSuite } from 'ng-bullet';
+import { ConfigService } from '../../../../services/configService';
+import { ManageShowStudentInfoComponent } from './manage-show-student-info.component';
+
+class ConfigServiceStub {
+  getPermissions() {}
+}
+
+let configService: ConfigService;
+let fixture: ComponentFixture<ManageShowStudentInfoComponent>;
+let http: HttpTestingController;
+let component: ManageShowStudentInfoComponent;
+const user: any = {};
+
+describe('ManageShowStudentInfoComponent', () => {
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      declarations: [ManageShowStudentInfoComponent],
+      imports: [HttpClientTestingModule, MatDialogModule, MomentModule],
+      providers: [
+        { provide: ConfigService, useClass: ConfigServiceStub },
+        { provide: MAT_DIALOG_DATA, useValue: user }
+      ]
+    });
+    configService = TestBed.inject(ConfigService);
+  });
+  beforeEach(() => {
+    http = TestBed.inject(HttpTestingController);
+    fixture = TestBed.createComponent(ManageShowStudentInfoComponent);
+    component = fixture.componentInstance;
+  });
+  usernameVisible();
+});
+
+function usernameVisible() {
+  describe('username', () => {
+    it('should appear when user has ViewStudentNames permission', () => {
+      spyOnCanViewStudentNames(true);
+      fixture.detectChanges();
+      expect(getUsernameDisplays().length).toEqual(2);
+    });
+    it('should not appear when user does not have ViewStudentNames permission', () => {
+      spyOnCanViewStudentNames(false);
+      fixture.detectChanges();
+      expect(getUsernameDisplays().length).toEqual(0);
+    });
+  });
+}
+
+function spyOnCanViewStudentNames(canView: boolean) {
+  spyOn(configService, 'getPermissions').and.returnValue({
+    canGradeStudentWork: true,
+    canViewStudentNames: canView,
+    canAuthorProject: true
+  });
+}
+
+function getUsernameDisplays() {
+  return fixture.debugElement.nativeElement.querySelectorAll('.username');
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.ts
@@ -14,10 +14,14 @@ export class ManageShowStudentInfo {
   constructor(
     protected dialog: MatDialog,
     private ConfigService: ConfigService,
+    private http: HttpClient,
     @Inject(MAT_DIALOG_DATA) public user: any
   ) {}
 
   ngOnInit() {
     this.canViewStudentNames = this.ConfigService.getPermissions().canViewStudentNames;
+    this.http.get(`/api/user/info/${this.user.id}`).subscribe((userInfo) => {
+      Object.assign(this.user, userInfo);
+    });
   }
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.ts
@@ -5,10 +5,9 @@ import { ConfigService } from '../../../../services/configService';
 
 @Component({
   selector: 'manage-show-student-info',
-  templateUrl: './manage-show-student-info.component.html',
-  styleUrls: ['./manage-show-student-info.component.scss']
+  templateUrl: './manage-show-student-info.component.html'
 })
-export class ManageShowStudentInfo {
+export class ManageShowStudentInfoComponent {
   canViewStudentNames: boolean;
 
   constructor(

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.ts
@@ -1,0 +1,23 @@
+import { HttpClient } from '@angular/common/http';
+import { Component, Inject } from '@angular/core';
+import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ConfigService } from '../../../../services/configService';
+
+@Component({
+  selector: 'manage-show-student-info',
+  templateUrl: './manage-show-student-info.component.html',
+  styleUrls: ['./manage-show-student-info.component.scss']
+})
+export class ManageShowStudentInfo {
+  canViewStudentNames: boolean;
+
+  constructor(
+    protected dialog: MatDialog,
+    private ConfigService: ConfigService,
+    @Inject(MAT_DIALOG_DATA) public user: any
+  ) {}
+
+  ngOnInit() {
+    this.canViewStudentNames = this.ConfigService.getPermissions().canViewStudentNames;
+  }
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html
@@ -1,2 +1,3 @@
 <span class="username" *ngIf="canViewStudentNames">{{user.name}} ({{user.username}})</span>
 <span class="username" *ngIf="!canViewStudentNames" i18n>Student {{user.id}}</span>
+<a class="userInfoLink" (click)="viewUserInfo()" i18n>Info</a>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html
@@ -1,3 +1,6 @@
-<span class="username" *ngIf="canViewStudentNames">{{user.name}} ({{user.username}})</span>
-<span class="username" *ngIf="!canViewStudentNames" i18n>Student {{user.id}}</span>
-<a class="userInfoLink" (click)="viewUserInfo()" i18n>Info</a>
+<div fxLayout="row" fxLayoutGap="4px">
+  <span class="username" *ngIf="canViewStudentNames">{{user.name}} ({{user.username}})</span>
+  <span class="username" *ngIf="!canViewStudentNames" i18n>Student {{user.id}}</span>
+  <span fxFlex></span>
+  <a class="userInfoLink" href="#" (click)="viewUserInfo($event)" i18n>Info</a>
+</div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
 import { configureTestSuite } from 'ng-bullet';
 import { ConfigService } from '../../../../services/configService';
@@ -16,7 +17,10 @@ describe('ManageUserComponent', () => {
   configureTestSuite(() => {
     TestBed.configureTestingModule({
       declarations: [ManageUserComponent],
-      providers: [{ provide: ConfigService, useClass: ConfigServiceStub }]
+      providers: [
+        { provide: ConfigService, useClass: ConfigServiceStub },
+        { provide: MatDialog, useValue: {} }
+      ]
     });
     configService = TestBed.inject(ConfigService);
   });

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ConfigService } from '../../../../services/configService';
-import { ManageShowStudentInfo } from '../manage-show-student-info/manage-show-student-info.component';
+import { ManageShowStudentInfoComponent } from '../manage-show-student-info/manage-show-student-info.component';
 
 @Component({
   selector: 'manage-user',
@@ -18,10 +18,11 @@ export class ManageUserComponent {
     this.canViewStudentNames = this.ConfigService.getPermissions().canViewStudentNames;
   }
 
-  viewUserInfo() {
-    this.dialog.open(ManageShowStudentInfo, {
+  viewUserInfo(event: Event) {
+    event.preventDefault();
+    this.dialog.open(ManageShowStudentInfoComponent, {
       data: this.user,
-      panelClass: 'mat-dialog--md'
+      panelClass: 'mat-dialog--sm'
     });
   }
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts
@@ -1,5 +1,7 @@
 import { Component, Input } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 import { ConfigService } from '../../../../services/configService';
+import { ManageShowStudentInfo } from '../manage-show-student-info/manage-show-student-info.component';
 
 @Component({
   selector: 'manage-user',
@@ -10,9 +12,16 @@ export class ManageUserComponent {
 
   canViewStudentNames: boolean;
 
-  constructor(private ConfigService: ConfigService) {}
+  constructor(private dialog: MatDialog, private ConfigService: ConfigService) {}
 
   ngOnInit() {
     this.canViewStudentNames = this.ConfigService.getPermissions().canViewStudentNames;
+  }
+
+  viewUserInfo() {
+    this.dialog.open(ManageShowStudentInfo, {
+      data: this.user,
+      panelClass: 'mat-dialog--md'
+    });
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -271,6 +271,10 @@
           <context context-type="linenumber">44</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/view-component-revisions/view-component-revisions.component.html</context>
           <context context-type="linenumber">139</context>
         </context-group>
@@ -406,10 +410,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html</context>
           <context context-type="linenumber">27</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html</context>
-          <context context-type="linenumber">30</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.html</context>
@@ -1996,10 +1996,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.html</context>
           <context context-type="linenumber">29</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html</context>
-          <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fa35e72aac432810b1ffca368a2e203c894d28eb" datatype="html">
@@ -8083,8 +8079,12 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">11</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html</context>
-          <context context-type="linenumber">2</context>
+          <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit>
       <trans-unit id="68e710782ccb5398b3acb8844caf0b199da2c3da" datatype="html">
@@ -8108,39 +8108,32 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8812acb117a7c33caa39ad528d0a5217225e749e" datatype="html">
-        <source>Student Information</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html</context>
-          <context context-type="linenumber">2</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="75f9b43ad69228e55dc9547a3e1f5da0ae73c3b3" datatype="html">
         <source>Student ID</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html</context>
-          <context context-type="linenumber">8</context>
+          <context context-type="linenumber">9</context>
         </context-group>
       </trans-unit>
       <trans-unit id="53684a4ac6d12088a94ed67fe4a63c7d5405be2e" datatype="html">
         <source>Most Recent Login</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html</context>
-          <context context-type="linenumber">16</context>
+          <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5e538d8948a58cc9389f36c011afcbb1e11da0f9" datatype="html">
         <source>Registration Date</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bb25f34009677c4c2254d0743979b7da782fdc92" datatype="html">
         <source>Number of Logins</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="aaea40b48d6391b2d7d409e743652d5015b3fbc6" datatype="html">
@@ -8168,7 +8161,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Info</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html</context>
-          <context context-type="linenumber">3</context>
+          <context context-type="linenumber">5</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f9c52903219e583ddefb23cd102d2057504ac980" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -408,6 +408,10 @@
           <context context-type="linenumber">27</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.html</context>
           <context context-type="linenumber">83</context>
         </context-group>
@@ -1992,6 +1996,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.html</context>
           <context context-type="linenumber">29</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html</context>
+          <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fa35e72aac432810b1ffca368a2e203c894d28eb" datatype="html">
@@ -8100,6 +8108,41 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="8812acb117a7c33caa39ad528d0a5217225e749e" datatype="html">
+        <source>Student Information</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="75f9b43ad69228e55dc9547a3e1f5da0ae73c3b3" datatype="html">
+        <source>Student ID</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="53684a4ac6d12088a94ed67fe4a63c7d5405be2e" datatype="html">
+        <source>Most Recent Login</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5e538d8948a58cc9389f36c011afcbb1e11da0f9" datatype="html">
+        <source>Registration Date</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="bb25f34009677c4c2254d0743979b7da782fdc92" datatype="html">
+        <source>Number of Logins</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="aaea40b48d6391b2d7d409e743652d5015b3fbc6" datatype="html">
         <source> Managing students in all periods is not currently supported. Please choose a specific period. </source>
         <context-group purpose="location">
@@ -8119,6 +8162,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html</context>
           <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="321e4419a943044e674beb55b8039f42a9761ca5" datatype="html">
+        <source>Info</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html</context>
+          <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f9c52903219e583ddefb23cd102d2057504ac980" datatype="html">


### PR DESCRIPTION
## Changes

- Added info button
- Fetch and display user info in a popup dialog

## Test

- Pull latest changes from wise-api manage-students-rewrite branch
- Info link appears next to the student
- User information displayed in the popup dialog when you click on the info link
- Share teachers without can view username permission (Should not be able to see the username in the popup)

## Notes

- Please style the UI as you see fit

Closes #260