### PR TITLE
Fix ViewComponentRevisions dialog styles

### DIFF
--- a/src/app/announcement/announcement.component.ts
+++ b/src/app/announcement/announcement.component.ts
@@ -27,7 +27,7 @@ export class AnnouncementComponent {
   showAnnouncementDetails() {
     this.dialog.open(AnnouncementDialogComponent, {
       data: this.announcement,
-      panelClass: 'mat-dialog--md'
+      panelClass: 'dialog-md'
     });
   }
 }

--- a/src/app/modules/library/community-library/community-library.component.ts
+++ b/src/app/modules/library/community-library/community-library.component.ts
@@ -33,7 +33,7 @@ export class CommunityLibraryComponent extends LibraryComponent {
 
   showInfo() {
     this.dialog.open(CommunityLibraryDetailsComponent, {
-      panelClass: 'mat-dialog--sm'
+      panelClass: 'dialog-sm'
     });
   }
 }

--- a/src/app/modules/library/library-project-details/library-project-details.component.ts
+++ b/src/app/modules/library/library-project-details/library-project-details.component.ts
@@ -111,12 +111,12 @@ export class LibraryProjectDetailsComponent implements OnInit {
     if (this.project.wiseVersion === 4) {
       this.dialog.open(UseWithClassWarningDialogComponent, {
         data: this.data,
-        panelClass: 'mat-dialog--md'
+        panelClass: 'dialog-md'
       });
     } else {
       this.dialog.open(CreateRunDialogComponent, {
         data: this.data,
-        panelClass: 'mat-dialog--md',
+        panelClass: 'dialog-md',
         disableClose: true
       });
     }

--- a/src/app/modules/library/library-project-menu/library-project-menu.component.ts
+++ b/src/app/modules/library/library-project-menu/library-project-menu.component.ts
@@ -68,7 +68,7 @@ export class LibraryProjectMenuComponent {
         projectRun.project = this.project;
         this.dialog.open(EditRunWarningDialogComponent, {
           data: { run: projectRun },
-          panelClass: 'mat-dialog--sm'
+          panelClass: 'dialog-sm'
         });
       } else {
         window.location.href = this.editLink;
@@ -79,7 +79,7 @@ export class LibraryProjectMenuComponent {
   shareProject() {
     this.dialog.open(ShareProjectDialogComponent, {
       data: { project: this.project },
-      panelClass: 'mat-dialog--md'
+      panelClass: 'dialog-md'
     });
   }
 }

--- a/src/app/modules/library/library-project/library-project.component.ts
+++ b/src/app/modules/library/library-project/library-project.component.ts
@@ -52,7 +52,7 @@ export class LibraryProjectComponent implements OnInit {
     this.dialog.open(LibraryProjectDetailsComponent, {
       ariaLabel: $localize`Unit Details`,
       data: { project: project },
-      panelClass: 'mat-dialog--md'
+      panelClass: 'dialog-md'
     });
   }
 }

--- a/src/app/modules/library/official-library/official-library.component.ts
+++ b/src/app/modules/library/official-library/official-library.component.ts
@@ -42,7 +42,7 @@ export class OfficialLibraryComponent extends LibraryComponent {
 
   showInfo() {
     this.dialog.open(OfficialLibraryDetailsComponent, {
-      panelClass: 'mat-dialog--sm'
+      panelClass: 'dialog-sm'
     });
   }
 }

--- a/src/app/modules/library/personal-library/personal-library.component.ts
+++ b/src/app/modules/library/personal-library/personal-library.component.ts
@@ -85,7 +85,7 @@ export class PersonalLibraryComponent extends LibraryComponent {
 
   showInfo() {
     this.dialog.open(PersonalLibraryDetailsComponent, {
-      panelClass: 'mat-dialog--sm'
+      panelClass: 'dialog-sm'
     });
   }
 }

--- a/src/app/modules/library/share-project-dialog/share-project-dialog.component.html
+++ b/src/app/modules/library/share-project-dialog/share-project-dialog.component.html
@@ -1,5 +1,5 @@
 <h2 class="mat-dialog-title" i18n>Share Unit</h2>
-<mat-dialog-content class="mat-dialog-content--scroll">
+<mat-dialog-content class="dialog-content-scroll">
   <p class="mat-subheading-1 accent-1">
     {{ project.name }} <span class="mat-caption" i18n>(Unit ID: {{ project.id }})</span>
   </p>

--- a/src/app/modules/library/teacher-project-library/teacher-project-library.component.ts
+++ b/src/app/modules/library/teacher-project-library/teacher-project-library.component.ts
@@ -63,7 +63,7 @@ export class TeacherProjectLibraryComponent implements OnInit {
 
   showInfo() {
     this.dialog.open(OfficialLibraryDetailsComponent, {
-      panelClass: 'mat-dialog--sm'
+      panelClass: 'dialog-sm'
     });
   }
 }

--- a/src/app/modules/shared/edit-password/edit-password.component.ts
+++ b/src/app/modules/shared/edit-password/edit-password.component.ts
@@ -84,7 +84,7 @@ export class EditPasswordComponent {
 
   unlinkGoogleAccount() {
     this.dialog.open(UnlinkGoogleAccountConfirmComponent, {
-      panelClass: 'mat-dialog--sm'
+      panelClass: 'dialog-sm'
     });
   }
 

--- a/src/app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.ts
+++ b/src/app/modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component.ts
@@ -12,7 +12,7 @@ export class UnlinkGoogleAccountConfirmComponent {
   continue() {
     this.dialog.closeAll();
     this.dialog.open(UnlinkGoogleAccountPasswordComponent, {
-      panelClass: 'mat-dialog--sm'
+      panelClass: 'dialog-sm'
     });
   }
 }

--- a/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html
+++ b/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html
@@ -3,7 +3,7 @@
   <span i18n>Unlink Google Account</span>
 </h2>
 <form [formGroup]="newPasswordFormGroup">
-  <mat-dialog-content class="mat-dialog-content--scroll" fxLayout="column">
+  <mat-dialog-content class="dialog-content-scroll" fxLayout="column">
     <h3 i18n>Create a WISE password:</h3>
     <mat-form-field appearance="fill">
       <mat-label i18n>New Password</mat-label>

--- a/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.ts
+++ b/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.ts
@@ -33,7 +33,7 @@ export class UnlinkGoogleAccountPasswordComponent {
         this.isSaving = false;
         this.dialog.closeAll();
         this.dialog.open(UnlinkGoogleAccountSuccessComponent, {
-          panelClass: 'mat-dialog--sm'
+          panelClass: 'dialog-sm'
         });
       });
   }

--- a/src/app/student/account/edit-profile/edit-profile.component.ts
+++ b/src/app/student/account/edit-profile/edit-profile.component.ts
@@ -99,7 +99,7 @@ export class EditProfileComponent {
 
   unlinkGoogleAccount() {
     this.dialog.open(UnlinkGoogleAccountConfirmComponent, {
-      panelClass: 'mat-dialog--sm'
+      panelClass: 'dialog-sm'
     });
   }
 }

--- a/src/app/student/student-run-list-item/student-run-list-item.component.ts
+++ b/src/app/student/student-run-list-item/student-run-list-item.component.ts
@@ -60,7 +60,7 @@ export class StudentRunListItemComponent implements OnInit {
     } else {
       this.dialog.open(TeamSignInDialogComponent, {
         data: { run: this.run },
-        panelClass: 'mat-dialog--sm',
+        panelClass: 'dialog-sm',
         disableClose: true
       });
     }

--- a/src/app/student/team-sign-in-dialog/team-sign-in-dialog.component.html
+++ b/src/app/student/team-sign-in-dialog/team-sign-in-dialog.component.html
@@ -1,5 +1,5 @@
 <h2 class="mat-dialog-title" i18n>Team Sign In</h2>
-<mat-dialog-content class="mat-dialog-content--scroll">
+<mat-dialog-content class="dialog-content-scroll">
   <p class="mat-subheading-2 accent-1">{{ run.name }}</p>
   <mat-divider></mat-divider>
   <p class="mat-body-2" fxLayoutAlign="start center" fxLayoutGap="2px">

--- a/src/app/student/team-sign-in-dialog/team-sign-in-dialog.component.scss
+++ b/src/app/student/team-sign-in-dialog/team-sign-in-dialog.component.scss
@@ -1,4 +1,4 @@
-.mat-dialog-content--scroll {
+.dialog-content-scroll {
   display: block !important;
 }
 

--- a/src/app/teacher/account/edit-profile/edit-profile.component.ts
+++ b/src/app/teacher/account/edit-profile/edit-profile.component.ts
@@ -152,7 +152,7 @@ export class EditProfileComponent {
 
   unlinkGoogleAccount() {
     this.dialog.open(UnlinkGoogleAccountConfirmComponent, {
-      panelClass: 'mat-dialog--sm'
+      panelClass: 'dialog-sm'
     });
   }
 }

--- a/src/app/teacher/create-run-dialog/create-run-dialog.component.html
+++ b/src/app/teacher/create-run-dialog/create-run-dialog.component.html
@@ -1,6 +1,6 @@
 <h2 class="mat-dialog-title" i18n>Use with Class</h2>
 <form *ngIf="!isCreated" [formGroup]="form" (ngSubmit)="create()">
-  <mat-dialog-content class="mat-dialog-content--scroll">
+  <mat-dialog-content class="dialog-content-scroll">
     <p class="mat-subheading-2 accent-1">
       {{ project.metadata.title }} <span class="mat-caption" i18n>(Unit ID: {{ project.id }})</span>
     </p>

--- a/src/app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html
+++ b/src/app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.html
@@ -18,7 +18,7 @@
 </ng-container>
 <ng-container *ngIf="courses.length && !isAdded">
   <form [formGroup]="form" (ngSubmit)="addToClassroom()">
-    <mat-dialog-content class="mat-dialog-content--scroll" fxLayout="column">
+    <mat-dialog-content class="dialog-content-scroll" fxLayout="column">
       <p class="mat-subheading-1 accent-1">
         {{ data.run.name }} <span class="mat-caption" i18n>(Run ID: {{ data.run.id }})</span>
       </p>

--- a/src/app/teacher/run-menu/run-menu.component.ts
+++ b/src/app/teacher/run-menu/run-menu.component.ts
@@ -40,7 +40,7 @@ export class RunMenuComponent implements OnInit {
   shareRun() {
     this.dialog.open(ShareRunDialogComponent, {
       data: { run: this.run },
-      panelClass: 'mat-dialog--md'
+      panelClass: 'dialog-md'
     });
   }
 
@@ -48,7 +48,7 @@ export class RunMenuComponent implements OnInit {
     const project = this.run.project;
     this.dialog.open(LibraryProjectDetailsComponent, {
       data: { project: project, isRunProject: true },
-      panelClass: 'mat-dialog--md'
+      panelClass: 'dialog-md'
     });
   }
 
@@ -73,7 +73,7 @@ export class RunMenuComponent implements OnInit {
     this.dialog.open(RunSettingsDialogComponent, {
       ariaLabel: $localize`Run Settings`,
       data: { run: run },
-      panelClass: 'mat-dialog--md',
+      panelClass: 'dialog-md',
       autoFocus: true
     });
   }
@@ -83,7 +83,7 @@ export class RunMenuComponent implements OnInit {
       this.dialog.open(EditRunWarningDialogComponent, {
         ariaLabel: $localize`Edit Classroom Unit Warning`,
         data: { run: this.run },
-        panelClass: 'mat-dialog--sm'
+        panelClass: 'dialog-sm'
       });
     } else {
       this.router.navigateByUrl(this.editLink);

--- a/src/app/teacher/run-settings-dialog/run-settings-dialog.component.html
+++ b/src/app/teacher/run-settings-dialog/run-settings-dialog.component.html
@@ -1,5 +1,5 @@
 <h2 class="mat-dialog-title" i18n>Edit Settings</h2>
-<mat-dialog-content class="mat-dialog-content--scroll">
+<mat-dialog-content class="dialog-content-scroll">
   <p class="mat-subheading-2 accent-1">
     {{ run.name }} <span class="mat-caption" i18n>(Run ID: {{ run.id }})</span>
   </p>

--- a/src/app/teacher/share-run-code-dialog/share-run-code-dialog.component.ts
+++ b/src/app/teacher/share-run-code-dialog/share-run-code-dialog.component.ts
@@ -68,7 +68,7 @@ export class ShareRunCodeDialogComponent {
     this.teacherService
       .getClassroomCourses(this.userService.getUser().getValue().username)
       .subscribe((courses) => {
-        const panelClass = courses.length ? 'mat-dialog--md' : '';
+        const panelClass = courses.length ? 'dialog-md' : '';
         this.dialog.open(ListClassroomCoursesDialogComponent, {
           data: { run: this.run, courses },
           panelClass: panelClass

--- a/src/app/teacher/share-run-dialog/share-run-dialog.component.html
+++ b/src/app/teacher/share-run-dialog/share-run-dialog.component.html
@@ -7,7 +7,7 @@
   <span fxFlex></span>
   <mat-icon *ngIf="transferRunWarning" color="warn">warning</mat-icon>
 </h2>
-<div mat-dialog-content [class.mat-dialog-content--scroll]="!transferRunWarning"
+<div mat-dialog-content [class.dialog-content-scroll]="!transferRunWarning"
     *ngIf="run != null">
   <div [class.info-block]="transferRunWarning">
     <p class="mat-subheading-1 accent-1">

--- a/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
+++ b/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
@@ -102,7 +102,7 @@ export class TeacherRunListItemComponent implements OnInit {
   shareCode() {
     this.dialog.open(ShareRunCodeDialogComponent, {
       data: { run: this.run },
-      panelClass: 'mat-dialog--sm'
+      panelClass: 'dialog-sm'
     });
   }
 }

--- a/src/app/teacher/teacher.service.ts
+++ b/src/app/teacher/teacher.service.ts
@@ -45,7 +45,7 @@ export class TeacherService {
   copyProject(project: Project, dialog: MatDialog) {
     dialog.open(CopyProjectDialogComponent, {
       data: { project: project },
-      panelClass: 'mat-dialog--sm'
+      panelClass: 'dialog-sm'
     });
   }
 

--- a/src/app/teacher/use-with-class-warning-dialog/use-with-class-warning-dialog.component.ts
+++ b/src/app/teacher/use-with-class-warning-dialog/use-with-class-warning-dialog.component.ts
@@ -23,7 +23,7 @@ export class UseWithClassWarningDialogComponent implements OnInit {
   proceedAnyway() {
     this.dialog.open(CreateRunDialogComponent, {
       data: this.data,
-      panelClass: 'mat-dialog--md',
+      panelClass: 'dialog-md',
       disableClose: true
     });
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/nodeIcon/node-icon.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/nodeIcon/node-icon.component.ts
@@ -57,7 +57,7 @@ export class NodeIconComponent {
   openNodeIconChooserDialog() {
     this.dialog.open(NodeIconChooserDialog, {
       data: { node: this.node },
-      panelClass: 'mat-dialog--md'
+      panelClass: 'dialog-md'
     });
   }
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/view-component-revisions/view-component-revisions.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/view-component-revisions/view-component-revisions.component.html
@@ -1,5 +1,5 @@
-<mat-toolbar color="primary" i18n>Revisions for {{usernames}}</mat-toolbar>
-<mat-dialog-content>
+<h2 class="mat-dialog-title" i18n>Revisions for {{usernames}}</h2>
+<mat-dialog-content class="dialog-content-scroll">
   <mat-list class="component-revisions">
     <mat-list-item *ngFor="let revision of revisionsSorted; index as i; first as isFirst"
         class="list-item md-whiteframe-1dp component-revisions__item"
@@ -10,9 +10,9 @@
         <h3 class="accent-1 md-body-2 gray-lightest-bg component__header">
           #{{totalRevisions - i}} <span *ngIf="isFirst">(Latest)</span>
         </h3>
-        <div style="padding: 20px;">
+        <div class="component--grading">
           <div class="component__content" fxLayout="row wrap">
-            <div fxFlex="100" fxFlex.gt-sm="66" fxLayout="column" class="component--grading__response">
+            <div fxFlex="100" fxFlex.gt-sm="66.67" fxLayout="column" class="component--grading__response">
               <animation-grading
                   *ngIf="revision.componentState.componentType === 'Animation'"
                   [nodeId]="nodeId"
@@ -109,15 +109,15 @@
                   [workgroupId]="workgroupId"
                   [isRevision]="true">
               </table-grading>
+              <span fxFlex></span>
               <div class="component__actions__info component--grading__actions__info md-caption">
                 <component-state-info [componentState]="revision.componentState" [isActive]="false">
                 </component-state-info>
               </div>
             </div>
             <edit-component-annotations
-                class="component--grading__annotations"
                 fxFlex="100"
-                fxFlex.gt-sm="33"
+                fxFlex.gt-sm="33.33"
                 [componentId]="componentId"
                 [componentStateId]="revision.componentState.id"
                 [fromWorkgroupId]="fromWorkgroupId"

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.ts
@@ -54,7 +54,7 @@ export class WorkgroupComponentGradingComponent {
         nodeId: this.nodeId,
         componentStates: this.componentStates
       },
-      panelClass: 'mat-dialog--md'
+      panelClass: 'dialog-lg'
     });
   }
 }

--- a/src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.html
+++ b/src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.html
@@ -16,7 +16,7 @@
       i18n-aria-label />
   <span i18n>Choose an Icon</span>
 </h2>
-<mat-dialog-content class="mat-dialog-content--scroll">
+<mat-dialog-content class="dialog-content-scroll">
   <div fxLayout="column" fxLayout.gt-sm="row" fxLayoutGap="16px">
     <div>
       <h3 i18n>Icon:</h3>

--- a/src/assets/wise5/components/match/match-student/match-student.component.ts
+++ b/src/assets/wise5/components/match/match-student/match-student.component.ts
@@ -753,7 +753,7 @@ export class MatchStudent extends ComponentStudent {
   addChoice(): void {
     this.dialog
       .open(AddMatchChoiceDialog, {
-        panelClass: 'mat-dialog--sm'
+        panelClass: 'dialog-sm'
       })
       .afterClosed()
       .subscribe((result) => {

--- a/src/style/abstracts/_mixins.scss
+++ b/src/style/abstracts/_mixins.scss
@@ -137,7 +137,7 @@
     border-radius: $card-border-radius;
   }
 
-  .mat-dialog-content--scroll {
+  .dialog-content-scroll {
     border-bottom: 1px solid;
     border-top: 1px solid;
   }
@@ -283,7 +283,7 @@
     }
   }
 
-  .mat-dialog-content--scroll {
+  .dialog-content-scroll {
     background-color: map-get($colors, notice-bg);
     border-color: map_get($background, background);
   }

--- a/src/style/components/_dialog.scss
+++ b/src/style/components/_dialog.scss
@@ -1,6 +1,6 @@
-.mat-dialog-container {
+mat-dialog-container.mat-dialog-container {
   max-width: 100%;
-  padding: 16px !important;
+  padding: 16px;
 
   .mat-dialog-content {
     margin: 0 -16px;
@@ -8,29 +8,25 @@
     font-size: mat-font-size($config, body-1);
   }
 
-  .mat-dialog-content--scroll {
+  .dialog-content-scroll {
     padding-top: 16px;
     padding-bottom: 16px;
   }
 }
 
-.dialog-menu {
-  margin: -8px -8px 8px 8px;
-}
-
-.mat-dialog--sm {
+.dialog-sm {
   width: breakpoint('sm.min');
 }
 
-.mat-dialog--md {
+.dialog-md {
   width: breakpoint('md.min');
 }
 
-.mat-dialog--lg {
+.dialog-lg {
   width: breakpoint('lg.min');
 }
 
-.mat-dialog--xl {
+.dialog-xl {
   width: breakpoint('xl.min');
 }
 


### PR DESCRIPTION
## Changes
Updated ViewComponentRevisions dialog styles to be consistent with other Angular Material dialogs.

Also changed some dialog-specific class names to distinguish them from Angular Material styles.

Closes #310.

## Test
- View component revisions from the Grade by Step or Grade by Student views in the Teacher Tools and make sure the updated dialog styles are applied.
- Make sure other Angular Material dialogs in the apps appear as before.