### PR TITLE
Expanding a workgroup with no work throws a console error

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.html
@@ -1,78 +1,80 @@
 <div class="component__content" fxLayout="row wrap">
   <div fxLayout="column" fxFlex="100" fxFlex.gt-sm="66" class="component--grading__response">
-    <animation-grading
-        *ngIf="component.type === 'Animation'"
-        [nodeId]="nodeId"
-        [componentId]="component.id"
-        [componentState]="latestComponentState">
-    </animation-grading>
-    <audio-oscillator-grading
-        *ngIf="component.type === 'AudioOscillator'"
-        [nodeId]="nodeId"
-        [componentId]="component.id"
-        [componentState]="latestComponentState">
-    </audio-oscillator-grading>
-    <concept-map-grading
-        *ngIf="component.type === 'ConceptMap'"
-        [nodeId]="nodeId"
-        [componentId]="component.id"
-        [componentState]="latestComponentState">
-    </concept-map-grading>
-    <discussion-grading
-        *ngIf="component.type === 'Discussion'"
-        [nodeId]="nodeId"
-        [componentId]="component.id"
-        [componentState]="latestComponentState"
-        [workgroupId]="workgroupId">
-    </discussion-grading>
-    <draw-grading
-        *ngIf="component.type === 'Draw'"
-        [nodeId]="nodeId"
-        [componentId]="component.id"
-        [componentState]="latestComponentState">
-    </draw-grading>
-    <embedded-grading
-        *ngIf="component.type === 'Embedded'"
-        [nodeId]="nodeId"
-        [componentId]="component.id"
-        [componentState]="latestComponentState">
-    </embedded-grading>
-    <graph-grading
-        *ngIf="component.type === 'Graph'"
-        [nodeId]="nodeId"
-        [componentId]="component.id"
-        [componentState]="latestComponentState">
-    </graph-grading>
-    <label-grading
-        *ngIf="component.type === 'Label'"
-        [nodeId]="nodeId"
-        [componentId]="component.id"
-        [componentState]="latestComponentState">
-    </label-grading>
-    <match-grading
-        *ngIf="component.type === 'Match'"
-        [nodeId]="nodeId"
-        [componentId]="component.id"
-        [componentState]="latestComponentState">
-    </match-grading>
-    <multiple-choice-grading
-        *ngIf="component.type === 'MultipleChoice'"
-        [nodeId]="nodeId"
-        [componentId]="component.id"
-        [componentState]="latestComponentState">
-    </multiple-choice-grading>
-    <open-response-grading
-        *ngIf="component.type === 'OpenResponse'"
-        [nodeId]="nodeId"
-        [componentId]="component.id"
-        [componentState]="latestComponentState">
-    </open-response-grading>
-    <table-grading
-        *ngIf="component.type === 'Table'"
-        [nodeId]="nodeId"
-        [componentId]="component.id"
-        [componentState]="latestComponentState">
-    </table-grading>
+    <ng-container *ngIf="latestComponentState != null">
+      <animation-grading
+          *ngIf="component.type === 'Animation'"
+          [nodeId]="nodeId"
+          [componentId]="component.id"
+          [componentState]="latestComponentState">
+      </animation-grading>
+      <audio-oscillator-grading
+          *ngIf="component.type === 'AudioOscillator'"
+          [nodeId]="nodeId"
+          [componentId]="component.id"
+          [componentState]="latestComponentState">
+      </audio-oscillator-grading>
+      <concept-map-grading
+          *ngIf="component.type === 'ConceptMap'"
+          [nodeId]="nodeId"
+          [componentId]="component.id"
+          [componentState]="latestComponentState">
+      </concept-map-grading>
+      <discussion-grading
+          *ngIf="component.type === 'Discussion'"
+          [nodeId]="nodeId"
+          [componentId]="component.id"
+          [componentState]="latestComponentState"
+          [workgroupId]="workgroupId">
+      </discussion-grading>
+      <draw-grading
+          *ngIf="component.type === 'Draw'"
+          [nodeId]="nodeId"
+          [componentId]="component.id"
+          [componentState]="latestComponentState">
+      </draw-grading>
+      <embedded-grading
+          *ngIf="component.type === 'Embedded'"
+          [nodeId]="nodeId"
+          [componentId]="component.id"
+          [componentState]="latestComponentState">
+      </embedded-grading>
+      <graph-grading
+          *ngIf="component.type === 'Graph'"
+          [nodeId]="nodeId"
+          [componentId]="component.id"
+          [componentState]="latestComponentState">
+      </graph-grading>
+      <label-grading
+          *ngIf="component.type === 'Label'"
+          [nodeId]="nodeId"
+          [componentId]="component.id"
+          [componentState]="latestComponentState">
+      </label-grading>
+      <match-grading
+          *ngIf="component.type === 'Match'"
+          [nodeId]="nodeId"
+          [componentId]="component.id"
+          [componentState]="latestComponentState">
+      </match-grading>
+      <multiple-choice-grading
+          *ngIf="component.type === 'MultipleChoice'"
+          [nodeId]="nodeId"
+          [componentId]="component.id"
+          [componentState]="latestComponentState">
+      </multiple-choice-grading>
+      <open-response-grading
+          *ngIf="component.type === 'OpenResponse'"
+          [nodeId]="nodeId"
+          [componentId]="component.id"
+          [componentState]="latestComponentState">
+      </open-response-grading>
+      <table-grading
+          *ngIf="component.type === 'Table'"
+          [nodeId]="nodeId"
+          [componentId]="component.id"
+          [componentState]="latestComponentState">
+      </table-grading>
+    </ng-container>
     <span fxFlex></span>
     <div *ngIf="componentStates.length === 0" class="component__actions__info component--grading__actions__info md-caption" i18n>
       Team has not saved any work
@@ -88,7 +90,7 @@
   <div fxFlex="100" fxFlex.gt-sm="33" class="component--grading__annotations">
     <edit-component-annotations
         [componentId]="component.id"
-        [componentStateId]="latestComponentState.id"
+        [componentStateId]="latestComponentStateId"
         [fromWorkgroupId]="teacherWorkgroupId"
         [isDisabled]="false"
         [nodeId]="nodeId"

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.ts
@@ -19,6 +19,7 @@ export class WorkgroupComponentGradingComponent {
   component: any;
   componentStates: any[];
   latestComponentState: any;
+  latestComponentStateId: number;
   teacherWorkgroupId: number;
 
   constructor(
@@ -43,6 +44,9 @@ export class WorkgroupComponentGradingComponent {
       this.nodeId,
       this.componentId
     );
+    if (this.latestComponentState != null) {
+      this.latestComponentStateId = this.latestComponentState.id;
+    }
   }
 
   showRevisions() {


### PR DESCRIPTION
1. Go to the Classroom Monitor
2. Go to the Grade By Step view
3. Click on a step
4. Click on a workgroup that has no work for that step
5. There should be no error in the console

It used to throw this error
```
angular.js:15570 TypeError: Cannot read properties of null (reading 'id')
    at WorkgroupComponentGradingComponent_Template (workgroup-component-grading.component.html:96)
    at executeTemplate (core.js:9549)
    at refreshView (core.js:9418)
    at refreshComponent (core.js:10584)
    at refreshChildComponents (core.js:9215)
    at refreshView (core.js:9468)
    at renderComponentOrTemplate (core.js:9532)
    at tickRootContext (core.js:10758)
    at detectChangesInRootView (core.js:10783)
    at RootViewRef.detectChanges (core.js:22751)
```

Closes #320