### PR TITLE
Fix match component moving wrong item from source

### DIFF
--- a/src/assets/wise5/components/match/match-student/match-student.component.html
+++ b/src/assets/wise5/components/match/match-student/match-student.component.html
@@ -26,7 +26,8 @@
             [cdkDragDisabled]="isDisabled"
             (cdkDragEntered)="dragEnter($event)"
             (cdkDragExited)="dragExit($event)"
-            *ngFor="let item of buckets[0].items">
+            *ngFor="let item of buckets[0].items; let position = index;"
+            [cdkDragData]="position">
           <match-choice-item [buckets]="buckets"
               [item]="item"
               [hasCorrectAnswer]="hasCorrectAnswer"
@@ -63,7 +64,8 @@
               [cdkDragDisabled]="isDisabled"
               (cdkDragEntered)="dragEnter($event)"
               (cdkDragExited)="dragExit($event)"
-              *ngFor="let item of bucket.items">
+              *ngFor="let item of bucket.items; let position = index;"
+              [cdkDragData]="position">
             <match-choice-item [buckets]="buckets"
                 [item]="item"
                 [hasCorrectAnswer]="hasCorrectAnswer"

--- a/src/assets/wise5/components/match/match-student/match-student.component.ts
+++ b/src/assets/wise5/components/match/match-student/match-student.component.ts
@@ -130,12 +130,12 @@ export class MatchStudent extends ComponentStudent {
 
   drop(event: CdkDragDrop<string[]>) {
     if (event.previousContainer === event.container) {
-      moveItemInArray(event.container.data, event.previousIndex, event.currentIndex);
+      moveItemInArray(event.container.data, event.item.data, event.currentIndex);
     } else {
       transferArrayItem(
         event.previousContainer.data,
         event.container.data,
-        event.previousIndex,
+        event.item.data,
         event.currentIndex
       );
     }


### PR DESCRIPTION
## Changes
Fixed a bug that was causing Match component to move a different item than the one that was dragged from the source bucket when there are more than 3 source items.

Resolves #324.

## Test
1. Create a step with a Match item.
2. Add 4 items to the source bucket.
3. Drag item 2 to a target bucket.
4. Verify that item 2 is correctly moved to the target bucket.
5. Try with more items in the source bucket and make sure the correct item is moved each time.