### PR TITLE
Add isSecondToLastSubmit rule in DialogGuidance

### DIFF
--- a/src/assets/wise5/components/dialogGuidance/CRaterIdea.ts
+++ b/src/assets/wise5/components/dialogGuidance/CRaterIdea.ts
@@ -1,0 +1,5 @@
+export class CRaterIdea {
+  name: string;
+  detected: boolean;
+  characterOffsets: any[];
+}

--- a/src/assets/wise5/components/dialogGuidance/CRaterResponse.ts
+++ b/src/assets/wise5/components/dialogGuidance/CRaterResponse.ts
@@ -7,8 +7,14 @@ export class CRaterResponse {
 
   constructor() {}
 
-  getDetectedIdeas(): CRaterIdea[] {
-    return this.ideas.filter((idea) => idea.detected);
+  getDetectedIdeaNames(): CRaterIdea[] {
+    const detectedIdeaNames = [];
+    this.ideas.forEach((idea: CRaterIdea) => {
+      if (idea.detected) {
+        detectedIdeaNames.push(idea.name);
+      }
+    });
+    return detectedIdeaNames;
   }
 
   getKIScore() {

--- a/src/assets/wise5/components/dialogGuidance/CRaterResponse.ts
+++ b/src/assets/wise5/components/dialogGuidance/CRaterResponse.ts
@@ -1,3 +1,6 @@
+import { CRaterIdea } from './CRaterIdea';
+import { CRaterScore } from './CRaterScore';
+
 export class CRaterResponse {
   scores: CRaterScore[];
   ideas: CRaterIdea[];
@@ -15,16 +18,4 @@ export class CRaterResponse {
       }
     }
   }
-}
-
-class CRaterScore {
-  id: string;
-  score: number;
-  realNumberScore: number;
-}
-
-class CRaterIdea {
-  name: string;
-  detected: boolean;
-  characterOffsets: any[];
 }

--- a/src/assets/wise5/components/dialogGuidance/CRaterScore.ts
+++ b/src/assets/wise5/components/dialogGuidance/CRaterScore.ts
@@ -1,0 +1,5 @@
+export class CRaterScore {
+  id: string;
+  score: number;
+  realNumberScore: number;
+}

--- a/src/assets/wise5/components/dialogGuidance/ComputerDialogResponse.ts
+++ b/src/assets/wise5/components/dialogGuidance/ComputerDialogResponse.ts
@@ -1,11 +1,13 @@
+import { CRaterIdea } from './CRaterIdea';
+import { CRaterScore } from './CRaterScore';
 import { DialogResponse } from './DialogResponse';
 
 export class ComputerDialogResponse extends DialogResponse {
-  ideas: any[];
-  scores: any[];
+  ideas: CRaterIdea[];
+  scores: CRaterScore[];
   user: string = 'Computer';
 
-  constructor(text: string, scores: any[], ideas: string[], timestamp: number) {
+  constructor(text: string, scores: CRaterScore[], ideas: CRaterIdea[], timestamp: number) {
     super(text, timestamp);
     this.ideas = ideas;
     this.scores = scores;

--- a/src/assets/wise5/components/dialogGuidance/FeedbackRule.ts
+++ b/src/assets/wise5/components/dialogGuidance/FeedbackRule.ts
@@ -6,4 +6,16 @@ export class FeedbackRule {
     this.feedback = feedback;
     this.ideas = ideas;
   }
+
+  static isSecondToLastSubmitRule(feedbackRule: FeedbackRule): boolean {
+    return feedbackRule.ideas[0] === 'isSecondToLastSubmit';
+  }
+
+  static isFinalSubmitRule(feedbackRule: FeedbackRule): boolean {
+    return feedbackRule.ideas[0] === 'isFinalSubmit';
+  }
+
+  static isDefaultRule(feedbackRule: FeedbackRule): boolean {
+    return feedbackRule.ideas[0] === 'isDefault';
+  }
 }

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.spec.ts
@@ -1,20 +1,75 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { FormsModule } from '@angular/forms';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { UpgradeModule } from '@angular/upgrade/static';
+import { Observable, Subject } from 'rxjs';
+import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-component-prompt/edit-component-prompt.component';
+import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
+import { ConfigService } from '../../../services/configService';
+import { NodeService } from '../../../services/nodeService';
+import { ProjectService } from '../../../services/projectService';
+import { SessionService } from '../../../services/sessionService';
+import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { UtilService } from '../../../services/utilService';
+import { EditDialogGuidanceFeedbackRulesComponent } from '../edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component';
 import { DialogGuidanceAuthoringComponent } from './dialog-guidance-authoring.component';
 
-xdescribe('DialogGuidanceAuthoringComponent', () => {
+class MockNodeService {
+  private starterStateResponseSource: Subject<any> = new Subject<any>();
+  public starterStateResponse$: Observable<any> = this.starterStateResponseSource.asObservable();
+  createNewComponentState() {
+    return {};
+  }
+}
+
+describe('DialogGuidanceAuthoringComponent', () => {
   let component: DialogGuidanceAuthoringComponent;
   let fixture: ComponentFixture<DialogGuidanceAuthoringComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [DialogGuidanceAuthoringComponent]
+      imports: [
+        BrowserAnimationsModule,
+        FormsModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        MatFormFieldModule,
+        MatInputModule,
+        UpgradeModule
+      ],
+      declarations: [
+        DialogGuidanceAuthoringComponent,
+        EditComponentPrompt,
+        EditDialogGuidanceFeedbackRulesComponent
+      ],
+      providers: [
+        ConfigService,
+        { provide: NodeService, useClass: MockNodeService },
+        ProjectAssetService,
+        ProjectService,
+        SessionService,
+        TeacherProjectService,
+        UtilService
+      ]
     }).compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DialogGuidanceAuthoringComponent);
     component = fixture.componentInstance;
+    const componentContent = createComponentContent();
+    spyOn(TestBed.inject(ProjectService), 'getComponentByNodeIdAndComponentId').and.returnValue(
+      JSON.parse(JSON.stringify(componentContent))
+    );
+    spyOn(
+      TestBed.inject(TeacherProjectService),
+      'getComponentByNodeIdAndComponentId'
+    ).and.returnValue(JSON.parse(JSON.stringify(componentContent)));
+    component.componentContent = JSON.parse(JSON.stringify(componentContent));
     fixture.detectChanges();
   });
 
@@ -22,3 +77,13 @@ xdescribe('DialogGuidanceAuthoringComponent', () => {
     expect(component).toBeTruthy();
   });
 });
+
+function createComponentContent() {
+  return {
+    id: 'i64ex48j1z',
+    type: 'DialogGuidance',
+    prompt: '',
+    showSaveButton: false,
+    showSubmitButton: false
+  };
+}

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-grading/dialog-guidance-grading.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-grading/dialog-guidance-grading.component.spec.ts
@@ -1,20 +1,31 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { UpgradeModule } from '@angular/upgrade/static';
+import { ConfigService } from '../../../services/configService';
+import { ProjectService } from '../../../services/projectService';
+import { SessionService } from '../../../services/sessionService';
+import { UtilService } from '../../../services/utilService';
+import { DialogResponsesComponent } from '../dialog-responses/dialog-responses.component';
 import { DialogGuidanceGradingComponent } from './dialog-guidance-grading.component';
 
-xdescribe('DialogGuidanceGradingComponent', () => {
+describe('DialogGuidanceGradingComponent', () => {
   let component: DialogGuidanceGradingComponent;
   let fixture: ComponentFixture<DialogGuidanceGradingComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [DialogGuidanceGradingComponent]
+      imports: [HttpClientTestingModule, UpgradeModule],
+      declarations: [DialogGuidanceGradingComponent, DialogResponsesComponent],
+      providers: [ConfigService, ProjectService, SessionService, UtilService]
     }).compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DialogGuidanceGradingComponent);
     component = fixture.componentInstance;
+    component.componentState = {
+      studentData: {}
+    };
     fixture.detectChanges();
   });
 

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.spec.ts
@@ -1,6 +1,14 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
+import { ComponentHeader } from '../../../directives/component-header/component-header.component';
 import { AnnotationService } from '../../../services/annotationService';
 import { ConfigService } from '../../../services/configService';
 import { CRaterService } from '../../../services/cRaterService';
@@ -15,8 +23,8 @@ import { UtilService } from '../../../services/utilService';
 import { MockNodeService } from '../../animation/animation-authoring/animation-authoring.component.spec';
 import { MockService } from '../../animation/animation-student/animation-student.component.spec';
 import { ComponentService } from '../../componentService';
+import { DialogResponsesComponent } from '../dialog-responses/dialog-responses.component';
 import { DialogGuidanceService } from '../dialogGuidanceService';
-
 import { DialogGuidanceStudentComponent } from './dialog-guidance-student.component';
 
 describe('DialogGuidanceStudentComponent', () => {
@@ -25,8 +33,22 @@ describe('DialogGuidanceStudentComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [DialogGuidanceStudentComponent],
-      imports: [HttpClientTestingModule, UpgradeModule],
+      declarations: [
+        ComponentHeader,
+        DialogGuidanceStudentComponent,
+        DialogResponsesComponent,
+        PossibleScoreComponent
+      ],
+      imports: [
+        BrowserAnimationsModule,
+        FormsModule,
+        HttpClientTestingModule,
+        MatCardModule,
+        MatFormFieldModule,
+        MatIconModule,
+        MatInputModule,
+        UpgradeModule
+      ],
       providers: [
         AnnotationService,
         ComponentService,
@@ -47,12 +69,19 @@ describe('DialogGuidanceStudentComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DialogGuidanceStudentComponent);
+    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
+      score: 0,
+      comment: ''
+    });
+    spyOn(TestBed.inject(ProjectService), 'getThemeSettings').and.returnValue({});
     component = fixture.componentInstance;
     component.componentContent = TestBed.inject(DialogGuidanceService).createComponent();
+    spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});
+    spyOn(component, 'isNotebookEnabled').and.returnValue(false);
     fixture.detectChanges();
   });
 
-  xit('should create', () => {
+  it('should create', () => {
     expect(component).toBeTruthy();
   });
 });

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
@@ -134,7 +134,7 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
     const computerDialogResponse = new ComputerDialogResponse(
       feedbackRule.feedback,
       response.scores,
-      ['idea' + response.getKIScore()],
+      response.ideas,
       new Date().getTime()
     );
     this.addDialogResponse(computerDialogResponse);

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
@@ -146,17 +146,48 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
 
   getFeedbackRule(response: CRaterResponse): FeedbackRule {
     for (const feedbackRule of this.componentContent.feedbackRules) {
-      if (this.hasMaxSubmitCountAndUsedAllSubmits() && feedbackRule.ideas[0] === 'isFinalSubmit') {
-        return feedbackRule;
-      }
-      if (
-        response.getDetectedIdeas().length > 0 &&
-        feedbackRule.ideas[0] === response.getDetectedIdeas()[0].name
-      ) {
+      if (this.satisfiesRule(response, feedbackRule)) {
         return feedbackRule;
       }
     }
-    return this.componentContent.feedbackRules.find((rule) => rule.ideas[0] === 'default');
+    return this.getDefaultRule(this.componentContent.feedbackRules);
+  }
+
+  satisfiesRule(response: CRaterResponse, feedbackRule: FeedbackRule): boolean {
+    return (
+      this.satisfiesFinalSubmitRule(feedbackRule) ||
+      this.satisfiesSecondToLastSubmitRule(feedbackRule) ||
+      this.satisfiesSpecificRule(response, feedbackRule)
+    );
+  }
+
+  satisfiesFinalSubmitRule(feedbackRule: FeedbackRule): boolean {
+    return (
+      this.hasMaxSubmitCountAndUsedAllSubmits() && FeedbackRule.isFinalSubmitRule(feedbackRule)
+    );
+  }
+
+  satisfiesSecondToLastSubmitRule(feedbackRule: FeedbackRule): boolean {
+    return (
+      this.hasMaxSubmitCount() &&
+      this.isSecondToLastSubmit() &&
+      FeedbackRule.isSecondToLastSubmitRule(feedbackRule)
+    );
+  }
+
+  isSecondToLastSubmit(): boolean {
+    return this.getNumberOfSubmitsLeft() === 1;
+  }
+
+  satisfiesSpecificRule(response: CRaterResponse, feedbackRule: FeedbackRule): boolean {
+    return this.UtilService.arraysContainSameValues(
+      response.getDetectedIdeaNames(),
+      feedbackRule.ideas
+    );
+  }
+
+  getDefaultRule(feedbackRules: FeedbackRule[]): FeedbackRule {
+    return feedbackRules.find((rule) => FeedbackRule.isDefaultRule(rule));
   }
 
   cRaterErrorResponse() {

--- a/src/assets/wise5/components/dialogGuidance/dialog-response/dialog-response.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-response/dialog-response.component.spec.ts
@@ -1,20 +1,28 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { MatIconModule } from '@angular/material/icon';
+import { UpgradeModule } from '@angular/upgrade/static';
+import { ConfigService } from '../../../services/configService';
+import { DialogResponse } from '../DialogResponse';
 import { DialogResponseComponent } from './dialog-response.component';
 
-xdescribe('DialogResponseComponent', () => {
+describe('DialogResponseComponent', () => {
   let component: DialogResponseComponent;
   let fixture: ComponentFixture<DialogResponseComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [DialogResponseComponent]
+      imports: [FlexLayoutModule, HttpClientTestingModule, MatIconModule, UpgradeModule],
+      declarations: [DialogResponseComponent],
+      providers: [ConfigService]
     }).compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DialogResponseComponent);
     component = fixture.componentInstance;
+    component.response = new DialogResponse('Hello World', new Date().getTime(), 1);
     fixture.detectChanges();
   });
 

--- a/src/assets/wise5/components/dialogGuidance/dialog-responses/dialog-responses.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-responses/dialog-responses.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentHeader } from '../../../directives/component-header/component-header.component';
 import { DialogResponsesComponent } from './dialog-responses.component';
 
 describe('DialogResponsesComponent', () => {
@@ -8,9 +8,8 @@ describe('DialogResponsesComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ DialogResponsesComponent ]
-    })
-    .compileComponents();
+      declarations: [ComponentHeader, DialogResponsesComponent]
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { EditDialogGuidanceFeedbackRulesComponent } from './edit-dialog-guidance-feedback-rules.component';
 
 describe('EditDialogGuidanceFeedbackRulesComponent', () => {
@@ -8,9 +7,8 @@ describe('EditDialogGuidanceFeedbackRulesComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ EditDialogGuidanceFeedbackRulesComponent ]
-    })
-    .compileComponents();
+      declarations: [EditDialogGuidanceFeedbackRulesComponent]
+    }).compileComponents();
   });
 
   beforeEach(() => {


### PR DESCRIPTION
Test
- isSecondToLastSubmit feedback
- isFinalSubmit feedback
- regular feedback
- default feedback

Here is what the feedback rules looks like. Note we have changed the "default" rule name to "isDefault".
```
{
  "id": "sneu5vdrcr",
  "type": "DialogGuidance",
  "feedbackRules": [
    {
      "ideas": [
        "isFinalSubmit"
      ],
      "feedback": "This is a generic response that is shown on a final submission"
    },
    {
      "ideas": [
        "isSecondToLastSubmit"
      ],
      "feedback": "This is a generic response that is shown on the second to last submission"
    },
    {
      "ideas": [
        "isDefault"
      ],
      "feedback": "You hit none of the ideas. Guidance: Default guidance text"
    }
  ]
}
```

Closes #336