### PR TITLE
Dialog Guidance add not operator

### DIFF
--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
@@ -68,6 +68,19 @@ describe('DialogGuidanceFeedbackRuleEvaluator', () => {
       expression: 'idea1',
       feedback: 'You hit idea1'
     },
+
+    {
+      expression: '!idea10',
+      feedback: '!idea10'
+    },
+    {
+      expression: 'idea10 && !idea11',
+      feedback: 'idea10 && !idea11'
+    },
+    {
+      expression: '!idea11 || idea12',
+      feedback: '!idea11 || idea12'
+    },
     {
       expression: 'idea2',
       feedback: 'You hit idea2'
@@ -131,7 +144,8 @@ describe('DialogGuidanceFeedbackRuleEvaluator', () => {
   matchRule_OneIdea();
   matchRule_MultipleIdeasUsingAnd();
   matchRule_MultipleIdeasUsingOr();
-  matchRule_MultipleIdeasUsingOrAndAnd();
+  matchRule_MultipleIdeasUsingAndOr();
+  matchRule_MultipleIdeasUsingNotAndOr();
   matchNoRule_ReturnDefault();
   secondToLastSubmit();
   finalSubmit();
@@ -144,20 +158,20 @@ function matchRule_OneIdea() {
 }
 
 function matchRule_MultipleIdeasUsingAnd() {
-  it('should find rule matching two ideas using && (and) operator', () => {
+  it('should find rule matching two ideas using && operator', () => {
     expectFeedbackForMatchedIdeas(['idea1', 'idea2'], 'You hit idea1 and idea2');
     expectFeedbackForMatchedIdeas(['idea2', 'idea3', 'idea4'], 'You hit idea2, idea3 and idea4');
   });
 }
 
 function matchRule_MultipleIdeasUsingOr() {
-  it('should find rule matching ideas using || (or) operator', () => {
+  it('should find rule matching ideas using || operator', () => {
     expectFeedbackForMatchedIdeas(['idea5'], 'You hit idea5 or idea6');
   });
 }
 
-function matchRule_MultipleIdeasUsingOrAndAnd() {
-  it('should find rule matching ideas using combination of && (and) and || (or) operators', () => {
+function matchRule_MultipleIdeasUsingAndOr() {
+  it('should find rule matching ideas using combination of && and || operators', () => {
     expectFeedbackForMatchedIdeas(['idea7', 'idea9'], 'You hit idea7 or idea8 and idea9');
     expectFeedbackForMatchedIdeas(['idea8', 'idea9'], 'You hit idea7 or idea8 and idea9');
     expectFeedbackForMatchedIdeas(['idea7', 'idea8'], 'You hit idea7 and idea8 or idea9');
@@ -165,9 +179,17 @@ function matchRule_MultipleIdeasUsingOrAndAnd() {
   });
 }
 
+function matchRule_MultipleIdeasUsingNotAndOr() {
+  it('should find rule matching ideas using combination of !, && and || operators', () => {
+    expectFeedbackForMatchedIdeas([], '!idea10');
+    expectFeedbackForMatchedIdeas(['idea10'], 'idea10 && !idea11');
+    expectFeedbackForMatchedIdeas(['idea10', 'idea11', 'idea12'], '!idea11 || idea12');
+  });
+}
+
 function matchNoRule_ReturnDefault() {
   it('should return default idea when no rule is matched', () => {
-    expectFeedbackForMatchedIdeas([], 'default feedback');
+    expectFeedbackForMatchedIdeas(['idea10', 'idea11'], 'default feedback');
   });
 }
 

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
@@ -53,6 +53,18 @@ describe('DialogGuidanceFeedbackRuleEvaluator', () => {
       feedback: 'You hit idea2, idea3 and idea4'
     },
     {
+      expression: 'idea5 || idea6',
+      feedback: 'You hit idea5 or idea6'
+    },
+    {
+      expression: 'idea7 || idea8 && idea9',
+      feedback: 'You hit idea7 or idea8 and idea9'
+    },
+    {
+      expression: 'idea7 && idea8 || idea9',
+      feedback: 'You hit idea7 and idea8 or idea9'
+    },
+    {
       expression: 'idea1',
       feedback: 'You hit idea1'
     },
@@ -117,7 +129,9 @@ describe('DialogGuidanceFeedbackRuleEvaluator', () => {
     evaluator = new DialogGuidanceFeedbackRuleEvaluator(component);
   });
   matchRule_OneIdea();
-  matchRule_MultipleIdeas();
+  matchRule_MultipleIdeasUsingAnd();
+  matchRule_MultipleIdeasUsingOr();
+  matchRule_MultipleIdeasUsingOrAndAnd();
   matchNoRule_ReturnDefault();
   secondToLastSubmit();
   finalSubmit();
@@ -129,10 +143,25 @@ function matchRule_OneIdea() {
   });
 }
 
-function matchRule_MultipleIdeas() {
-  it('should find rule matching two ideas using && operator', () => {
+function matchRule_MultipleIdeasUsingAnd() {
+  it('should find rule matching two ideas using && (and) operator', () => {
     expectFeedbackForMatchedIdeas(['idea1', 'idea2'], 'You hit idea1 and idea2');
     expectFeedbackForMatchedIdeas(['idea2', 'idea3', 'idea4'], 'You hit idea2, idea3 and idea4');
+  });
+}
+
+function matchRule_MultipleIdeasUsingOr() {
+  it('should find rule matching ideas using || (or) operator', () => {
+    expectFeedbackForMatchedIdeas(['idea5'], 'You hit idea5 or idea6');
+  });
+}
+
+function matchRule_MultipleIdeasUsingOrAndAnd() {
+  it('should find rule matching ideas using combination of && (and) and || (or) operators', () => {
+    expectFeedbackForMatchedIdeas(['idea7', 'idea9'], 'You hit idea7 or idea8 and idea9');
+    expectFeedbackForMatchedIdeas(['idea8', 'idea9'], 'You hit idea7 or idea8 and idea9');
+    expectFeedbackForMatchedIdeas(['idea7', 'idea8'], 'You hit idea7 and idea8 or idea9');
+    expectFeedbackForMatchedIdeas(['idea9'], 'You hit idea7 and idea8 or idea9');
   });
 }
 

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
@@ -65,8 +65,8 @@ export class DialogGuidanceFeedbackRuleEvaluator {
     return true;
   }
 
-  private evaluateOperator(term: string, termStack: string[], response: CRaterResponse) {
-    if (this.evaluateOperatorExpression(term, termStack, response)) {
+  private evaluateOperator(operator: string, termStack: string[], response: CRaterResponse) {
+    if (this.evaluateOperatorExpression(operator, termStack, response)) {
       termStack.push('true');
     } else {
       termStack.push('false');
@@ -74,24 +74,31 @@ export class DialogGuidanceFeedbackRuleEvaluator {
   }
 
   private evaluateOperatorExpression(
-    term: string,
+    operator: string,
+    termStack: string[],
+    response: CRaterResponse
+  ): boolean {
+    if (['&&', '||'].includes(operator)) {
+      return this.evaluateAndOrExpression(operator, termStack, response);
+    } else {
+      return this.evaluateNotExpression(termStack, response);
+    }
+  }
+
+  private evaluateAndOrExpression(
+    operator: string,
     termStack: string[],
     response: CRaterResponse
   ): boolean {
     const term1 = termStack.pop();
     const term2 = termStack.pop();
-    return (
-      (term === '&&' && this.evaluateAndExpression(term1, term2, response)) ||
-      (term === '||' && this.evaluateOrExpression(term1, term2, response))
-    );
+    return operator === '&&'
+      ? this.evaluateTerm(term1, response) && this.evaluateTerm(term2, response)
+      : this.evaluateTerm(term1, response) || this.evaluateTerm(term2, response);
   }
 
-  private evaluateAndExpression(term1: string, term2: string, response: CRaterResponse): boolean {
-    return this.evaluateTerm(term1, response) && this.evaluateTerm(term2, response);
-  }
-
-  private evaluateOrExpression(term1: string, term2: string, response: CRaterResponse): boolean {
-    return this.evaluateTerm(term1, response) || this.evaluateTerm(term2, response);
+  private evaluateNotExpression(termStack: string[], response: CRaterResponse): boolean {
+    return !this.evaluateTerm(termStack.pop(), response);
   }
 
   private evaluateTerm(term: string, response: CRaterResponse): boolean {

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
@@ -78,21 +78,19 @@ export class DialogGuidanceFeedbackRuleEvaluator {
     termStack: string[],
     response: CRaterResponse
   ): boolean {
+    const term1 = termStack.pop();
+    const term2 = termStack.pop();
     return (
-      (term === '&&' && this.evaluateAndExpression(termStack, response)) ||
-      (term === '||' && this.evaluateOrExpression(termStack, response))
+      (term === '&&' && this.evaluateAndExpression(term1, term2, response)) ||
+      (term === '||' && this.evaluateOrExpression(term1, term2, response))
     );
   }
 
-  private evaluateAndExpression(termStack: string[], response: CRaterResponse): boolean {
-    const term1 = termStack.pop();
-    const term2 = termStack.pop();
+  private evaluateAndExpression(term1: string, term2: string, response: CRaterResponse): boolean {
     return this.evaluateTerm(term1, response) && this.evaluateTerm(term2, response);
   }
 
-  private evaluateOrExpression(termStack: string[], response: CRaterResponse): boolean {
-    const term1 = termStack.pop();
-    const term2 = termStack.pop();
+  private evaluateOrExpression(term1: string, term2: string, response: CRaterResponse): boolean {
     return this.evaluateTerm(term1, response) || this.evaluateTerm(term2, response);
   }
 

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
@@ -56,13 +56,7 @@ export class DialogGuidanceFeedbackRuleEvaluator {
       if (FeedbackRule.isOperand(term)) {
         termStack.push(term);
       } else {
-        if (term === '&&') {
-          if (this.evaluateAndExpression(termStack, response)) {
-            termStack.push('true');
-          } else {
-            return false;
-          }
-        }
+        this.evaluateOperator(term, termStack, response);
       }
     }
     if (termStack.length === 1) {
@@ -71,10 +65,35 @@ export class DialogGuidanceFeedbackRuleEvaluator {
     return true;
   }
 
+  private evaluateOperator(term: string, termStack: string[], response: CRaterResponse) {
+    if (this.evaluateOperatorExpression(term, termStack, response)) {
+      termStack.push('true');
+    } else {
+      termStack.push('false');
+    }
+  }
+
+  private evaluateOperatorExpression(
+    term: string,
+    termStack: string[],
+    response: CRaterResponse
+  ): boolean {
+    return (
+      (term === '&&' && this.evaluateAndExpression(termStack, response)) ||
+      (term === '||' && this.evaluateOrExpression(termStack, response))
+    );
+  }
+
   private evaluateAndExpression(termStack: string[], response: CRaterResponse): boolean {
     const term1 = termStack.pop();
     const term2 = termStack.pop();
     return this.evaluateTerm(term1, response) && this.evaluateTerm(term2, response);
+  }
+
+  private evaluateOrExpression(termStack: string[], response: CRaterResponse): boolean {
+    const term1 = termStack.pop();
+    const term2 = termStack.pop();
+    return this.evaluateTerm(term1, response) || this.evaluateTerm(term2, response);
   }
 
   private evaluateTerm(term: string, response: CRaterResponse): boolean {

--- a/src/assets/wise5/components/dialogGuidance/FeedbackRule.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/FeedbackRule.spec.ts
@@ -9,6 +9,7 @@ function getPostfixExpression() {
     it('should convert rule to postfix format', () => {
       expectPostfixExpression('idea1 && idea2 && idea3', ['idea1', 'idea2', '&&', 'idea3', '&&']);
       expectPostfixExpression('idea1 || idea2 && idea3', ['idea1', 'idea2', '||', 'idea3', '&&']);
+      expectPostfixExpression('!idea1 && !idea2', ['idea1', '!', 'idea2', '!', '&&']);
     });
   });
 }

--- a/src/assets/wise5/components/dialogGuidance/FeedbackRule.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/FeedbackRule.spec.ts
@@ -7,9 +7,14 @@ describe('FeedbackRule', () => {
 function getPostfixExpression() {
   describe('getPostfixRule()', () => {
     it('should convert rule to postfix format', () => {
-      const feedbackRule = new FeedbackRule();
-      feedbackRule.expression = 'idea1 && idea2 && idea3';
-      expect(feedbackRule.getPostfixExpression()).toEqual(['idea1', 'idea2', '&&', 'idea3', '&&']);
+      expectPostfixExpression('idea1 && idea2 && idea3', ['idea1', 'idea2', '&&', 'idea3', '&&']);
+      expectPostfixExpression('idea1 || idea2 && idea3', ['idea1', 'idea2', '||', 'idea3', '&&']);
     });
   });
+}
+
+function expectPostfixExpression(expression: string, expectedResult: string[]) {
+  const feedbackRule = new FeedbackRule();
+  feedbackRule.expression = expression;
+  expect(feedbackRule.getPostfixExpression()).toEqual(expectedResult);
 }

--- a/src/assets/wise5/components/dialogGuidance/FeedbackRule.ts
+++ b/src/assets/wise5/components/dialogGuidance/FeedbackRule.ts
@@ -14,17 +14,17 @@ export class FeedbackRule {
     return feedbackRule.expression === 'isDefault';
   }
 
-  // uses shunting yard algorithm to get expression in postfix (reverse-polish) notation
+  // uses shunting-yard algorithm to get expression in postfix (reverse-polish) notation
   getPostfixExpression(): string[] {
     const result = [];
     const operatorStack = [];
     for (const symbol of this.getExpressionAsArray()) {
       if (FeedbackRule.isOperator(symbol)) {
         while (operatorStack.length > 0) {
-          const last = operatorStack[operatorStack.length - 1];
+          const topOperatorOnStack = operatorStack[operatorStack.length - 1];
           if (
-            FeedbackRule.hasGreaterPrecedence(last, symbol) ||
-            FeedbackRule.hasSamePrecedence(last, symbol)
+            FeedbackRule.hasGreaterPrecedence(topOperatorOnStack, symbol) ||
+            FeedbackRule.hasSamePrecedence(topOperatorOnStack, symbol)
           ) {
             result.push(operatorStack.pop());
           } else {
@@ -43,11 +43,11 @@ export class FeedbackRule {
   }
 
   private getExpressionAsArray(): string[] {
-    return this.expression.replace(/ /g, '').split(/(&&)/g);
+    return this.expression.replace(/ /g, '').split(/(&&|\|\|)/g);
   }
 
   static isOperator(symbol: string): boolean {
-    return ['&&'].includes(symbol);
+    return ['&&', '||'].includes(symbol);
   }
 
   static isOperand(symbol: string): boolean {
@@ -63,7 +63,7 @@ export class FeedbackRule {
   }
 
   static getPrecedence(symbol: string): number {
-    if (['&&'].includes(symbol)) {
+    if (['&&', '||'].includes(symbol)) {
       return 1;
     } else {
       return 0;

--- a/src/assets/wise5/components/dialogGuidance/FeedbackRule.ts
+++ b/src/assets/wise5/components/dialogGuidance/FeedbackRule.ts
@@ -1,6 +1,7 @@
 export class FeedbackRule {
   expression: string;
   feedback: string;
+  static operatorPrecedences = { '!': 2, '&&': 1, '||': 1 };
 
   static isSecondToLastSubmitRule(feedbackRule: FeedbackRule): boolean {
     return feedbackRule.expression === 'isSecondToLastSubmit';
@@ -43,11 +44,14 @@ export class FeedbackRule {
   }
 
   private getExpressionAsArray(): string[] {
-    return this.expression.replace(/ /g, '').split(/(&&|\|\|)/g);
+    return this.expression
+      .replace(/ /g, '')
+      .split(/(&&|\|\||!)/g)
+      .filter((el) => el !== '');
   }
 
   static isOperator(symbol: string): boolean {
-    return ['&&', '||'].includes(symbol);
+    return ['&&', '||', '!'].includes(symbol);
   }
 
   static isOperand(symbol: string): boolean {
@@ -63,10 +67,6 @@ export class FeedbackRule {
   }
 
   static getPrecedence(symbol: string): number {
-    if (['&&', '||'].includes(symbol)) {
-      return 1;
-    } else {
-      return 0;
-    }
+    return FeedbackRule.operatorPrecedences[symbol] ?? 0;
   }
 }


### PR DESCRIPTION
## Changes
- Add support for ! (not) operator in the FeedbackRule.expression

## Test
- add ! (not) expression FeedbackRules and see if they work
```
{
  "expression": "idea1 && !idea2", 
  "feedback": "you hit idea1 but not idea2"
},
{
  "expression": "!idea4 || !idea5", 
  "feedback": "you didn't hit idea4 or idea5"
}
```
- make sure that other expressions still work:
  - ```"expression": "ideaX"```
  - ```"expression": "isFinalSubmit"```
  - ```"expression": "isSecondToLastSubmit"```
  - ```"expression": "isDefault"```

Closes #353