### PR TITLE
Add isNonScorable expression support to Dialog Guidance

### DIFF
--- a/src/assets/wise5/components/dialogGuidance/CRaterResponse.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/CRaterResponse.spec.ts
@@ -31,11 +31,9 @@ function getKIScore() {
 
 function isNonScorable() {
   describe('isNonScorable()', () => {
-    it('should return true for non-scorable item', () => {
+    it('should return true for non-scorable item and false for scorable item', () => {
       response.scores = [{ id: 'nonscorable', score: 1, realNumberScore: 1 }];
       expect(response.isNonScorable()).toBeTruthy();
-    });
-    it('should return false for scorable item', () => {
       response.scores = [{ id: 'nonscorable', score: 0, realNumberScore: 0 }];
       expect(response.isNonScorable()).toBeFalsy();
     });

--- a/src/assets/wise5/components/dialogGuidance/CRaterResponse.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/CRaterResponse.spec.ts
@@ -1,0 +1,43 @@
+import { CRaterResponse } from './CRaterResponse';
+
+const response = new CRaterResponse();
+describe('CRaterResponse', () => {
+  getDetectedIdeaNames();
+  getKIScore();
+  isNonScorable();
+});
+
+function getDetectedIdeaNames() {
+  describe('getDetectedIdeaNames()', () => {
+    it('should return ideas that were detected in the response', () => {
+      response.ideas = [
+        { name: 'idea1', detected: true, characterOffsets: [] },
+        { name: 'idea2', detected: false, characterOffsets: [] },
+        { name: 'idea3', detected: true, characterOffsets: [] }
+      ];
+      expect(response.getDetectedIdeaNames()).toEqual(['idea1', 'idea3']);
+    });
+  });
+}
+
+function getKIScore() {
+  describe('getKIScore()', () => {
+    it('should return the KI score', () => {
+      response.scores = [{ id: 'ki', score: 2, realNumberScore: 2.13 }];
+      expect(response.getKIScore()).toEqual(2);
+    });
+  });
+}
+
+function isNonScorable() {
+  describe('isNonScorable()', () => {
+    it('should return true for non-scorable item', () => {
+      response.scores = [{ id: 'nonscorable', score: 1, realNumberScore: 1 }];
+      expect(response.isNonScorable()).toBeTruthy();
+    });
+    it('should return false for scorable item', () => {
+      response.scores = [{ id: 'nonscorable', score: 0, realNumberScore: 0 }];
+      expect(response.isNonScorable()).toBeFalsy();
+    });
+  });
+}

--- a/src/assets/wise5/components/dialogGuidance/CRaterResponse.ts
+++ b/src/assets/wise5/components/dialogGuidance/CRaterResponse.ts
@@ -2,8 +2,8 @@ import { CRaterIdea } from './CRaterIdea';
 import { CRaterScore } from './CRaterScore';
 
 export class CRaterResponse {
-  scores: CRaterScore[];
   ideas: CRaterIdea[];
+  scores: CRaterScore[];
 
   constructor() {}
 
@@ -23,5 +23,9 @@ export class CRaterResponse {
         return score.score;
       }
     }
+  }
+
+  isNonScorable(): boolean {
+    return this.scores.some((score) => score.id === 'nonscorable' && score.score === 1);
   }
 }

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
@@ -143,6 +143,7 @@ describe('DialogGuidanceFeedbackRuleEvaluator', () => {
     spyOn(component, 'isNotebookEnabled').and.returnValue(false);
     component.componentContent = TestBed.inject(DialogGuidanceService).createComponent();
     component.componentContent.feedbackRules = defaultFeedbackRules;
+    component.componentContent.maxSubmitCount = 5;
     fixture.detectChanges();
     evaluator = new DialogGuidanceFeedbackRuleEvaluator(component);
   });
@@ -201,7 +202,6 @@ function matchNoRule_ReturnDefault() {
 
 function secondToLastSubmit() {
   it('should return second to last submit rule when there is one submit left', () => {
-    component.componentContent.maxSubmitCount = 5;
     component.submitCounter = 4;
     expectFeedback(['idea1'], [], 'second to last submission');
   });
@@ -209,7 +209,6 @@ function secondToLastSubmit() {
 
 function finalSubmit() {
   it('should return final submit rule when no more submits left', () => {
-    component.componentContent.maxSubmitCount = 5;
     component.submitCounter = 5;
     expectFeedback(['idea1'], [], 'final submission');
   });

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
@@ -19,10 +19,16 @@ export class DialogGuidanceFeedbackRuleEvaluator {
   }
 
   private satisfiesRule(response: CRaterResponse, feedbackRule: FeedbackRule): boolean {
+    return this.isSpecialRule(feedbackRule)
+      ? this.satisfiesSpecialRule(response, feedbackRule)
+      : this.satisfiesSpecificRule(response, feedbackRule);
+  }
+
+  private satisfiesSpecialRule(response: CRaterResponse, feedbackRule: FeedbackRule): boolean {
     return (
+      this.satisfiesNonScorableRule(response, feedbackRule) ||
       this.satisfiesFinalSubmitRule(feedbackRule) ||
-      this.satisfiesSecondToLastSubmitRule(feedbackRule) ||
-      (!this.isSpecialRule(feedbackRule) && this.satisfiesSpecificRule(response, feedbackRule))
+      this.satisfiesSecondToLastSubmitRule(feedbackRule)
     );
   }
 
@@ -45,8 +51,14 @@ export class DialogGuidanceFeedbackRuleEvaluator {
     return this.component.getNumberOfSubmitsLeft() === 1;
   }
 
+  private satisfiesNonScorableRule(response: CRaterResponse, feedbackRule: FeedbackRule): boolean {
+    return feedbackRule.expression === 'isNonScorable' && response.isNonScorable();
+  }
+
   private isSpecialRule(feedbackRule: FeedbackRule): boolean {
-    return ['isFinalSubmit', 'isSecondToLastSubmit'].includes(feedbackRule.expression);
+    return ['isFinalSubmit', 'isSecondToLastSubmit', 'isNonScorable'].includes(
+      feedbackRule.expression
+    );
   }
 
   private satisfiesSpecificRule(response: CRaterResponse, feedbackRule: FeedbackRule): boolean {

--- a/src/assets/wise5/services/cRaterService.ts
+++ b/src/assets/wise5/services/cRaterService.ts
@@ -10,32 +10,33 @@ export class CRaterService {
   constructor(protected http: HttpClient, protected ConfigService: ConfigService) {}
 
   /**
-   * Make a CRater request to score student data
-   * @param cRaterItemId
-   * @param cRaterResponseId a randomly generated id used to keep track of the request
-   * @param studentData the student data
+   * Make a CRater request to score student response
+   * @param itemId CRater item ID
+   * @param responseId number used to keep track of this request
+   * @param responseText the student's response to CRater item
    * @returns a promise that returns the result of the CRater request
    */
   makeCRaterScoringRequest(
-    cRaterItemId: string,
-    cRaterResponseId: number,
-    studentData: any
+    itemId: string,
+    responseId: number,
+    responseText: string
   ): Observable<any> {
-    if (cRaterItemId === 'MI_SPEED_MOCK') {
-      return this.mockSpeedResponse(studentData);
+    if (itemId === 'MOCK') {
+      return this.mockResponse(responseText);
     } else {
       return this.http.post(`${this.ConfigService.getCRaterRequestURL()}/score`, {
-        itemId: cRaterItemId,
-        responseId: cRaterResponseId,
-        responseText: studentData
+        itemId: itemId,
+        responseId: responseId,
+        responseText: responseText
       });
     }
   }
 
-  private mockSpeedResponse(responseText: string): Observable<any> {
+  private mockResponse(responseText: string): Observable<any> {
     const ideasFound = responseText.match(/idea([a-zA-Z0-9]+)/g) ?? [];
+    const isNonScorable = responseText.includes('isNonScorable') ? 1 : 0;
     return of({
-      scores: [],
+      scores: [{ id: 'nonscorable', score: isNonScorable }],
       ideas: ideasFound.map((idea) => {
         return { name: idea, detected: true, characterOffsets: [] };
       })


### PR DESCRIPTION
## Changes
- Add FeedbackRule to match non-scorable items
- Change MI_SPEED_MOCK CRaterItemId to MOCK
- Add tests for CRaterResponse and clean up CRaterService

## Test Prep
- In component content for DG item, change "MI_SPEED_MOCK" CRaterItemId to "MOCK"
- Add a new FeedbackRule to match when an item is not scorable
```
...
        {
            "expression": "isNonScorable",
            "feedback": "This item is NonScorable"
        },
...
```

## Test
- In preview mode, type "isNonScorable" in the text input and verify that the feedback is "This item is NonScorable"
- Make sure that other expressions still work:
  - ```"expression": "ideaX"```
  - ```"expression": "isFinalSubmit"```
  - ```"expression": "isSecondToLastSubmit"```
  - ```"expression": "isDefault"```
- Also test the "isNonScorable" item using a live CRater engine


Closes #360