### PR TITLE
Allow Open Response textarea to auto-grow based on input text

### DIFF
--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.html
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.html
@@ -27,7 +27,7 @@
       [(ngModel)]="studentResponse"
       (ngModelChange)="studentDataChanged()"
       [disabled]="isDisabled"
-      md-no-autogrow>
+      cdkTextareaAutosize>
   </textarea>
 </div>
 <div *ngIf="isStudentAttachmentEnabled" fxLayout="row wrap" fxLayoutAlign="start center">

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.scss
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.scss
@@ -5,10 +5,10 @@
 
 .student-response {
   width: 99%;
-  height: 5em;
+  min-height: 80px;
   background-color: #f7f7f7;
-  resize: none;
   padding: 8px;
+  overflow: hidden;
 }
 
 .student-response:focus {


### PR DESCRIPTION
Make sure the Open Response student textarea grows when the student writes a lot of text. There should never be a scrollbar on the textarea.

Closes #344