### PR TITLE
feat(Dialog Guidance): Export component data 

### DIFF
--- a/src/assets/wise5/classroomMonitor/dataExport/dataExportController.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/dataExportController.ts
@@ -3478,23 +3478,77 @@ class DataExportController {
       if (response.user === 'Student') {
         revisionCounter++;
         revisionLabel = `${this.dialogGuidanceRevisionLabel} ${revisionCounter}`;
-        row[columnNameToNumber[`${this.dialogGuidanceStudentResponseLabel} ${revisionLabel}`]] =
-          response.text;
+        this.addDialogGuidanceStudentResponseToRow(
+          row,
+          columnNameToNumber,
+          revisionLabel,
+          response.text
+        );
       } else if (response.user === 'Computer') {
-        for (const idea of response.ideas) {
-          row[
-            columnNameToNumber[`${this.dialogGuidanceIdeaLabel} ${idea.name} ${revisionLabel}`]
-          ] = idea.detected ? 1 : 0;
+        if (response.ideas != null) {
+          this.addDialogGuidanceIdeasToRow(row, columnNameToNumber, revisionLabel, response.ideas);
         }
-        for (const score of response.scores) {
-          row[columnNameToNumber[`${this.dialogGuidanceScoreLabel} ${score.id} ${revisionLabel}`]] =
-            score.score;
+        if (response.scores != null) {
+          this.addDialogGuidanceScoresToRow(
+            row,
+            columnNameToNumber,
+            revisionLabel,
+            response.scores
+          );
         }
-        row[columnNameToNumber[`${this.dialogGuidanceComputerResponseLabel} ${revisionLabel}`]] =
-          response.text;
+        this.addDialogGuidanceComputerResponseToRow(
+          row,
+          columnNameToNumber,
+          revisionLabel,
+          response.text
+        );
       }
     }
     return row;
+  }
+
+  addDialogGuidanceStudentResponseToRow(
+    row: any[],
+    columnNameToNumber: any,
+    revisionLabel: string,
+    text: string
+  ): void {
+    row[columnNameToNumber[`${this.dialogGuidanceStudentResponseLabel} ${revisionLabel}`]] = text;
+  }
+
+  addDialogGuidanceIdeasToRow(
+    row: any[],
+    columnNameToNumber: any,
+    revisionLabel: string,
+    ideas: any[]
+  ): void {
+    for (const ideaObject of ideas) {
+      row[
+        columnNameToNumber[`${this.dialogGuidanceIdeaLabel} ${ideaObject.name} ${revisionLabel}`]
+      ] = ideaObject.detected ? 1 : 0;
+    }
+  }
+
+  addDialogGuidanceScoresToRow(
+    row: any[],
+    columnNameToNumber: any,
+    revisionLabel: string,
+    scores: any[]
+  ): void {
+    for (const scoreObject of scores) {
+      row[
+        columnNameToNumber[`${this.dialogGuidanceScoreLabel} ${scoreObject.id} ${revisionLabel}`]
+      ] = scoreObject.score;
+    }
+  }
+
+  addDialogGuidanceComputerResponseToRow(
+    row: any[],
+    columnNameToNumber: any,
+    revisionLabel: string,
+    text: string
+  ): void {
+    row[columnNameToNumber[`${this.dialogGuidanceComputerResponseLabel} ${revisionLabel}`]] = text;
   }
 
   showDownloadingExportMessage() {

--- a/src/assets/wise5/classroomMonitor/dataExport/dataExportController.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/dataExportController.ts
@@ -8,7 +8,6 @@ import { TeacherDataService } from '../../services/teacherDataService';
 import { UtilService } from '../../services/utilService';
 import * as angular from 'angular';
 import { TeacherProjectService } from '../../services/teacherProjectService';
-import { VERSION } from '@angular/core';
 
 class DataExportController {
   $translate: any;

--- a/src/assets/wise5/classroomMonitor/dataExport/dataExportController.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/dataExportController.ts
@@ -46,6 +46,12 @@ class DataExportController {
   ];
   canViewStudentNames: boolean = false;
   componentTypeToComponentService: any = {};
+  dialogGuidanceComputerResponseLabel: string = 'Computer Response';
+  dialogGuidanceIdeaLabel: string = 'Idea';
+  dialogGuidanceItemIdLabel: string = 'Item ID';
+  dialogGuidanceRevisionLabel: string = 'Revision';
+  dialogGuidanceScoreLabel: string = 'Score';
+  dialogGuidanceStudentResponseLabel: string = 'Student Response';
   exportStepSelectionType: string = 'exportAllSteps';
   exportType: string = null; // type of export: [latestWork, allWork, events]
   includeAnnotations: boolean;
@@ -2627,12 +2633,13 @@ class DataExportController {
    * @param component The component content object.
    */
   exportComponentAllRevisions(nodeId: string, component: any) {
+    this.setAllWorkSelectionType();
     if (component.type === 'Match') {
-      this.exportMatchComponentAllRevisions(nodeId, component);
+      this.exportMatchComponent(nodeId, component);
     } else if (component.type === 'Discussion') {
       this.exportDiscussionComponent(nodeId, component);
     } else if (component.type === 'DialogGuidance') {
-      this.exportDialogGuidanceAllRevisions(nodeId, component);
+      this.exportDialogGuidanceComponent(nodeId, component);
     }
   }
 
@@ -2642,10 +2649,11 @@ class DataExportController {
    * @param component The component content object.
    */
   exportComponentLatestRevisions(nodeId: string, component: any) {
+    this.setLatestWorkSelectionType();
     if (component.type === 'Match') {
-      this.exportMatchComponentLatestRevisions(nodeId, component);
+      this.exportMatchComponent(nodeId, component);
     } else if (component.type === 'DialogGuidance') {
-      this.exportDialogGuidanceLatestRevisions(nodeId, component);
+      this.exportDialogGuidanceComponent(nodeId, component);
     }
   }
 
@@ -2890,16 +2898,6 @@ class DataExportController {
     return runId + '_step_' + stepNumber + '_component_' + componentNumber + '_discussion_work.csv';
   }
 
-  exportMatchComponentAllRevisions(nodeId: string, component: any) {
-    this.workSelectionType = 'exportAllWork';
-    this.exportMatchComponent(nodeId, component);
-  }
-
-  exportMatchComponentLatestRevisions(nodeId: string, component: any) {
-    this.workSelectionType = 'exportLatestWork';
-    this.exportMatchComponent(nodeId, component);
-  }
-
   /**
    * Generate an export for a specific match component.
    * TODO: Move these Match export functions to the MatchService.
@@ -2914,17 +2912,8 @@ class DataExportController {
   }
 
   generateMatchComponentExport(nodeId: string, component: any) {
-    const runId = this.ConfigService.getRunId();
-    const stepNumber = this.ProjectService.getNodePositionById(nodeId);
-    const componentNumber =
-      this.ProjectService.getComponentPositionByNodeIdAndComponentId(nodeId, component.id) + 1;
-    const fileName = this.getMatchExportFileName(
-      runId,
-      stepNumber,
-      componentNumber,
-      this.workSelectionType
-    );
     const rows = this.getExportMatchComponentRows(nodeId, component);
+    const fileName = this.getComponentExportFileName(nodeId, component.id, 'match');
     this.generateCSVFile(rows, fileName);
     this.hideDownloadingExportMessage();
   }
@@ -2935,24 +2924,9 @@ class DataExportController {
     let rows = [];
     rows.push(this.generateMatchComponentHeaderRow(component, columnNames, columnNameToNumber));
     rows = rows.concat(
-      this.generateMatchComponentWorkRows(component, columnNames, columnNameToNumber, nodeId)
+      this.generateComponentWorkRows(component, columnNames, columnNameToNumber, nodeId)
     );
     return rows;
-  }
-
-  getMatchExportFileName(
-    runId: number,
-    stepNumber: number,
-    componentNumber: number,
-    workSelectionType: string
-  ) {
-    let allOrLatest = '';
-    if (workSelectionType === 'exportAllWork') {
-      allOrLatest = 'all';
-    } else if (workSelectionType === 'exportLatestWork') {
-      allOrLatest = 'latest';
-    }
-    return `${runId}_step_${stepNumber}_component_${componentNumber}_${allOrLatest}_match_work.csv`;
   }
 
   /**
@@ -2964,46 +2938,18 @@ class DataExportController {
    * of column name to column number.
    */
   populateMatchColumnNames(component, columnNames, columnNameToNumber) {
-    let defaultMatchColumnNames = [
-      '#',
-      'Workgroup ID',
-      'User ID 1',
-      'Student Name 1',
-      'User ID 2',
-      'Student Name 2',
-      'User ID 3',
-      'Student Name 3',
-      'Class Period',
-      'Project ID',
-      'Project Name',
-      'Run ID',
-      'Start Date',
-      'End Date',
-      'Student Work ID',
-      'Server Timestamp',
-      'Client Timestamp',
-      'Node ID',
-      'Component ID',
-      'Component Part Number',
-      'Step Title',
-      'Component Type',
-      'Component Prompt',
-      'Student Data',
-      'Component Revision Counter',
-      'Is Submit',
-      'Submit Count'
-    ];
-
     /*
      * Add the default column names that contain the information about the
      * student, project, run, node, and component.
      */
-    for (let c = 0; c < defaultMatchColumnNames.length; c++) {
-      let defaultMatchColumnName = defaultMatchColumnNames[c];
-      columnNameToNumber[defaultMatchColumnName] = c;
-      columnNames.push(defaultMatchColumnName);
+    for (const defaultMatchColumnName of this.componentExportDefaultColumnNames) {
+      this.addColumnNameToColumnDataStructures(
+        columnNameToNumber,
+        columnNames,
+        defaultMatchColumnName
+      );
     }
-    for (let choice of component.choices) {
+    for (const choice of component.choices) {
       columnNameToNumber[choice.id] = columnNames.length;
       columnNames.push(choice.value);
     }
@@ -3012,8 +2958,7 @@ class DataExportController {
         columnNameToNumber[choice.id + '-boolean'] = columnNames.length;
         columnNames.push(choice.value);
       }
-      columnNameToNumber['Is Correct'] = columnNames.length;
-      columnNames.push('Is Correct');
+      this.addColumnNameToColumnDataStructures(columnNameToNumber, columnNames, 'Is Correct');
     }
   }
 
@@ -3026,120 +2971,7 @@ class DataExportController {
    */
   generateMatchComponentHeaderRow(component, columnNames, columnNameToNumber) {
     this.populateMatchColumnNames(component, columnNames, columnNameToNumber);
-    const headerRow = [];
-    for (const columnName of columnNames) {
-      headerRow.push(columnName);
-    }
-    return headerRow;
-  }
-
-  /**
-   * Generate all the rows for all the workgroups.
-   * @param component The component content object.
-   * @param columnNames All the header column names.
-   * @param columnNameToNumber The mapping from column name to column number.
-   * @param nodeId The node id the component is in.
-   * @return An array of rows.
-   */
-  generateMatchComponentWorkRows(component, columnNames, columnNameToNumber, nodeId) {
-    let componentId = component.id;
-    let workgroups = this.ConfigService.getClassmateUserInfosSortedByWorkgroupId();
-    let rows = [];
-    let rowCounter = 1;
-    for (const workgroup of workgroups) {
-      let rowsForWorkgroup = this.generateMatchComponentWorkRowsForWorkgroup(
-        component,
-        workgroup,
-        columnNames,
-        columnNameToNumber,
-        nodeId,
-        componentId,
-        rowCounter
-      );
-      rows = rows.concat(rowsForWorkgroup);
-      rowCounter += rowsForWorkgroup.length;
-    }
-    return rows;
-  }
-
-  /**
-   * Generate all the rows for a workgroup.
-   * @param component The component content object.
-   * @param workgroup The workgroup.
-   * @param columnNames An array of column name headers.
-   * @param columnNameToNumber The mapping from column name to column number.
-   * @param nodeId The node the component is in.
-   * @param componentId The component id.
-   * @param rowCounter The current row number we will be creating.
-   */
-  generateMatchComponentWorkRowsForWorkgroup(
-    component,
-    workgroup,
-    columnNames,
-    columnNameToNumber,
-    nodeId,
-    componentId,
-    rowCounter
-  ) {
-    let rows = [];
-    let workgroupId = workgroup.workgroupId;
-    let periodName = workgroup.periodName;
-    let userInfo = this.ConfigService.getUserInfoByWorkgroupId(workgroupId);
-    let extractedUserIDsAndStudentNames = this.extractUserIDsAndStudentNames(userInfo.users);
-
-    /*
-     * a mapping from component to component revision counter.
-     * the key will be {{nodeId}}_{{componentId}} and the
-     * value will be a number.
-     */
-    let componentRevisionCounter = {};
-    let matchComponentStates = this.TeacherDataService.getComponentStatesByWorkgroupIdAndComponentId(
-      workgroupId,
-      componentId
-    );
-    if (matchComponentStates != null) {
-      for (let c = 0; c < matchComponentStates.length; c++) {
-        let matchComponentState = matchComponentStates[c];
-        let exportRow = true;
-        if (this.includeOnlySubmits && !matchComponentState.isSubmit) {
-          exportRow = false;
-        } else if (
-          this.workSelectionType == 'exportLatestWork' &&
-          c != matchComponentStates.length - 1
-        ) {
-          exportRow = false;
-        }
-
-        if (exportRow) {
-          rows.push(
-            this.generateMatchComponentWorkRow(
-              component,
-              columnNames,
-              columnNameToNumber,
-              rowCounter,
-              workgroupId,
-              extractedUserIDsAndStudentNames['userId1'],
-              extractedUserIDsAndStudentNames['userId2'],
-              extractedUserIDsAndStudentNames['userId3'],
-              extractedUserIDsAndStudentNames['studentName1'],
-              extractedUserIDsAndStudentNames['studentName2'],
-              extractedUserIDsAndStudentNames['studentName3'],
-              periodName,
-              componentRevisionCounter,
-              matchComponentState
-            )
-          );
-          rowCounter++;
-        } else {
-          /*
-           * We do not want to add this row in the export but
-           * we still want to increment the revision counter.
-           */
-          this.incrementRevisionCounter(componentRevisionCounter, nodeId, componentId);
-        }
-      }
-    }
-    return rows;
+    return columnNames;
   }
 
   /**
@@ -3237,14 +3069,16 @@ class DataExportController {
     }
   }
 
-  exportDialogGuidanceAllRevisions(nodeId: string, component: any): void {
-    this.workSelectionType = 'exportAllWork';
-    this.exportDialogGuidanceComponent(nodeId, component);
+  setAllWorkSelectionType(): void {
+    this.setWorkSelectionType('exportAllWork');
   }
 
-  exportDialogGuidanceLatestRevisions(nodeId: string, component: any): void {
-    this.workSelectionType = 'exportLatestWork';
-    this.exportDialogGuidanceComponent(nodeId, component);
+  setLatestWorkSelectionType(): void {
+    this.setWorkSelectionType('exportLatestWork');
+  }
+
+  setWorkSelectionType(workSelectionType: string): void {
+    this.workSelectionType = workSelectionType;
   }
 
   exportDialogGuidanceComponent(nodeId: string, component: any): void {
@@ -3255,35 +3089,26 @@ class DataExportController {
   }
 
   generateDialogGuidanceComponentExport(nodeId: string, component: any): void {
-    const runId = this.ConfigService.getRunId();
-    const stepNumber = this.ProjectService.getNodePositionById(nodeId);
-    const componentNumber =
-      this.ProjectService.getComponentPositionByNodeIdAndComponentId(nodeId, component.id) + 1;
-    const fileName = this.getDialogGuidanceExportFileName(
-      runId,
-      stepNumber,
-      componentNumber,
-      this.workSelectionType
-    );
     const rows = this.getExportDialogGuidanceComponentRows(nodeId, component);
+    const fileName = this.getComponentExportFileName(nodeId, component.id, 'dialog_guidance');
     this.generateCSVFile(rows, fileName);
     this.hideDownloadingExportMessage();
   }
 
-  getDialogGuidanceExportFileName(
-    runId: number,
-    stepNumber: number,
-    componentNumber: number,
-    workSelectionType: string
-  ) {
+  getComponentExportFileName(nodeId: string, componentId: string, componentType: string): string {
+    const runId = this.ConfigService.getRunId();
+    const stepNumber = this.ProjectService.getNodePositionById(nodeId);
+    const componentNumber =
+      this.ProjectService.getComponentPositionByNodeIdAndComponentId(nodeId, componentId) + 1;
     let allOrLatest = '';
-    if (workSelectionType === 'exportAllWork') {
+    if (this.workSelectionType === 'exportAllWork') {
       allOrLatest = 'all';
-    } else if (workSelectionType === 'exportLatestWork') {
+    } else if (this.workSelectionType === 'exportLatestWork') {
       allOrLatest = 'latest';
     }
-    return `run_${runId}_step_${stepNumber}_component_${componentNumber}_${allOrLatest}_dialog_guidance_work.csv`;
+    return `run_${runId}_step_${stepNumber}_component_${componentNumber}_${allOrLatest}_${componentType}_work.csv`;
   }
+
   getExportDialogGuidanceComponentRows(nodeId: string, component: any): string[] {
     const columnNames = [];
     const columnNameToNumber = {};
@@ -3292,12 +3117,7 @@ class DataExportController {
       this.generateDialogGuidanceComponentHeaderRow(component, columnNames, columnNameToNumber)
     );
     rows = rows.concat(
-      this.generateDialogGuidanceComponentWorkRows(
-        component,
-        columnNames,
-        columnNameToNumber,
-        nodeId
-      )
+      this.generateComponentWorkRows(component, columnNames, columnNameToNumber, nodeId)
     );
     return rows;
   }
@@ -3308,11 +3128,7 @@ class DataExportController {
     columnNameToNumber: any
   ): string[] {
     this.populateDialogGuidanceColumnNames(component, columnNames, columnNameToNumber);
-    const headerRow = [];
-    for (const columnName of columnNames) {
-      headerRow.push(columnName);
-    }
-    return headerRow;
+    return columnNames;
   }
 
   populateDialogGuidanceColumnNames(
@@ -3320,33 +3136,57 @@ class DataExportController {
     columnNames: string[],
     columnNameToNumber: any
   ): void {
-    for (let c = 0; c < this.componentExportDefaultColumnNames.length; c++) {
-      let defaultMatchColumnName = this.componentExportDefaultColumnNames[c];
-      columnNameToNumber[defaultMatchColumnName] = c;
-      columnNames.push(defaultMatchColumnName);
+    for (const defaultMatchColumnName of this.componentExportDefaultColumnNames) {
+      this.addColumnNameToColumnDataStructures(
+        columnNameToNumber,
+        columnNames,
+        defaultMatchColumnName
+      );
     }
+    this.addColumnNameToColumnDataStructures(
+      columnNameToNumber,
+      columnNames,
+      this.dialogGuidanceItemIdLabel
+    );
     const componentStates = this.TeacherDataService.getComponentStatesByComponentId(component.id);
     const ideaNames = this.getDialogGuidanceIdeaNames(componentStates);
     const scoreNames = this.getDialogGuidanceScoreNames(componentStates);
     for (let r = 0; r < this.getMaxNumberOfStudentResponses(componentStates); r++) {
-      const revisionNumber = `Revision ${r + 1}`;
-      const studentResponseColumnName = `Student Response ${revisionNumber}`;
-      columnNameToNumber[studentResponseColumnName] = columnNames.length;
-      columnNames.push(studentResponseColumnName);
+      const revisionNumber = `${this.dialogGuidanceRevisionLabel} ${r + 1}`;
+      this.addColumnNameToColumnDataStructures(
+        columnNameToNumber,
+        columnNames,
+        `${this.dialogGuidanceStudentResponseLabel} ${revisionNumber}`
+      );
       for (const ideaName of ideaNames) {
-        const columnName = `Idea ${ideaName} ${revisionNumber}`;
-        columnNameToNumber[columnName] = columnNames.length;
-        columnNames.push(columnName);
+        this.addColumnNameToColumnDataStructures(
+          columnNameToNumber,
+          columnNames,
+          `${this.dialogGuidanceIdeaLabel} ${ideaName} ${revisionNumber}`
+        );
       }
       for (const scoreName of scoreNames) {
-        const columnName = `Score ${scoreName} ${revisionNumber}`;
-        columnNameToNumber[columnName] = columnNames.length;
-        columnNames.push(columnName);
+        this.addColumnNameToColumnDataStructures(
+          columnNameToNumber,
+          columnNames,
+          `${this.dialogGuidanceScoreLabel} ${scoreName} ${revisionNumber}`
+        );
       }
-      const computerResponseColumnName = `Computer Response ${revisionNumber}`;
-      columnNameToNumber[computerResponseColumnName] = columnNames.length;
-      columnNames.push(computerResponseColumnName);
+      this.addColumnNameToColumnDataStructures(
+        columnNameToNumber,
+        columnNames,
+        `${this.dialogGuidanceComputerResponseLabel} ${revisionNumber}`
+      );
     }
+  }
+
+  addColumnNameToColumnDataStructures(
+    columnNameToNumber: any,
+    columnNames: string[],
+    columnName: string
+  ): void {
+    columnNameToNumber[columnName] = columnNames.length;
+    columnNames.push(columnName);
   }
 
   getDialogGuidanceIdeaNames(componentStates: any[]): string[] {
@@ -3365,12 +3205,16 @@ class DataExportController {
     for (const idea of ideas) {
       ideaNames.push(idea.name);
     }
-    return ideaNames.sort(this.sortIdeas);
+    return ideaNames.sort(this.sortIdeaNames);
   }
 
-  sortIdeas(a: any, b: any): number {
+  sortIdeaNames(a: any, b: any): number {
     const aInt = parseInt(a);
     const bInt = parseInt(b);
+    // if a and b are the same number but one of them contains a letter, we will sort alphabetically
+    // when a string like "5a" is given to parseInt(), it will return 5
+    // therefore if we are comparing "5" and "5a" we will sort alphabetically because we want
+    // 5 to show up before 5a
     if (!isNaN(aInt) && !isNaN(bInt) && aInt !== bInt) {
       // sort numerically
       return aInt - bInt;
@@ -3426,13 +3270,18 @@ class DataExportController {
     return count;
   }
 
-  generateDialogGuidanceComponentWorkRows(component, columnNames, columnNameToNumber, nodeId) {
-    let componentId = component.id;
-    let workgroups = this.ConfigService.getClassmateUserInfosSortedByWorkgroupId();
+  generateComponentWorkRows(
+    component: any,
+    columnNames: string[],
+    columnNameToNumber: any,
+    nodeId: string
+  ): string[] {
+    const componentId = component.id;
+    const workgroups = this.ConfigService.getClassmateUserInfosSortedByWorkgroupId();
     let rows = [];
     let rowCounter = 1;
     for (const workgroup of workgroups) {
-      let rowsForWorkgroup = this.generateDialogGuidanceComponentWorkRowsForWorkgroup(
+      const rowsForWorkgroup = this.generateWorkgroupComponentWorkRows(
         component,
         workgroup,
         columnNames,
@@ -3447,96 +3296,166 @@ class DataExportController {
     return rows;
   }
 
-  generateDialogGuidanceComponentWorkRowsForWorkgroup(
-    component,
-    workgroup,
-    columnNames,
-    columnNameToNumber,
-    nodeId,
-    componentId,
-    rowCounter
-  ) {
-    let rows = [];
-    let workgroupId = workgroup.workgroupId;
-    let periodName = workgroup.periodName;
-    let userInfo = this.ConfigService.getUserInfoByWorkgroupId(workgroupId);
-    let extractedUserIDsAndStudentNames = this.extractUserIDsAndStudentNames(userInfo.users);
+  generateWorkgroupComponentWorkRows(
+    component: any,
+    workgroup: any,
+    columnNames: string[],
+    columnNameToNumber: any,
+    nodeId: string,
+    componentId: string,
+    rowCounter: number
+  ): string[] {
+    return this.generateComponentWorkRowsForWorkgroup(
+      component,
+      workgroup,
+      columnNames,
+      columnNameToNumber,
+      nodeId,
+      componentId,
+      rowCounter
+    );
+  }
 
-    /*
-     * a mapping from component to component revision counter.
-     * the key will be {{nodeId}}_{{componentId}} and the
-     * value will be a number.
-     */
-    let componentRevisionCounter = {};
-    let matchComponentStates = this.TeacherDataService.getComponentStatesByWorkgroupIdAndComponentId(
+  generateComponentWorkRowsForWorkgroup(
+    component: any,
+    workgroup: any,
+    columnNames: string[],
+    columnNameToNumber: any,
+    nodeId: string,
+    componentId: string,
+    rowCounter: number
+  ): string[] {
+    const rows = [];
+    const workgroupId = workgroup.workgroupId;
+    const periodName = workgroup.periodName;
+    const userInfo = this.ConfigService.getUserInfoByWorkgroupId(workgroupId);
+    const extractedUserIDsAndStudentNames = this.extractUserIDsAndStudentNames(userInfo.users);
+
+    // A mapping from component to component revision counter. The key will be
+    // {{nodeId}}_{{componentId}} and the value will be a number.
+    const componentRevisionCounter = {};
+    const componentStates = this.TeacherDataService.getComponentStatesByWorkgroupIdAndComponentId(
       workgroupId,
       componentId
     );
-    if (matchComponentStates != null) {
-      for (let c = 0; c < matchComponentStates.length; c++) {
-        let matchComponentState = matchComponentStates[c];
-        let exportRow = true;
-        if (this.includeOnlySubmits && !matchComponentState.isSubmit) {
-          exportRow = false;
-        } else if (
-          this.workSelectionType == 'exportLatestWork' &&
-          c != matchComponentStates.length - 1
-        ) {
-          exportRow = false;
-        }
-
-        if (exportRow) {
-          rows.push(
-            this.generateDialogGuidanceComponentWorkRow(
-              component,
-              columnNames,
-              columnNameToNumber,
-              rowCounter,
-              workgroupId,
-              extractedUserIDsAndStudentNames['userId1'],
-              extractedUserIDsAndStudentNames['userId2'],
-              extractedUserIDsAndStudentNames['userId3'],
-              extractedUserIDsAndStudentNames['studentName1'],
-              extractedUserIDsAndStudentNames['studentName2'],
-              extractedUserIDsAndStudentNames['studentName3'],
-              periodName,
-              componentRevisionCounter,
-              matchComponentState
-            )
-          );
-          rowCounter++;
-        } else {
-          /*
-           * We do not want to add this row in the export but
-           * we still want to increment the revision counter.
-           */
-          this.incrementRevisionCounter(componentRevisionCounter, nodeId, componentId);
-        }
+    for (let c = 0; c < componentStates.length; c++) {
+      const componentState = componentStates[c];
+      if (this.shouldExportRow(componentState, c, componentStates.length)) {
+        const row = this.generateComponentWorkRow(
+          component,
+          columnNames,
+          columnNameToNumber,
+          rowCounter,
+          workgroupId,
+          extractedUserIDsAndStudentNames['userId1'],
+          extractedUserIDsAndStudentNames['userId2'],
+          extractedUserIDsAndStudentNames['userId3'],
+          extractedUserIDsAndStudentNames['studentName1'],
+          extractedUserIDsAndStudentNames['studentName2'],
+          extractedUserIDsAndStudentNames['studentName3'],
+          periodName,
+          componentRevisionCounter,
+          componentState
+        );
+        rows.push(row);
+        rowCounter++;
+      } else {
+        // We do not want to add this component state as a row in the export but we still want to
+        // increment the revision counter.
+        this.incrementRevisionCounter(componentRevisionCounter, nodeId, componentId);
       }
     }
     return rows;
   }
 
+  shouldExportRow(
+    componentState: any,
+    componentStateIndex: number,
+    numComponentStates: number
+  ): boolean {
+    let exportRow = true;
+    if (this.includeOnlySubmits && !componentState.isSubmit) {
+      exportRow = false;
+    } else if (
+      this.workSelectionType === 'exportLatestWork' &&
+      componentStateIndex != numComponentStates - 1
+    ) {
+      exportRow = false;
+    }
+    return exportRow;
+  }
+
+  generateComponentWorkRow(
+    component: any,
+    columnNames: string[],
+    columnNameToNumber: any,
+    rowCounter: number,
+    workgroupId: number,
+    userId1: number,
+    userId2: number,
+    userId3: number,
+    studentName1: string,
+    studentName2: string,
+    studentName3: string,
+    periodName: string,
+    componentRevisionCounter: any,
+    componentState: any
+  ): string[] {
+    if (componentState.componentType === 'Match') {
+      return this.generateMatchComponentWorkRow(
+        component,
+        columnNames,
+        columnNameToNumber,
+        rowCounter,
+        workgroupId,
+        userId1,
+        userId2,
+        userId3,
+        studentName1,
+        studentName2,
+        studentName3,
+        periodName,
+        componentRevisionCounter,
+        componentState
+      );
+    } else if (componentState.componentType === 'DialogGuidance') {
+      return this.generateDialogGuidanceComponentWorkRow(
+        component,
+        columnNames,
+        columnNameToNumber,
+        rowCounter,
+        workgroupId,
+        userId1,
+        userId2,
+        userId3,
+        studentName1,
+        studentName2,
+        studentName3,
+        periodName,
+        componentRevisionCounter,
+        componentState
+      );
+    }
+  }
+
   generateDialogGuidanceComponentWorkRow(
-    component,
-    columnNames,
-    columnNameToNumber,
-    rowCounter,
-    workgroupId,
-    userId1,
-    userId2,
-    userId3,
-    studentName1,
-    studentName2,
-    studentName3,
-    periodName,
-    componentRevisionCounter,
-    dialogGuidanceComponentState
-  ) {
-    /*
-     * Populate the cells in the row that contain the information about the
-     * student, project, run, step, and component.
-     */
+    component: any,
+    columnNames: string[],
+    columnNameToNumber: any,
+    rowCounter: number,
+    workgroupId: number,
+    userId1: number,
+    userId2: number,
+    userId3: number,
+    studentName1: string,
+    studentName2: string,
+    studentName3: string,
+    periodName: string,
+    componentRevisionCounter: any,
+    dialogGuidanceComponentState: any
+  ): string[] {
+    // Populate the cells in the row that contain the information about the student, project, run,
+    // step, and component.
     let row = this.createStudentWorkExportRow(
       columnNames,
       columnNameToNumber,
@@ -3552,21 +3471,27 @@ class DataExportController {
       componentRevisionCounter,
       dialogGuidanceComponentState
     );
+    row[columnNameToNumber[this.dialogGuidanceItemIdLabel]] = component.itemId;
     let revisionCounter = 0;
     let revisionLabel = '';
     for (const response of dialogGuidanceComponentState.studentData.responses) {
       if (response.user === 'Student') {
         revisionCounter++;
-        revisionLabel = `Revision ${revisionCounter}`;
-        row[columnNameToNumber[`Student Response ${revisionLabel}`]] = response.text;
+        revisionLabel = `${this.dialogGuidanceRevisionLabel} ${revisionCounter}`;
+        row[columnNameToNumber[`${this.dialogGuidanceStudentResponseLabel} ${revisionLabel}`]] =
+          response.text;
       } else if (response.user === 'Computer') {
         for (const idea of response.ideas) {
-          row[columnNameToNumber[`Idea ${idea.name} ${revisionLabel}`]] = idea.detected ? 1 : 0;
+          row[
+            columnNameToNumber[`${this.dialogGuidanceIdeaLabel} ${idea.name} ${revisionLabel}`]
+          ] = idea.detected ? 1 : 0;
         }
         for (const score of response.scores) {
-          row[columnNameToNumber[`Score ${score.id} ${revisionLabel}`]] = score.score;
+          row[columnNameToNumber[`${this.dialogGuidanceScoreLabel} ${score.id} ${revisionLabel}`]] =
+            score.score;
         }
-        row[columnNameToNumber[`Computer Response ${revisionLabel}`]] = response.text;
+        row[columnNameToNumber[`${this.dialogGuidanceComputerResponseLabel} ${revisionLabel}`]] =
+          response.text;
       }
     }
     return row;


### PR DESCRIPTION
Make sure Dialog Guidance export works
1. Find a run that has Dialog Guidance student data
2. Launch the Classroom Monitor for the run
3. Go to the Data Export view
4. Click the "Export Component Data" button
5. Scroll down and find a Dialog Guidance component
6. Click "All" and "Latest" download buttons to download the export

Make sure the researcher requirements have been fulfilled.
- one student per row
- for each item, these variables as columns
  - original student response
  - one column per idea (for all ideas a model has) with 0 (idea not detected) or 1 (idea detected)
  - Prompt given by computer
  - student response
  - prompt given by computer (no idea detection because second prompt is always fixed)
  - student revision
  - if existing add
    - c-rater KI and subscores in each one column for initial and revised student response
  - for items without idea models, no need to show the idea columns of course, only show student response, prompt, response, prompt, revision

Make sure Match export still works since common functions were refactored.

Closes #372