### PR TITLE
feat(Milestone Report Graph): Specify location for graph

### DIFF
--- a/src/assets/wise5/directives/milestoneReportGraph/milestoneReportGraph.js
+++ b/src/assets/wise5/directives/milestoneReportGraph/milestoneReportGraph.js
@@ -83,7 +83,7 @@ class MilestoneReportGraphController {
     const color = this.barColor ? this.barColor : this.defaultColor;
     const step = 100 / this.data.length / 100;
     let opacity = 0;
-    for (const componentData of this.data) {
+    for (const componentData of this.getDataToGraph(this.data, this.locations)) {
       opacity += step;
       const singleSeries = {
         name: this.UtilService.trimToLength(componentData.stepTitle, 26),
@@ -93,6 +93,20 @@ class MilestoneReportGraphController {
       series.push(singleSeries);
     }
     this.series = series;
+  }
+
+  getDataToGraph(data, locations) {
+    if (locations == null) {
+      return data;
+    } else {
+      return this.getDataFromLocations(data, locations);
+    }
+  }
+
+  getDataFromLocations(data, locations) {
+    const dataFromLocations = [];
+    locations.forEach((location) => { dataFromLocations.push(data[location]) });
+    return dataFromLocations;
   }
 
   getComponentSeriesData(componentData) {
@@ -120,6 +134,7 @@ MilestoneReportGraphController.$inject = ['$filter', 'UtilService'];
 const MilestoneReportGraph = {
   bindings: {
     id: '@',
+    locations: '<',
     name: '@',
     titleColor: '@',
     barColor: '@',

--- a/src/assets/wise5/directives/milestoneReportGraph/milestoneReportGraph.js
+++ b/src/assets/wise5/directives/milestoneReportGraph/milestoneReportGraph.js
@@ -105,7 +105,7 @@ class MilestoneReportGraphController {
 
   getDataFromLocations(data, locations) {
     const dataFromLocations = [];
-    locations.forEach((location) => { dataFromLocations.push(data[location]) });
+    locations.forEach((location) => { dataFromLocations.push(data[location - 1]) });
     return dataFromLocations;
   }
 


### PR DESCRIPTION
Test that the locations parameter for milestone-report-graph works.

Examples
```
Shows all locations (if locations is not provided)
<milestone-report-graph id="ki" name="Overall KI Score" flex></milestone-report-graph>

Shows location 1
<milestone-report-graph id="science" name="Science" locations="[1]" flex></milestone-report-graph>

Shows location 2
<milestone-report-graph id="experimentation" name="Experimentation" locations="[2]" flex></milestone-report-graph>

Shows location 2 and 1 in that order
<milestone-report-graph id="test" name="Test" locations="[2,1]" flex></milestone-report-graph>
```

Closes #377