### PR TITLE
fix(Dialog Guidance): Save single score

### DIFF
--- a/src/assets/wise5/components/dialogGuidance/CRaterResponse.ts
+++ b/src/assets/wise5/components/dialogGuidance/CRaterResponse.ts
@@ -2,7 +2,8 @@ import { CRaterIdea } from './CRaterIdea';
 import { CRaterScore } from './CRaterScore';
 
 export class CRaterResponse {
-  ideas: CRaterIdea[];
+  ideas: CRaterIdea[] = [];
+  score: number;
   scores: CRaterScore[];
 
   constructor() {}

--- a/src/assets/wise5/components/dialogGuidance/CRaterScore.ts
+++ b/src/assets/wise5/components/dialogGuidance/CRaterScore.ts
@@ -2,4 +2,10 @@ export class CRaterScore {
   id: string;
   score: number;
   realNumberScore: number;
+
+  constructor(id: string, score: number, realNumberScore: number) {
+    this.id = id;
+    this.score = score;
+    this.realNumberScore = realNumberScore;
+  }
 }

--- a/src/assets/wise5/components/dialogGuidance/ComputerDialogResponse.ts
+++ b/src/assets/wise5/components/dialogGuidance/ComputerDialogResponse.ts
@@ -1,15 +1,12 @@
 import { CRaterIdea } from './CRaterIdea';
-import { CRaterScore } from './CRaterScore';
 import { DialogResponse } from './DialogResponse';
 
 export class ComputerDialogResponse extends DialogResponse {
   ideas: CRaterIdea[];
-  scores: CRaterScore[];
   user: string = 'Computer';
 
-  constructor(text: string, scores: CRaterScore[], ideas: CRaterIdea[], timestamp: number) {
+  constructor(text: string, ideas: CRaterIdea[], timestamp: number) {
     super(text, timestamp);
     this.ideas = ideas;
-    this.scores = scores;
   }
 }

--- a/src/assets/wise5/components/dialogGuidance/ComputerDialogResponseMultipleScores.ts
+++ b/src/assets/wise5/components/dialogGuidance/ComputerDialogResponseMultipleScores.ts
@@ -1,0 +1,12 @@
+import { ComputerDialogResponse } from './ComputerDialogResponse';
+import { CRaterIdea } from './CRaterIdea';
+import { CRaterScore } from './CRaterScore';
+
+export class ComputerDialogResponseMultipleScores extends ComputerDialogResponse {
+  scores: CRaterScore[];
+
+  constructor(text: string, scores: CRaterScore[], ideas: CRaterIdea[], timestamp: number) {
+    super(text, ideas, timestamp);
+    this.scores = scores;
+  }
+}

--- a/src/assets/wise5/components/dialogGuidance/ComputerDialogResponseSingleScore.ts
+++ b/src/assets/wise5/components/dialogGuidance/ComputerDialogResponseSingleScore.ts
@@ -1,0 +1,11 @@
+import { ComputerDialogResponse } from './ComputerDialogResponse';
+import { CRaterIdea } from './CRaterIdea';
+
+export class ComputerDialogResponseSingleScore extends ComputerDialogResponse {
+  score: number;
+
+  constructor(text: string, score: number, ideas: CRaterIdea[], timestamp: number) {
+    super(text, ideas, timestamp);
+    this.score = score;
+  }
+}

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
@@ -153,6 +153,7 @@ describe('DialogGuidanceFeedbackRuleEvaluator', () => {
   matchRule_MultipleIdeasUsingAndOr();
   matchRule_MultipleIdeasUsingNotAndOr();
   matchNoRule_ReturnDefault();
+  matchNoRule_NoDefaultFeedbackAuthored_ReturnApplicationDefault();
   secondToLastSubmit();
   finalSubmit();
   nonScorable();
@@ -197,6 +198,13 @@ function matchRule_MultipleIdeasUsingNotAndOr() {
 function matchNoRule_ReturnDefault() {
   it('should return default idea when no rule is matched', () => {
     expectFeedback(['idea10', 'idea11'], [], 'default feedback');
+  });
+}
+
+function matchNoRule_NoDefaultFeedbackAuthored_ReturnApplicationDefault() {
+  it('should return application default rule when no rule is matched and no default is authored', () => {
+    component.componentContent.feedbackRules = [];
+    expectFeedback(['idea10', 'idea11'], [], evaluator.defaultFeedback);
   });
 }
 

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
@@ -4,6 +4,7 @@ import { FeedbackRule } from './FeedbackRule';
 
 export class DialogGuidanceFeedbackRuleEvaluator {
   component: DialogGuidanceStudentComponent;
+  defaultFeedback = $localize`Thanks for submitting your response.`;
 
   constructor(component: DialogGuidanceStudentComponent) {
     this.component = component;
@@ -122,6 +123,12 @@ export class DialogGuidanceFeedbackRuleEvaluator {
   }
 
   private getDefaultRule(feedbackRules: FeedbackRule[]): FeedbackRule {
-    return feedbackRules.find((rule) => FeedbackRule.isDefaultRule(rule));
+    return (
+      feedbackRules.find((rule) => FeedbackRule.isDefaultRule(rule)) ||
+      Object.assign(new FeedbackRule(), {
+        expression: 'isDefault',
+        feedback: this.defaultFeedback
+      })
+    );
   }
 }

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
@@ -139,8 +139,8 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
 
   cRaterSuccessResponse(response: CRaterResponse): void {
     this.hideWaitingForComputerResponse();
-    this.addDialogResponse(this.createComputerDialogResponse(response));
     this.submitButtonClicked();
+    this.addDialogResponse(this.createComputerDialogResponse(response));
     if (this.hasMaxSubmitCountAndUsedAllSubmits()) {
       this.disableStudentResponse();
     } else {
@@ -148,23 +148,21 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
     }
   }
 
-  createComputerDialogResponse(response: any): ComputerDialogResponse {
+  createComputerDialogResponse(response: CRaterResponse): ComputerDialogResponse {
     const feedbackRule: FeedbackRule = this.feedbackRuleEvaluator.getFeedbackRule(response);
-    if (response.scores != null) {
-      return new ComputerDialogResponseMultipleScores(
-        feedbackRule.feedback,
-        response.scores,
-        response.ideas,
-        new Date().getTime()
-      );
-    } else if (response.score != null) {
-      return new ComputerDialogResponseSingleScore(
-        feedbackRule.feedback,
-        response.score,
-        response.ideas,
-        new Date().getTime()
-      );
-    }
+    return response.scores != null
+      ? new ComputerDialogResponseMultipleScores(
+          feedbackRule.feedback,
+          response.scores,
+          response.ideas,
+          new Date().getTime()
+        )
+      : new ComputerDialogResponseSingleScore(
+          feedbackRule.feedback,
+          response.score,
+          response.ideas,
+          new Date().getTime()
+        );
   }
 
   cRaterErrorResponse() {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9655,35 +9655,35 @@ Are you ready to receive feedback on this answer?</source>
         <source> Show Amplitude Input </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.html</context>
-          <context context-type="linenumber">93,94</context>
+          <context context-type="linenumber">94,95</context>
         </context-group>
       </trans-unit>
       <trans-unit id="267799b6a3f95111ede597b3bdfac1b68ca4755e" datatype="html">
         <source> Allow Student to Edit Amplitude </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.html</context>
-          <context context-type="linenumber">102,103</context>
+          <context context-type="linenumber">103,104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="584114dd79e680cb2262384fe8fc40c40149e9b3" datatype="html">
         <source>Oscillator Width (Pixels)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.html</context>
-          <context context-type="linenumber">112</context>
+          <context context-type="linenumber">113</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dd7074cd090ce1bc8c04b82d5e86dc19e550819c" datatype="html">
         <source>Oscillator Height (Pixels)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.html</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">121</context>
         </context-group>
       </trans-unit>
       <trans-unit id="45565845bc7e8f7999ef848f155e2c7d5dbb248e" datatype="html">
         <source>Oscillator Grid Size (Pixels)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.html</context>
-          <context context-type="linenumber">128</context>
+          <context context-type="linenumber">129</context>
         </context-group>
       </trans-unit>
       <trans-unit id="69c3a88db813e4b07df0bd518f272ac529b2c3f1" datatype="html">
@@ -10423,6 +10423,13 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/edit-concept-map-connected-components/edit-concept-map-connected-components.component.ts</context>
           <context context-type="linenumber">38</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5596810972110629301" datatype="html">
+        <source>Thanks for submitting your response.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts</context>
+          <context context-type="linenumber">7</context>
         </context-group>
       </trans-unit>
       <trans-unit id="27e0b1e650bef276e8c29dd8d547e3fc8c4f833f" datatype="html">


### PR DESCRIPTION
- Make sure the single score is saved if the Item ID only returns a single score. You can test it with GREENROOF-II.
- Make sure a "submit" component state is saved whenever the student clicks send.
- Make sure the submit counter is not incremented if the CRater request fails. This should still save a "save" component state.

Closes #379