### PR TITLE
feat(Table Component): Use textarea for editable cells

### DIFF
--- a/src/assets/wise5/components/table/table-student/table-student.component.html
+++ b/src/assets/wise5/components/table/table-student/table-student.component.html
@@ -39,14 +39,14 @@
         <mat-form-field *ngIf="cell.editable"
             class="cell-input form-field-no-label form-field-no-hint"
             appearance="outline">
-          <input
+          <textarea cdkTextareaAutosize
               matInput
               type="text"
               [(ngModel)]="cell.text"
               (ngModelChange)="studentDataChanged()"
               [disabled]="isDisabled"
               i18n-aria-label
-              aria-label="Cell content" />
+              aria-label="Cell content"></textarea>
         </mat-form-field>
         <ng-container *ngIf="!cell.editable">{{cell.text}}</ng-container>
       </td>

--- a/src/assets/wise5/components/table/table-student/table-student.component.scss
+++ b/src/assets/wise5/components/table/table-student/table-student.component.scss
@@ -20,5 +20,5 @@
 }
 
 .cell-input {
-  max-width: 100%;
+  width: 100%;
 }


### PR DESCRIPTION
### Changes
Replaces `<input>` elements with `<textarea>` elements for editable cells in Table components. Allows input to grow with content.

Closes #387.

### Test
- Make sure table component editable cells work as before.
- Verify that cell and textarea height increases to show all input content.