### PR TITLE
fix(Connected Components): Send work on save and submit

### DIFF
--- a/src/assets/wise5/vle/node/nodeController.ts
+++ b/src/assets/wise5/vle/node/nodeController.ts
@@ -536,6 +536,9 @@ class NodeController {
             componentEvents,
             componentAnnotations
           } = this.getDataArraysToSaveFromComponentStates(componentStatesFromComponents);
+          componentStates.forEach((componentState: any) => {
+            this.notifyConnectedParts(componentId, componentState);
+          });
           return this.StudentDataService.saveToServer(
             componentStates,
             componentEvents,


### PR DESCRIPTION
Test that submitting the Embedded table renders the graph.
https://wise.berkeley.edu/preview/unit/32968/node162

Make sure to use the updated appliances table that saves on submit.
https://wise.berkeley.edu/curriculum/shared/appliances-kwh-co2-table/v1/appliances-new.html

Previously, submitting the updated appliances table would not trigger the graph rendering but now it should.

Also make sure other instances of connected components on the same step still work properly. For example [Thermodynamics Challenge - 2.8: Run Your Experiments](https://wise.berkeley.edu/preview/unit/32121/node81).

Closes #389