### PR TITLE
fix(Angular Material): Add support for multiline hints

### DIFF
--- a/src/app/teacher/create-run-dialog/create-run-dialog.component.html
+++ b/src/app/teacher/create-run-dialog/create-run-dialog.component.html
@@ -12,7 +12,7 @@
         </mat-checkbox>
       </span>
     </p>
-    <mat-form-field appearance="fill" class="mat-form-field--longhint">
+    <mat-form-field appearance="fill" class="period-input form-field-long-hint">
       <mat-label i18n>Add your own periods</mat-label>
       <input matInput id="customPeriods" name="customPeriods" formControlName="customPeriods" />
       <mat-hint i18n>For "Period 9", just enter the number 9. Separate periods with commas (e.g. "Section 1, Section 2"). Manually named periods should be no more than 16 characters long.
@@ -48,7 +48,7 @@
           <mat-datepicker #endDatePicker></mat-datepicker>
         </mat-form-field>
       </div>
-      <div fxLayoutAlign="center center" style="padding-bottom: 1.34375em;">
+      <div fxLayoutAlign="start center" style="padding-bottom: 1.34375em;">
         <mat-checkbox formControlName="isLockedAfterEndDate" i18n>
           Lock After End Date
         </mat-checkbox>&nbsp;

--- a/src/app/teacher/create-run-dialog/create-run-dialog.component.scss
+++ b/src/app/teacher/create-run-dialog/create-run-dialog.component.scss
@@ -1,3 +1,7 @@
 .period-select {
   margin-right: 24px;
 }
+
+.period-input {
+  width: 100%;
+}

--- a/src/app/teacher/run-settings-dialog/run-settings-dialog.component.html
+++ b/src/app/teacher/run-settings-dialog/run-settings-dialog.component.html
@@ -1,14 +1,15 @@
 <h2 class="mat-dialog-title" i18n>Edit Settings</h2>
 <mat-dialog-content class="dialog-content-scroll">
-  <p class="mat-subheading-2 accent-1">
-    {{ run.name }} <span class="mat-caption" i18n>(Run ID: {{ run.id }})</span>
-  </p>
+  <p class="mat-subheading-2 accent-1"> {{ run.name }} <span class="mat-caption" i18n>(Run ID: {{ run.id }})</span> </p>
   <h3 i18n>Class Periods</h3>
   <div fxLayoutGap="8px" fxLayout="row wrap">
     <div *ngFor="let period of run.periods" class="info-block" fxLayoutAlign="center center">
       <span class="mat-body-2 ">{{ period }}</span>
-      <button mat-icon-button color="accent" (click)="deletePeriod(period)" i18n-aria-label
-              aria-label="Delete period">
+      <button mat-icon-button
+          color="accent"
+          (click)="deletePeriod(period)"
+          i18n-aria-label
+          aria-label="Delete period">
         <mat-icon>close</mat-icon>
       </button>
     </div>
@@ -16,35 +17,46 @@
   <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
     <mat-form-field appearance="fill" fxFlex="0 0 auto" fxFlex.xs="0 0 100%">
       <mat-label i18n>Add new period</mat-label>
-      <input [(ngModel)]="newPeriodName" (keyup)="newPeriodNameKeyUp($event)"
-             (keyup.enter)="addPeriod()" matInput id="newPeriod" name="newPeriod" />
-      <button mat-icon-button matSuffix color="primary" (click)="addPeriod()" i18n-aria-label
-              aria-label="Add period">
+      <input [(ngModel)]="newPeriodName"
+          (keyup)="newPeriodNameKeyUp($event)"
+          (keyup.enter)="addPeriod()"
+          matInput
+          id="newPeriod"
+          name="newPeriod" 
+          maxlength="16" />
+      <button mat-icon-button matSuffix color="primary" (click)="addPeriod()" i18n-aria-label aria-label="Add period">
         <mat-icon>add_circle</mat-icon>
       </button>
       <mat-hint *ngIf="addPeriodMessage" class="warn">{{ addPeriodMessage }}</mat-hint>
+      <mat-hint *ngIf="!addPeriodMessage" i18n>For "Period 9", just enter the number 9.</mat-hint>
     </mat-form-field>
   </div>
   <mat-divider></mat-divider>
   <h3 i18n>Students Per Team</h3>
   <mat-radio-group [(ngModel)]="maxStudentsPerTeam" #rGroup fxLayoutGap="16px">
-    <mat-radio-button value="1" radioGroup="rGroup" (click)="changeMaxStudentsPerTeam(1)" i18n>Only
-      1 student</mat-radio-button>
-    <mat-radio-button value="3" radioGroup="rGroup" (click)="changeMaxStudentsPerTeam(3)" i18n>1-3
-      students</mat-radio-button>
+    <mat-radio-button value="1" radioGroup="rGroup" (click)="changeMaxStudentsPerTeam(1)" i18n>
+      Only 1 student
+    </mat-radio-button>
+    <mat-radio-button value="3" radioGroup="rGroup" (click)="changeMaxStudentsPerTeam(3)" i18n>
+      1-3 students
+    </mat-radio-button>
   </mat-radio-group>
   <mat-divider></mat-divider>
   <h3>
     <ng-container i18n>Schedule</ng-container>&nbsp;
-    <span *ngIf="run.lastRun" class="mat-caption" i18n>(Last student login:
-      {{ run.lastRun | amCalendar }})</span>
+    <span *ngIf="run.lastRun" class="mat-caption" i18n>
+      (Last student login: {{ run.lastRun | amCalendar }})
+    </span>
   </h3>
   <div fxLayout="row wrap" fxLayout.xs="column" fxLayoutGap.gt-xs="16px">
     <div>
       <mat-form-field appearance="fill" fxFlexAlign="start" fxFlex="0 0 auto" fxFlex.xs="0 0 100%">
         <mat-label i18n>Start date</mat-label>
-        <input [(ngModel)]="startDate" matInput [matDatepicker]="startDatePicker"
-               (dateChange)="updateStartTime()" [max]="maxStartDate">
+        <input [(ngModel)]="startDate"
+            matInput
+            [matDatepicker]="startDatePicker"
+            (dateChange)="updateStartTime()"
+            [max]="maxStartDate">
         <mat-datepicker-toggle matSuffix [for]="startDatePicker"></mat-datepicker-toggle>
         <mat-datepicker #startDatePicker></mat-datepicker>
         <mat-error i18n>Start date is required.</mat-error>
@@ -54,21 +66,27 @@
     <div>
       <mat-form-field appearance="fill" fxFlexAlign="start" fxFlex="0 0 auto" fxFlex.xs="0 0 100%">
         <mat-label i18n>End date</mat-label>
-        <input [(ngModel)]="endDate" matInput [matDatepicker]="endDatePicker"
-               (dateChange)="updateEndTime()" [min]="minEndDate">
+        <input [(ngModel)]="endDate"
+            matInput
+            [matDatepicker]="endDatePicker"
+            (dateChange)="updateEndTime()"
+            [min]="minEndDate">
         <mat-datepicker-toggle matSuffix [for]="endDatePicker"></mat-datepicker-toggle>
         <mat-datepicker #endDatePicker [startAt]="targetEndDate"></mat-datepicker>
         <mat-hint *ngIf="endDateMessage" class="warn">{{ endDateMessage }}</mat-hint>
       </mat-form-field>
     </div>
     <div fxLayoutAlign="center center" style="padding-bottom: 1.34375em;">
-      <mat-checkbox [(ngModel)]="isLockedAfterEndDate" (change)="updateIsLockedAfterEndDate()"
-                    [disabled]="!isLockedAfterEndDateCheckboxEnabled" i18n>
+      <mat-checkbox [(ngModel)]="isLockedAfterEndDate"
+          (change)="updateIsLockedAfterEndDate()"
+          [disabled]="!isLockedAfterEndDateCheckboxEnabled"
+          i18n>
         Lock After End Date
       </mat-checkbox>&nbsp;
       <mat-icon class="info"
-                matTooltip="If the End Date has passed and the unit is locked, students will no longer be able to save new work"
-                matTooltipPosition="above" i18n-matTooltip>help</mat-icon>
+          matTooltip="If the End Date has passed and the unit is locked, students will no longer be able to save new work"
+          matTooltipPosition="above"
+          i18n-matTooltip>help</mat-icon>
     </div>
   </div>
 </mat-dialog-content>

--- a/src/app/teacher/run-settings-dialog/run-settings-dialog.component.scss
+++ b/src/app/teacher/run-settings-dialog/run-settings-dialog.component.scss
@@ -6,5 +6,3 @@
     padding: 4px 4px 4px 8px;
   }
 }
-
-

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -5267,7 +5267,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">97</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/share-run-dialog/share-run-dialog.component.html</context>
@@ -7179,7 +7179,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6becdc6f27b75d5697cfd21fa1c80856ee184e64" datatype="html">
@@ -7197,7 +7197,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">71</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4005b12b4826f1ebfe46b5d64ecb84915f61be73" datatype="html">
@@ -7215,7 +7215,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
-          <context context-type="linenumber">70</context>
+          <context context-type="linenumber">90</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dfe5fb2242551f7f7aae712b5449e38ec0ca79a8" datatype="html">
@@ -7293,7 +7293,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
-          <context context-type="linenumber">4</context>
+          <context context-type="linenumber">3</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/share-run-code-dialog/share-run-code-dialog.component.html</context>
@@ -7522,77 +7522,84 @@
         <source>Class Periods</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
-          <context context-type="linenumber">6</context>
+          <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
       <trans-unit id="200beac9fb92373dc2bb97201d34e1346d1c08a0" datatype="html">
         <source>Delete period</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
-          <context context-type="linenumber">11</context>
+          <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d82dfc07206fd771e111875d19d04941fb255662" datatype="html">
         <source>Add new period</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
-          <context context-type="linenumber">18</context>
+          <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d184c11334133744f14daeee4fc04735cdc88e9e" datatype="html">
         <source>Add period</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
-          <context context-type="linenumber">22</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8e4f6fbd6f10462ce24ec7b579764cbb0e7208da" datatype="html">
+        <source>For &quot;Period 9&quot;, just enter the number 9.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
+          <context context-type="linenumber">34</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9e52801929bc9e355f8de5c5c13ba357055d1bdf" datatype="html">
         <source>Students Per Team</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
-          <context context-type="linenumber">29</context>
+          <context context-type="linenumber">38</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="17fa4b58d131328449acdbaad4bbe404bfd31264" datatype="html">
-        <source>Only 1 student</source>
+      <trans-unit id="3830ac25d707cb610ab5eae521c759a557fb7d7d" datatype="html">
+        <source> Only 1 student </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
-          <context context-type="linenumber">31,32</context>
+          <context context-type="linenumber">41,42</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="975a4029af4b0992dcdcbe682bcba819ea8cf809" datatype="html">
-        <source>1-3 students</source>
+      <trans-unit id="3e3d338fd6b6cce651564a6cd4868c6c31d7df26" datatype="html">
+        <source> 1-3 students </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
-          <context context-type="linenumber">33,34</context>
+          <context context-type="linenumber">44,45</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4a4f46a2dcec36bd5c8c371ceee55c2226dec27f" datatype="html">
         <source>Schedule</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
-          <context context-type="linenumber">38</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="c1d7798f7e66f0c74760feddb4a5ebe92a5dd49f" datatype="html">
-        <source>(Last student login: <x id="INTERPOLATION" equiv-text="{{ run.lastRun | amCalendar }}"/>)</source>
+      <trans-unit id="2987d3838d160f224644ae6a7d19eea2d40ef7e6" datatype="html">
+        <source> (Last student login: <x id="INTERPOLATION" equiv-text="{{ run.lastRun | amCalendar }}"/>) </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
-          <context context-type="linenumber">39,40</context>
+          <context context-type="linenumber">50,52</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a1c89f5496e99086127a54d08cecba1d0920397e" datatype="html">
         <source>Start date is required.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">65</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1758732318fe8d8d5820744ec9691104301ced4f" datatype="html">
         <source> Lock After End Date </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.html</context>
-          <context context-type="linenumber">67,68</context>
+          <context context-type="linenumber">87,88</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5800344060320957157" datatype="html">

--- a/src/style/components/_inputs.scss
+++ b/src/style/components/_inputs.scss
@@ -3,6 +3,20 @@
   border-radius: 0;
 }
 
+.form-field-long-hint {
+  .mat-form-field-wrapper {
+    padding-bottom: 0;
+  }
+
+  .mat-form-field-underline {
+    position: initial;
+  }
+
+  .mat-form-field-subscript-wrapper {
+    position: relative;
+  }
+}
+
 .form-field-no-label {
   &.mat-form-field-appearance-fill, &.mat-form-field-appearance-outline {
     .mat-form-field-wrapper {


### PR DESCRIPTION
### Changes
Add support for multiline hints for Angular Material form fields. This stops hint text in the Custom Periods input in the Create Run dialog from overlapping the content below.

Also adds a hint to the Add Period input in the Run Settings dialog to match the Custom Periods hint and limits the length of the Add Period input text to 16 characters.

Closes #391 .

### Test
Check to verify that the overlapping text is resolved in the Create Run Dialog, both for wide and narrow viewports.