### PR TITLE
fix(Authoring): Always show default feedback authoring

### DIFF
--- a/src/app/authoring-tool/edit-advanced-component/edit-component-default-feedback/edit-component-default-feedback.component.ts
+++ b/src/app/authoring-tool/edit-advanced-component/edit-component-default-feedback/edit-component-default-feedback.component.ts
@@ -34,6 +34,7 @@ export class EditComponentDefaultFeedback {
       this.authoringComponentContent.defaultFeedback = [];
     }
     this.authoringComponentContent.defaultFeedback.push('');
+    this.authoringComponentContent.showSubmitButton = true;
     this.componentChanged();
   }
 

--- a/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.html
+++ b/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.html
@@ -9,7 +9,6 @@
     (maxSubmitCountChange)="maxSubmitCountChanged($event)">
 </edit-component-max-submit>
 <edit-component-default-feedback
-    *ngIf="authoringComponentContent.showSubmitButton"
     [authoringComponentContent]="authoringComponentContent">
 </edit-component-default-feedback>
 <div fxLayout="column" fxLayoutAlign="start start">

--- a/src/assets/wise5/components/draw/edit-draw-advanced/edit-draw-advanced.component.html
+++ b/src/assets/wise5/components/draw/edit-draw-advanced/edit-draw-advanced.component.html
@@ -13,7 +13,6 @@
     (maxSubmitCountChange)="maxSubmitCountChanged($event)">
 </edit-component-max-submit>
 <edit-component-default-feedback
-    *ngIf="authoringComponentContent.showSubmitButton"
     [authoringComponentContent]="authoringComponentContent">
 </edit-component-default-feedback>
 <div fxLayout="column" fxLayoutAlign="start start">

--- a/src/assets/wise5/components/label/edit-label-advanced/edit-label-advanced.component.html
+++ b/src/assets/wise5/components/label/edit-label-advanced/edit-label-advanced.component.html
@@ -13,7 +13,6 @@
     (maxSubmitCountChange)="maxSubmitCountChanged($event)">
 </edit-component-max-submit>
 <edit-component-default-feedback
-    *ngIf="authoringComponentContent.showSubmitButton"
     [authoringComponentContent]="authoringComponentContent">
 </edit-component-default-feedback>
 <div fxLayout="column" fxLayoutAlign="start start">

--- a/src/assets/wise5/components/match/edit-match-advanced/edit-match-advanced.component.html
+++ b/src/assets/wise5/components/match/edit-match-advanced/edit-match-advanced.component.html
@@ -39,7 +39,6 @@
     (maxSubmitCountChange)="maxSubmitCountChanged($event)">
 </edit-component-max-submit>
 <edit-component-default-feedback
-    *ngIf="authoringComponentContent.showSubmitButton"
     [authoringComponentContent]="authoringComponentContent">
 </edit-component-default-feedback>
 <div fxLayout="column" fxLayoutAlign="start start">

--- a/src/assets/wise5/components/multipleChoice/edit-multiple-choice-advanced/edit-multiple-choice-advanced.component.html
+++ b/src/assets/wise5/components/multipleChoice/edit-multiple-choice-advanced/edit-multiple-choice-advanced.component.html
@@ -18,7 +18,6 @@
     (maxSubmitCountChange)="maxSubmitCountChanged($event)">
 </edit-component-max-submit>
 <edit-component-default-feedback
-    *ngIf="authoringComponentContent.showSubmitButton"
     [authoringComponentContent]="authoringComponentContent">
 </edit-component-default-feedback>
 <div fxLayout="column" fxLayoutAlign="start start">

--- a/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html
+++ b/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html
@@ -150,7 +150,6 @@
     (maxSubmitCountChange)="maxSubmitCountChanged($event)">
 </edit-component-max-submit>
 <edit-component-default-feedback
-    *ngIf="authoringComponentContent.showSubmitButton"
     [authoringComponentContent]="authoringComponentContent">
 </edit-component-default-feedback>
 <div fxLayout="column" fxLayoutAlign="start start">


### PR DESCRIPTION
Go to the component advanced view and make sure the "Default Feedback on Submit" authoring is shown even if the submit button is not enabled. When you add a default feedback by clicking the + button, the "Show Submit Button" should become enabled. This should work for all component types that save work.

Closes #373