### PR TITLE
fix(Events Export): Fix duplicate events bug

### DIFF
--- a/src/assets/wise5/classroomMonitor/dataExport/dataExportController.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/dataExportController.ts
@@ -963,32 +963,71 @@ class DataExportController {
     columnNameToNumber: any,
     events: any[]
   ): number {
-    const workgroups = this.ConfigService.getClassmateUserInfosSortedByWorkgroupId();
-    for (const workgroup of workgroups) {
-      const workgroupId = workgroup.workgroupId;
-      const periodName = workgroup.periodName;
-      const userInfo = this.ConfigService.getUserInfoByWorkgroupId(workgroupId);
-      const extractedUserIDsAndStudentNames = this.extractUserIDsAndStudentNames(userInfo.users);
-      for (const event of events) {
-        const row = this.createStudentEventExportRow(
+    for (const workgroup of this.ConfigService.getClassmateUserInfosSortedByWorkgroupId()) {
+      rowCounter = this.addStudentEventsForWorkgroup(
+        workgroup,
+        rows,
+        rowCounter,
+        columnNames,
+        columnNameToNumber,
+        events
+      );
+    }
+    return rowCounter;
+  }
+
+  addStudentEventsForWorkgroup(
+    workgroup: any,
+    rows: any[],
+    rowCounter: number,
+    columnNames: string[],
+    columnNameToNumber: any,
+    events: any
+  ): number {
+    for (const event of events) {
+      if (event.workgroupId === workgroup.workgroupId) {
+        rowCounter = this.addStudentEventRow(
+          workgroup,
+          rows,
+          rowCounter,
           columnNames,
           columnNameToNumber,
-          rowCounter,
-          workgroupId,
-          extractedUserIDsAndStudentNames['userId1'],
-          extractedUserIDsAndStudentNames['userId2'],
-          extractedUserIDsAndStudentNames['userId3'],
-          extractedUserIDsAndStudentNames['studentName1'],
-          extractedUserIDsAndStudentNames['studentName2'],
-          extractedUserIDsAndStudentNames['studentName3'],
-          periodName,
           event
         );
-        rows.push(row);
-        rowCounter++;
       }
     }
     return rowCounter;
+  }
+
+  addStudentEventRow(
+    workgroup: any,
+    rows: any[],
+    rowCounter: number,
+    columnNames: string[],
+    columnNameToNumber: any,
+    event: any
+  ): number {
+    const workgroupId = workgroup.workgroupId;
+    const periodName = workgroup.periodName;
+    const userInfo = this.ConfigService.getUserInfoByWorkgroupId(workgroupId);
+    const extractedUserIDsAndStudentNames = this.extractUserIDsAndStudentNames(userInfo.users);
+    rows.push(
+      this.createStudentEventExportRow(
+        columnNames,
+        columnNameToNumber,
+        rowCounter,
+        workgroupId,
+        extractedUserIDsAndStudentNames['userId1'],
+        extractedUserIDsAndStudentNames['userId2'],
+        extractedUserIDsAndStudentNames['userId3'],
+        extractedUserIDsAndStudentNames['studentName1'],
+        extractedUserIDsAndStudentNames['studentName2'],
+        extractedUserIDsAndStudentNames['studentName3'],
+        periodName,
+        event
+      )
+    );
+    return ++rowCounter;
   }
 
   addTeacherEvents(


### PR DESCRIPTION
1. Go to a run that has at least 2 workgroups with events
2. Download the Events export
3. Make sure all the event rows are unique. If you copy an Event ID in the export (Column R) and search for it, you should only find it in one row.

The fix was a one liner but I also refactored some functions. This line with the workgroupId check was the only thing that was needed to fix the bug.
https://github.com/WISE-Community/WISE-Client/blob/3c0abe9c1c7b5afe7a9446ece25161f810de0983/src/assets/wise5/classroomMonitor/dataExport/dataExportController.ts#L987-L988

Closes #404