### PR TITLE
feat(Events): Stop saving component events

### DIFF
--- a/src/assets/wise5/components/draw/draw-student/draw-student.component.ts
+++ b/src/assets/wise5/components/draw/draw-student/draw-student.component.ts
@@ -85,7 +85,6 @@ export class DrawStudent extends ComponentStudent {
     this.initializeStudentData();
     this.disableComponentIfNecessary();
     this.setDrawingChangedListener();
-    this.setToolChangedListener();
     this.DrawService.setUpTools(this.drawingToolId, this.componentContent.tools, this.isDisabled);
 
     if (this.hasMaxSubmitCountAndUsedAllSubmits()) {
@@ -178,17 +177,6 @@ export class DrawStudent extends ComponentStudent {
         this.studentDataChanged();
       });
     }, 500);
-  }
-
-  setToolChangedListener(): void {
-    this.drawingTool.on('tool:changed', (toolName: string) => {
-      const category = 'Tool';
-      const event = 'toolSelected';
-      const data = {
-        selectedToolName: toolName
-      };
-      this.StudentDataService.saveComponentEvent(this, category, event, data);
-    });
   }
 
   handleConnectedComponentsPostProcess(): void {

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.ts
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.ts
@@ -191,14 +191,6 @@ export class MultipleChoiceStudent extends ComponentStudent {
     if (this.isDisabled) {
       return;
     }
-    if (this.mode === 'student') {
-      const category = 'StudentInteraction';
-      const event = 'choiceSelected';
-      const data: any = {
-        selectedChoiceId: choiceId
-      };
-      this.StudentDataService.saveComponentEvent(this, category, event, data);
-    }
   }
 
   checkboxClicked(choiceId: string): void {
@@ -207,15 +199,6 @@ export class MultipleChoiceStudent extends ComponentStudent {
     }
     this.addOrRemoveFromStudentChoices(choiceId);
     this.studentDataChanged();
-    if (this.mode === 'student') {
-      const category = 'StudentInteraction';
-      const event = 'choiceSelected';
-      const data: any = {
-        selectedChoiceId: choiceId,
-        choicesAfter: this.studentChoices
-      };
-      this.StudentDataService.saveComponentEvent(this, category, event, data);
-    }
   }
 
   addOrRemoveFromStudentChoices(choiceId: string): void {


### PR DESCRIPTION
Make sure these events are no longer saved when logged in as a student. These are the only component events we were previously saving.
- Selecting a radio choice in Multiple Choice
- Selecting a checkbox in Multiple Choice
- Selecting a tool in Draw

Closes #403