### PR TITLE
feat(Peer Group): Implement teacher manual assignment view

### DIFF
--- a/src/app/teacher-hybrid-angular.module.ts
+++ b/src/app/teacher-hybrid-angular.module.ts
@@ -26,6 +26,7 @@ import { StepToolsComponent } from '../assets/wise5/common/stepTools/step-tools.
 import { UpdateWorkgroupService } from './services/updateWorkgroupService';
 import { GetWorkgroupService } from './services/getWorkgroupService';
 import { WorkgroupService } from './services/workgroup.service';
+import { PeerGroupService } from '../assets/wise5/services/peerGroupService';
 
 @NgModule({
   declarations: [StepToolsComponent],
@@ -42,6 +43,7 @@ import { WorkgroupService } from './services/workgroup.service';
     InsertNodesService,
     MilestoneService,
     MoveNodesService,
+    PeerGroupService,
     ProjectAssetService,
     SpaceService,
     StudentStatusService,

--- a/src/app/teacher/classroom-monitor.module.ts
+++ b/src/app/teacher/classroom-monitor.module.ts
@@ -36,6 +36,12 @@ import { MilestoneReportDataComponent } from './milestone/milestone-report-data/
 import { ChangeTeamPeriodDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component';
 import { ManageShowStudentInfoComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component';
 import { RemoveUserConfirmDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/remove-user-confirm-dialog/remove-user-confirm-dialog.component';
+import { PeerGroupAssignedWorkgroupsComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-assigned-workgroups/peer-group-assigned-workgroups.component';
+import { PeerGroupDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component';
+import { PeerGroupGroupingComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-grouping/peer-group-grouping.component';
+import { PeerGroupMoveWorkgroupConfirmDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component';
+import { PeerGroupUnassignedWorkgroupsComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component';
+import { PeerGroupWorkgroupComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component';
 
 @NgModule({
   declarations: [
@@ -61,6 +67,12 @@ import { RemoveUserConfirmDialogComponent } from '../../assets/wise5/classroomMo
     MilestoneReportDataComponent,
     MoveUserConfirmDialogComponent,
     NavItemProgressComponent,
+    PeerGroupAssignedWorkgroupsComponent,
+    PeerGroupDialogComponent,
+    PeerGroupGroupingComponent,
+    PeerGroupMoveWorkgroupConfirmDialogComponent,
+    PeerGroupUnassignedWorkgroupsComponent,
+    PeerGroupWorkgroupComponent,
     RemoveUserConfirmDialogComponent,
     SelectPeriodComponent,
     ShowStudentInfoComponent,

--- a/src/app/teacher/classroom-monitor.module.ts
+++ b/src/app/teacher/classroom-monitor.module.ts
@@ -15,7 +15,6 @@ import { ManageUserComponent } from '../../assets/wise5/classroomMonitor/classro
 import { MoveUserConfirmDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/move-user-confirm-dialog/move-user-confirm-dialog.component';
 import { WorkgroupInfoComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroupInfo/workgroup-info.component';
 import { NavItemScoreComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/navItemScore/nav-item-score.component';
-import { SelectPeriodComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component';
 import { WorkgroupNodeScoreComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/shared/workgroupNodeScore/workgroup-node-score.component';
 import { ViewComponentRevisionsComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/view-component-revisions/view-component-revisions.component';
 import { WorkgroupComponentGradingComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component';
@@ -36,12 +35,8 @@ import { MilestoneReportDataComponent } from './milestone/milestone-report-data/
 import { ChangeTeamPeriodDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component';
 import { ManageShowStudentInfoComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-show-student-info/manage-show-student-info.component';
 import { RemoveUserConfirmDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/remove-user-confirm-dialog/remove-user-confirm-dialog.component';
-import { PeerGroupAssignedWorkgroupsComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-assigned-workgroups/peer-group-assigned-workgroups.component';
-import { PeerGroupDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component';
-import { PeerGroupGroupingComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-grouping/peer-group-grouping.component';
-import { PeerGroupMoveWorkgroupConfirmDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component';
-import { PeerGroupUnassignedWorkgroupsComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component';
-import { PeerGroupWorkgroupComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component';
+import { PeerGroupGradingModule } from './peer-group-grading.module';
+import { SelectPeriodModule } from './select-period.module';
 
 @NgModule({
   declarations: [
@@ -67,14 +62,7 @@ import { PeerGroupWorkgroupComponent } from '../../assets/wise5/classroomMonitor
     MilestoneReportDataComponent,
     MoveUserConfirmDialogComponent,
     NavItemProgressComponent,
-    PeerGroupAssignedWorkgroupsComponent,
-    PeerGroupDialogComponent,
-    PeerGroupGroupingComponent,
-    PeerGroupMoveWorkgroupConfirmDialogComponent,
-    PeerGroupUnassignedWorkgroupsComponent,
-    PeerGroupWorkgroupComponent,
     RemoveUserConfirmDialogComponent,
-    SelectPeriodComponent,
     ShowStudentInfoComponent,
     StatusIconComponent,
     StepInfoComponent,
@@ -87,6 +75,6 @@ import { PeerGroupWorkgroupComponent } from '../../assets/wise5/classroomMonitor
     NavItemScoreComponent,
     WorkgroupNodeStatusComponent
   ],
-  imports: [AngularJSModule, ComponentGradingModule]
+  imports: [AngularJSModule, ComponentGradingModule, PeerGroupGradingModule, SelectPeriodModule]
 })
 export class ClassroomMonitorModule {}

--- a/src/app/teacher/peer-group-grading.module.ts
+++ b/src/app/teacher/peer-group-grading.module.ts
@@ -3,6 +3,7 @@ import { PeerGroupAssignedWorkgroupsComponent } from '../../assets/wise5/classro
 import { PeerGroupDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component';
 import { PeerGroupGroupingComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-grouping/peer-group-grouping.component';
 import { PeerGroupMoveWorkgroupConfirmDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component';
+import { PeerGroupPeriodComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component';
 import { PeerGroupUnassignedWorkgroupsComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component';
 import { PeerGroupWorkgroupComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component';
 import { AngularJSModule } from '../common-hybrid-angular.module';
@@ -14,6 +15,7 @@ import { SelectPeriodModule } from './select-period.module';
     PeerGroupDialogComponent,
     PeerGroupGroupingComponent,
     PeerGroupMoveWorkgroupConfirmDialogComponent,
+    PeerGroupPeriodComponent,
     PeerGroupUnassignedWorkgroupsComponent,
     PeerGroupWorkgroupComponent
   ],
@@ -23,6 +25,7 @@ import { SelectPeriodModule } from './select-period.module';
     PeerGroupDialogComponent,
     PeerGroupGroupingComponent,
     PeerGroupMoveWorkgroupConfirmDialogComponent,
+    PeerGroupPeriodComponent,
     PeerGroupUnassignedWorkgroupsComponent,
     PeerGroupWorkgroupComponent
   ]

--- a/src/app/teacher/peer-group-grading.module.ts
+++ b/src/app/teacher/peer-group-grading.module.ts
@@ -1,0 +1,30 @@
+import { NgModule } from '@angular/core';
+import { PeerGroupAssignedWorkgroupsComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-assigned-workgroups/peer-group-assigned-workgroups.component';
+import { PeerGroupDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component';
+import { PeerGroupGroupingComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-grouping/peer-group-grouping.component';
+import { PeerGroupMoveWorkgroupConfirmDialogComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component';
+import { PeerGroupUnassignedWorkgroupsComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component';
+import { PeerGroupWorkgroupComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component';
+import { AngularJSModule } from '../common-hybrid-angular.module';
+import { SelectPeriodModule } from './select-period.module';
+
+@NgModule({
+  declarations: [
+    PeerGroupAssignedWorkgroupsComponent,
+    PeerGroupDialogComponent,
+    PeerGroupGroupingComponent,
+    PeerGroupMoveWorkgroupConfirmDialogComponent,
+    PeerGroupUnassignedWorkgroupsComponent,
+    PeerGroupWorkgroupComponent
+  ],
+  imports: [AngularJSModule, SelectPeriodModule],
+  exports: [
+    PeerGroupAssignedWorkgroupsComponent,
+    PeerGroupDialogComponent,
+    PeerGroupGroupingComponent,
+    PeerGroupMoveWorkgroupConfirmDialogComponent,
+    PeerGroupUnassignedWorkgroupsComponent,
+    PeerGroupWorkgroupComponent
+  ]
+})
+export class PeerGroupGradingModule {}

--- a/src/app/teacher/select-period.module.ts
+++ b/src/app/teacher/select-period.module.ts
@@ -1,0 +1,12 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { SelectPeriodComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component';
+
+@NgModule({
+  imports: [CommonModule, MatFormFieldModule, MatSelectModule],
+  declarations: [SelectPeriodComponent],
+  exports: [SelectPeriodComponent]
+})
+export class SelectPeriodModule {}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneGradingView/milestoneGradingView.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneGradingView/milestoneGradingView.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '../../../../services/configService';
 import { MilestoneService } from '../../../../services/milestoneService';
 import { NodeService } from '../../../../services/nodeService';
 import { NotificationService } from '../../../../services/notificationService';
+import { PeerGroupService } from '../../../../services/peerGroupService';
 import { StudentStatusService } from '../../../../services/studentStatusService';
 import { TeacherDataService } from '../../../../services/teacherDataService';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
@@ -27,6 +28,7 @@ class MilestoneGradingViewController extends NodeGradingViewController {
     protected MilestoneService: MilestoneService,
     protected NodeService: NodeService,
     protected NotificationService: NotificationService,
+    protected PeerGroupService: PeerGroupService,
     protected ProjectService: TeacherProjectService,
     protected StudentStatusService: StudentStatusService,
     protected TeacherDataService: TeacherDataService
@@ -38,6 +40,7 @@ class MilestoneGradingViewController extends NodeGradingViewController {
       MilestoneService,
       NodeService,
       NotificationService,
+      PeerGroupService,
       ProjectService,
       StudentStatusService,
       TeacherDataService

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/nodeGrading.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/nodeGrading.ts
@@ -7,6 +7,7 @@ import * as angular from 'angular';
 import { WorkgroupInfoComponent } from './workgroupInfo/workgroup-info.component';
 import { downgradeComponent } from '@angular/upgrade/static';
 import MilestoneWorkgroupItem from '../milestones/milestoneWorkgroupItem/milestoneWorkgroupItem';
+import { PeerGroupDialogComponent } from '../peer-group/peer-group-dialog/peer-group-dialog.component';
 
 const NodeGrading = angular
   .module('nodeGrading', [])
@@ -14,6 +15,10 @@ const NodeGrading = angular
   .directive(
     'componentSelect',
     downgradeComponent({ component: ComponentSelectComponent }) as angular.IDirectiveFactory
+  )
+  .directive(
+    'peerGroupDialog',
+    downgradeComponent({ component: PeerGroupDialogComponent }) as angular.IDirectiveFactory
   )
   .directive(
     'workgroupInfo',

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/nodeGradingView/nodeGradingView.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/nodeGradingView/nodeGradingView.html
@@ -24,7 +24,7 @@
           class="md-raised info"
           ng-click="$ctrl.showPeerGroupGroupings($ctrl.nodeId, peerGroupComponentId)">
         <md-icon class="info">groups</md-icon>
-        <span class="info">{{ ::'peerGroup' | translate }}</span>
+        <span class="info">{{ ::'peerGroups' | translate }}</span>
       </md-button>
       <md-button ng-click="$ctrl.showRubric($event)" class="md-raised info">
         <md-icon class="info"> info_outline </md-icon>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/nodeGradingView/nodeGradingView.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/nodeGradingView/nodeGradingView.html
@@ -20,6 +20,12 @@
         <md-icon class="info"> flag </md-icon>
         <span>{{ ::'REPORT' | translate }}</span>
       </md-button>
+      <md-button ng-repeat="peerGroupComponentId in $ctrl.peerGroupComponentIds"
+          class="md-raised info"
+          ng-click="$ctrl.showPeerGroupGroupings($ctrl.nodeId, peerGroupComponentId)">
+        <md-icon class="info">groups</md-icon>
+        <span class="info">{{ ::'peerGroup' | translate }}</span>
+      </md-button>
       <md-button ng-click="$ctrl.showRubric($event)" class="md-raised info">
         <md-icon class="info"> info_outline </md-icon>
         <span ng-if="!$ctrl.numRubrics">{{ ::'STEP_INFO' | translate }}</span>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/nodeGradingView/nodeGradingView.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/nodeGradingView/nodeGradingView.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '../../../../services/configService';
 import { NodeService } from '../../../../services/nodeService';
 import { MilestoneService } from '../../../../services/milestoneService';
 import { NotificationService } from '../../../../services/notificationService';
+import { PeerGroupService } from '../../../../services/peerGroupService';
 import { StudentStatusService } from '../../../../services/studentStatusService';
 import { TeacherDataService } from '../../../../services/teacherDataService';
 import * as angular from 'angular';
@@ -29,6 +30,7 @@ export class NodeGradingViewController {
   nodeHasWork: boolean;
   nodeId: string;
   numRubrics: number;
+  peerGroupComponentIds: string[];
   sortOrder: object = {
     team: ['-isVisible', 'workgroupId'],
     '-team': ['-isVisible', '-workgroupId'],
@@ -52,6 +54,7 @@ export class NodeGradingViewController {
     'MilestoneService',
     'NodeService',
     'NotificationService',
+    'PeerGroupService',
     'ProjectService',
     'StudentStatusService',
     'TeacherDataService'
@@ -64,6 +67,7 @@ export class NodeGradingViewController {
     protected MilestoneService: MilestoneService,
     protected NodeService: NodeService,
     protected NotificationService: NotificationService,
+    protected PeerGroupService: PeerGroupService,
     protected ProjectService: TeacherProjectService,
     protected StudentStatusService: StudentStatusService,
     protected TeacherDataService: TeacherDataService
@@ -78,6 +82,7 @@ export class NodeGradingViewController {
     this.sort = this.TeacherDataService.nodeGradingSort;
     this.nodeContent = this.ProjectService.getNodeById(this.nodeId);
     this.milestoneReport = this.MilestoneService.getMilestoneReportByNodeId(this.nodeId);
+    this.peerGroupComponentIds = this.PeerGroupService.getPeerGroupComponentIds(this.node);
     this.retrieveStudentData();
     this.subscribeToEvents();
   }
@@ -358,6 +363,14 @@ export class NodeGradingViewController {
 
   showReport($event) {
     this.MilestoneService.showMilestoneDetails(this.milestoneReport, $event);
+  }
+
+  showPeerGroupGroupings(nodeId: string, componentId: string): void {
+    this.NodeService.showPeerGroupDetails(
+      this.TeacherDataService.getCurrentPeriod().periodId,
+      nodeId,
+      componentId
+    );
   }
 }
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-assigned-workgroups/peer-group-assigned-workgroups.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-assigned-workgroups/peer-group-assigned-workgroups.component.html
@@ -1,0 +1,6 @@
+<div fxLayout="row wrap" fxLayoutAlign="start stretch">
+  <mat-card *ngFor="let grouping of groupings" class="peer-group-card notice-bg-bg">
+    <peer-group-grouping [grouping]="grouping" (moveWorkgroup)="emitMoveWorkgroup($event)">
+    </peer-group-grouping>
+  </mat-card>
+</div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-assigned-workgroups/peer-group-assigned-workgroups.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-assigned-workgroups/peer-group-assigned-workgroups.component.html
@@ -1,6 +1,12 @@
 <div fxLayout="row wrap" fxLayoutAlign="start stretch">
-  <mat-card *ngFor="let grouping of groupings" class="peer-group-card notice-bg-bg">
-    <peer-group-grouping [grouping]="grouping" (moveWorkgroup)="emitMoveWorkgroup($event)">
-    </peer-group-grouping>
-  </mat-card>
+  <div *ngFor="let grouping of groupings"
+        class="group-container"
+        fxFlex="100"
+        fxFlex.gt-sm="50"
+        fxFlex.gt-md="33.33">
+    <mat-card class="group notice-bg-bg">
+      <peer-group-grouping [grouping]="grouping" (moveWorkgroup)="emitMoveWorkgroup($event)">
+      </peer-group-grouping>
+    </mat-card>
+  </div>
 </div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-assigned-workgroups/peer-group-assigned-workgroups.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-assigned-workgroups/peer-group-assigned-workgroups.component.scss
@@ -1,0 +1,6 @@
+.peer-group-card {
+  width: 47%;
+  margin: 4px;
+  padding: 4px;
+  box-shadow: none;
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-assigned-workgroups/peer-group-assigned-workgroups.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-assigned-workgroups/peer-group-assigned-workgroups.component.scss
@@ -1,6 +1,3 @@
-.peer-group-card {
-  width: 47%;
-  margin: 4px;
-  padding: 4px;
-  box-shadow: none;
+.group-container {
+  padding: 4px
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-assigned-workgroups/peer-group-assigned-workgroups.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-assigned-workgroups/peer-group-assigned-workgroups.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PeerGroupAssignedWorkgroupsComponent } from './peer-group-assigned-workgroups.component';
+
+describe('PeerGroupAssignedWorkgroupsComponent', () => {
+  let component: PeerGroupAssignedWorkgroupsComponent;
+  let fixture: ComponentFixture<PeerGroupAssignedWorkgroupsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PeerGroupAssignedWorkgroupsComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PeerGroupAssignedWorkgroupsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-assigned-workgroups/peer-group-assigned-workgroups.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-assigned-workgroups/peer-group-assigned-workgroups.component.ts
@@ -1,0 +1,25 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+
+@Component({
+  selector: 'peer-group-assigned-workgroups',
+  templateUrl: './peer-group-assigned-workgroups.component.html',
+  styleUrls: [
+    '../peer-group-workgroups-container/peer-group-workgroups-container.component.scss',
+    './peer-group-assigned-workgroups.component.scss'
+  ]
+})
+export class PeerGroupAssignedWorkgroupsComponent implements OnInit {
+  @Input()
+  groupings: any[];
+
+  @Output()
+  moveWorkgroup: EventEmitter<any> = new EventEmitter<any>();
+
+  constructor() {}
+
+  ngOnInit() {}
+
+  emitMoveWorkgroup(event: any): void {
+    this.moveWorkgroup.emit(event);
+  }
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html
@@ -1,27 +1,14 @@
-<h4 class="mat-body-2" i18n>Student Groupings for {{ componentLabel }} activity in Step {{ stepTitle }}</h4>
-<div>
+<h2 mat-dialog-title fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="8px">
+  <span i18n>Groupings for {{ componentLabel }} in {{ stepNumber }}</span>
+  <span fxFlex fxHide.xs></span>
   <select-period></select-period>
-  <div fxFlex></div>
-  <button mat-stroked-button
-      color="primary"
-      aria-label="Create a new group"
-      i18n-aria-label
-      (click)="createNewGroup()">
-    <mat-icon class="text-secondary" color="primary">group_add</mat-icon>
-    &nbsp;
-    <span i18n>New Group</span>
-  </button>
+</h2>
+<div mat-dialog-content class="dialog-content-scroll">
+    <peer-group-period *ngFor="let period of periods"
+        [nodeId]="nodeId"
+        [componentId]="componentId"
+        [period]="period"></peer-group-period>
 </div>
-<div cdkDropListGroup>
-  <peer-group-unassigned-workgroups
-      [unassignedWorkgroups]="unassignedWorkgroups"
-      (moveWorkgroup)="moveWorkgroup($event)">
-  </peer-group-unassigned-workgroups>
-  <peer-group-assigned-workgroups
-      [groupings]="groupings"
-      (moveWorkgroup)="moveWorkgroup($event)">
-  </peer-group-assigned-workgroups>
-</div>
-<div mat-dialog-actions class="close-div" fxLayoutAlign="end center">
+<div mat-dialog-actions fxLayoutAlign="end center">
   <button mat-button mat-dialog-close i18n>Close</button>
 </div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html
@@ -1,3 +1,4 @@
+<h4 class="mat-body-2" i18n>Student Groupings for Step {{ stepTitle }}</h4>
 <div>
   <select-period></select-period>
   <div fxFlex></div>
@@ -20,4 +21,7 @@
       [groupings]="groupings"
       (moveWorkgroup)="moveWorkgroup($event)">
   </peer-group-assigned-workgroups>
+</div>
+<div mat-dialog-actions class="close-div" fxLayoutAlign="end center">
+  <button mat-button mat-dialog-close i18n>Close</button>
 </div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html
@@ -4,6 +4,7 @@
   <select-period></select-period>
 </h2>
 <div mat-dialog-content class="dialog-content-scroll">
+    <p class="info" i18n>Tip: Drag students to change groups for this activity.</p>
     <peer-group-period *ngFor="let period of periods"
         [nodeId]="nodeId"
         [componentId]="componentId"

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html
@@ -1,0 +1,23 @@
+<div>
+  <select-period></select-period>
+  <div fxFlex></div>
+  <button mat-stroked-button
+      color="primary"
+      aria-label="Create a new group"
+      i18n-aria-label
+      (click)="createNewGroup()">
+    <mat-icon class="text-secondary" color="primary">group_add</mat-icon>
+    &nbsp;
+    <span i18n>New Group</span>
+  </button>
+</div>
+<div cdkDropListGroup>
+  <peer-group-unassigned-workgroups
+      [unassignedWorkgroups]="unassignedWorkgroups"
+      (moveWorkgroup)="moveWorkgroup($event)">
+  </peer-group-unassigned-workgroups>
+  <peer-group-assigned-workgroups
+      [groupings]="groupings"
+      (moveWorkgroup)="moveWorkgroup($event)">
+  </peer-group-assigned-workgroups>
+</div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html
@@ -1,4 +1,4 @@
-<h4 class="mat-body-2" i18n>Student Groupings for Step {{ stepTitle }}</h4>
+<h4 class="mat-body-2" i18n>Student Groupings for {{ componentLabel }} activity in Step {{ stepTitle }}</h4>
 <div>
   <select-period></select-period>
   <div fxFlex></div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.scss
@@ -5,3 +5,7 @@ peer-group-period {
     margin-top: 16px;
   }
 }
+
+.info {
+  text-align: end;
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.scss
@@ -1,4 +1,7 @@
-.close-div {
-  padding: 0px;
-  min-height: 0px;
+peer-group-period {
+  display: block;
+
+  &:not(:first-child) {
+    margin-top: 16px;
+  }
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.scss
@@ -1,0 +1,4 @@
+.close-div {
+  padding: 0px;
+  min-height: 0px;
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.spec.ts
@@ -1,74 +1,41 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { MatCardModule } from '@angular/material/card';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatIconModule } from '@angular/material/icon';
 import { MatSelectModule } from '@angular/material/select';
 import { UpgradeModule } from '@angular/upgrade/static';
-import { Observable, of } from 'rxjs';
 import { WorkgroupService } from '../../../../../../app/services/workgroup.service';
 import { AchievementService } from '../../../../services/achievementService';
 import { AnnotationService } from '../../../../services/annotationService';
 import { ConfigService } from '../../../../services/configService';
 import { NotificationService } from '../../../../services/notificationService';
-import { PeerGroupService } from '../../../../services/peerGroupService';
 import { ProjectService } from '../../../../services/projectService';
 import { SessionService } from '../../../../services/sessionService';
 import { StudentDataService } from '../../../../services/studentDataService';
 import { StudentStatusService } from '../../../../services/studentStatusService';
 import { TagService } from '../../../../services/tagService';
 import { TeacherDataService } from '../../../../services/teacherDataService';
-import { TeacherProjectService } from '../../../../services/teacherProjectService';
+import { TeacherProjectService } from '../../../../services/teacherProjectService'; 
 import { TeacherWebSocketService } from '../../../../services/teacherWebSocketService';
 import { UtilService } from '../../../../services/utilService';
 import { SelectPeriodComponent } from '../../select-period/select-period.component';
-import { PeerGroupAssignedWorkgroupsComponent } from '../peer-group-assigned-workgroups/peer-group-assigned-workgroups.component';
-import { PeerGroupUnassignedWorkgroupsComponent } from '../peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component';
-import { FlexLayoutModule } from '@angular/flex-layout';
 
 import { PeerGroupDialogComponent } from './peer-group-dialog.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { DragDropModule } from '@angular/cdk/drag-drop';
 import { CommonModule } from '@angular/common';
-import { PeerGroupGroupingComponent } from '../peer-group-grouping/peer-group-grouping.component';
-import { PeerGroupWorkgroupComponent } from '../peer-group-workgroup/peer-group-workgroup.component';
 
 describe('PeerGroupDialogComponent', () => {
   let component: PeerGroupDialogComponent;
   let fixture: ComponentFixture<PeerGroupDialogComponent>;
-  let grouping1: any;
-  let grouping2: any;
-  let workgroup1: any;
-  let workgroup2: any;
-  let workgroup3: any;
-  let workgroup4: any;
-  let workgroup5: any;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [
-        PeerGroupAssignedWorkgroupsComponent,
-        PeerGroupDialogComponent,
-        PeerGroupGroupingComponent,
-        PeerGroupUnassignedWorkgroupsComponent,
-        PeerGroupWorkgroupComponent,
-        SelectPeriodComponent
-      ],
+      declarations: [PeerGroupDialogComponent, SelectPeriodComponent],
       imports: [
         BrowserAnimationsModule,
         CommonModule,
-        DragDropModule,
-        FlexLayoutModule,
-        FormsModule,
         HttpClientTestingModule,
-        MatCardModule,
         MatDialogModule,
-        MatFormFieldModule,
-        MatIconModule,
-        MatSelectModule,
-        ReactiveFormsModule
+        MatSelectModule
       ],
       providers: [
         AchievementService,
@@ -76,7 +43,6 @@ describe('PeerGroupDialogComponent', () => {
         ConfigService,
         { provide: MAT_DIALOG_DATA, useValue: {} },
         NotificationService,
-        PeerGroupService,
         ProjectService,
         SessionService,
         StudentDataService,
@@ -96,104 +62,20 @@ describe('PeerGroupDialogComponent', () => {
     fixture = TestBed.createComponent(PeerGroupDialogComponent);
     spyOn(TestBed.inject(TeacherProjectService), 'getStartNodeId').and.returnValue('node1');
     spyOn(TestBed.inject(TeacherProjectService), 'getRootNode').and.returnValue({ id: 'group0' });
-    spyOn(TestBed.inject(TeacherDataService), 'getCurrentPeriod').and.returnValue({ periodId: 1 });
-    spyOn(TestBed.inject(TeacherDataService), 'getPeriods').and.returnValue([{ id: 1 }]);
-    spyOn(TestBed.inject(PeerGroupService), 'moveWorkgroupToGroup').and.callFake(() => {
-      return new Observable<any>();
+    spyOn(TestBed.inject(TeacherDataService), 'getCurrentPeriod').and.returnValue({
+      periodId: 1,
+      periodName: '1'
     });
+    spyOn(TestBed.inject(TeacherDataService), 'getPeriods').and.returnValue([{ periodId: 1, periodName: '1' }, 
+        {id: 2, periodName: '2'}]);
+    spyOn(TestBed.inject(ProjectService), 'getComponentType').and.returnValue('PeerChat');
+    spyOn(TestBed.inject(UtilService), 'getComponentTypeLabel').and.returnValue('Peer Chat');
+    spyOn(TestBed.inject(WorkgroupService), 'getWorkgroupsInPeriod').and.returnValue(new Map());
     component = fixture.componentInstance;
-    workgroup1 = createWorkgroup(1);
-    workgroup2 = createWorkgroup(2);
-    workgroup3 = createWorkgroup(3);
-    workgroup4 = createWorkgroup(4);
-    workgroup5 = createWorkgroup(5);
-    component.workgroups = [workgroup1, workgroup2, workgroup3, workgroup4];
-    component.unassignedWorkgroups = [workgroup5];
-    grouping1 = createGrouping(1, [workgroup1, workgroup2]);
-    grouping2 = createGrouping(2, [workgroup3, workgroup4]);
-    component.groupings = [grouping1, grouping2];
-    component.nextAvailableGroupId = 3;
     fixture.detectChanges();
   });
 
-  function createWorkgroup(id: number): any {
-    return {
-      username: '',
-      workgroupId: id
-    };
-  }
-
-  function createGrouping(id: number, workgroups: any[]): any {
-    return {
-      id: id,
-      workgroups: workgroups
-    };
-  }
-
-  function createEvent(
-    workgroupId: number,
-    previousContainerId: number,
-    newContainerId: number
-  ): any {
-    return {
-      container: {
-        data: {
-          id: newContainerId
-        }
-      },
-      item: {
-        data: workgroupId
-      },
-      previousContainer: {
-        data: {
-          id: previousContainerId
-        }
-      }
-    };
-  }
-
-  function moveWorkgroup() {
-    describe('moveWorkgroup()', () => {
-      it('should move a workgroup from unassigned to assigned', () => {
-        expectGroupingWorkgroupsLength(grouping1, 2);
-        const event = createEvent(5, 0, 1);
-        component.moveWorkgroup(event);
-        expectGroupingWorkgroupsLength(grouping1, 3);
-      });
-
-      it('should move a workgroup from assigned to unassigned', () => {
-        expectGroupingWorkgroupsLength(grouping1, 2);
-        const event = createEvent(1, 1, 0);
-        component.moveWorkgroup(event);
-        expectGroupingWorkgroupsLength(grouping1, 1);
-      });
-
-      it('should move a workgroup from assigned to assigned', () => {
-        expectGroupingWorkgroupsLength(grouping1, 2);
-        expectGroupingWorkgroupsLength(grouping2, 2);
-        const event = createEvent(1, 1, 2);
-        component.moveWorkgroup(event);
-        expectGroupingWorkgroupsLength(grouping1, 1);
-        expectGroupingWorkgroupsLength(grouping2, 3);
-      });
-    });
-  }
-
-  function expectGroupingWorkgroupsLength(grouping: any, expectedNumWorkgroups: number): void {
-    expect(grouping.workgroups.length).toEqual(expectedNumWorkgroups);
-  }
-
-  function createNewGroup() {
-    describe('createNewGroup()', () => {
-      it('should create a new group', () => {
-        expect(component.groupings.length).toEqual(2);
-        spyOn(TestBed.inject(PeerGroupService), 'createNewGroup').and.returnValue(of({ id: 5 }));
-        component.createNewGroup();
-        expect(component.groupings.length).toEqual(3);
-      });
-    });
-  }
-
-  createNewGroup();
-  moveWorkgroup();
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
 });

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.spec.ts
@@ -1,0 +1,199 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
+import { UpgradeModule } from '@angular/upgrade/static';
+import { Observable, of } from 'rxjs';
+import { WorkgroupService } from '../../../../../../app/services/workgroup.service';
+import { AchievementService } from '../../../../services/achievementService';
+import { AnnotationService } from '../../../../services/annotationService';
+import { ConfigService } from '../../../../services/configService';
+import { NotificationService } from '../../../../services/notificationService';
+import { PeerGroupService } from '../../../../services/peerGroupService';
+import { ProjectService } from '../../../../services/projectService';
+import { SessionService } from '../../../../services/sessionService';
+import { StudentDataService } from '../../../../services/studentDataService';
+import { StudentStatusService } from '../../../../services/studentStatusService';
+import { TagService } from '../../../../services/tagService';
+import { TeacherDataService } from '../../../../services/teacherDataService';
+import { TeacherProjectService } from '../../../../services/teacherProjectService';
+import { TeacherWebSocketService } from '../../../../services/teacherWebSocketService';
+import { UtilService } from '../../../../services/utilService';
+import { SelectPeriodComponent } from '../../select-period/select-period.component';
+import { PeerGroupAssignedWorkgroupsComponent } from '../peer-group-assigned-workgroups/peer-group-assigned-workgroups.component';
+import { PeerGroupUnassignedWorkgroupsComponent } from '../peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component';
+import { FlexLayoutModule } from '@angular/flex-layout';
+
+import { PeerGroupDialogComponent } from './peer-group-dialog.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { DragDropModule } from '@angular/cdk/drag-drop';
+import { CommonModule } from '@angular/common';
+import { PeerGroupGroupingComponent } from '../peer-group-grouping/peer-group-grouping.component';
+import { PeerGroupWorkgroupComponent } from '../peer-group-workgroup/peer-group-workgroup.component';
+
+describe('PeerGroupDialogComponent', () => {
+  let component: PeerGroupDialogComponent;
+  let fixture: ComponentFixture<PeerGroupDialogComponent>;
+  let grouping1: any;
+  let grouping2: any;
+  let workgroup1: any;
+  let workgroup2: any;
+  let workgroup3: any;
+  let workgroup4: any;
+  let workgroup5: any;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        PeerGroupAssignedWorkgroupsComponent,
+        PeerGroupDialogComponent,
+        PeerGroupGroupingComponent,
+        PeerGroupUnassignedWorkgroupsComponent,
+        PeerGroupWorkgroupComponent,
+        SelectPeriodComponent
+      ],
+      imports: [
+        BrowserAnimationsModule,
+        CommonModule,
+        DragDropModule,
+        FlexLayoutModule,
+        FormsModule,
+        HttpClientTestingModule,
+        MatCardModule,
+        MatDialogModule,
+        MatFormFieldModule,
+        MatIconModule,
+        MatSelectModule,
+        ReactiveFormsModule
+      ],
+      providers: [
+        AchievementService,
+        AnnotationService,
+        ConfigService,
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        NotificationService,
+        PeerGroupService,
+        ProjectService,
+        SessionService,
+        StudentDataService,
+        StudentStatusService,
+        TagService,
+        TeacherDataService,
+        TeacherProjectService,
+        TeacherWebSocketService,
+        UpgradeModule,
+        UtilService,
+        WorkgroupService
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PeerGroupDialogComponent);
+    spyOn(TestBed.inject(TeacherProjectService), 'getStartNodeId').and.returnValue('node1');
+    spyOn(TestBed.inject(TeacherProjectService), 'getRootNode').and.returnValue({ id: 'group0' });
+    spyOn(TestBed.inject(TeacherDataService), 'getCurrentPeriod').and.returnValue({ periodId: 1 });
+    spyOn(TestBed.inject(TeacherDataService), 'getPeriods').and.returnValue([{ id: 1 }]);
+    spyOn(TestBed.inject(PeerGroupService), 'moveWorkgroupToGroup').and.callFake(() => {
+      return new Observable<any>();
+    });
+    component = fixture.componentInstance;
+    workgroup1 = createWorkgroup(1);
+    workgroup2 = createWorkgroup(2);
+    workgroup3 = createWorkgroup(3);
+    workgroup4 = createWorkgroup(4);
+    workgroup5 = createWorkgroup(5);
+    component.workgroups = [workgroup1, workgroup2, workgroup3, workgroup4];
+    component.unassignedWorkgroups = [workgroup5];
+    grouping1 = createGrouping(1, [workgroup1, workgroup2]);
+    grouping2 = createGrouping(2, [workgroup3, workgroup4]);
+    component.groupings = [grouping1, grouping2];
+    component.nextAvailableGroupId = 3;
+    fixture.detectChanges();
+  });
+
+  function createWorkgroup(id: number): any {
+    return {
+      username: '',
+      workgroupId: id
+    };
+  }
+
+  function createGrouping(id: number, workgroups: any[]): any {
+    return {
+      id: id,
+      workgroups: workgroups
+    };
+  }
+
+  function createEvent(
+    workgroupId: number,
+    previousContainerId: number,
+    newContainerId: number
+  ): any {
+    return {
+      container: {
+        data: {
+          id: newContainerId
+        }
+      },
+      item: {
+        data: workgroupId
+      },
+      previousContainer: {
+        data: {
+          id: previousContainerId
+        }
+      }
+    };
+  }
+
+  function moveWorkgroup() {
+    describe('moveWorkgroup()', () => {
+      it('should move a workgroup from unassigned to assigned', () => {
+        expectGroupingWorkgroupsLength(grouping1, 2);
+        const event = createEvent(5, 0, 1);
+        component.moveWorkgroup(event);
+        expectGroupingWorkgroupsLength(grouping1, 3);
+      });
+
+      it('should move a workgroup from assigned to unassigned', () => {
+        expectGroupingWorkgroupsLength(grouping1, 2);
+        const event = createEvent(1, 1, 0);
+        component.moveWorkgroup(event);
+        expectGroupingWorkgroupsLength(grouping1, 1);
+      });
+
+      it('should move a workgroup from assigned to assigned', () => {
+        expectGroupingWorkgroupsLength(grouping1, 2);
+        expectGroupingWorkgroupsLength(grouping2, 2);
+        const event = createEvent(1, 1, 2);
+        component.moveWorkgroup(event);
+        expectGroupingWorkgroupsLength(grouping1, 1);
+        expectGroupingWorkgroupsLength(grouping2, 3);
+      });
+    });
+  }
+
+  function expectGroupingWorkgroupsLength(grouping: any, expectedNumWorkgroups: number): void {
+    expect(grouping.workgroups.length).toEqual(expectedNumWorkgroups);
+  }
+
+  function createNewGroup() {
+    describe('createNewGroup()', () => {
+      it('should create a new group', () => {
+        expect(component.groupings.length).toEqual(2);
+        spyOn(TestBed.inject(PeerGroupService), 'createNewGroup').and.returnValue(of({ id: 5 }));
+        component.createNewGroup();
+        expect(component.groupings.length).toEqual(3);
+      });
+    });
+  }
+
+  createNewGroup();
+  moveWorkgroup();
+});

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.ts
@@ -3,6 +3,7 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Subscription } from 'rxjs';
 import { ConfigService } from '../../../../services/configService';
 import { PeerGroupService } from '../../../../services/peerGroupService';
+import { ProjectService } from '../../../../services/projectService';
 import { TeacherDataService } from '../../../../services/teacherDataService';
 
 @Component({
@@ -16,8 +17,9 @@ export class PeerGroupDialogComponent implements OnInit {
 
   componentId: string;
   currentPeriodChangedSubscription: Subscription;
-  nextAvailableGroupId: number = 1;
   groupings: any[] = [];
+  nextAvailableGroupId: number = 1;
+  stepTitle: string;
   unassignedWorkgroups: any[] = [];
   workgroups: any[] = [];
 
@@ -25,6 +27,7 @@ export class PeerGroupDialogComponent implements OnInit {
     private ConfigService: ConfigService,
     @Inject(MAT_DIALOG_DATA) public data: any,
     private PeerGroupService: PeerGroupService,
+    private ProjectService: ProjectService,
     private TeacherDataService: TeacherDataService
   ) {
     this.componentId = data.componentId;
@@ -34,6 +37,7 @@ export class PeerGroupDialogComponent implements OnInit {
 
   ngOnInit() {
     this.subscribeToPeriodChanged();
+    this.stepTitle = this.ProjectService.getNodePositionAndTitleByNodeId(this.nodeId);
     this.PeerGroupService.retrieveGroupings(this.nodeId, this.componentId).subscribe(
       (groupings: any) => {
         // TODO

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.ts
@@ -1,10 +1,9 @@
 import { Component, Inject, Input, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Subscription } from 'rxjs';
-import { ConfigService } from '../../../../services/configService';
-import { PeerGroupService } from '../../../../services/peerGroupService';
 import { ProjectService } from '../../../../services/projectService';
 import { TeacherDataService } from '../../../../services/teacherDataService';
+import { UtilService } from '../../../../services/utilService';
 
 @Component({
   selector: 'peer-group-dialog',
@@ -17,22 +16,15 @@ export class PeerGroupDialogComponent implements OnInit {
 
   componentId: string;
   componentLabel: string;
-  componentTypeToLabel: any = {
-    PeerChat: 'Peer Chat'
-  };
   currentPeriodChangedSubscription: Subscription;
-  groupings: any[] = [];
-  nextAvailableGroupId: number = 1;
-  stepTitle: string;
-  unassignedWorkgroups: any[] = [];
-  workgroups: any[] = [];
+  periods: any[];
+  stepNumber: string;
 
   constructor(
-    private ConfigService: ConfigService,
     @Inject(MAT_DIALOG_DATA) public data: any,
-    private PeerGroupService: PeerGroupService,
     private ProjectService: ProjectService,
-    private TeacherDataService: TeacherDataService
+    private TeacherDataService: TeacherDataService,
+    private UtilService: UtilService
   ) {
     this.componentId = data.componentId;
     this.nodeId = data.nodeId;
@@ -40,170 +32,24 @@ export class PeerGroupDialogComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.periods = this.TeacherDataService.getVisiblePeriodsById(this.periodId);
     this.subscribeToPeriodChanged();
-    this.componentLabel = this.componentTypeToLabel[
+    this.componentLabel = this.UtilService.getComponentTypeLabel(
       this.ProjectService.getComponentType(this.nodeId, this.componentId)
-    ];
-    this.stepTitle = this.ProjectService.getNodePositionAndTitleByNodeId(this.nodeId);
-    this.PeerGroupService.retrieveGroupings(this.nodeId, this.componentId).subscribe(
-      (groupings: any) => {
-        // TODO
-      },
-      () => {
-        this.workgroups = this.getWorkgroupsInPeriod();
-        this.setDummyGroupingsAndUnassignedWorkgroups();
-      }
     );
+    this.stepNumber = this.ProjectService.getNodePositionById(this.nodeId);
   }
 
   subscribeToPeriodChanged(): void {
     this.currentPeriodChangedSubscription = this.TeacherDataService.currentPeriodChanged$.subscribe(
       ({ currentPeriod }) => {
         this.periodId = currentPeriod.periodId;
-        this.workgroups = this.getWorkgroupsInPeriod();
-        this.setDummyGroupingsAndUnassignedWorkgroups();
+        this.periods = this.TeacherDataService.getVisiblePeriodsById(this.periodId);
       }
-    );
-  }
-
-  getWorkgroupsInPeriod(): any[] {
-    return this.ConfigService.getWorkgroupsByPeriod(this.periodId).filter(
-      (workgroup) => workgroup.workgroupId != null
     );
   }
 
   ngOnDestroy() {
     this.currentPeriodChangedSubscription.unsubscribe();
-  }
-
-  setDummyGroupingsAndUnassignedWorkgroups(): void {
-    this.groupings = [];
-    this.unassignedWorkgroups = [];
-    const numUnassignedWorkgroups = this.getDummyNumUnassignedWorkgroups(this.workgroups);
-    let tempWorkgroups = [];
-    for (let w = 0; w < this.workgroups.length - numUnassignedWorkgroups; w++) {
-      tempWorkgroups.push(this.workgroups[w]);
-      if (tempWorkgroups.length >= 2) {
-        this.addGrouping(this.createGrouping(this.nextAvailableGroupId++, tempWorkgroups));
-        tempWorkgroups = [];
-      }
-    }
-    for (
-      let w = this.workgroups.length - numUnassignedWorkgroups;
-      w < this.workgroups.length;
-      w++
-    ) {
-      this.unassignedWorkgroups.push(this.workgroups[w]);
-    }
-  }
-
-  getDummyNumUnassignedWorkgroups(workgroups: any[]): number {
-    if (workgroups.length >= 4) {
-      return 2;
-    } else if (workgroups.length === 3) {
-      return 1;
-    } else {
-      return 0;
-    }
-  }
-
-  createGrouping(id: number = this.nextAvailableGroupId, workgroups: any[]): any {
-    return {
-      id: id,
-      workgroups: workgroups
-    };
-  }
-
-  addGrouping(grouping: any): void {
-    this.groupings.push(grouping);
-  }
-
-  createNewGroup(): Subscription {
-    return this.PeerGroupService.createNewGroup(this.nodeId, this.componentId).subscribe(
-      (group) => {
-        this.addGrouping(this.createGrouping(group.id, []));
-      },
-      () => {
-        this.addGrouping(this.createGrouping(this.nextAvailableGroupId++, []));
-      }
-    );
-  }
-
-  moveWorkgroup(event: any): void {
-    const workgroupId = event.item.data;
-    const previousLocation = event.previousContainer.data.id;
-    const newLocation = event.container.data.id;
-    this.removeWorkgroup(workgroupId, previousLocation);
-    this.addWorkgroupToGroup(workgroupId, newLocation);
-    this.PeerGroupService.moveWorkgroupToGroup(
-      workgroupId,
-      newLocation,
-      this.nodeId,
-      this.componentId
-    ).subscribe(
-      () => {
-        // TODO
-      },
-      () => {
-        // TODO
-      }
-    );
-  }
-
-  removeWorkgroup(workgroupId: number, location: number): void {
-    if (location === 0) {
-      this.removeWorkgroupFromUnassigned(workgroupId);
-    } else {
-      this.removeWorkgroupFromGroup(workgroupId, location);
-    }
-  }
-
-  removeWorkgroupFromUnassigned(workgroupId: any): void {
-    for (let w = 0; w < this.unassignedWorkgroups.length; w++) {
-      if (this.unassignedWorkgroups[w].workgroupId === workgroupId) {
-        this.unassignedWorkgroups.splice(w, 1);
-        return;
-      }
-    }
-  }
-
-  removeWorkgroupFromGroup(workgroupId: number, location: number): void {
-    for (const group of this.groupings) {
-      if (group.id === location) {
-        for (let w = 0; w < group.workgroups.length; w++) {
-          if (group.workgroups[w].workgroupId === workgroupId) {
-            group.workgroups.splice(w, 1);
-            return;
-          }
-        }
-      }
-    }
-  }
-
-  addWorkgroupToGroup(workgroupId: number, location: number): void {
-    if (location === 0) {
-      this.unassignedWorkgroups.push(this.getWorkgroup(workgroupId));
-    } else {
-      const group = this.getGroup(location);
-      group.workgroups.push(this.getWorkgroup(workgroupId));
-    }
-  }
-
-  getGroup(groupId: number): any {
-    for (const group of this.groupings) {
-      if (group.id === groupId) {
-        return group;
-      }
-    }
-    return null;
-  }
-
-  getWorkgroup(workgroupId: number): any {
-    for (const workgroup of this.workgroups) {
-      if (workgroup.workgroupId === workgroupId) {
-        return workgroup;
-      }
-    }
-    return null;
   }
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.ts
@@ -50,19 +50,25 @@ export class PeerGroupDialogComponent implements OnInit {
         // TODO
       },
       () => {
-        this.workgroups = this.ConfigService.getWorkgroupsByPeriod(this.periodId);
+        this.workgroups = this.getWorkgroupsInPeriod();
         this.setDummyGroupingsAndUnassignedWorkgroups();
       }
     );
   }
 
-  subscribeToPeriodChanged() {
+  subscribeToPeriodChanged(): void {
     this.currentPeriodChangedSubscription = this.TeacherDataService.currentPeriodChanged$.subscribe(
       ({ currentPeriod }) => {
         this.periodId = currentPeriod.periodId;
-        this.workgroups = this.ConfigService.getWorkgroupsByPeriod(this.periodId);
+        this.workgroups = this.getWorkgroupsInPeriod();
         this.setDummyGroupingsAndUnassignedWorkgroups();
       }
+    );
+  }
+
+  getWorkgroupsInPeriod(): any[] {
+    return this.ConfigService.getWorkgroupsByPeriod(this.periodId).filter(
+      (workgroup) => workgroup.workgroupId != null
     );
   }
 
@@ -144,7 +150,7 @@ export class PeerGroupDialogComponent implements OnInit {
     );
   }
 
-  removeWorkgroup(workgroupId: number, location: number) {
+  removeWorkgroup(workgroupId: number, location: number): void {
     if (location === 0) {
       this.removeWorkgroupFromUnassigned(workgroupId);
     } else {
@@ -174,7 +180,7 @@ export class PeerGroupDialogComponent implements OnInit {
     }
   }
 
-  addWorkgroupToGroup(workgroupId: number, location: number) {
+  addWorkgroupToGroup(workgroupId: number, location: number): void {
     if (location === 0) {
       this.unassignedWorkgroups.push(this.getWorkgroup(workgroupId));
     } else {
@@ -183,7 +189,7 @@ export class PeerGroupDialogComponent implements OnInit {
     }
   }
 
-  getGroup(groupId: number) {
+  getGroup(groupId: number): any {
     for (const group of this.groupings) {
       if (group.id === groupId) {
         return group;

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.ts
@@ -1,0 +1,192 @@
+import { Component, Inject, Input, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Subscription } from 'rxjs';
+import { ConfigService } from '../../../../services/configService';
+import { PeerGroupService } from '../../../../services/peerGroupService';
+import { TeacherDataService } from '../../../../services/teacherDataService';
+
+@Component({
+  selector: 'peer-group-dialog',
+  templateUrl: './peer-group-dialog.component.html',
+  styleUrls: ['./peer-group-dialog.component.scss']
+})
+export class PeerGroupDialogComponent implements OnInit {
+  @Input() nodeId: string;
+  @Input() periodId: number;
+
+  componentId: string;
+  currentPeriodChangedSubscription: Subscription;
+  nextAvailableGroupId: number = 1;
+  groupings: any[] = [];
+  unassignedWorkgroups: any[] = [];
+  workgroups: any[] = [];
+
+  constructor(
+    private ConfigService: ConfigService,
+    @Inject(MAT_DIALOG_DATA) public data: any,
+    private PeerGroupService: PeerGroupService,
+    private TeacherDataService: TeacherDataService
+  ) {
+    this.componentId = data.componentId;
+    this.nodeId = data.nodeId;
+    this.periodId = data.periodId;
+  }
+
+  ngOnInit() {
+    this.subscribeToPeriodChanged();
+    this.PeerGroupService.retrieveGroupings(this.nodeId, this.componentId).subscribe(
+      (groupings: any) => {
+        // TODO
+      },
+      () => {
+        this.workgroups = this.ConfigService.getWorkgroupsByPeriod(this.periodId);
+        this.setDummyGroupingsAndUnassignedWorkgroups();
+      }
+    );
+  }
+
+  subscribeToPeriodChanged() {
+    this.currentPeriodChangedSubscription = this.TeacherDataService.currentPeriodChanged$.subscribe(
+      ({ currentPeriod }) => {
+        this.periodId = currentPeriod.periodId;
+        this.workgroups = this.ConfigService.getWorkgroupsByPeriod(this.periodId);
+        this.setDummyGroupingsAndUnassignedWorkgroups();
+      }
+    );
+  }
+
+  ngOnDestroy() {
+    this.currentPeriodChangedSubscription.unsubscribe();
+  }
+
+  setDummyGroupingsAndUnassignedWorkgroups(): void {
+    this.groupings = [];
+    this.unassignedWorkgroups = [];
+    const numUnassignedWorkgroups = this.getDummyNumUnassignedWorkgroups(this.workgroups);
+    let tempWorkgroups = [];
+    for (let w = 0; w < this.workgroups.length - numUnassignedWorkgroups; w++) {
+      tempWorkgroups.push(this.workgroups[w]);
+      if (tempWorkgroups.length >= 2) {
+        this.addGrouping(this.createGrouping(this.nextAvailableGroupId++, tempWorkgroups));
+        tempWorkgroups = [];
+      }
+    }
+    for (
+      let w = this.workgroups.length - numUnassignedWorkgroups;
+      w < this.workgroups.length;
+      w++
+    ) {
+      this.unassignedWorkgroups.push(this.workgroups[w]);
+    }
+  }
+
+  getDummyNumUnassignedWorkgroups(workgroups: any[]): number {
+    if (workgroups.length >= 4) {
+      return 2;
+    } else if (workgroups.length === 3) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  createGrouping(id: number = this.nextAvailableGroupId, workgroups: any[]): any {
+    return {
+      id: id,
+      workgroups: workgroups
+    };
+  }
+
+  addGrouping(grouping: any): void {
+    this.groupings.push(grouping);
+  }
+
+  createNewGroup(): Subscription {
+    return this.PeerGroupService.createNewGroup(this.nodeId, this.componentId).subscribe(
+      (group) => {
+        this.addGrouping(this.createGrouping(group.id, []));
+      },
+      () => {
+        this.addGrouping(this.createGrouping(this.nextAvailableGroupId++, []));
+      }
+    );
+  }
+
+  moveWorkgroup(event: any): void {
+    const workgroupId = event.item.data;
+    const previousLocation = event.previousContainer.data.id;
+    const newLocation = event.container.data.id;
+    this.removeWorkgroup(workgroupId, previousLocation);
+    this.addWorkgroupToGroup(workgroupId, newLocation);
+    this.PeerGroupService.moveWorkgroupToGroup(
+      workgroupId,
+      newLocation,
+      this.nodeId,
+      this.componentId
+    ).subscribe(
+      () => {
+        // TODO
+      },
+      () => {
+        // TODO
+      }
+    );
+  }
+
+  removeWorkgroup(workgroupId: number, location: number) {
+    if (location === 0) {
+      this.removeWorkgroupFromUnassigned(workgroupId);
+    } else {
+      this.removeWorkgroupFromGroup(workgroupId, location);
+    }
+  }
+
+  removeWorkgroupFromUnassigned(workgroupId: any): void {
+    for (let w = 0; w < this.unassignedWorkgroups.length; w++) {
+      if (this.unassignedWorkgroups[w].workgroupId === workgroupId) {
+        this.unassignedWorkgroups.splice(w, 1);
+        return;
+      }
+    }
+  }
+
+  removeWorkgroupFromGroup(workgroupId: number, location: number): void {
+    for (const group of this.groupings) {
+      if (group.id === location) {
+        for (let w = 0; w < group.workgroups.length; w++) {
+          if (group.workgroups[w].workgroupId === workgroupId) {
+            group.workgroups.splice(w, 1);
+            return;
+          }
+        }
+      }
+    }
+  }
+
+  addWorkgroupToGroup(workgroupId: number, location: number) {
+    if (location === 0) {
+      this.unassignedWorkgroups.push(this.getWorkgroup(workgroupId));
+    } else {
+      const group = this.getGroup(location);
+      group.workgroups.push(this.getWorkgroup(workgroupId));
+    }
+  }
+
+  getGroup(groupId: number) {
+    for (const group of this.groupings) {
+      if (group.id === groupId) {
+        return group;
+      }
+    }
+    return null;
+  }
+
+  getWorkgroup(workgroupId: number): any {
+    for (const workgroup of this.workgroups) {
+      if (workgroup.workgroupId === workgroupId) {
+        return workgroup;
+      }
+    }
+    return null;
+  }
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.ts
@@ -16,6 +16,10 @@ export class PeerGroupDialogComponent implements OnInit {
   @Input() periodId: number;
 
   componentId: string;
+  componentLabel: string;
+  componentTypeToLabel: any = {
+    PeerChat: 'Peer Chat'
+  };
   currentPeriodChangedSubscription: Subscription;
   groupings: any[] = [];
   nextAvailableGroupId: number = 1;
@@ -37,6 +41,9 @@ export class PeerGroupDialogComponent implements OnInit {
 
   ngOnInit() {
     this.subscribeToPeriodChanged();
+    this.componentLabel = this.componentTypeToLabel[
+      this.ProjectService.getComponentType(this.nodeId, this.componentId)
+    ];
     this.stepTitle = this.ProjectService.getNodePositionAndTitleByNodeId(this.nodeId);
     this.PeerGroupService.retrieveGroupings(this.nodeId, this.componentId).subscribe(
       (groupings: any) => {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-grouping/peer-group-grouping.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-grouping/peer-group-grouping.component.html
@@ -1,6 +1,6 @@
 <div class="mat-card-title" fxLayoutAlign="start center">
   <mat-icon class="mat-24 secondary-text avatar"
-      [ngStyle]="{'color': avatarColor}">account_circle</mat-icon>
+      [ngStyle]="{'color': avatarColor}">group</mat-icon>
   <h4 class="mat-body-2" i18n>Group {{ grouping.id }}</h4>
 </div>
 <mat-card-content class="peer-group-card-content">

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-grouping/peer-group-grouping.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-grouping/peer-group-grouping.component.html
@@ -1,0 +1,20 @@
+<div class="mat-card-title" fxLayoutAlign="start center">
+  <mat-icon class="mat-24 secondary-text avatar"
+      [ngStyle]="{'color': avatarColor}">account_circle</mat-icon>
+  <h4 class="mat-body-2" i18n>Group {{ grouping.id }}</h4>
+</div>
+<mat-card-content class="peer-group-card-content">
+  <ul class="peer-group-ul"
+      cdkDropList
+      [cdkDropListData]="grouping"
+      (cdkDropListDropped)="dropWorkgroup($event)">
+    <li *ngFor="let workgroup of grouping.workgroups"
+        class="peer-group-li"
+        cdkDrag
+        [cdkDragData]="workgroup.workgroupId"
+        (cdkDragEntered)="dragEnter($event)"
+        (cdkDragExited)="dragExit($event)">
+      <peer-group-workgroup [workgroup]="workgroup"></peer-group-workgroup>
+    </li>
+  </ul>
+</mat-card-content>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-grouping/peer-group-grouping.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-grouping/peer-group-grouping.component.spec.ts
@@ -1,0 +1,111 @@
+import { DragDropModule } from '@angular/cdk/drag-drop';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatCardModule } from '@angular/material/card';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { UpgradeModule } from '@angular/upgrade/static';
+import { of } from 'rxjs';
+import { ConfigService } from '../../../../services/configService';
+
+import { PeerGroupGroupingComponent } from './peer-group-grouping.component';
+
+describe('PeerGroupGroupingComponent', () => {
+  let component: PeerGroupGroupingComponent;
+  let container1: any;
+  let container2: any;
+  let fixture: ComponentFixture<PeerGroupGroupingComponent>;
+  let dialogOpenSpy: any;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PeerGroupGroupingComponent],
+      imports: [
+        BrowserAnimationsModule,
+        DragDropModule,
+        HttpClientTestingModule,
+        MatCardModule,
+        MatDialogModule
+      ],
+      providers: [ConfigService, UpgradeModule]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PeerGroupGroupingComponent);
+    spyOn(TestBed.inject(ConfigService), 'getAvatarColorForWorkgroupId').and.returnValue('#E91E63');
+    container1 = createContainer(1);
+    container2 = createContainer(2);
+    component = fixture.componentInstance;
+    component.grouping = { id: 1 };
+    dialogOpenSpy = spyOn(TestBed.inject(MatDialog), 'open');
+    fixture.detectChanges();
+  });
+
+  function createEvent(workgroupId: number, previousContainer: any, container: any): any {
+    return {
+      container: container,
+      item: {
+        data: workgroupId
+      },
+      previousContainer: previousContainer
+    };
+  }
+
+  function createContainer(id: number): any {
+    return {
+      data: {
+        id: id
+      },
+      element: {
+        nativeElement: {
+          classList: createClassList('primary-bg')
+        }
+      }
+    };
+  }
+
+  function createClassList(className: string): any {
+    const dummyDiv = document.createElement('div');
+    const classList = dummyDiv.classList;
+    classList.add(className);
+    return classList;
+  }
+
+  it('should drop workgroup onto same container it came from', () => {
+    const event = createEvent(1, container1, container1);
+    component.dropWorkgroup(event);
+    expect(dialogOpenSpy).not.toHaveBeenCalled();
+  });
+
+  it('should drop workgroup onto different container', () => {
+    dialogOpenSpy.and.callThrough();
+    const event = createEvent(1, container1, container2);
+    component.dropWorkgroup(event);
+    expect(dialogOpenSpy).toHaveBeenCalled();
+  });
+
+  it('should drop workgroup onto different container and cancel move', () => {
+    dropWorkgroupAndRespond(false);
+  });
+
+  it('should drop workgroup onto different container and confirm move', () => {
+    dropWorkgroupAndRespond(true);
+  });
+
+  function dropWorkgroupAndRespond(confirmResponse: boolean): void {
+    const dialogRefSpyObj = jasmine.createSpyObj({ afterClosed: of(confirmResponse), close: null });
+    const dialogOpenConfirmSpy = dialogOpenSpy.and.returnValue(dialogRefSpyObj);
+    const event = createEvent(1, container1, container2);
+    const emitSpy = spyOn(component.moveWorkgroup, 'emit');
+    expect(container2.element.nativeElement.classList.contains('primary-bg')).toBeTruthy();
+    component.dropWorkgroup(event);
+    expect(dialogOpenConfirmSpy).toHaveBeenCalled();
+    if (confirmResponse) {
+      expect(emitSpy).toHaveBeenCalled();
+    } else {
+      expect(emitSpy).not.toHaveBeenCalled();
+    }
+    expect(container2.element.nativeElement.classList.contains('primary-bg')).toBeFalsy();
+  }
+});

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-grouping/peer-group-grouping.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-grouping/peer-group-grouping.component.ts
@@ -1,0 +1,23 @@
+import { Component, Input } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { ConfigService } from '../../../../services/configService';
+import { PeerGroupWorkgroupsContainerComponent } from '../peer-group-workgroups-container/peer-group-workgroups-container.component';
+
+@Component({
+  selector: 'peer-group-grouping',
+  templateUrl: './peer-group-grouping.component.html',
+  styleUrls: ['../peer-group-workgroups-container/peer-group-workgroups-container.component.scss']
+})
+export class PeerGroupGroupingComponent extends PeerGroupWorkgroupsContainerComponent {
+  @Input() grouping: any;
+
+  avatarColor: string;
+
+  constructor(private ConfigService: ConfigService, protected dialog: MatDialog) {
+    super(dialog);
+  }
+
+  ngOnInit(): void {
+    this.avatarColor = this.ConfigService.getAvatarColorForWorkgroupId(this.grouping.id);
+  }
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html
@@ -1,0 +1,15 @@
+<h2 mat-dialog-title fxLayoutAlign="start center">
+  <span i18n>Move Workgroup</span>
+  <span fxFlex></span>
+  <mat-icon color="warn" i18n-aria-label aria-label="Warning">warning</mat-icon>
+</h2>
+<mat-dialog-content>
+  <div class="info-block">
+    <p *ngIf="isMovingFromPeerGroup" class="warn" i18n>Warning: Moving a workroup from a Peer Group will result in the workgroup losing all the messages they sent in that Peer Group.</p>
+    <p i18n>Are you sure you want to move this workgroup?</p>
+  </div>
+</mat-dialog-content>
+<mat-dialog-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="end" fxLayoutGap="8px">
+  <button mat-flat-button color="primary" [mat-dialog-close]="false" i18n>Cancel</button>
+  <button mat-button [color]="isMovingFromPeerGroup ? 'warn' : ''" [mat-dialog-close]="true" i18n>Proceed</button>
+</mat-dialog-actions>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html
@@ -1,15 +1,20 @@
 <h2 mat-dialog-title fxLayoutAlign="start center">
-  <span i18n>Move Workgroup</span>
+  <span i18n>Change Grouping</span>
   <span fxFlex></span>
-  <mat-icon color="warn" i18n-aria-label aria-label="Warning">warning</mat-icon>
+  <mat-icon *ngIf="isMovingFromPeerGroup" color="warn" i18n-aria-label aria-label="Warning">warning</mat-icon>
 </h2>
 <mat-dialog-content>
   <div class="info-block">
-    <p *ngIf="isMovingFromPeerGroup" class="warn" i18n>Warning: Moving a workroup from a Peer Group will result in the workgroup losing all the messages they sent in that Peer Group.</p>
-    <p i18n>Are you sure you want to move this workgroup?</p>
+    <ng-container *ngIf="isMovingFromPeerGroup">
+      <p class="warn" i18n>Warning: If you remove students from a Peer Group, they will no longer see any contributions they made to that group.</p>
+      <p>Their contributions will still be visible to remaining group members.</p>
+    </ng-container>
+    <p i18n>Are you sure you want to move this team?</p>
   </div>
 </mat-dialog-content>
 <mat-dialog-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="end" fxLayoutGap="8px">
-  <button mat-flat-button color="primary" [mat-dialog-close]="false" i18n>Cancel</button>
-  <button mat-button [color]="isMovingFromPeerGroup ? 'warn' : ''" [mat-dialog-close]="true" i18n>Proceed</button>
+  <button *ngIf="isMovingFromPeerGroup" mat-flat-button color="primary" [mat-dialog-close]="false" i18n>Cancel</button>
+  <button *ngIf="!isMovingFromPeerGroup" mat-button [mat-dialog-close]="false" i18n>Cancel</button>
+  <button *ngIf="isMovingFromPeerGroup" mat-button color="warn" [mat-dialog-close]="true" i18n>Proceed</button>
+  <button *ngIf="!isMovingFromPeerGroup" mat-flat-button color="primary" [mat-dialog-close]="true" i18n>Proceed</button>
 </mat-dialog-actions>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.spec.ts
@@ -1,0 +1,29 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+
+import { PeerGroupMoveWorkgroupConfirmDialogComponent } from './peer-group-move-workgroup-confirm-dialog.component';
+
+describe('PeerGroupMoveWorkgroupConfirmDialogComponent', () => {
+  let component: PeerGroupMoveWorkgroupConfirmDialogComponent;
+  let fixture: ComponentFixture<PeerGroupMoveWorkgroupConfirmDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PeerGroupMoveWorkgroupConfirmDialogComponent],
+      imports: [MatButtonModule, MatDialogModule, MatIconModule],
+      providers: [{ provide: MAT_DIALOG_DATA, useValue: {} }]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PeerGroupMoveWorkgroupConfirmDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.ts
@@ -1,0 +1,17 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-peer-group-move-workgroup-confirm-dialog',
+  templateUrl: './peer-group-move-workgroup-confirm-dialog.component.html',
+  styleUrls: ['./peer-group-move-workgroup-confirm-dialog.component.scss']
+})
+export class PeerGroupMoveWorkgroupConfirmDialogComponent implements OnInit {
+  isMovingFromPeerGroup: boolean;
+
+  constructor(@Inject(MAT_DIALOG_DATA) public data: any) {
+    this.isMovingFromPeerGroup = data.isMovingFromPeerGroup;
+  }
+
+  ngOnInit(): void {}
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.ts
@@ -7,11 +7,7 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
   styleUrls: ['./peer-group-move-workgroup-confirm-dialog.component.scss']
 })
 export class PeerGroupMoveWorkgroupConfirmDialogComponent implements OnInit {
-  isMovingFromPeerGroup: boolean;
-
-  constructor(@Inject(MAT_DIALOG_DATA) public data: any) {
-    this.isMovingFromPeerGroup = data.isMovingFromPeerGroup;
-  }
+  constructor(@Inject(MAT_DIALOG_DATA) public isMovingFromPeerGroup: boolean) {}
 
   ngOnInit(): void {}
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.html
@@ -1,0 +1,22 @@
+<mat-card>
+  <div fxLayoutAlign="start center">
+    <h3 class="mat-display-1 accent-1" i18n>Period {{period.periodName}}</h3>
+    <span fxFlex></span>
+    <button mat-stroked-button
+        color="primary"
+        aria-label="Create a new group"
+        i18n-aria-label
+        (click)="createNewGroup()">
+      <mat-icon class="text-secondary" color="primary">group_add</mat-icon>
+      &nbsp;
+      <span i18n>New Group</span>
+    </button>
+  </div>
+  <div class="groups" cdkDropListGroup>
+    <peer-group-unassigned-workgroups [unassignedWorkgroups]="unassignedWorkgroups"
+        (moveWorkgroup)="moveWorkgroup($event)">
+    </peer-group-unassigned-workgroups>
+    <peer-group-assigned-workgroups [groupings]="groupings" (moveWorkgroup)="moveWorkgroup($event)">
+    </peer-group-assigned-workgroups>
+  </div>
+</mat-card>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.scss
@@ -5,3 +5,8 @@
 .groups {
   margin-top: 16px;
 }
+
+peer-group-assigned-workgroups {
+  display: block;
+  margin: 8px -4px 0;
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.scss
@@ -1,0 +1,7 @@
+.mat-display-1 {
+  margin: 0;
+}
+
+.groups {
+  margin-top: 16px;
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.spec.ts
@@ -1,0 +1,196 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
+import { UpgradeModule } from '@angular/upgrade/static';
+import { Observable, of } from 'rxjs';
+import { WorkgroupService } from '../../../../../../app/services/workgroup.service';
+import { AchievementService } from '../../../../services/achievementService';
+import { AnnotationService } from '../../../../services/annotationService';
+import { ConfigService } from '../../../../services/configService';
+import { NotificationService } from '../../../../services/notificationService';
+import { PeerGroupService } from '../../../../services/peerGroupService';
+import { ProjectService } from '../../../../services/projectService';
+import { SessionService } from '../../../../services/sessionService';
+import { StudentDataService } from '../../../../services/studentDataService';
+import { StudentStatusService } from '../../../../services/studentStatusService';
+import { TagService } from '../../../../services/tagService';
+import { TeacherDataService } from '../../../../services/teacherDataService';
+import { TeacherProjectService } from '../../../../services/teacherProjectService';
+import { TeacherWebSocketService } from '../../../../services/teacherWebSocketService';
+import { UtilService } from '../../../../services/utilService';
+import { SelectPeriodComponent } from '../../select-period/select-period.component';
+import { PeerGroupAssignedWorkgroupsComponent } from '../peer-group-assigned-workgroups/peer-group-assigned-workgroups.component';
+import { PeerGroupUnassignedWorkgroupsComponent } from '../peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component';
+import { FlexLayoutModule } from '@angular/flex-layout';
+
+import { PeerGroupPeriodComponent } from './peer-group-period.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { DragDropModule } from '@angular/cdk/drag-drop';
+import { CommonModule } from '@angular/common';
+import { PeerGroupGroupingComponent } from '../peer-group-grouping/peer-group-grouping.component';
+import { PeerGroupWorkgroupComponent } from '../peer-group-workgroup/peer-group-workgroup.component';
+
+describe('PeerGroupPeriodComponent', () => {
+  let component: PeerGroupPeriodComponent;
+  let fixture: ComponentFixture<PeerGroupPeriodComponent>;
+  let grouping1: any;
+  let grouping2: any;
+  let workgroup1: any;
+  let workgroup2: any;
+  let workgroup3: any;
+  let workgroup4: any;
+  let workgroup5: any;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        PeerGroupAssignedWorkgroupsComponent,
+        PeerGroupPeriodComponent,
+        PeerGroupGroupingComponent,
+        PeerGroupUnassignedWorkgroupsComponent,
+        PeerGroupWorkgroupComponent,
+        SelectPeriodComponent
+      ],
+      imports: [
+        BrowserAnimationsModule,
+        CommonModule,
+        DragDropModule,
+        FlexLayoutModule,
+        FormsModule,
+        HttpClientTestingModule,
+        MatCardModule,
+        MatDialogModule,
+        MatFormFieldModule,
+        MatIconModule,
+        MatSelectModule,
+        ReactiveFormsModule
+      ],
+      providers: [
+        AchievementService,
+        AnnotationService,
+        ConfigService,
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        NotificationService,
+        PeerGroupService,
+        ProjectService,
+        SessionService,
+        StudentDataService,
+        StudentStatusService,
+        TagService,
+        TeacherDataService,
+        TeacherProjectService,
+        TeacherWebSocketService,
+        UpgradeModule,
+        UtilService,
+        WorkgroupService
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PeerGroupPeriodComponent);
+    spyOn(TestBed.inject(PeerGroupService), 'moveWorkgroupToGroup').and.callFake(() => {
+      return new Observable<any>();
+    });
+    component = fixture.componentInstance;
+    component.period = { periodId: 1, periodName: '1' };
+    workgroup1 = createWorkgroup(1);
+    workgroup2 = createWorkgroup(2);
+    workgroup3 = createWorkgroup(3);
+    workgroup4 = createWorkgroup(4);
+    workgroup5 = createWorkgroup(5);
+    component.workgroups = [workgroup1, workgroup2, workgroup3, workgroup4];
+    component.unassignedWorkgroups = [workgroup5];
+    grouping1 = createGrouping(1, [workgroup1, workgroup2]);
+    grouping2 = createGrouping(2, [workgroup3, workgroup4]);
+    component.groupings = [grouping1, grouping2];
+    component.nextAvailableGroupId = 3;
+    fixture.detectChanges();
+  });
+
+  function createWorkgroup(id: number): any {
+    return {
+      username: '',
+      workgroupId: id
+    };
+  }
+
+  function createGrouping(id: number, workgroups: any[]): any {
+    return {
+      id: id,
+      workgroups: workgroups
+    };
+  }
+
+  function createEvent(
+    workgroupId: number,
+    previousContainerId: number,
+    newContainerId: number
+  ): any {
+    return {
+      container: {
+        data: {
+          id: newContainerId
+        }
+      },
+      item: {
+        data: workgroupId
+      },
+      previousContainer: {
+        data: {
+          id: previousContainerId
+        }
+      }
+    };
+  }
+
+  function moveWorkgroup() {
+    describe('moveWorkgroup()', () => {
+      it('should move a workgroup from unassigned to assigned', () => {
+        expectGroupingWorkgroupsLength(grouping1, 2);
+        const event = createEvent(5, 0, 1);
+        component.moveWorkgroup(event);
+        expectGroupingWorkgroupsLength(grouping1, 3);
+      });
+
+      it('should move a workgroup from assigned to unassigned', () => {
+        expectGroupingWorkgroupsLength(grouping1, 2);
+        const event = createEvent(1, 1, 0);
+        component.moveWorkgroup(event);
+        expectGroupingWorkgroupsLength(grouping1, 1);
+      });
+
+      it('should move a workgroup from assigned to assigned', () => {
+        expectGroupingWorkgroupsLength(grouping1, 2);
+        expectGroupingWorkgroupsLength(grouping2, 2);
+        const event = createEvent(1, 1, 2);
+        component.moveWorkgroup(event);
+        expectGroupingWorkgroupsLength(grouping1, 1);
+        expectGroupingWorkgroupsLength(grouping2, 3);
+      });
+    });
+  }
+
+  function expectGroupingWorkgroupsLength(grouping: any, expectedNumWorkgroups: number): void {
+    expect(grouping.workgroups.length).toEqual(expectedNumWorkgroups);
+  }
+
+  function createNewGroup() {
+    describe('createNewGroup()', () => {
+      it('should create a new group', () => {
+        expect(component.groupings.length).toEqual(2);
+        spyOn(TestBed.inject(PeerGroupService), 'createNewGroup').and.returnValue(of({ id: 5 }));
+        component.createNewGroup();
+        expect(component.groupings.length).toEqual(3);
+      });
+    });
+  }
+
+  createNewGroup();
+  moveWorkgroup();
+});

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.ts
@@ -1,0 +1,174 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { ConfigService } from '../../../../services/configService';
+import { PeerGroupService } from '../../../../services/peerGroupService';
+
+@Component({
+  selector: 'peer-group-period',
+  templateUrl: './peer-group-period.component.html',
+  styleUrls: ['./peer-group-period.component.scss']
+})
+export class PeerGroupPeriodComponent implements OnInit {
+  @Input() componentId: string;
+  @Input() nodeId: string;
+  @Input() period: any;
+
+  groupings: any[] = [];
+  nextAvailableGroupId: number = 1;
+  unassignedWorkgroups: any[] = [];
+  workgroups: any[] = [];
+
+  constructor(private ConfigService: ConfigService, private PeerGroupService: PeerGroupService) {}
+
+  ngOnInit(): void {}
+
+  ngOnChanges(): void {
+    this.PeerGroupService.retrieveGroupings(this.nodeId, this.componentId).subscribe(
+      (groupings: any) => {
+        // TODO
+      },
+      () => {
+        // TODO: Handle error
+      }
+    );
+    this.workgroups = this.getWorkgroupsInPeriod();
+    this.setDummyGroupingsAndUnassignedWorkgroups();
+  }
+
+  getWorkgroupsInPeriod(): any[] {
+    return this.ConfigService.getWorkgroupsByPeriod(this.period.periodId).filter(
+      (workgroup) => workgroup.workgroupId != null
+    );
+  }
+
+  setDummyGroupingsAndUnassignedWorkgroups(): void {
+    this.groupings = [];
+    this.unassignedWorkgroups = [];
+    const numUnassignedWorkgroups = this.getDummyNumUnassignedWorkgroups(this.workgroups);
+    let tempWorkgroups = [];
+    for (let w = 0; w < this.workgroups.length - numUnassignedWorkgroups; w++) {
+      tempWorkgroups.push(this.workgroups[w]);
+      if (tempWorkgroups.length >= 2) {
+        this.addGrouping(this.createGrouping(this.nextAvailableGroupId++, tempWorkgroups));
+        tempWorkgroups = [];
+      }
+    }
+    for (
+      let w = this.workgroups.length - numUnassignedWorkgroups;
+      w < this.workgroups.length;
+      w++
+    ) {
+      this.unassignedWorkgroups.push(this.workgroups[w]);
+    }
+  }
+
+  getDummyNumUnassignedWorkgroups(workgroups: any[]): number {
+    if (workgroups.length >= 4) {
+      return 2;
+    } else if (workgroups.length === 3) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  createGrouping(id: number = this.nextAvailableGroupId, workgroups: any[]): any {
+    return {
+      id: id,
+      workgroups: workgroups
+    };
+  }
+
+  addGrouping(grouping: any): void {
+    this.groupings.push(grouping);
+  }
+
+  createNewGroup(): Subscription {
+    return this.PeerGroupService.createNewGroup(this.nodeId, this.componentId).subscribe(
+      (group) => {
+        this.addGrouping(this.createGrouping(group.id, []));
+      },
+      () => {
+        this.addGrouping(this.createGrouping(this.nextAvailableGroupId++, []));
+      }
+    );
+  }
+
+  moveWorkgroup(event: any): void {
+    const workgroupId = event.item.data;
+    const previousLocation = event.previousContainer.data.id;
+    const newLocation = event.container.data.id;
+    this.removeWorkgroup(workgroupId, previousLocation);
+    this.addWorkgroupToGroup(workgroupId, newLocation);
+    this.PeerGroupService.moveWorkgroupToGroup(
+      workgroupId,
+      newLocation,
+      this.nodeId,
+      this.componentId
+    ).subscribe(
+      () => {
+        // TODO
+      },
+      () => {
+        // TODO
+      }
+    );
+  }
+
+  removeWorkgroup(workgroupId: number, location: number): void {
+    if (location === 0) {
+      this.removeWorkgroupFromUnassigned(workgroupId);
+    } else {
+      this.removeWorkgroupFromGroup(workgroupId, location);
+    }
+  }
+
+  removeWorkgroupFromUnassigned(workgroupId: any): void {
+    for (let w = 0; w < this.unassignedWorkgroups.length; w++) {
+      if (this.unassignedWorkgroups[w].workgroupId === workgroupId) {
+        this.unassignedWorkgroups.splice(w, 1);
+        return;
+      }
+    }
+  }
+
+  removeWorkgroupFromGroup(workgroupId: number, location: number): void {
+    for (const group of this.groupings) {
+      if (group.id === location) {
+        for (let w = 0; w < group.workgroups.length; w++) {
+          if (group.workgroups[w].workgroupId === workgroupId) {
+            group.workgroups.splice(w, 1);
+            return;
+          }
+        }
+      }
+    }
+  }
+
+  addWorkgroupToGroup(workgroupId: number, location: number): void {
+    if (location === 0) {
+      this.unassignedWorkgroups.push(this.getWorkgroup(workgroupId));
+    } else {
+      const group = this.getGroup(location);
+      group.workgroups.push(this.getWorkgroup(workgroupId));
+    }
+  }
+
+  getGroup(groupId: number): any {
+    for (const group of this.groupings) {
+      if (group.id === groupId) {
+        return group;
+      }
+    }
+    return null;
+  }
+
+  getWorkgroup(workgroupId: number): any {
+    for (const workgroup of this.workgroups) {
+      if (workgroup.workgroupId === workgroupId) {
+        return workgroup;
+      }
+    }
+    return null;
+  }
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component.html
@@ -1,0 +1,22 @@
+<mat-card class="peer-group-card notice-bg-bg">
+  <div class="mat-card-title">
+    <h4 class="mat-body-2" i18n>Unassigned Workgroups</h4>
+  </div>
+  <mat-card-content class="peer-group-card-content">
+    <ul class="peer-group-ul"
+        cdkDropList
+        [cdkDropListData]="{ id: 0 }"
+        (cdkDropListDropped)="dropWorkgroup($event)"
+        [ngStyle.gt-sm]="{ columns: 2 }"
+        [ngStyle.gt-md]="{ columns: 3 }">
+      <li *ngFor="let workgroup of unassignedWorkgroups"
+          class="peer-group-li"
+          cdkDrag
+          [cdkDragData]="workgroup.workgroupId"
+          (cdkDragEntered)="dragEnter($event)"
+          (cdkDragExited)="dragExit($event)">
+        <peer-group-workgroup [workgroup]="workgroup"></peer-group-workgroup>
+      </li>
+    </ul>
+  </mat-card-content>
+</mat-card>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component.html
@@ -1,16 +1,14 @@
-<mat-card class="peer-group-card notice-bg-bg">
+<mat-card class="group notice-bg-bg">
   <div class="mat-card-title">
-    <h4 class="mat-body-2" i18n>Unassigned Workgroups</h4>
+    <h4 class="mat-body-2" i18n>Teams Without a Group</h4>
   </div>
-  <mat-card-content class="peer-group-card-content">
-    <ul class="peer-group-ul"
-        cdkDropList
+  <mat-card-content>
+    <ul cdkDropList
         [cdkDropListData]="{ id: 0 }"
         (cdkDropListDropped)="dropWorkgroup($event)"
         [ngStyle.gt-sm]="{ columns: 2 }"
         [ngStyle.gt-md]="{ columns: 3 }">
       <li *ngFor="let workgroup of unassignedWorkgroups"
-          class="peer-group-li"
           cdkDrag
           [cdkDragData]="workgroup.workgroupId"
           (cdkDragEntered)="dragEnter($event)"

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component.html
@@ -1,6 +1,6 @@
 <mat-card class="group notice-bg-bg">
   <div class="mat-card-title">
-    <h4 class="mat-body-2" i18n>Teams Without a Group</h4>
+    <h4 class="mat-body-2" i18n>Ungrouped</h4>
   </div>
   <mat-card-content>
     <ul cdkDropList

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component.spec.ts
@@ -1,0 +1,29 @@
+import { DragDropModule } from '@angular/cdk/drag-drop';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { MatCardModule } from '@angular/material/card';
+import { MatDialogModule } from '@angular/material/dialog';
+
+import { PeerGroupUnassignedWorkgroupsComponent } from './peer-group-unassigned-workgroups.component';
+
+describe('PeerGroupUnassignedWorkgroupsComponent', () => {
+  let component: PeerGroupUnassignedWorkgroupsComponent;
+  let fixture: ComponentFixture<PeerGroupUnassignedWorkgroupsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PeerGroupUnassignedWorkgroupsComponent],
+      imports: [DragDropModule, FlexLayoutModule, MatCardModule, MatDialogModule]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PeerGroupUnassignedWorkgroupsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input } from '@angular/core';
+import { PeerGroupWorkgroupsContainerComponent } from '../peer-group-workgroups-container/peer-group-workgroups-container.component';
+
+@Component({
+  selector: 'peer-group-unassigned-workgroups',
+  templateUrl: './peer-group-unassigned-workgroups.component.html',
+  styleUrls: ['../peer-group-workgroups-container/peer-group-workgroups-container.component.scss']
+})
+export class PeerGroupUnassignedWorkgroupsComponent extends PeerGroupWorkgroupsContainerComponent {
+  @Input()
+  unassignedWorkgroups: any[];
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.html
@@ -1,0 +1,1 @@
+<div class="workgroup control-bg-bg mat-elevation-z1">{{ workgroupUsernames }}</div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.html
@@ -1,1 +1,6 @@
-<div class="workgroup control-bg-bg mat-elevation-z1">{{ workgroupUsernames }}</div>
+<div class="team control-bg-bg mat-elevation-z1" fxLayoutAlign="start center" fxLayoutGap="4px">
+  <mat-icon class="mat-24 secondary-text avatar" [ngStyle]="{'color': avatarColor}">account_circle</mat-icon>
+  <div>
+    <strong>{{ workgroupUsernames }}</strong>&nbsp;<span i18n>(Team {{ workgroup.workgroupId }})</span>
+  </div>
+</div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.scss
@@ -1,7 +1,8 @@
 @import '~style/abstracts/variables';
 
-.workgroup {
+.team {
   display: block;
   padding: 4px 8px;
   border-radius: $button-border-radius;
+  min-height: 40px;
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.scss
@@ -1,0 +1,7 @@
+@import '~style/abstracts/variables';
+
+.workgroup {
+  display: block;
+  padding: 4px 8px;
+  border-radius: $button-border-radius;
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PeerGroupWorkgroupComponent } from './peer-group-workgroup.component';
+
+describe('PeerGroupWorkgroupComponent', () => {
+  let component: PeerGroupWorkgroupComponent;
+  let fixture: ComponentFixture<PeerGroupWorkgroupComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PeerGroupWorkgroupComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PeerGroupWorkgroupComponent);
+    component = fixture.componentInstance;
+    component.workgroup = { username: '' };
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.spec.ts
@@ -1,5 +1,7 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { UpgradeModule } from '@angular/upgrade/static';
+import { ConfigService } from '../../../../services/configService';
 import { PeerGroupWorkgroupComponent } from './peer-group-workgroup.component';
 
 describe('PeerGroupWorkgroupComponent', () => {
@@ -8,7 +10,9 @@ describe('PeerGroupWorkgroupComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [PeerGroupWorkgroupComponent]
+      imports: [HttpClientTestingModule],
+      declarations: [PeerGroupWorkgroupComponent],
+      providers: [ConfigService, UpgradeModule]
     }).compileComponents();
   });
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'peer-group-workgroup',
+  templateUrl: './peer-group-workgroup.component.html',
+  styleUrls: ['./peer-group-workgroup.component.scss']
+})
+export class PeerGroupWorkgroupComponent implements OnInit {
+  @Input() workgroup: any;
+
+  workgroupUsernames: string;
+
+  constructor() {}
+
+  ngOnInit(): void {
+    this.workgroupUsernames = this.workgroup.username.replace(/:/g, ' and ');
+  }
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { ConfigService } from '../../../../services/configService';
 
 @Component({
   selector: 'peer-group-workgroup',
@@ -8,11 +9,13 @@ import { Component, Input, OnInit } from '@angular/core';
 export class PeerGroupWorkgroupComponent implements OnInit {
   @Input() workgroup: any;
 
+  avatarColor: string;
   workgroupUsernames: string;
 
-  constructor() {}
+  constructor(private ConfigrService: ConfigService) {}
 
   ngOnInit(): void {
-    this.workgroupUsernames = this.workgroup.username.replace(/:/g, ' and ');
+    this.workgroupUsernames = this.workgroup.displayNames;
+    this.avatarColor = this.ConfigrService.getAvatarColorForWorkgroupId(this.workgroup.workgroupId);
   }
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroups-container/peer-group-workgroups-container.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroups-container/peer-group-workgroups-container.component.scss
@@ -1,0 +1,48 @@
+@import '~style/abstracts/variables';
+
+.peer-group-card {
+  &.mat-card {
+    margin: 4px;
+    padding: 8px 8px 0;
+    box-shadow: none;
+  }
+
+  .mat-card-title {
+    margin-bottom: 4px;
+  }
+}
+
+.peer-group-card-content {
+  margin-bottom: 0;
+}
+
+h4 {
+  margin: 0;
+}
+
+.avatar {
+  margin-right: 4px;
+}
+
+.peer-group-ul {
+  min-height: 46px;
+  padding: 4px;
+  margin: -4px -8px;
+  transition: background-color 250ms;
+  border-bottom-left-radius: $card-border-radius;
+  border-bottom-right-radius: $card-border-radius;
+  column-gap: 0;
+}
+
+.peer-group-li {
+  list-style-type: none;
+  cursor: move;
+  padding: 4px;
+  -webkit-column-break-inside: avoid;
+  page-break-inside: avoid;
+  break-inside: avoid;
+}
+
+.cdk-drag-placeholder {
+  opacity: .4;
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroups-container/peer-group-workgroups-container.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroups-container/peer-group-workgroups-container.component.scss
@@ -1,19 +1,16 @@
 @import '~style/abstracts/variables';
 
-.peer-group-card {
-  &.mat-card {
-    margin: 4px;
+.group.mat-card {
     padding: 8px 8px 0;
     box-shadow: none;
   }
 
-  .mat-card-title {
-    margin-bottom: 4px;
-  }
+.mat-card-title {
+  margin-bottom: 4px;
 }
 
-.peer-group-card-content {
-  margin-bottom: 0;
+.mat-card-content {
+  margin: 0;
 }
 
 h4 {
@@ -24,8 +21,8 @@ h4 {
   margin-right: 4px;
 }
 
-.peer-group-ul {
-  min-height: 46px;
+ul {
+  min-height: 48px;
   padding: 4px;
   margin: -4px -8px;
   transition: background-color 250ms;
@@ -34,7 +31,7 @@ h4 {
   column-gap: 0;
 }
 
-.peer-group-li {
+li {
   list-style-type: none;
   cursor: move;
   padding: 4px;

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroups-container/peer-group-workgroups-container.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroups-container/peer-group-workgroups-container.component.ts
@@ -37,6 +37,8 @@ export abstract class PeerGroupWorkgroupsContainerComponent implements OnInit {
           }
           this.removeBackgroundColor(event);
         });
+    } else {
+      this.removeBackgroundColor(event);
     }
   }
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroups-container/peer-group-workgroups-container.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroups-container/peer-group-workgroups-container.component.ts
@@ -1,0 +1,54 @@
+import { CdkDragDrop, CdkDragEnter, CdkDragExit } from '@angular/cdk/drag-drop';
+import { Directive, EventEmitter, OnInit, Output } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { PeerGroupMoveWorkgroupConfirmDialogComponent } from '../peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component';
+
+@Directive()
+export abstract class PeerGroupWorkgroupsContainerComponent implements OnInit {
+  @Output()
+  moveWorkgroup: EventEmitter<any> = new EventEmitter<any>();
+
+  constructor(protected dialog: MatDialog) {}
+
+  ngOnInit(): void {}
+
+  dragEnter(event: CdkDragEnter) {
+    this.addBackgroundColor(event);
+  }
+
+  dragExit(event: CdkDragExit) {
+    this.removeBackgroundColor(event);
+  }
+
+  dropWorkgroup(event: CdkDragDrop<any>): void {
+    if (event.previousContainer !== event.container) {
+      const isMovingFromPeerGroup = this.isFromAssignedContainer(event);
+      this.dialog
+        .open(PeerGroupMoveWorkgroupConfirmDialogComponent, {
+          data: {
+            isMovingFromPeerGroup: isMovingFromPeerGroup
+          },
+          panelClass: 'dialog-sm'
+        })
+        .afterClosed()
+        .subscribe((isMove: boolean) => {
+          if (isMove) {
+            this.moveWorkgroup.emit(event);
+          }
+          this.removeBackgroundColor(event);
+        });
+    }
+  }
+
+  isFromAssignedContainer(event: CdkDragDrop<any>): boolean {
+    return event.previousContainer.data.id !== 0;
+  }
+
+  addBackgroundColor(event: any): void {
+    event.container.element.nativeElement.classList.add('primary-bg');
+  }
+
+  removeBackgroundColor(event: any): void {
+    event.container.element.nativeElement.classList.remove('primary-bg');
+  }
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroups-container/peer-group-workgroups-container.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroups-container/peer-group-workgroups-container.component.ts
@@ -22,12 +22,9 @@ export abstract class PeerGroupWorkgroupsContainerComponent implements OnInit {
 
   dropWorkgroup(event: CdkDragDrop<any>): void {
     if (event.previousContainer !== event.container) {
-      const isMovingFromPeerGroup = this.isFromAssignedContainer(event);
       this.dialog
         .open(PeerGroupMoveWorkgroupConfirmDialogComponent, {
-          data: {
-            isMovingFromPeerGroup: isMovingFromPeerGroup
-          },
+          data: this.isFromAssignedContainer(event),
           panelClass: 'dialog-sm'
         })
         .afterClosed()

--- a/src/assets/wise5/classroomMonitor/i18n/i18n_en.json
+++ b/src/assets/wise5/classroomMonitor/i18n/i18n_en.json
@@ -165,7 +165,7 @@
   "openInNewWindow": "Open in New Window",
   "partiallyCompleted": "Partially Completed",
   "pauseStudentScreens": "Pause Student Screens",
-  "peerGroup": "Peer Group",
+  "peerGroups": "Peer Groups",
   "percentCompleted": "{{percent}}% completed",
   "percentCompletedPeriod": "{{percent}}% completed (Period: {{period}})",
   "percentCompletedPeriodAll": "{{percent}}% completed (All periods)",

--- a/src/assets/wise5/classroomMonitor/i18n/i18n_en.json
+++ b/src/assets/wise5/classroomMonitor/i18n/i18n_en.json
@@ -165,6 +165,7 @@
   "openInNewWindow": "Open in New Window",
   "partiallyCompleted": "Partially Completed",
   "pauseStudentScreens": "Pause Student Screens",
+  "peerGroup": "Peer Group",
   "percentCompleted": "{{percent}}% completed",
   "percentCompletedPeriod": "{{percent}}% completed (Period: {{period}})",
   "percentCompletedPeriodAll": "{{percent}}% completed (All periods)",

--- a/src/assets/wise5/services/nodeService.ts
+++ b/src/assets/wise5/services/nodeService.ts
@@ -8,6 +8,7 @@ import { UpgradeModule } from '@angular/upgrade/static';
 import { ChooseBranchPathDialogComponent } from '../../../app/preview/modules/choose-branch-path-dialog/choose-branch-path-dialog.component';
 import { DataService } from '../../../app/services/data.service';
 import { Observable, Subject } from 'rxjs';
+import { PeerGroupDialogComponent } from '../classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component';
 
 @Injectable()
 export class NodeService {
@@ -840,6 +841,17 @@ export class NodeService {
     const subscription = this.DataService.currentNodeChanged$.subscribe(() => {
       this.scrollToComponentAndHighlight(componentId);
       subscription.unsubscribe();
+    });
+  }
+
+  showPeerGroupDetails(periodId: number, nodeId: string, componentId: string): void {
+    this.dialog.open(PeerGroupDialogComponent, {
+      data: {
+        componentId: componentId,
+        nodeId: nodeId,
+        periodId: periodId
+      },
+      width: '80%'
     });
   }
 }

--- a/src/assets/wise5/services/nodeService.ts
+++ b/src/assets/wise5/services/nodeService.ts
@@ -851,7 +851,7 @@ export class NodeService {
         nodeId: nodeId,
         periodId: periodId
       },
-      width: '80%'
+      panelClass: 'dialog-lg'
     });
   }
 }

--- a/src/assets/wise5/services/peerGroupService.ts
+++ b/src/assets/wise5/services/peerGroupService.ts
@@ -1,0 +1,57 @@
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ConfigService } from './configService';
+import { ProjectService } from './projectService';
+
+@Injectable()
+export class PeerGroupService {
+  constructor(
+    private ConfigService: ConfigService,
+    private http: HttpClient,
+    private ProjectService: ProjectService
+  ) {}
+
+  getPeerGroupComponentIds(node: any): string[] {
+    const componentIds = [];
+    for (const component of node.components) {
+      if (component.type === 'PeerChat') {
+        componentIds.push(component.id);
+      }
+    }
+    return componentIds;
+  }
+
+  retrieveGroupings(nodeId: string, componentId: string): Observable<any> {
+    const runId = this.ConfigService.getRunId();
+    const headers = new HttpHeaders().set('Content-Type', 'application/json');
+    return this.http.get(`/api/teacher/peer-group-info/${runId}/${nodeId}/${componentId}`, {
+      headers: headers
+    });
+  }
+
+  createNewGroup(nodeId: string, componentId: string): Observable<any> {
+    const runId = this.ConfigService.getRunId();
+    const headers = new HttpHeaders().set('Content-Type', 'application/x-www-form-urlencoded');
+    return this.http.post(
+      `/api/peer-group/create/${runId}/${nodeId}/${componentId}`,
+      new HttpParams(),
+      { headers: headers }
+    );
+  }
+
+  moveWorkgroupToGroup(
+    workgroupId: number,
+    groupId: number,
+    nodeId: string,
+    componentId: string
+  ): Observable<any> {
+    const runId = this.ConfigService.getRunId();
+    const headers = new HttpHeaders().set('Content-Type', 'application/x-www-form-urlencoded');
+    return this.http.post(
+      `/api/peer-group/move-member/${runId}/${nodeId}/${componentId}/${groupId}/${workgroupId}`,
+      new HttpParams(),
+      { headers: headers }
+    );
+  }
+}

--- a/src/assets/wise5/services/peerGroupService.ts
+++ b/src/assets/wise5/services/peerGroupService.ts
@@ -1,6 +1,7 @@
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { Node } from '../common/Node';
 import { ConfigService } from './configService';
 import { ProjectService } from './projectService';
 
@@ -12,7 +13,7 @@ export class PeerGroupService {
     private ProjectService: ProjectService
   ) {}
 
-  getPeerGroupComponentIds(node: any): string[] {
+  getPeerGroupComponentIds(node: Node): string[] {
     const componentIds = [];
     for (const component of node.components) {
       if (component.type === 'PeerChat') {

--- a/src/assets/wise5/services/teacherDataService.ts
+++ b/src/assets/wise5/services/teacherDataService.ts
@@ -709,6 +709,14 @@ export class TeacherDataService extends DataService {
     return this.runStatus;
   }
 
+  getVisiblePeriodsById(currentPeriodId: number): any {
+    if (currentPeriodId === -1) {
+      return this.getPeriods().slice(1);
+    } else {
+      return [this.getPeriodById(currentPeriodId)];
+    }
+  }
+
   setCurrentWorkgroup(workgroup) {
     this.currentWorkgroup = workgroup;
     this.broadcastCurrentWorkgroupChanged({ currentWorkgroup: this.currentWorkgroup });

--- a/src/assets/wise5/teacher/teacher-angular-js-module.ts
+++ b/src/assets/wise5/teacher/teacher-angular-js-module.ts
@@ -10,6 +10,7 @@ import { ImportComponentService } from '../services/importComponentService';
 import { InsertComponentService } from '../services/insertComponentService';
 import { MilestoneService } from '../services/milestoneService';
 import { MoveNodesService } from '../services/moveNodesService';
+import { PeerGroupService } from '../services/peerGroupService';
 import { TeacherProjectService } from '../services/teacherProjectService';
 import { SpaceService } from '../services/spaceService';
 import { StudentStatusService } from '../services/studentStatusService';
@@ -30,6 +31,7 @@ angular
   .factory('InsertComponentService', downgradeInjectable(InsertComponentService))
   .factory('MilestoneService', downgradeInjectable(MilestoneService))
   .factory('MoveNodesService', downgradeInjectable(MoveNodesService))
+  .factory('PeerGroupService', downgradeInjectable(PeerGroupService))
   .factory('ProjectService', downgradeInjectable(TeacherProjectService))
   .factory('SpaceService', downgradeInjectable(SpaceService))
   .factory('StudentStatusService', downgradeInjectable(StudentStatusService))

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -8782,8 +8782,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="516cc085017fb40ff72a02bff7ec36d346532472" datatype="html">
-        <source>Teams Without a Group</source>
+      <trans-unit id="8bf3b0baf010fe9279d91e2dd07ba3632dfce8e7" datatype="html">
+        <source>Ungrouped</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component.html</context>
           <context context-type="linenumber">3</context>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -279,8 +279,12 @@
           <context context-type="linenumber">32</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/view-component-revisions/view-component-revisions.component.html</context>
-          <context context-type="linenumber">147</context>
+          <context context-type="linenumber">155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ea4d9fe61420a3fce81cf54c4c615e3c19c646a6" datatype="html">
@@ -430,6 +434,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/remove-user-confirm-dialog/remove-user-confirm-dialog.component.html</context>
           <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html</context>
+          <context context-type="linenumber">13</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.html</context>
@@ -886,6 +894,14 @@
           <context context-type="linenumber">390</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html</context>
           <context context-type="linenumber">20</context>
         </context-group>
@@ -899,6 +915,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
           <context context-type="linenumber">396</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">86</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html</context>
@@ -918,6 +942,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
           <context context-type="linenumber">378</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">66</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html</context>
@@ -3751,6 +3783,10 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/move-user-confirm-dialog/move-user-confirm-dialog.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html</context>
           <context context-type="linenumber">4</context>
         </context-group>
         <context-group purpose="location">
@@ -6746,8 +6782,8 @@
           <context context-type="linenumber">9</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2ac78802200564a04e42b0c60d0283d32e04060e" datatype="html">
-        <source>This run has ended. Please talk to your teacher.</source>
+      <trans-unit id="89ee531cf4e4888dc082f0f36383ea22c5c47150" datatype="html">
+        <source>This unit has ended. Please talk to your teacher.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/student/add-project-dialog/add-project-dialog.component.html</context>
           <context context-type="linenumber">10</context>
@@ -7343,6 +7379,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/remove-user-confirm-dialog/remove-user-confirm-dialog.component.html</context>
           <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html</context>
+          <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
       <trans-unit id="76de164da3c441addbf9b14950150aa869b00fdb" datatype="html">
@@ -8506,6 +8546,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-period/manage-period.component.html</context>
           <context context-type="linenumber">7</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="fb9afd2d75a06297a21925ee9cb13cf36939fee9" datatype="html">
         <source> Students: <x id="INTERPOLATION" equiv-text="{{students.size}}"/> | Teams: <x id="INTERPOLATION_1" equiv-text="{{teams.size}}"/> </source>
@@ -8682,6 +8726,62 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="2b077437ecbac737ec20e69f17994e9cb36386f5" datatype="html">
+        <source>Groupings for <x id="INTERPOLATION" equiv-text="{{ componentLabel }}"/> in <x id="INTERPOLATION_1" equiv-text="{{ stepNumber }}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="aa8af53ef82a759864d7bd58f34de5e10f6a7512" datatype="html">
+        <source>Group <x id="INTERPOLATION" equiv-text="{{ grouping.id }}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-grouping/peer-group-grouping.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="576d9eeef35c7fb080960cd6a5b1ef4b52ba70e2" datatype="html">
+        <source>Move Workgroup</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="373efcb82d51c1016a0fd2dc9ee08b7d88210f14" datatype="html">
+        <source>Warning: Moving a workroup from a Peer Group will result in the workgroup losing all the messages they sent in that Peer Group.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="a15e8715cee1b6a8d8babc57aa55f2e67fb16c2f" datatype="html">
+        <source>Are you sure you want to move this workgroup?</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="f5107331eb9fdd387751866b18c225f7a569045a" datatype="html">
+        <source>Create a new group</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="653539a38f21a5bf189859ce97c43e722585bcc9" datatype="html">
+        <source>New Group</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="812b7bcda82fdeaf9364e3b6a6c90c8330148ee2" datatype="html">
+        <source>Unassigned Workgroups</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="4fc1ce64a0242febe825d1737eb8b0da1f5c3865" datatype="html">
         <source>All Periods</source>
         <context-group purpose="location">
@@ -8742,21 +8842,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Show more</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/view-component-revisions/view-component-revisions.component.html</context>
-          <context context-type="linenumber">142</context>
+          <context context-type="linenumber">150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="149546eb32bc1b69012afcd34945c180f0790dbf" datatype="html">
         <source> Team has not saved any work </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.html</context>
-          <context context-type="linenumber">86,87</context>
+          <context context-type="linenumber">93,94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1a68048cfcd964c630f4316c43db20f0b8e3a80d" datatype="html">
         <source>See revisions</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.html</context>
-          <context context-type="linenumber">92</context>
+          <context context-type="linenumber">99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="058b73757ea9dc14dee9cb48d52bf312fbb8ab15" datatype="html">
@@ -9655,35 +9755,35 @@ Are you ready to receive feedback on this answer?</source>
         <source> Show Amplitude Input </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.html</context>
-          <context context-type="linenumber">93,94</context>
+          <context context-type="linenumber">94,95</context>
         </context-group>
       </trans-unit>
       <trans-unit id="267799b6a3f95111ede597b3bdfac1b68ca4755e" datatype="html">
         <source> Allow Student to Edit Amplitude </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.html</context>
-          <context context-type="linenumber">102,103</context>
+          <context context-type="linenumber">103,104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="584114dd79e680cb2262384fe8fc40c40149e9b3" datatype="html">
         <source>Oscillator Width (Pixels)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.html</context>
-          <context context-type="linenumber">112</context>
+          <context context-type="linenumber">113</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dd7074cd090ce1bc8c04b82d5e86dc19e550819c" datatype="html">
         <source>Oscillator Height (Pixels)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.html</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">121</context>
         </context-group>
       </trans-unit>
       <trans-unit id="45565845bc7e8f7999ef848f155e2c7d5dbb248e" datatype="html">
         <source>Oscillator Grid Size (Pixels)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.html</context>
-          <context context-type="linenumber">128</context>
+          <context context-type="linenumber">129</context>
         </context-group>
       </trans-unit>
       <trans-unit id="69c3a88db813e4b07df0bd518f272ac529b2c3f1" datatype="html">
@@ -9823,21 +9923,21 @@ Are you ready to receive feedback on this answer?</source>
         <source>Saved</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/component-student.component.ts</context>
-          <context context-type="linenumber">566</context>
+          <context context-type="linenumber">570</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6643018309880261465" datatype="html">
         <source>Auto Saved</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/component-student.component.ts</context>
-          <context context-type="linenumber">570</context>
+          <context context-type="linenumber">574</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1612722476211621614" datatype="html">
         <source>Submitted</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/component-student.component.ts</context>
-          <context context-type="linenumber">574</context>
+          <context context-type="linenumber">578</context>
         </context-group>
       </trans-unit>
       <trans-unit id="818444ddcd112e756ab725357dcfb238b9257324" datatype="html">
@@ -10437,6 +10537,10 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.html</context>
           <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html</context>
+          <context context-type="linenumber">94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="427e92e019c34109656b0e1fc9576bfb833934d9" datatype="html">
@@ -13114,6 +13218,229 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">7</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="758cc560477368488b8af4c8b702581f881fbed2" datatype="html">
+        <source>Show Work From Other Component (Optional)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="310b6ade177e4fb8a9f30579b05696c0122f08a6" datatype="html">
+        <source>(None)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">81</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
+          <context context-type="linenumber">79</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
+          <context context-type="linenumber">96</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="9d85a9b5d7364a651b364165c47e6ac83cfe379f" datatype="html">
+        <source>Second Prompt (Optional)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="a51bb2ce39d7715e05bc737ff1db2b630ab7c8af" datatype="html">
+        <source>Enter Second Prompt Here</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6253f75659909146431b0b8ab1e722961d05807b" datatype="html">
+        <source>Grouping Logic</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3fdcdc54529fdb3af326f6c54a49089ecb9bc4d8" datatype="html">
+        <source>Add Logic</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="59791d6eb791a78307615f26e49998e0827b686a" datatype="html">
+        <source>Grouping Logic Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="f5d6ddf23866822ce4a21612e7e4aab5b36c5b4d" datatype="html">
+        <source>Delete Logic</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">94</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1440ff5a5169f5f2b7365695c44b6dff0f2fd5ce" datatype="html">
+        <source>Threshold Count</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">102</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="a5044e2b75990016e18dbe505d6301074753feeb" datatype="html">
+        <source>Threshold Percent</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">110</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="79628c3cb5efb40551927e8a89802e3fecc8564e" datatype="html">
+        <source>Number of Workgroups Per Grouping</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">118</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="69890220efa72f501c096cd863f5f9dcf16fd321" datatype="html">
+        <source>Question Bank</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">127</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html</context>
+          <context context-type="linenumber">114</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4188ef67a196ca21d68f20405b99fb6b2f6476c7" datatype="html">
+        <source>Add Question</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">131</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="41c1492a9607184843c5c616e1fc9a177ec199e4" datatype="html">
+        <source> There are no questions in the Question Bank
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">138,139</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2fa3b16b569acf67b1d1a29e8083acc8d07b0595" datatype="html">
+        <source>Question</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">143</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="fcd136e851e5a1529bc5fe218211eba600af39bf" datatype="html">
+        <source>Move Question Up</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">152</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="a4b685e418fa98f3dd90c323d8d1d8d2ddb14cb4" datatype="html">
+        <source>Move Question Down</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">161</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6253ef6a810d57c9c0e00a10cff0cc989117d199" datatype="html">
+        <source>Delete Question</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html</context>
+          <context context-type="linenumber">169</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="378433084725731138" datatype="html">
+        <source>You are not allowed to delete this Grouping Logic because you must have at least one.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.ts</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7573168323775479211" datatype="html">
+        <source>Are you sure you want to delete this Grouping Logic?</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.ts</context>
+          <context context-type="linenumber">108</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2774207815872923451" datatype="html">
+        <source>Are you sure you want to delete this question?</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.ts</context>
+          <context context-type="linenumber">143</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="28094f38aac43d3cb6edaf98a281fe443a930b5e" datatype="html">
+        <source>Me</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-message/peer-chat-message.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-message/peer-chat-message.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="25425e789276c52c975ffa09b25adcf5c676cdf7" datatype="html">
+        <source>Classmate</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-message/peer-chat-message.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-message/peer-chat-message.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="fb434e8704b01261704a26366692bd957c172b20" datatype="html">
+        <source> Peer Chat Not Available Yet </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html</context>
+          <context context-type="linenumber">78,79</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="a93bfb3e1753bcd8f4eafa16a3c77f0b15826372" datatype="html">
+        <source> Send </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html</context>
+          <context context-type="linenumber">107,108</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6310961320545154131" datatype="html">
+        <source>Peer Chat</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peerChatService.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="b7476b3f8bc67f93405690b807d8751371cdf7ed" datatype="html">
         <source> Choose the step and component to show the summary data for:
 </source>
@@ -13666,17 +13993,6 @@ If this problem continues, let your teacher know and move on to the next activit
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
           <context context-type="linenumber">71</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="310b6ade177e4fb8a9f30579b05696c0122f08a6" datatype="html">
-        <source>(None)</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">79</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">96</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a3e2cbd23a21040a6893d669847148041dd03868" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -280,7 +280,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html</context>
-          <context context-type="linenumber">13</context>
+          <context context-type="linenumber">14</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/view-component-revisions/view-component-revisions.component.html</context>
@@ -6782,8 +6782,8 @@
           <context context-type="linenumber">9</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="89ee531cf4e4888dc082f0f36383ea22c5c47150" datatype="html">
-        <source>This unit has ended. Please talk to your teacher.</source>
+      <trans-unit id="2ac78802200564a04e42b0c60d0283d32e04060e" datatype="html">
+        <source>This run has ended. Please talk to your teacher.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/student/add-project-dialog/add-project-dialog.component.html</context>
           <context context-type="linenumber">10</context>
@@ -8733,6 +8733,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">2</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="a12ba7f20727963eb3398b38f332f111c511eee4" datatype="html">
+        <source>Tip: Drag students to change groups for this activity.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="aa8af53ef82a759864d7bd58f34de5e10f6a7512" datatype="html">
         <source>Group <x id="INTERPOLATION" equiv-text="{{ grouping.id }}"/></source>
         <context-group purpose="location">
@@ -8775,11 +8782,18 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="812b7bcda82fdeaf9364e3b6a6c90c8330148ee2" datatype="html">
-        <source>Unassigned Workgroups</source>
+      <trans-unit id="516cc085017fb40ff72a02bff7ec36d346532472" datatype="html">
+        <source>Teams Without a Group</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-unassigned-workgroups/peer-group-unassigned-workgroups.component.html</context>
           <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1d97c888b0e2c614e58b7f85781b43976e021529" datatype="html">
+        <source>(Team <x id="INTERPOLATION" equiv-text="{{ workgroup.workgroupId }}"/>)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.html</context>
+          <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4fc1ce64a0242febe825d1737eb8b0da1f5c3865" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -437,7 +437,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html</context>
-          <context context-type="linenumber">13</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html</context>
+          <context context-type="linenumber">17</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.html</context>
@@ -7382,7 +7386,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html</context>
-          <context context-type="linenumber">14</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html</context>
+          <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="76de164da3c441addbf9b14950150aa869b00fdb" datatype="html">
@@ -8747,25 +8755,25 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="576d9eeef35c7fb080960cd6a5b1ef4b52ba70e2" datatype="html">
-        <source>Move Workgroup</source>
+      <trans-unit id="68dd47f9321c42011c95481d3a55b20c600014d5" datatype="html">
+        <source>Change Grouping</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html</context>
           <context context-type="linenumber">2</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="373efcb82d51c1016a0fd2dc9ee08b7d88210f14" datatype="html">
-        <source>Warning: Moving a workroup from a Peer Group will result in the workgroup losing all the messages they sent in that Peer Group.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html</context>
-          <context context-type="linenumber">8</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="a15e8715cee1b6a8d8babc57aa55f2e67fb16c2f" datatype="html">
-        <source>Are you sure you want to move this workgroup?</source>
+      <trans-unit id="83c23c9ae2e0107b7ea0c664eefd413f8186104a" datatype="html">
+        <source>Warning: If you remove students from a Peer Group, they will no longer see any contributions they made to that group.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html</context>
           <context context-type="linenumber">9</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5b91a52468ba60dd4b2a46076827d8ae5c62aea0" datatype="html">
+        <source>Are you sure you want to move this team?</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-move-workgroup-confirm-dialog/peer-group-move-workgroup-confirm-dialog.component.html</context>
+          <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f5107331eb9fdd387751866b18c225f7a569045a" datatype="html">


### PR DESCRIPTION
1. Log in as a teacher and open the Classroom Monitor for a run that contains a Peer Chat component
2. Go to the Grade By Step view for the step that contains the Peer Chat component
3. Click the "Peer Group" button near the top of the step to open the Peer Group view
4. The Groups in this view are mocked using the existing workgroups in the run. Nothing has been hooked up with the backend so nothing will save.
5. Test out moving the workgroups around
6. Test out creating a new group
7. Test out changing periods

Some questions
Should we allow the teacher to create groups across periods in the the All Periods view?
What are we going to show in the [Peer Chat activity details](https://balsamiq.cloud/s8brvqj/p9j1not/r2370) popup in the upper right?

Closes #407