### PR TITLE
feat(Peer Chat): Add manual grouping option to Peer Chat authoring

### DIFF
--- a/src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html
@@ -61,7 +61,7 @@
       </mat-option>
     </mat-select>
   </mat-form-field>
-  <ng-container *ngIf="singleLogic.name !== 'random'">
+  <ng-container *ngIf="singleLogic.name !== 'random' && singleLogic.name !== 'manual'">
     <mat-form-field>
       <mat-label i18n>Step</mat-label>
       <mat-select [(ngModel)]="singleLogic.nodeId"

--- a/src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.spec.ts
@@ -1,8 +1,15 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { Observable, Subject } from 'rxjs';
+import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-component-prompt/edit-component-prompt.component';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
@@ -39,14 +46,24 @@ const componentContent = {
   secondPrompt: 'Discuss. Use the Question Bank.'
 };
 
-describe('PeerChatAuthoringComponent', () => {
+fdescribe('PeerChatAuthoringComponent', () => {
   let component: PeerChatAuthoringComponent;
   let fixture: ComponentFixture<PeerChatAuthoringComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
-      declarations: [PeerChatAuthoringComponent],
+      imports: [
+        BrowserAnimationsModule,
+        FormsModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        MatFormFieldModule,
+        MatIconModule,
+        MatInputModule,
+        MatSelectModule,
+        UpgradeModule
+      ],
+      declarations: [EditComponentPrompt, PeerChatAuthoringComponent],
       providers: [
         ConfigService,
         { provide: NodeService, useClass: MockNodeService },
@@ -79,7 +96,63 @@ describe('PeerChatAuthoringComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+  function addLogic() {
+    it('should add grouping logic', () => {
+      const logic = component.authoringComponentContent.logic;
+      expect(logic.length).toEqual(1);
+      component.addLogic();
+      expect(logic.length).toEqual(2);
+    });
+  }
+
+  function deleteLogic() {
+    it('should not delete grouping logic when there is only one', () => {
+      const logic = component.authoringComponentContent.logic;
+      expect(logic.length).toEqual(1);
+      const alertSpy = spyOn(window, 'alert');
+      component.deleteLogic(0);
+      expect(alertSpy).toHaveBeenCalled();
+      expect(logic.length).toEqual(1);
+    });
+
+    it('should ask to delete grouping logic when there is more than one', () => {
+      const logic = component.authoringComponentContent.logic;
+      logic.push({ name: 'random' });
+      const confirmSpy = spyOn(window, 'confirm').and.returnValue(true);
+      expect(logic.length).toEqual(2);
+      component.deleteLogic(0);
+      expect(confirmSpy).toHaveBeenCalled();
+      expect(logic.length).toEqual(1);
+    });
+  }
+
+  function logicNameChanged() {
+    it('should change logic name to random', () => {
+      shouldChangeLogicNameWithNoNodeIdComponentId('random');
+    });
+
+    it('should change logic name to manual', () => {
+      shouldChangeLogicNameWithNoNodeIdComponentId('manual');
+    });
+  }
+
+  function shouldChangeLogicNameWithNoNodeIdComponentId(logicName: string): void {
+    const logicObject = component.authoringComponentContent.logic[0];
+    expectLogicName(component.authoringComponentContent.logic[0], 'maximizeSimilarIdeas');
+    expect(logicObject.nodeId).not.toBeNull();
+    expect(logicObject.componentId).not.toBeNull();
+    logicObject.name = logicName;
+    component.logicNameChanged(logicObject);
+    expectLogicName(component.authoringComponentContent.logic[0], logicName);
+    expect(logicObject.nodeId).toBeUndefined();
+    expect(logicObject.componentId).toBeUndefined();
+  }
+
+  function expectLogicName(logicObject: any, expectedName: string): void {
+    expect(logicObject.name).toEqual(expectedName);
+  }
+
+  addLogic();
+  deleteLogic();
+  logicNameChanged();
 });

--- a/src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.ts
@@ -37,6 +37,10 @@ export class PeerChatAuthoringComponent extends ComponentAuthoring {
     {
       value: 'maximizeDifferentIdeas',
       text: 'Maximize Different Ideas'
+    },
+    {
+      value: 'manual',
+      text: 'Manual'
     }
   ];
   nodeIds: string[];
@@ -112,7 +116,7 @@ export class PeerChatAuthoringComponent extends ComponentAuthoring {
   }
 
   logicNameChanged(logicObject: any): void {
-    if (logicObject.name === 'random') {
+    if (logicObject.name === 'random' || logicObject.name === 'manual') {
       delete logicObject.nodeId;
       delete logicObject.componentId;
     }


### PR DESCRIPTION
Test that you can change the Grouping Logic Name to "Manual" in Peer Chat authoring. Also make sure the nodeId and componentId fields are removed when changing to "Manual" logic.

```
{
    "id": "kngbwfopsa",
    "type": "PeerChat",
    "logic": [
        {
            "name": "maximizeDifferentIdeas",
            "nodeId": "node34",
            "componentId": "hfn1ev33cv"
        }
    ],
}
```

```
{
    "id": "kngbwfopsa",
    "type": "PeerChat",
    "logic": [
        {
            "name": "manual"
        }
    ],
}
```
Closes #424