### PR TITLE
feat(Peer Group): Allow teacher to move workgroup to unassigned

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.spec.ts
@@ -97,6 +97,9 @@ describe('PeerGroupPeriodComponent', () => {
     spyOn(TestBed.inject(PeerGroupService), 'moveWorkgroupToGroup').and.callFake(() => {
       return of({});
     });
+    spyOn(TestBed.inject(PeerGroupService), 'removeWorkgroupFromGroup').and.callFake(() => {
+      return of({});
+    });
     spyOn(TestBed.inject(ConfigService), 'getDisplayUsernamesByWorkgroupId').and.callFake(() => {
       return 'Student Name Here';
     });

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.ts
@@ -13,6 +13,8 @@ export class PeerGroupPeriodComponent implements OnInit {
   @Input() nodeId: string;
   @Input() period: any;
 
+  UNASSIGNED_GROUP_ID = 0;
+
   groupings: any[] = [];
   nextAvailableGroupId: number = 1;
   unassignedWorkgroups: any[] = [];
@@ -84,12 +86,27 @@ export class PeerGroupPeriodComponent implements OnInit {
 
   moveWorkgroup(event: any): Subscription {
     const workgroupId = event.item.data;
-    const previousLocation = event.previousContainer.data.id;
-    const newLocation = event.container.data.id;
-    return this.PeerGroupService.moveWorkgroupToGroup(workgroupId, newLocation).subscribe(
-      (workgroup) => {
-        this.removeWorkgroup(workgroupId, previousLocation);
-        this.addWorkgroupToGroup(workgroupId, newLocation);
+    const previousGroupId = event.previousContainer.data.id;
+    const newGroupId = event.container.data.id;
+    if (this.isUnassignedGroupId(newGroupId)) {
+      return this.removeWorkgroupFromGroupRequest(workgroupId, previousGroupId, newGroupId);
+    } else {
+      return this.moveWorkgroupToGroupRequest(workgroupId, previousGroupId, newGroupId);
+    }
+  }
+
+  isUnassignedGroupId(groupId: number): boolean {
+    return groupId === this.UNASSIGNED_GROUP_ID;
+  }
+
+  removeWorkgroupFromGroupRequest(
+    workgroupId: number,
+    previousGroupId: number,
+    newGroupId: number
+  ): Subscription {
+    return this.PeerGroupService.removeWorkgroupFromGroup(workgroupId, previousGroupId).subscribe(
+      () => {
+        this.moveWorkgroupSuccess(workgroupId, previousGroupId, newGroupId);
       },
       () => {
         // TODO
@@ -97,11 +114,31 @@ export class PeerGroupPeriodComponent implements OnInit {
     );
   }
 
-  removeWorkgroup(workgroupId: number, location: number): void {
-    if (location === 0) {
+  moveWorkgroupToGroupRequest(
+    workgroupId: number,
+    previousGroupId: number,
+    newGroupId: number
+  ): Subscription {
+    return this.PeerGroupService.moveWorkgroupToGroup(workgroupId, newGroupId).subscribe(
+      () => {
+        this.moveWorkgroupSuccess(workgroupId, previousGroupId, newGroupId);
+      },
+      () => {
+        // TODO
+      }
+    );
+  }
+
+  moveWorkgroupSuccess(workgroupId: number, previousGroupId: number, newGroupId: number): void {
+    this.removeWorkgroup(workgroupId, previousGroupId);
+    this.addWorkgroupToGroup(workgroupId, newGroupId);
+  }
+
+  removeWorkgroup(workgroupId: number, groupId: number): void {
+    if (this.isUnassignedGroupId(groupId)) {
       this.removeWorkgroupFromUnassigned(workgroupId);
     } else {
-      this.removeWorkgroupFromGroup(workgroupId, location);
+      this.removeWorkgroupFromGroup(workgroupId, groupId);
     }
   }
 
@@ -114,9 +151,9 @@ export class PeerGroupPeriodComponent implements OnInit {
     }
   }
 
-  removeWorkgroupFromGroup(workgroupId: number, location: number): void {
+  removeWorkgroupFromGroup(workgroupId: number, groupId: number): void {
     for (const group of this.groupings) {
-      if (group.id === location) {
+      if (group.id === groupId) {
         for (let w = 0; w < group.members.length; w++) {
           if (group.members[w].id === workgroupId) {
             group.members.splice(w, 1);
@@ -127,12 +164,12 @@ export class PeerGroupPeriodComponent implements OnInit {
     }
   }
 
-  addWorkgroupToGroup(workgroupId: number, location: number): void {
+  addWorkgroupToGroup(workgroupId: number, groupId: number): void {
     const member = { id: workgroupId, periodId: this.period.periodId };
-    if (location === 0) {
+    if (this.isUnassignedGroupId(groupId)) {
       this.unassignedWorkgroups.push(member);
     } else {
-      const group = this.getGroup(location);
+      const group = this.getGroup(groupId);
       group.members.push(member);
     }
   }

--- a/src/assets/wise5/services/peerGroupService.ts
+++ b/src/assets/wise5/services/peerGroupService.ts
@@ -36,4 +36,8 @@ export class PeerGroupService {
   moveWorkgroupToGroup(workgroupId: number, groupId: number): Observable<any> {
     return this.http.post(`/api/peer-group/membership/add/${groupId}/${workgroupId}`, {});
   }
+
+  removeWorkgroupFromGroup(workgroupId: number, groupId: number): Observable<any> {
+    return this.http.delete(`/api/peer-group/membership/${groupId}/${workgroupId}`);
+  }
 }


### PR DESCRIPTION
In the teacher Peer Group view, make sure the teacher can move a workgroup out of a Peer Group and into unassigned.

Closes #428