### PR TITLE
fix(Graph): Allow authoring connected component show classmate work

### DIFF
--- a/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.html
+++ b/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.html
@@ -162,9 +162,37 @@
   <edit-component-add-to-notebook-button [authoringComponentContent]="authoringComponentContent">
   </edit-component-add-to-notebook-button>
 </div>
-<edit-common-advanced
+<edit-component-save-button [authoringComponentContent]="authoringComponentContent">
+</edit-component-save-button>
+<br/>
+<edit-component-submit-button [authoringComponentContent]="authoringComponentContent">
+</edit-component-submit-button>
+<edit-component-max-submit
+    *ngIf="authoringComponentContent.showSubmitButton"
+    [(maxSubmitCount)]="authoringComponentContent.maxSubmitCount"
+    (maxSubmitCountChange)="maxSubmitCountChanged($event)">
+</edit-component-max-submit>
+<edit-component-default-feedback
+    [authoringComponentContent]="authoringComponentContent">
+</edit-component-default-feedback>
+<div fxLayout="column" fxLayoutAlign="start start">
+  <edit-component-max-score [authoringComponentContent]="authoringComponentContent">
+  </edit-component-max-score>
+  <edit-component-exclude-from-total-score [authoringComponentContent]="authoringComponentContent">
+  </edit-component-exclude-from-total-score>
+  <edit-component-width [authoringComponentContent]="authoringComponentContent">
+  </edit-component-width>
+  <edit-component-rubric [authoringComponentContent]="authoringComponentContent">
+  </edit-component-rubric>
+  <edit-component-tags [authoringComponentContent]="authoringComponentContent">
+  </edit-component-tags>
+</div>
+<edit-graph-connected-components
     [nodeId]="nodeId"
     [componentId]="componentId"
     [allowedConnectedComponentTypes]="allowedConnectedComponentTypes"
-    [authoringComponentContent]="authoringComponentContent">
-</edit-common-advanced>
+    [componentContent]="authoringComponentContent"
+    [connectedComponents]="authoringComponentContent.connectedComponents"
+    (connectedComponentsChanged)="connectedComponentsChanged($event)">
+</edit-graph-connected-components>
+<edit-component-json [nodeId]="nodeId" [componentId]="componentId"></edit-component-json>


### PR DESCRIPTION
1. Log in as a teacher
2. Launch a run unit in the Authoring Tool
3. Create a Graph component (if you already have one you don't need to create a new one). I will refer to this as component1.
4. Create a new Graph component in a different step. I will refer to this as component2.
5. Go to the advanced view for component2.
6. Add a Connected Component and make it point to component1.
7. Set the "Type" to "Show Classmate Work".
8. Set the "Show Classmate Work Source" to "Period".
9. Create a new Graph component in a different step. I will refer to this as component3.
10. Go to the advanced view for component3.
11. Add a Connected Component and make it point to component1.
12. Set the "Type" to "Show Classmate Work".
13. Set the "Show Classmate Work Source" to "Class".
14. Test out the Graph components as a real student and make sure component2 and component3 properly show the correct classmate work.

Closes #436