### PR TITLE
feat(Error Handling): Filter errors from external requests

### DIFF
--- a/src/app/http-error.interceptor.ts
+++ b/src/app/http-error.interceptor.ts
@@ -9,10 +9,11 @@ import {
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { ConfigService } from './services/config.service';
 
 @Injectable()
 export class HttpErrorInterceptor implements HttpInterceptor {
-  constructor(public snackBar: MatSnackBar) {}
+  constructor(protected configService: ConfigService, public snackBar: MatSnackBar) {}
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(request).pipe(
@@ -29,11 +30,26 @@ export class HttpErrorInterceptor implements HttpInterceptor {
         }
 
         if (err.status >= 500 || err.status === 0) {
-          this.snackBar.open($localize`An error occurred. Please refresh this page and try again.`);
+          this.processError(err);
         }
-
         return throwError(err);
       })
     );
+  }
+
+  processError(err: HttpErrorResponse): void {
+    try {
+      const requestUrl = new URL(err.url);
+      if (requestUrl.origin === this.configService.getWISEHostname()) {
+        this.showError();
+      }
+    } catch (e) {
+      // request was from a relative (or invalid) URL
+      this.showError();
+    }
+  }
+
+  showError() {
+    this.snackBar.open($localize`An error occurred. Please refresh this page and try again.`);
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -4331,21 +4331,21 @@
         <source>An error occurred: </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/http-error.interceptor.ts</context>
-          <context context-type="linenumber">22</context>
+          <context context-type="linenumber">23</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8903463267282596576" datatype="html">
         <source>Backend returned code <x id="status" equiv-text="err.status"/>, body was: <x id="error" equiv-text="err.error"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/http-error.interceptor.ts</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6272363620327622591" datatype="html">
         <source>An error occurred. Please refresh this page and try again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/http-error.interceptor.ts</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="050473ed2d269f07090850ebf8f56f635436869e" datatype="html">


### PR DESCRIPTION
## Changes
Don't show toast message when external request results in an HttpError.

Closes #437.

## Test
Verify that generic toast message is shown for HttpErrors from internal requests but not for external requests like `https://wise-discuss.berkeley.edu/...`.