### PR TITLE
refactor(OpenResponse): Remove mode=student checks

### DIFF
--- a/src/assets/wise5/authoringTool/components/preview-component/previewComponent.ts
+++ b/src/assets/wise5/authoringTool/components/preview-component/previewComponent.ts
@@ -107,8 +107,7 @@ class PreviewComponentController {
           </multiple-choice-student>
           <open-response-student ng-switch-when="OpenResponse"
               [node-id]="nodeId"
-              [component-content]="componentContent"
-              [mode]="mode">
+              [component-content]="componentContent">
           </open-response-student>
           <outside-url-student ng-switch-when="OutsideURL"
               [node-id]="nodeId"

--- a/src/assets/wise5/components/component/component.component.html
+++ b/src/assets/wise5/components/component/component.component.html
@@ -85,8 +85,7 @@
       [nodeId]="nodeId"
       [componentContent]="componentContent"
       [componentState]="componentState"
-      [workgroupId]="workgroupId"
-      mode="student">
+      [workgroupId]="workgroupId">
   </open-response-student>
   <outside-url-student *ngSwitchCase="'OutsideURL'"
       [nodeId]="nodeId"

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.html
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.html
@@ -118,7 +118,6 @@
     (submitButtonClicked)="submitButtonClicked($event)">
 </component-save-submit-buttons>
 <component-annotations
-    *ngIf="mode === 'student'"
     [annotations]="latestAnnotations"
     [maxScore]="componentContent.maxScore"
     [nodeId]="nodeId"

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
@@ -64,55 +64,33 @@ export class OpenResponseStudent extends ComponentStudent {
   ngOnInit(): void {
     super.ngOnInit();
 
-    if (this.mode === 'student') {
-      this.isSaveButtonVisible = this.componentContent.showSaveButton;
-      this.isSubmitButtonVisible = this.componentContent.showSubmitButton;
-    } else if (this.mode === 'showPreviousWork') {
-      this.isSaveButtonVisible = false;
-      this.isSubmitButtonVisible = false;
-      this.isDisabled = true;
-    }
-
-    if (this.mode == 'student') {
-      if (this.UtilService.hasShowWorkConnectedComponent(this.componentContent)) {
-        // we will show work from another component
-        this.handleConnectedComponents();
-      } else if (
-        this.componentState != null &&
-        this.OpenResponseService.componentStateHasStudentWork(
-          this.componentState,
-          this.componentContent
-        )
-      ) {
-        /*
-         * the student has work so we will populate the work into this
-         * component
-         */
-        this.setStudentWork(this.componentState);
-      } else if (this.UtilService.hasConnectedComponent(this.componentContent)) {
-        // we will import work from another component
-        this.handleConnectedComponents();
-      } else if (this.componentState == null) {
-        // check if we need to import work
-
-        if (this.UtilService.hasConnectedComponent(this.componentContent)) {
-          /*
-           * the student does not have any work and there are connected
-           * components so we will get the work from the connected
-           * components
-           */
-          this.handleConnectedComponents();
-        } else if (this.componentContent.starterSentence != null) {
-          /*
-           * the student has not done any work and there is a starter sentence
-           * so we will populate the textarea with the starter sentence
-           */
-          this.studentResponse = this.componentContent.starterSentence;
-        }
-      }
-    } else {
-      // populate the student work into this component
+    if (this.UtilService.hasShowWorkConnectedComponent(this.componentContent)) {
+      this.handleConnectedComponents();
+    } else if (
+      this.componentState != null &&
+      this.OpenResponseService.componentStateHasStudentWork(
+        this.componentState,
+        this.componentContent
+      )
+    ) {
       this.setStudentWork(this.componentState);
+    } else if (this.UtilService.hasConnectedComponent(this.componentContent)) {
+      this.handleConnectedComponents();
+    } else if (this.componentState == null) {
+      if (this.UtilService.hasConnectedComponent(this.componentContent)) {
+        /*
+         * the student does not have any work and there are connected
+         * components so we will get the work from the connected
+         * components
+         */
+        this.handleConnectedComponents();
+      } else if (this.componentContent.starterSentence != null) {
+        /*
+         * the student has not done any work and there is a starter sentence
+         * so we will populate the textarea with the starter sentence
+         */
+        this.studentResponse = this.componentContent.starterSentence;
+      }
     }
 
     if (this.hasMaxSubmitCountAndUsedAllSubmits()) {
@@ -500,18 +478,6 @@ export class OpenResponseStudent extends ComponentStudent {
 
     componentState.annotations = [autoScoreAnnotation];
 
-    if (this.mode === 'authoring') {
-      if (this.latestAnnotations == null) {
-        this.latestAnnotations = {};
-      }
-
-      /*
-       * we are in the authoring view so we will set the
-       * latest score annotation manually
-       */
-      this.latestAnnotations.score = autoScoreAnnotation;
-    }
-
     let autoComment = null;
     const submitCounter = this.submitCounter;
 
@@ -548,18 +514,6 @@ export class OpenResponseStudent extends ComponentStudent {
         }
       }
       componentState.annotations.push(autoCommentAnnotation);
-
-      if (this.mode === 'authoring') {
-        if (this.latestAnnotations == null) {
-          this.latestAnnotations = {};
-        }
-
-        /*
-         * we are in the authoring view so we will set the
-         * latest comment annotation manually
-         */
-        this.latestAnnotations.comment = autoCommentAnnotation;
-      }
     }
     if (
       this.componentContent.enableNotifications &&

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10514,11 +10514,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">206</context>
+          <context context-type="linenumber">184</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">222</context>
+          <context context-type="linenumber">200</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4965414112249568013" datatype="html">
@@ -11117,7 +11117,7 @@ Are you ready to receive feedback on this answer?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">209</context>
+          <context context-type="linenumber">187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8429316238784832901" datatype="html">
@@ -13950,7 +13950,7 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">213</context>
+          <context context-type="linenumber">191</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7482125205220618294" datatype="html">
@@ -13959,7 +13959,7 @@ Are you ready to receive feedback on this answer?</source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">225</context>
+          <context context-type="linenumber">203</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6316287012266891697" datatype="html">
@@ -13968,21 +13968,21 @@ Are you ready to receive feedback on this answer?</source>
 Are you ready to submit this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">229</context>
+          <context context-type="linenumber">207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8936495196157450285" datatype="html">
         <source>We are scoring your work...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">373</context>
+          <context context-type="linenumber">351</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2283191014272031538" datatype="html">
         <source>Please Wait</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">375</context>
+          <context context-type="linenumber">353</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8785209093929133444" datatype="html">
@@ -13990,21 +13990,21 @@ Are you ready to submit this answer?</source>
 If this problem continues, let your teacher know and move on to the next activity. Your work will still be saved.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">396</context>
+          <context context-type="linenumber">374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5445965000497851580" datatype="html">
         <source>This will replace your existing recording. Is this OK?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">820</context>
+          <context context-type="linenumber">774</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8057349329324626950" datatype="html">
         <source>Are you sure you want to delete your recording?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">864</context>
+          <context context-type="linenumber">818</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2e0e07912515c250498d28841610709033392606" datatype="html">


### PR DESCRIPTION
## Changes
- Removed mode=student input and tests in open-response-student component because they're redundant. I think this is remnants from the time when a the teacher and student views shared the same component code. Now that we have separated out into -student, -grading, -authoring components, we shouldn't need to do these checks anymore.

## Test 
- OpenResponse component works as before
   - show work
   - import work
   - authoring
   - authoring preview
   - grading

Closes #462