### PR TITLE
feat(Show Group Work): Add side-by-side layout option

### DIFF
--- a/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.html
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.html
@@ -40,3 +40,29 @@
     Show My Work
   </mat-checkbox>
 </div>
+<div class="layout-select"
+    fxLayout.xs="column"
+    fxLayout.gt-xs="row wrap"
+    fxLayoutAlign.gt-xs="start center"
+    fxLayoutGap="12px">
+  <label id="layout-select-label" i18n>Layout:</label>
+  <mat-radio-group [(ngModel)]="authoringComponentContent.layout"
+      (ngModelChange)="componentChanged()"
+      ngDefaultControl
+      color="primary"
+      aria-label-i18n
+      aria-label="Select a layout option"
+      aria-labelledby="layout-select-label"
+      fxLayoutGap="12px">
+    <mat-radio-button value="column">
+      <span fxLayoutAlign="start center">
+        <mat-icon>table_rows</mat-icon>&nbsp;<span i18n>Stacked Vertically</span>
+      </span>
+    </mat-radio-button>
+    <mat-radio-button value="row">
+      <span fxLayoutAlign="start center">
+        <mat-icon>view_columns</mat-icon>&nbsp;<span i18n>Side-by-Side</span>
+      </span>
+    </mat-radio-button>
+  </mat-radio-group>
+</div>

--- a/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.scss
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.scss
@@ -1,0 +1,3 @@
+.layout-select {
+  margin: 8px 0 16px;
+}

--- a/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.ts
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.ts
@@ -19,12 +19,4 @@ export class ShowGroupWorkAuthoringComponent extends ShowMyWorkAuthoringComponen
   ) {
     super(configService, nodeService, projectAssetService, projectService);
   }
-
-  ngOnInit(): void {
-    super.ngOnInit();
-
-    if (!this.authoringComponentContent.hasOwnProperty('layout')) {
-      this.authoringComponentContent.layout = 'column';
-    }
-  }
 }

--- a/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.ts
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.ts
@@ -22,5 +22,9 @@ export class ShowGroupWorkAuthoringComponent extends ShowMyWorkAuthoringComponen
 
   ngOnInit(): void {
     super.ngOnInit();
+
+    if (!this.authoringComponentContent.hasOwnProperty('layout')) {
+      this.authoringComponentContent.layout = 'column';
+    }
   }
 }

--- a/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.html
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.html
@@ -1,18 +1,23 @@
 <component-header [componentContent]="componentContent"></component-header>
-<div fxLayout="column" fxLayoutGap="16px">
-  <mat-card *ngFor="let studentWork of studentWorkFromGroupMembers" class="mat-elevation-z0 notice-bg-bg">
-    <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
-      <mat-icon class="mat-30" [ngStyle]="{'color': workgroupInfos[studentWork.workgroupId].avatarColor}">
-        account_circle
-      </mat-icon>
-      <span class="mat-body-2">{{ workgroupInfos[studentWork.workgroupId].displayNames }}</span>
-    </div>
-    <mat-card-content class="app-bg-bg">
-      <span class="text-secondary" *ngIf="studentWork == null" i18n>(No response)</span>
-      <show-work-student [studentWork]="studentWork"
-        [componentContent]="showWorkComponentContent"
-        [nodeId]="showWorkNodeId">
-      </show-work-student>
-    </mat-card-content>
-  </mat-card>
+<div [fxLayout]="flexLayout">
+  <div *ngFor="let studentWork of studentWorkFromGroupMembers"
+      fxFlex="100"
+      [fxFlex.gt-sm]="widthMd"
+      [fxFlex.gt-md]="widthLg">
+    <mat-card class="mat-elevation-z0 notice-bg-bg">
+      <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
+        <mat-icon class="mat-30" [ngStyle]="{'color': workgroupInfos[studentWork.workgroupId].avatarColor}">
+          account_circle
+        </mat-icon>
+        <span class="mat-body-2">{{ workgroupInfos[studentWork.workgroupId].displayNames }}</span>
+      </div>
+      <mat-card-content class="app-bg-bg">
+        <span class="text-secondary" *ngIf="studentWork == null" i18n>(No response)</span>
+        <show-work-student [studentWork]="studentWork"
+            [componentContent]="showWorkComponentContent"
+            [nodeId]="showWorkNodeId">
+        </show-work-student>
+      </mat-card-content>
+    </mat-card>
+  </div>
 </div>

--- a/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.scss
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.scss
@@ -1,10 +1,11 @@
 @import '~style/abstracts/variables';
 
 .mat-card {
+  margin: 4px;
   padding: 8px;
 }
 
-mat-card-content {
+.mat-card-content {
   margin-top: 8px;
   padding: 8px;
   border-radius: $button-border-radius;

--- a/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.ts
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.ts
@@ -18,9 +18,14 @@ import { ComponentService } from '../../componentService';
   styleUrls: ['./show-group-work-student.component.scss']
 })
 export class ShowGroupWorkStudentComponent extends ComponentStudent {
+  flexLayout: string = 'column';
+  narrowComponentTypes: string[] = ['MultipleChoice', 'OpenResponse'];
+  numWorkgroups: number;
   showWorkComponentContent: any;
   showWorkNodeId: string;
   studentWorkFromGroupMembers: any[];
+  widthLg: number = 100;
+  widthMd: number = 100;
   workgroupInfos: any = {};
 
   constructor(
@@ -84,7 +89,9 @@ export class ShowGroupWorkStudentComponent extends ComponentStudent {
         studentWorkFromGroupMembers
       );
     }
+    this.numWorkgroups = this.studentWorkFromGroupMembers.length;
     this.setWorkgroupInfos();
+    this.setLayout();
   }
 
   private getGroupStudentWorkNotIncludingMyWork(studentWorkFromGroupMembers: any[]): any[] {
@@ -106,5 +113,28 @@ export class ShowGroupWorkStudentComponent extends ComponentStudent {
       avatarColor: this.ConfigService.getAvatarColorForWorkgroupId(workgroupId),
       displayNames: this.ConfigService.getUsernamesStringByWorkgroupId(workgroupId)
     };
+  }
+
+  setLayout(): void {
+    if (this.componentContent.layout === 'row' && this.isNarrow()) {
+      this.flexLayout = 'row wrap';
+      this.setWidths();
+    }
+  }
+
+  isNarrow(): boolean {
+    return this.narrowComponentTypes.indexOf(this.showWorkComponentContent.type) > -1;
+  }
+
+  setWidths(): void {
+    if (this.isNarrow()) {
+      if (this.numWorkgroups > 1) {
+        this.widthMd = 50;
+        this.widthLg = 50;
+      }
+      if (this.numWorkgroups > 2) {
+        this.widthLg = 33.33;
+      }
+    }
   }
 }

--- a/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.ts
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.ts
@@ -132,6 +132,6 @@ export class ShowGroupWorkStudentComponent extends ComponentStudent {
   }
 
   isNarrow(): boolean {
-    return this.narrowComponentTypes.indexOf(this.showWorkComponentContent.type) > -1;
+    return this.narrowComponentTypes.includes(this.showWorkComponentContent.type);
   }
 }

--- a/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.ts
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.ts
@@ -116,25 +116,22 @@ export class ShowGroupWorkStudentComponent extends ComponentStudent {
   }
 
   setLayout(): void {
-    if (this.componentContent.layout === 'row' && this.isNarrow()) {
+    if (this.componentContent.layout === 'row') {
       this.flexLayout = 'row wrap';
       this.setWidths();
+    }
+  }
+  setWidths(): void {
+    if (this.numWorkgroups > 1) {
+      this.widthMd = 50;
+      this.widthLg = 50;
+    }
+    if (this.numWorkgroups > 2 && this.isNarrow()) {
+      this.widthLg = 33.33;
     }
   }
 
   isNarrow(): boolean {
     return this.narrowComponentTypes.indexOf(this.showWorkComponentContent.type) > -1;
-  }
-
-  setWidths(): void {
-    if (this.isNarrow()) {
-      if (this.numWorkgroups > 1) {
-        this.widthMd = 50;
-        this.widthLg = 50;
-      }
-      if (this.numWorkgroups > 2) {
-        this.widthLg = 33.33;
-      }
-    }
   }
 }

--- a/src/assets/wise5/components/showGroupWork/showGroupWorkService.ts
+++ b/src/assets/wise5/components/showGroupWork/showGroupWorkService.ts
@@ -23,6 +23,7 @@ export class ShowGroupWorkService extends ComponentService {
     component.showWorkComponentId = '';
     component.peerGroupActivityTag = '';
     component.isShowMyWork = true;
+    component.layout = 'column';
     return component;
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -14535,11 +14535,32 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">40,41</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="c0e23e3cdbac881ae9b97dbc68a38e649066dacb" datatype="html">
+        <source>Layout:</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3583552a7ce6df3916c7d4e18909aeef0aedc728" datatype="html">
+        <source>Stacked Vertically</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.html</context>
+          <context context-type="linenumber">59</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="eafcf772e6e9935d21a9e0f77bec0d241b252e40" datatype="html">
+        <source>Side-by-Side</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="3e4063d41615b0bdb15dd79a55e0334dabeb361f" datatype="html">
         <source>(No response)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.html</context>
-          <context context-type="linenumber">11</context>
+          <context context-type="linenumber">15</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.html</context>


### PR DESCRIPTION
## Description
- Authors can choose between display layout orientation: column (default) vs row.
- Max of 2 groups' work shown in row (side-by-side) orientation except for Open Response and Multiple Choice components, which show up to 3 work from 3 workgroups in a row on wide screens.
- Row orientation is responsive: work is 100% width on small screens, max 50% on medium screens, max 50% or 33% on large screens.

Closes #468.

## Test
- Test a ShowGroupWork component with 1, 2, and 3 workgroups in a run.
- Toggle between row and column orientation in authoring, make sure corresponding layout is reflected in student view.
- Change window width and make sure display is responsive.
- Verify that Multiple Choice and Open Response components can show up to 3 work displays in same row on large screens.