### PR TITLE
refactor(ManagePeerGroups): Use PeerGroupActivityTag

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/nodeGradingView/nodeGradingView.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/nodeGradingView/nodeGradingView.html
@@ -20,9 +20,9 @@
         <md-icon class="info"> flag </md-icon>
         <span>{{ ::'REPORT' | translate }}</span>
       </md-button>
-      <md-button ng-repeat="peerGroupComponentId in $ctrl.peerGroupComponentIds"
+      <md-button ng-repeat="peerGroupActivityTag in $ctrl.peerGroupActivityTags"
           class="md-raised info"
-          ng-click="$ctrl.showPeerGroupGroupings($ctrl.nodeId, peerGroupComponentId)">
+          ng-click="$ctrl.showPeerGroupDetails(peerGroupActivityTag)">
         <md-icon class="info">groups</md-icon>
         <span class="info">{{ ::'peerGroups' | translate }}</span>
       </md-button>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/nodeGradingView/nodeGradingView.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/nodeGradingView/nodeGradingView.ts
@@ -18,7 +18,6 @@ import { Node } from '../../../../common/Node';
 
 @Directive()
 export class NodeGradingViewController {
-  $translate: any;
   canViewStudentNames: boolean;
   hiddenComponents: any = [];
   isExpandAll: boolean;
@@ -30,7 +29,7 @@ export class NodeGradingViewController {
   nodeHasWork: boolean;
   nodeId: string;
   numRubrics: number;
-  peerGroupComponentIds: string[];
+  peerGroupActivityTags: string[];
   sortOrder: object = {
     team: ['-isVisible', 'workgroupId'],
     '-team': ['-isVisible', '-workgroupId'],
@@ -71,9 +70,7 @@ export class NodeGradingViewController {
     protected ProjectService: TeacherProjectService,
     protected StudentStatusService: StudentStatusService,
     protected TeacherDataService: TeacherDataService
-  ) {
-    this.$translate = this.$filter('translate');
-  }
+  ) {}
 
   $onInit() {
     this.maxScore = this.getMaxScore();
@@ -82,7 +79,9 @@ export class NodeGradingViewController {
     this.sort = this.TeacherDataService.nodeGradingSort;
     this.nodeContent = this.ProjectService.getNodeById(this.nodeId);
     this.milestoneReport = this.MilestoneService.getMilestoneReportByNodeId(this.nodeId);
-    this.peerGroupComponentIds = this.PeerGroupService.getPeerGroupComponentIds(this.node);
+    this.peerGroupActivityTags = Array.from(
+      this.PeerGroupService.getPeerGroupActivityTags(this.node)
+    );
     this.retrieveStudentData();
     this.subscribeToEvents();
   }
@@ -365,12 +364,8 @@ export class NodeGradingViewController {
     this.MilestoneService.showMilestoneDetails(this.milestoneReport, $event);
   }
 
-  showPeerGroupGroupings(nodeId: string, componentId: string): void {
-    this.NodeService.showPeerGroupDetails(
-      this.TeacherDataService.getCurrentPeriod().periodId,
-      nodeId,
-      componentId
-    );
+  showPeerGroupDetails(peerGroupActivityTag: string): void {
+    this.PeerGroupService.showPeerGroupDetails(peerGroupActivityTag);
   }
 }
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html
@@ -1,13 +1,12 @@
 <h2 mat-dialog-title fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="8px">
-  <span i18n>Groupings for {{ componentLabel }} in {{ stepNumber }}</span>
+  <span i18n>Groupings for {{ peerGroupActivityTag }}</span>
   <span fxFlex fxHide.xs></span>
   <select-period></select-period>
 </h2>
 <div mat-dialog-content class="dialog-content-scroll">
     <p class="info" i18n>Tip: Drag students to change groups for this activity.</p>
     <peer-group-period *ngFor="let period of periods"
-        [nodeId]="nodeId"
-        [componentId]="componentId"
+        [peerGroupActivityTag]="peerGroupActivityTag"
         [period]="period"></peer-group-period>
 </div>
 <div mat-dialog-actions fxLayoutAlign="end center">

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.spec.ts
@@ -14,7 +14,7 @@ import { StudentDataService } from '../../../../services/studentDataService';
 import { StudentStatusService } from '../../../../services/studentStatusService';
 import { TagService } from '../../../../services/tagService';
 import { TeacherDataService } from '../../../../services/teacherDataService';
-import { TeacherProjectService } from '../../../../services/teacherProjectService'; 
+import { TeacherProjectService } from '../../../../services/teacherProjectService';
 import { TeacherWebSocketService } from '../../../../services/teacherWebSocketService';
 import { UtilService } from '../../../../services/utilService';
 import { SelectPeriodComponent } from '../../select-period/select-period.component';
@@ -62,12 +62,15 @@ describe('PeerGroupDialogComponent', () => {
     fixture = TestBed.createComponent(PeerGroupDialogComponent);
     spyOn(TestBed.inject(TeacherProjectService), 'getStartNodeId').and.returnValue('node1');
     spyOn(TestBed.inject(TeacherProjectService), 'getRootNode').and.returnValue({ id: 'group0' });
+    spyOn(TestBed.inject(TeacherDataService), 'getCurrentPeriodId').and.returnValue(1);
     spyOn(TestBed.inject(TeacherDataService), 'getCurrentPeriod').and.returnValue({
       periodId: 1,
       periodName: '1'
     });
-    spyOn(TestBed.inject(TeacherDataService), 'getPeriods').and.returnValue([{ periodId: 1, periodName: '1' }, 
-        {id: 2, periodName: '2'}]);
+    spyOn(TestBed.inject(TeacherDataService), 'getPeriods').and.returnValue([
+      { periodId: 1, periodName: '1' },
+      { id: 2, periodName: '2' }
+    ]);
     spyOn(TestBed.inject(ProjectService), 'getComponentType').and.returnValue('PeerChat');
     spyOn(TestBed.inject(UtilService), 'getComponentTypeLabel').and.returnValue('Peer Chat');
     spyOn(TestBed.inject(WorkgroupService), 'getWorkgroupsInPeriod').and.returnValue(new Map());

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.ts
@@ -1,9 +1,7 @@
-import { Component, Inject, Input, OnInit } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Subscription } from 'rxjs';
-import { ProjectService } from '../../../../services/projectService';
 import { TeacherDataService } from '../../../../services/teacherDataService';
-import { UtilService } from '../../../../services/utilService';
 
 @Component({
   selector: 'peer-group-dialog',
@@ -11,42 +9,29 @@ import { UtilService } from '../../../../services/utilService';
   styleUrls: ['./peer-group-dialog.component.scss']
 })
 export class PeerGroupDialogComponent implements OnInit {
-  @Input() nodeId: string;
-  @Input() periodId: number;
-
-  componentId: string;
-  componentLabel: string;
   currentPeriodChangedSubscription: Subscription;
   periods: any[];
-  stepNumber: string;
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public data: any,
-    private ProjectService: ProjectService,
-    private TeacherDataService: TeacherDataService,
-    private UtilService: UtilService
-  ) {
-    this.componentId = data.componentId;
-    this.nodeId = data.nodeId;
-    this.periodId = data.periodId;
-  }
+    @Inject(MAT_DIALOG_DATA) public peerGroupActivityTag: string,
+    private TeacherDataService: TeacherDataService
+  ) {}
 
   ngOnInit() {
-    this.periods = this.TeacherDataService.getVisiblePeriodsById(this.periodId);
+    this.setPeriods(this.TeacherDataService.getCurrentPeriodId());
     this.subscribeToPeriodChanged();
-    this.componentLabel = this.UtilService.getComponentTypeLabel(
-      this.ProjectService.getComponentType(this.nodeId, this.componentId)
-    );
-    this.stepNumber = this.ProjectService.getNodePositionById(this.nodeId);
   }
 
   subscribeToPeriodChanged(): void {
     this.currentPeriodChangedSubscription = this.TeacherDataService.currentPeriodChanged$.subscribe(
       ({ currentPeriod }) => {
-        this.periodId = currentPeriod.periodId;
-        this.periods = this.TeacherDataService.getVisiblePeriodsById(this.periodId);
+        this.setPeriods(currentPeriod.periodId);
       }
     );
+  }
+
+  setPeriods(periodId: number): void {
+    this.periods = this.TeacherDataService.getVisiblePeriodsById(periodId);
   }
 
   ngOnDestroy() {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.ts
@@ -9,8 +9,7 @@ import { PeerGroupService } from '../../../../services/peerGroupService';
   styleUrls: ['./peer-group-period.component.scss']
 })
 export class PeerGroupPeriodComponent implements OnInit {
-  @Input() componentId: string;
-  @Input() nodeId: string;
+  @Input() peerGroupActivityTag: string;
   @Input() period: any;
 
   UNASSIGNED_GROUP_ID = 0;
@@ -25,7 +24,7 @@ export class PeerGroupPeriodComponent implements OnInit {
   ngOnInit(): void {}
 
   ngOnChanges(): void {
-    this.PeerGroupService.retrieveGroupings(this.nodeId, this.componentId).subscribe(
+    this.PeerGroupService.retrievePeerGroupInfo(this.peerGroupActivityTag).subscribe(
       ({ peerGroups, workgroupsNotInPeerGroup }) => {
         for (const peerGroup of this.getPeerGroupsInPeriod(peerGroups, this.period.periodId)) {
           this.addGrouping(peerGroup);
@@ -72,8 +71,7 @@ export class PeerGroupPeriodComponent implements OnInit {
   createNewGroup(): Subscription {
     return this.PeerGroupService.createNewGroup(
       this.period.periodId,
-      this.nodeId,
-      this.componentId
+      this.peerGroupActivityTag
     ).subscribe(
       (group) => {
         this.addGrouping(group);

--- a/src/assets/wise5/services/nodeService.ts
+++ b/src/assets/wise5/services/nodeService.ts
@@ -8,7 +8,6 @@ import { UpgradeModule } from '@angular/upgrade/static';
 import { ChooseBranchPathDialogComponent } from '../../../app/preview/modules/choose-branch-path-dialog/choose-branch-path-dialog.component';
 import { DataService } from '../../../app/services/data.service';
 import { Observable, Subject } from 'rxjs';
-import { PeerGroupDialogComponent } from '../classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component';
 
 @Injectable()
 export class NodeService {
@@ -838,17 +837,6 @@ export class NodeService {
     const subscription = this.DataService.currentNodeChanged$.subscribe(() => {
       this.scrollToComponentAndHighlight(componentId);
       subscription.unsubscribe();
-    });
-  }
-
-  showPeerGroupDetails(periodId: number, nodeId: string, componentId: string): void {
-    this.dialog.open(PeerGroupDialogComponent, {
-      data: {
-        componentId: componentId,
-        nodeId: nodeId,
-        periodId: periodId
-      },
-      panelClass: 'dialog-lg'
     });
   }
 }

--- a/src/assets/wise5/services/peerGroupService.ts
+++ b/src/assets/wise5/services/peerGroupService.ts
@@ -1,6 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 import { Observable } from 'rxjs';
+import { PeerGroupDialogComponent } from '../classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component';
 import { Node } from '../common/Node';
 import { PeerGroup } from '../components/peerChat/PeerGroup';
 import { ConfigService } from './configService';
@@ -9,18 +11,22 @@ import { ConfigService } from './configService';
 export class PeerGroupService {
   runId: number;
 
-  constructor(private ConfigService: ConfigService, private http: HttpClient) {
+  constructor(
+    private ConfigService: ConfigService,
+    private dialog: MatDialog,
+    private http: HttpClient
+  ) {
     this.runId = this.ConfigService.getRunId();
   }
 
-  getPeerGroupComponentIds(node: Node): string[] {
-    const componentIds = [];
-    for (const component of node.components) {
-      if (component.type === 'PeerChat') {
-        componentIds.push(component.id);
+  getPeerGroupActivityTags(node: Node): Set<string> {
+    const tags = new Set<string>();
+    node.components.forEach((component) => {
+      if (component.peerGroupActivityTag != null) {
+        tags.add(component.peerGroupActivityTag);
       }
-    }
-    return componentIds;
+    });
+    return tags;
   }
 
   retrievePeerGroup(peerGroupActivityTag: string): Observable<any> {
@@ -41,13 +47,13 @@ export class PeerGroupService {
     );
   }
 
-  retrieveGroupings(nodeId: string, componentId: string): Observable<any> {
-    return this.http.get(`/api/teacher/peer-group-info/${this.runId}/${nodeId}/${componentId}`);
+  retrievePeerGroupInfo(peerGroupActivityTag: string): Observable<any> {
+    return this.http.get(`/api/teacher/peer-group-info/${this.runId}/${peerGroupActivityTag}`);
   }
 
-  createNewGroup(periodId: number, nodeId: string, componentId: string): Observable<any> {
+  createNewGroup(periodId: number, peerGroupActivityTag: string): Observable<any> {
     return this.http.post(
-      `/api/peer-group/create/${this.runId}/${periodId}/${nodeId}/${componentId}`,
+      `/api/peer-group/create/${this.runId}/${periodId}/${peerGroupActivityTag}`,
       {}
     );
   }
@@ -58,5 +64,12 @@ export class PeerGroupService {
 
   removeWorkgroupFromGroup(workgroupId: number, groupId: number): Observable<any> {
     return this.http.delete(`/api/peer-group/membership/${groupId}/${workgroupId}`);
+  }
+
+  showPeerGroupDetails(peerGroupActivityTag: string): void {
+    this.dialog.open(PeerGroupDialogComponent, {
+      data: peerGroupActivityTag,
+      panelClass: 'dialog-lg'
+    });
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -284,7 +284,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html</context>
-          <context context-type="linenumber">14</context>
+          <context context-type="linenumber">13</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/view-component-revisions/view-component-revisions.component.html</context>
@@ -9761,8 +9761,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2b077437ecbac737ec20e69f17994e9cb36386f5" datatype="html">
-        <source>Groupings for <x id="INTERPOLATION" equiv-text="{{ componentLabel }}"/> in <x id="INTERPOLATION_1" equiv-text="{{ stepNumber }}"/></source>
+      <trans-unit id="1122479349c26fc9252e6d4037890c2b43bd530f" datatype="html">
+        <source>Groupings for <x id="INTERPOLATION" equiv-text="{{ peerGroupActivityTag }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.html</context>
           <context context-type="linenumber">2</context>
@@ -15457,7 +15457,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Step Info</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/nodeService.ts</context>
-          <context context-type="linenumber">726</context>
+          <context context-type="linenumber">725</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1384916903989385807" datatype="html">


### PR DESCRIPTION
## Changes
- Use PeerGroupActivityTag on components to 
   - show the manage PeerGroup dialog buttons 
   - retrieve PeerGroup info
   - create new PeerGroups

## Test
- Review PR 96 in API first
- In the grade-by-step view, the "Peer Group" button should appear for each unique PeerGroupActivityTag that is on a component in the step.
- Clicking on the "Peer Group" button will show the manage peer group dialog for the peer group activity, and show grouping details
- You can create new Peer Groups in the manage peer group dialog

Closes #493