### PR TITLE
refactor(PeerChat): Use tag to look up Peer Group

### DIFF
--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.spec.ts
@@ -7,6 +7,7 @@ import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
 import { NotificationService } from '../../../services/notificationService';
+import { PeerGroupService } from '../../../services/peerGroupService';
 import { ProjectService } from '../../../services/projectService';
 import { SessionService } from '../../../services/sessionService';
 import { StudentAssetService } from '../../../services/studentAssetService';
@@ -63,6 +64,7 @@ describe('PeerChatStudentComponent', () => {
         { provide: NotebookService, useClass: MockService },
         NotificationService,
         PeerChatService,
+        PeerGroupService,
         ProjectService,
         SessionService,
         StudentAssetService,

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
@@ -5,6 +5,7 @@ import { AnnotationService } from '../../../services/annotationService';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
+import { PeerGroupService } from '../../../services/peerGroupService';
 import { StudentAssetService } from '../../../services/studentAssetService';
 import { StudentDataService } from '../../../services/studentDataService';
 import { StudentWebSocketService } from '../../../services/studentWebSocketService';
@@ -29,6 +30,7 @@ export class PeerChatStudentComponent extends ComponentStudent {
   peerChatWorkgroupIds: number[] = [];
   peerChatWorkgroupInfos: any = {};
   peerGroupId: number;
+  peerGroupActivityTag: string;
   peerWorkFromAnotherComponent: any = {};
   requestTimeout: number = 10000;
   response: string;
@@ -42,6 +44,7 @@ export class PeerChatStudentComponent extends ComponentStudent {
     protected dialog: MatDialog,
     protected NodeService: NodeService,
     protected NotebookService: NotebookService,
+    private peerGroupService: PeerGroupService,
     private PeerChatService: PeerChatService,
     protected StudentAssetService: StudentAssetService,
     protected StudentDataService: StudentDataService,
@@ -66,6 +69,7 @@ export class PeerChatStudentComponent extends ComponentStudent {
     this.myWorkgroupId = this.ConfigService.getWorkgroupId();
     this.showWorkComponentId = this.componentContent.showWorkComponentId;
     this.showWorkNodeId = this.componentContent.showWorkNodeId;
+    this.peerGroupActivityTag = this.componentContent.peerGroupActivityTag;
     this.requestChatWorkgroups();
     this.registerStudentWorkReceivedListener();
   }
@@ -83,7 +87,8 @@ export class PeerChatStudentComponent extends ComponentStudent {
   }
 
   requestChatWorkgroups(): void {
-    this.PeerChatService.retrievePeerChatWorkgroups(this.nodeId, this.componentId)
+    this.peerGroupService
+      .retrievePeerGroup(this.peerGroupActivityTag)
       .pipe(timeout(this.requestTimeout))
       .subscribe(
         (peerGroup: any) => {
@@ -99,7 +104,7 @@ export class PeerChatStudentComponent extends ComponentStudent {
     this.isPeerChatWorkgroupsResponseReceived = true;
     this.peerGroupId = peerGroup.id;
     this.setPeerChatWorkgroups(this.getPeerGroupWorkgroupIds(peerGroup));
-    this.getPeerChatComponentStates(peerGroup.id);
+    this.getPeerChatComponentStates(peerGroup);
   }
 
   getPeerGroupWorkgroupIds(peerGroup: PeerGroup): number[] {
@@ -110,8 +115,9 @@ export class PeerChatStudentComponent extends ComponentStudent {
     this.isPeerChatWorkgroupsResponseReceived = true;
   }
 
-  getPeerChatComponentStates(peerGroupId: number): void {
-    this.PeerChatService.retrievePeerChatComponentStatesByPeerGroup(peerGroupId)
+  getPeerChatComponentStates(peerGroup: PeerGroup): void {
+    this.peerGroupService
+      .retrievePeerGroupWork(peerGroup)
       .pipe(timeout(this.requestTimeout))
       .subscribe(
         (componentStates: any[]) => {

--- a/src/assets/wise5/components/peerChat/peerChatService.ts
+++ b/src/assets/wise5/components/peerChat/peerChatService.ts
@@ -33,23 +33,6 @@ export class PeerChatService extends ComponentService {
     return component;
   }
 
-  retrievePeerChatWorkgroups(nodeId: string, componentId: string): Observable<any> {
-    if (this.ConfigService.isPreview()) {
-      this.ConfigService.config.runId = 1;
-    }
-    const headers = new HttpHeaders().set('Content-Type', 'application/json');
-    const runId = this.ConfigService.getRunId();
-    const workgroupId = this.ConfigService.getWorkgroupId();
-    return this.http.get(`/api/peer-group/${runId}/${workgroupId}/${nodeId}/${componentId}`, {
-      headers: headers
-    });
-  }
-
-  retrievePeerChatComponentStatesByPeerGroup(peerGroupId: number): Observable<any> {
-    const headers = new HttpHeaders().set('Content-Type', 'application/json');
-    return this.http.get(`/api/peer-group/${peerGroupId}/student-work`, { headers: headers });
-  }
-
   retrievePeerChatComponentStates(
     nodeId: string,
     componentId: string,
@@ -64,38 +47,6 @@ export class PeerChatService extends ComponentService {
       `/api/peer-group/${runId}/${workgroupId}/${nodeId}/${componentId}/student-work`,
       { headers: headers }
     );
-  }
-
-  createDummyComponentStates(workgroupIds: number[]): any[] {
-    const componentStates = [];
-    for (const workgroupId of workgroupIds) {
-      componentStates.push(
-        this.createDummyComponentState(
-          workgroupId,
-          'PeerChat',
-          `Hello this is ${workgroupId}`,
-          new Date().getTime()
-        )
-      );
-    }
-    return componentStates;
-  }
-
-  createDummyComponentState(
-    workgroupId: number,
-    componentType: string,
-    response: string,
-    timestamp: number
-  ): any {
-    return {
-      componentType: componentType,
-      studentData: {
-        attachments: [],
-        response: response
-      },
-      serverSaveTime: timestamp,
-      workgroupId: workgroupId
-    };
   }
 
   convertComponentStateToPeerChatMessage(componentState: any): PeerChatMessage {

--- a/src/assets/wise5/services/peerGroupService.ts
+++ b/src/assets/wise5/services/peerGroupService.ts
@@ -35,6 +35,10 @@ export class PeerGroupService {
     return this.http.get(`/api/peer-group/${runId}/${workgroupId}/${peerGroupActivityTag}`);
   }
 
+  retrievePeerGroupWork(peerGroup: PeerGroup): Observable<any> {
+    return this.http.get(`/api/peer-group/${peerGroup.id}/student-work`);
+  }
+
   retrieveStudentWork(
     peerGroup: PeerGroup,
     nodeId: string,


### PR DESCRIPTION
## Changes
- Use peerGroupActivityTag to look up Peer Group
- Move ```PeerChatService.retrievePeerChatComponentStatesByPeerGroup()``` to ```PeerGroupService.retrievePeerGroupWork()```
- Clean up unused dummy code

## Test
- Make sure that Peer Chat component has peerGroupActivityTag, and students are paired in Peer Groups (use teacher's Manage Peer Groups view to group students)
- Peer Chat works as before
   - Can chat with Peer Group members
   - Can see posts from before

Closes #496