### PR TITLE
Use show work views in ShowWorkStudent

### DIFF
--- a/src/assets/wise5/components/multipleChoice/multiple-choice-show-work/multiple-choice-show-work.component.html
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-show-work/multiple-choice-show-work.component.html
@@ -1,52 +1,48 @@
-<div class="component--grading__response__content">
-  <div *ngIf="componentState"
-      class="md-block input-container--open-response input-container--component md-no-float"
-      [ngSwitch]="componentContent.choiceType">
-    <div *ngSwitchCase="'radio'" class="choices">
-      <mat-radio-group [(ngModel)]="studentChoiceId">
-        <div *ngFor="let choice of choices" class="choice">
-          <mat-radio-button
-              color="primary"
-              [value]="choice.id"
-              [disabled]="true">
-            <span [innerHTML]="choice.text">
-            </span>
-            <span *ngIf="componentState.isSubmit && showFeedback && choice.feedback !== '' && choice.id === studentChoiceId"
-                [ngClass]="{'success': hasCorrectAnswer && choice.isCorrect, 'warn': hasCorrectAnswer && !choice.isCorrect, 'info': !hasCorrectAnswer}">
-                {{choice.feedback}}
-            </span>
-          </mat-radio-button>
-        </div>
-      </mat-radio-group>
-    </div>
-    <div *ngSwitchCase="'checkbox'" class="choices">
+<ng-container *ngIf="componentState" [ngSwitch]="componentContent.choiceType">
+  <div *ngSwitchCase="'radio'" class="choices">
+    <mat-radio-group [(ngModel)]="studentChoiceId">
       <div *ngFor="let choice of choices" class="choice">
-        <mat-checkbox
+        <mat-radio-button
             color="primary"
-            aria-label="choice.text"
-            [(ngModel)]="choice.isSelected"
+            [value]="choice.id"
             [disabled]="true">
           <span [innerHTML]="choice.text">
           </span>
-          <span *ngIf="componentState.isSubmit && showFeedback && choice.isSelected"
+          <span *ngIf="componentState.isSubmit && showFeedback && choice.feedback !== '' && choice.id === studentChoiceId"
               [ngClass]="{'success': hasCorrectAnswer && choice.isCorrect, 'warn': hasCorrectAnswer && !choice.isCorrect, 'info': !hasCorrectAnswer}">
               {{choice.feedback}}
           </span>
-        </mat-checkbox>
+        </mat-radio-button>
       </div>
-    </div>
-    <div *ngIf="componentContent.maxSubmitCount != null" i18n>
-      You have used {{componentState.studentData.submitCounter}} of {{componentContent.maxSubmitCount}} attempt(s)
-    </div>
-    <div *ngIf="hasCorrectAnswer && isStudentAnswerCorrect"
-        class="success"
-        i18n>
-      Correct
-    </div>
-    <div *ngIf="hasCorrectAnswer && !isStudentAnswerCorrect"
-        class="warn"
-        i18n>
-      Incorrect
+    </mat-radio-group>
+  </div>
+  <div *ngSwitchCase="'checkbox'" class="choices">
+    <div *ngFor="let choice of choices" class="choice">
+      <mat-checkbox
+          color="primary"
+          aria-label="choice.text"
+          [(ngModel)]="choice.isSelected"
+          [disabled]="true">
+        <span [innerHTML]="choice.text">
+        </span>
+        <span *ngIf="componentState.isSubmit && showFeedback && choice.isSelected"
+            [ngClass]="{'success': hasCorrectAnswer && choice.isCorrect, 'warn': hasCorrectAnswer && !choice.isCorrect, 'info': !hasCorrectAnswer}">
+            {{choice.feedback}}
+        </span>
+      </mat-checkbox>
     </div>
   </div>
-</div>
+  <div class="details" *ngIf="componentContent.maxSubmitCount != null" i18n>
+    You have used {{componentState.studentData.submitCounter}} of {{componentContent.maxSubmitCount}} attempt(s)
+  </div>
+  <div *ngIf="hasCorrectAnswer && isStudentAnswerCorrect"
+      class="success details"
+      i18n>
+    Correct
+  </div>
+  <div *ngIf="hasCorrectAnswer && !isStudentAnswerCorrect"
+      class="warn details"
+      i18n>
+    Incorrect
+  </div>
+</ng-container>

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-show-work/multiple-choice-show-work.component.scss
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-show-work/multiple-choice-show-work.component.scss
@@ -1,9 +1,9 @@
 
-.choices {
-  margin-bottom: 20px;
+.details {
+  margin-top: 16px;
 }
 
 .choice {
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin-top: 8px;
+  margin-bottom: 8px;
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.html
@@ -15,3 +15,7 @@
     </div>
   </div>
 </ng-container>
+<div *ngIf="!isPeerChatWorkgroupsAvailable" class="notice mat-body-2" i18n>
+  This Peer Chat activity is not yet available. Please check back later or wait for a notification to return.
+  <!-- TODO: Show different message when student has not completed required previous component(s) -->
+</div>

--- a/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.module.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.module.ts
@@ -1,11 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
 import { PeerChatModule } from '../peer-chat.module';
 import { PeerChatShowWorkComponent } from './peer-chat-show-work.component';
 
 @NgModule({
   declarations: [PeerChatShowWorkComponent],
-  imports: [CommonModule, PeerChatModule],
+  imports: [CommonModule, FlexLayoutModule, PeerChatModule],
   exports: [PeerChatShowWorkComponent]
 })
 export class PeerChatShowWorkModule {}

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.scss
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.scss
@@ -1,3 +1,1 @@
-.previous-work {
-  margin-bottom: 24px;
-}
+

--- a/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.html
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.html
@@ -18,7 +18,7 @@
         </span>
         <show-work-student *ngIf="workgroupIdToWork.get(member.id) != null"
             [studentWork]="workgroupIdToWork.get(member.id)"
-            [componentContent]="showWorkComponentContent"
+            [componentId]="showWorkComponentId"
             [nodeId]="showWorkNodeId">
         </show-work-student>
       </mat-card-content>

--- a/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.ts
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.ts
@@ -23,6 +23,7 @@ export class ShowGroupWorkStudentComponent extends ComponentStudent {
   narrowComponentTypes: string[] = ['MultipleChoice', 'OpenResponse'];
   peerGroup: PeerGroup = new PeerGroup();
   showWorkComponentContent: any;
+  showWorkComponentId: string;
   showWorkNodeId: string;
   studentWorkFromGroupMembers: any[];
   widthLg: number = 100;
@@ -84,6 +85,7 @@ export class ShowGroupWorkStudentComponent extends ComponentStudent {
       this.showWorkComponentContent
     );
     this.showWorkNodeId = this.componentContent.showWorkNodeId;
+    this.showWorkComponentId = this.componentContent.showWorkComponentId;
   }
 
   setStudentWorkFromGroupMembers(studentWorkFromGroupMembers: any[]): void {

--- a/src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.html
+++ b/src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.html
@@ -2,8 +2,10 @@
 <mat-card class="mat-elevation-z0 notice-bg-bg">
   <mat-card-content class="app-bg-bg">
     <span class="text-secondary" *ngIf="studentWork == null" i18n>(No response)</span>
-    <show-work-student [studentWork]="studentWork"
+    <show-work-student *ngIf="studentWork != null"
+        [studentWork]="studentWork"
         [componentContent]="showWorkComponentContent"
+        [componentId]="showWorkComponentId"
         [nodeId]="showWorkNodeId"></show-work-student>
   </mat-card-content>
 </mat-card>

--- a/src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.scss
+++ b/src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.scss
@@ -1,0 +1,12 @@
+@import '~style/abstracts/variables';
+
+.mat-card {
+  margin: 4px;
+  padding: 8px;
+}
+
+.mat-card-content {
+  padding: 8px;
+  border-radius: $button-border-radius;
+  overflow: auto;
+}

--- a/src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.ts
+++ b/src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.ts
@@ -18,6 +18,7 @@ import { ComponentService } from '../../componentService';
 })
 export class ShowMyWorkStudentComponent extends ComponentStudent {
   showWorkComponentContent: any;
+  showWorkComponentId: string;
   showWorkNodeId: string;
   studentWork: any;
 
@@ -55,6 +56,7 @@ export class ShowMyWorkStudentComponent extends ComponentStudent {
     this.showWorkComponentContent = this.projectService.injectAssetPaths(
       this.showWorkComponentContent
     );
+    this.showWorkComponentId = this.componentContent.showWorkComponentId;
     this.showWorkNodeId = this.componentContent.showWorkNodeId;
     this.studentWork = this.studentDataService.getLatestComponentStateByNodeIdAndComponentId(
       this.componentContent.showWorkNodeId,

--- a/src/assets/wise5/components/showWork/show-work-student/show-work-student.component.html
+++ b/src/assets/wise5/components/showWork/show-work-student/show-work-student.component.html
@@ -1,36 +1,24 @@
 <ng-container [ngSwitch]="studentWork.componentType">
-  <animation-student *ngSwitchCase="'Animation'"
+  <animation-show-work *ngSwitchCase="'Animation'"
       [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      [componentState]="studentWork"
-      [isDisabled]="true"
-      [workgroupId]="studentWork.workgroupId"
-      [mode]="student">
-  </animation-student>
-  <audio-oscillator-student *ngSwitchCase="'AudioOscillator'"
+      [componentId]="componentId"
+      [componentState]="studentWork">
+  </animation-show-work>
+  <audio-oscillator-show-work *ngSwitchCase="'AudioOscillator'"
       [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      [componentState]="studentWork"
-      [isDisabled]="true"
-      [workgroupId]="studentWork.workgroupId"
-      [mode]="student">
-  </audio-oscillator-student>
-  <concept-map-student *ngSwitchCase="'ConceptMap'"
+      [componentId]="componentId"
+      [componentState]="studentWork">
+  </audio-oscillator-show-work>
+  <concept-map-show-work *ngSwitchCase="'ConceptMap'"
       [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      [componentState]="studentWork"
-      [isDisabled]="true"
-      [workgroupId]="studentWork.workgroupId"
-      [mode]="student">
-  </concept-map-student>
-  <dialog-guidance-student *ngSwitchCase="'DialogGuidance'"
+      [componentId]="componentId"
+      [componentState]="studentWork">
+  </concept-map-show-work>
+  <dialog-guidance-show-work *ngSwitchCase="'DialogGuidance'"
       [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      [componentState]="studentWork"
-      [isDisabled]="true"
-      [workgroupId]="studentWork.workgroupId"
-      [mode]="student">
-  </dialog-guidance-student>
+      [componentId]="componentId"
+      [componentState]="studentWork">
+  </dialog-guidance-show-work>
   <discussion-student *ngSwitchCase="'Discussion'"
       [nodeId]="nodeId"
       [componentContent]="componentContent"
@@ -39,73 +27,39 @@
       [workgroupId]="studentWork.workgroupId"
       [mode]="student">
   </discussion-student>
-  <draw-student *ngSwitchCase="'Draw'"
+  <draw-show-work *ngSwitchCase="'Draw'"
       [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      [componentState]="studentWork"
-      [isDisabled]="true"
-      [workgroupId]="studentWork.workgroupId"
-      [mode]="student">
-  </draw-student>
-  <embedded-student *ngSwitchCase="'Embedded'"
+      [componentId]="componentId"
+      [componentState]="studentWork">
+  </draw-show-work>
+  <embedded-show-work *ngSwitchCase="'Embedded'"
       [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      [componentState]="studentWork"
-      [isDisabled]="true"
-      [workgroupId]="studentWork.workgroupId"
-      [mode]="student">
-  </embedded-student>
-  <graph-student *ngSwitchCase="'Graph'"
+      [componentId]="componentId"
+      [componentState]="studentWork">
+  </embedded-show-work>
+  <graph-show-work *ngSwitchCase="'Graph'"
       [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      [componentState]="studentWork"
-      [isDisabled]="true"
-      [workgroupId]="studentWork.workgroupId"
-      [mode]="student">
-  </graph-student>
-  <html-student *ngSwitchCase="'HTML'"
+      [componentId]="componentId"
+      [componentState]="studentWork">
+  </graph-show-work>
+  <label-show-work *ngSwitchCase="'Label'"
       [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      [mode]="student">
-  </html-student>
-  <label-student *ngSwitchCase="'Label'"
+      [componentId]="componentId"
+      [componentState]="studentWork">
+  </label-show-work>
+  <match-show-work *ngSwitchCase="'Match'"
       [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      [componentState]="studentWork"
-      [isDisabled]="true"
-      [workgroupId]="studentWork.workgroupId"
-      [mode]="student">
-  </label-student>
-  <match-student *ngSwitchCase="'Match'"
+      [componentId]="componentId"
+      [componentState]="studentWork"></match-show-work>
+  <multiple-choice-show-work *ngSwitchCase="'MultipleChoice'"
       [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      [componentState]="studentWork"
-      [isDisabled]="true"
-      [isDisabled]="true"
-      [workgroupId]="studentWork.workgroupId"
-      [mode]="student">
-  </match-student>
-  <multiple-choice-student *ngSwitchCase="'MultipleChoice'"
+      [componentId]="componentId"
+      [componentState]="studentWork">
+  </multiple-choice-show-work>
+  <open-response-show-work *ngSwitchCase="'OpenResponse'"
       [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      [componentState]="studentWork"
-      [isDisabled]="true"
-      [workgroupId]="studentWork.workgroupId"
-      [mode]="student">
-  </multiple-choice-student>
-  <open-response-student *ngSwitchCase="'OpenResponse'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      [componentState]="studentWork"
-      [isDisabled]="true"
-      [workgroupId]="studentWork.workgroupId"
-      [mode]="student">
-  </open-response-student>
-  <outside-url-student *ngSwitchCase="'OutsideURL'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      [mode]="student">
-  </outside-url-student>
+      [componentId]="componentId"
+      [componentState]="studentWork"></open-response-show-work>
   <peer-chat-student *ngSwitchCase="'PeerChat'"
       [nodeId]="nodeId"
       [componentContent]="componentContent"
@@ -113,19 +67,9 @@
       [workgroupId]="studentWork.workgroupId"
       [mode]="student">
   </peer-chat-student>
-  <summary-student *ngSwitchCase="'Summary'"
+  <table-show-work *ngSwitchCase="'Table'"
       [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      [componentState]="studentWork"
-      [workgroupId]="studentWork.workgroupId"
-      [mode]="student">
-  </summary-student>
-  <table-student *ngSwitchCase="'Table'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      [componentState]="studentWork"
-      [isDisabled]="true"
-      [workgroupId]="studentWork.workgroupId"
-      [mode]="student">
-  </table-student>
+      [componentId]="componentId"
+      [componentState]="studentWork">
+  </table-show-work>
 </ng-container>

--- a/src/assets/wise5/components/showWork/show-work-student/show-work-student.component.ts
+++ b/src/assets/wise5/components/showWork/show-work-student/show-work-student.component.ts
@@ -7,6 +7,7 @@ import { Component, Input, OnInit } from '@angular/core';
 })
 export class ShowWorkStudentComponent implements OnInit {
   @Input() componentContent: any;
+  @Input() componentId: string;
   @Input() nodeId: string;
   @Input() studentWork: any;
 

--- a/src/assets/wise5/components/showWork/show-work-student/show-work-student.module.ts
+++ b/src/assets/wise5/components/showWork/show-work-student/show-work-student.module.ts
@@ -1,37 +1,37 @@
 import { NgModule } from '@angular/core';
 import { AngularJSModule } from '../../../../../app/common-hybrid-angular.module';
-import { AnimationStudentModule } from '../../animation/animation-student/animation-student.module';
-import { AudioOscillatorStudentModule } from '../../audioOscillator/audio-oscillator-student/audio-oscillator.module';
-import { ConceptMapStudentModule } from '../../conceptMap/concept-map-student/concept-map-student.module';
-import { DialogGuidanceStudentModule } from '../../dialogGuidance/dialogGuidanceStudentModule';
+import { AnimationShowWorkModule } from '../../animation/animation-show-work/animation-show-work.module';
+import { AudioOscillatorShowWorkModule } from '../../audioOscillator/audio-oscillator-show-work/audio-oscillator-show-work.module';
+import { ConceptMapShowWorkModule } from '../../conceptMap/concept-map-show-work/concept-map-show-work.module';
+import { DialogGuidanceShowWorkModule } from '../../dialogGuidance/dialog-guidance-show-work/dialog-guidance-show-work.module';
 import { DiscussionStudentModule } from '../../discussion/discussion-student/discussion-student.module';
-import { DrawStudentModule } from '../../draw/draw-student/draw-student-module';
-import { EmbeddedStudentModule } from '../../embedded/embedded-student/embedded-student.module';
-import { GraphStudentModule } from '../../graph/graph-student/graph-student.module';
-import { LabelStudentModule } from '../../label/label-student/label-student.module';
-import { MatchStudentModule } from '../../match/match-student/match-student.module';
-import { MultipleChoiceStudentModule } from '../../multipleChoice/multiple-choice-student/multiple-choice-student.module';
-import { OpenResponseStudentModule } from '../../openResponse/open-response-student/open-response-student.module';
-import { TableStudentModule } from '../../table/table-student/table-student.module';
+import { DrawShowWorkModule } from '../../draw/draw-show-work/draw-show-work.module';
+import { EmbeddedShowWorkModule } from '../../embedded/embedded-show-work/embedded-show-work.module';
+import { GraphShowWorkModule } from '../../graph/graph-show-work/graph-show-work.module';
+import { LabelShowWorkModule } from '../../label/label-show-work/label-show-work.module';
+import { MatchShowWorkModule } from '../../match/match-show-work/match-show-work-module';
+import { MultipleChoiceShowWorkModule } from '../../multipleChoice/multiple-choice-show-work/multiple-choice-show-work.module';
+import { OpenResponseShowWorkModule } from '../../openResponse/open-response-show-work/open-response-show-work.module';
+import { TableShowWorkModule } from '../../table/table-show-work/table-show-work.module';
 import { ShowWorkStudentComponent } from './show-work-student.component';
 
 @NgModule({
   declarations: [ShowWorkStudentComponent],
   imports: [
     AngularJSModule,
-    AnimationStudentModule,
-    AudioOscillatorStudentModule,
-    ConceptMapStudentModule,
-    DialogGuidanceStudentModule,
+    AnimationShowWorkModule,
+    AudioOscillatorShowWorkModule,
+    ConceptMapShowWorkModule,
+    DialogGuidanceShowWorkModule,
     DiscussionStudentModule,
-    DrawStudentModule,
-    EmbeddedStudentModule,
-    GraphStudentModule,
-    LabelStudentModule,
-    MatchStudentModule,
-    MultipleChoiceStudentModule,
-    OpenResponseStudentModule,
-    TableStudentModule
+    DrawShowWorkModule,
+    EmbeddedShowWorkModule,
+    GraphShowWorkModule,
+    LabelShowWorkModule,
+    MatchShowWorkModule,
+    MultipleChoiceShowWorkModule,
+    OpenResponseShowWorkModule,
+    TableShowWorkModule
   ],
   exports: [ShowWorkStudentComponent]
 })

--- a/src/assets/wise5/components/table/table-show-work/table-show-work.component.scss
+++ b/src/assets/wise5/components/table/table-show-work/table-show-work.component.scss
@@ -1,29 +1,4 @@
-.table {
-  margin-bottom: 20px;
-}
-
-::ng-deep.mat-form-field-disabled .mat-form-field-underline { 
-  background-image: linear-gradient( to right, rgba(0, 0, 0, 1) 0, rgba(0, 0, 0, 0.42) 33%, #c2c7cc 0 ) !important; 
-  background-size: 1px 100% !important;
-  background-repeat: repeat-x !important; 
-}
-
-.mat-input-element:disabled {
-  color: rgba(0, 0, 0, 1);
-}
-
-::ng-deep .mat-form-field-wrapper{
-  margin-bottom: -1em;
-}
-
-::ng-deep.mat-select-value-text {
-  color: rgba(0, 0, 0, 1) !important;
-}
-
-.data-explorer-div {
-  margin-bottom: 20px;
-}
-
-.data-explorer-field {
-  margin-right: 20px;
+.table-container {
+  margin-top: 0;
+  padding: 0;
 }

--- a/src/assets/wise5/components/table/table-show-work/table-show-work.component.ts
+++ b/src/assets/wise5/components/table/table-show-work/table-show-work.component.ts
@@ -5,7 +5,7 @@ import { ComponentShowWorkDirective } from '../../component-show-work.directive'
 @Component({
   selector: 'table-show-work',
   templateUrl: 'table-show-work.component.html',
-  styleUrls: ['../table-student/table-student.component.scss']
+  styleUrls: ['../table-student/table-student.component.scss', 'table-show-work.component.scss']
 })
 export class TableShowWorkComponent extends ComponentShowWorkDirective {
   tableData: any[];

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -14671,7 +14671,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source> This Peer Chat activity is not yet available. Please check back later or wait for a notification to return. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.html</context>
-          <context context-type="linenumber">21,22</context>
+          <context context-type="linenumber">19,20</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html</context>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13630,6 +13630,10 @@ Warning: This will delete all existing choices and buckets in this component.</s
           <context context-type="linenumber">10,11</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-show-work/multiple-choice-show-work.component.html</context>
+          <context context-type="linenumber">41,42</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.html</context>
           <context context-type="linenumber">55,56</context>
         </context-group>
@@ -13639,6 +13643,10 @@ Warning: This will delete all existing choices and buckets in this component.</s
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-feedback-section/match-feedback-section.component.html</context>
           <context context-type="linenumber">15,16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-show-work/multiple-choice-show-work.component.html</context>
+          <context context-type="linenumber">46,47</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.html</context>
@@ -13777,25 +13785,11 @@ Warning: This will delete all existing choices in this component.</source>
           <context context-type="linenumber">132</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="f80d8048e1a73a4f0c35681cc5f8a250754eaf4b" datatype="html">
+      <trans-unit id="06ce7d94965efa6522f9a9615a9bdc6c163f64b3" datatype="html">
         <source> You have used <x id="INTERPOLATION" equiv-text="{{componentState.studentData.submitCounter}}"/> of <x id="INTERPOLATION_1" equiv-text="{{componentContent.maxSubmitCount}}"/> attempt(s) </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-show-work/multiple-choice-show-work.component.html</context>
-          <context context-type="linenumber">38,40</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="00a48b9fab48a5ccc0ebf0a2793495ee1cc9f968" datatype="html">
-        <source> Correct </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-show-work/multiple-choice-show-work.component.html</context>
-          <context context-type="linenumber">44,45</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="49a3371af0eb58f02e541105eb395340048527ec" datatype="html">
-        <source> Incorrect </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-show-work/multiple-choice-show-work.component.html</context>
-          <context context-type="linenumber">49,50</context>
+          <context context-type="linenumber">35,37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="15a55678173547662c25708af440a302696f5a0c" datatype="html">
@@ -14675,6 +14669,10 @@ If this problem continues, let your teacher know and move on to the next activit
       </trans-unit>
       <trans-unit id="375ead964bf5b0ae938bb0b600db793ac0d32683" datatype="html">
         <source> This Peer Chat activity is not yet available. Please check back later or wait for a notification to return. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.html</context>
+          <context context-type="linenumber">21,22</context>
+        </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html</context>
           <context context-type="linenumber">2,3</context>


### PR DESCRIPTION
## Changes
- Display corresponding `<[component type]-show-work>` for each component type in ShowWorkStudent.
- Discussion and PeerChat still use student views because their show work views require teacher service and/or teacher permissions. (Will create separate issues.)
- Removed HTML, OutsideURL, and Summary component types, since we don't need show work views for those.

Closes #498.

## Test
- Make sure that ShowMyWork and ShowGroupWork components work for each component type (except Discussion and Peer Chat).
- Make sure that grading still works for each component type.