### PR TITLE
refactor(DG Avatar): Use array to store avatar ids

### DIFF
--- a/src/assets/wise5/components/dialogGuidance/ComputerAvatarSettings.ts
+++ b/src/assets/wise5/components/dialogGuidance/ComputerAvatarSettings.ts
@@ -1,5 +1,5 @@
 export class ComputerAvatarSettings {
-  ids: {};
+  ids: string[];
   label: string;
   prompt: string;
   initialResponse: string;

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.ts
@@ -36,14 +36,14 @@ export class EditDialogGuidanceComputerAvatarComponent implements OnInit {
 
   private tryInitializeComputerAvatarIds(): void {
     if (this.computerAvatarSettings.ids == null) {
-      this.computerAvatarSettings.ids = {};
+      this.computerAvatarSettings.ids = [];
       this.selectAllComputerAvatars();
     }
   }
 
   private populateSelectedComputerAvatars(): void {
     for (const availableComputerAvatar of this.allComputerAvatars) {
-      if (this.computerAvatarSettings.ids[availableComputerAvatar.id]) {
+      if (this.computerAvatarSettings.ids.includes(availableComputerAvatar.id)) {
         availableComputerAvatar.isSelected = true;
       }
     }
@@ -86,15 +86,14 @@ export class EditDialogGuidanceComputerAvatarComponent implements OnInit {
   }
 
   private getNumSelectedComputerAvatars(): number {
-    return Object.keys(this.computerAvatarSettings.ids).length;
+    return this.computerAvatarSettings.ids.length;
   }
 
   saveSelectedComputerAvatars(): void {
+    this.computerAvatarSettings.ids = [];
     for (const computerAvatar of this.allComputerAvatars) {
       if (computerAvatar.isSelected) {
-        this.computerAvatarSettings.ids[computerAvatar.id] = true;
-      } else {
-        delete this.computerAvatarSettings.ids[computerAvatar.id];
+        this.computerAvatarSettings.ids.push(computerAvatar.id);
       }
     }
     this.componentChanged();

--- a/src/assets/wise5/vle/computer-avatar-selector/computer-avatar-selector.component.ts
+++ b/src/assets/wise5/vle/computer-avatar-selector/computer-avatar-selector.component.ts
@@ -32,14 +32,8 @@ export class ComputerAvatarSelectorComponent implements OnInit {
     }
   }
 
-  filterAvatars(allAvatars: ComputerAvatar[], avatarIdsToUse: any): ComputerAvatar[] {
-    const avatars = [];
-    for (const avatar of allAvatars) {
-      if (avatarIdsToUse[avatar.id] === true) {
-        avatars.push(avatar);
-      }
-    }
-    return avatars;
+  filterAvatars(allAvatars: ComputerAvatar[], avatarIdsToUse: string[]): ComputerAvatar[] {
+    return allAvatars.filter((avatar) => avatarIdsToUse.includes(avatar.id));
   }
 
   highlightAvatar(avatarClicked: ComputerAvatar): void {


### PR DESCRIPTION
## Changes
- Use array instead of Map to store selectable avatars

## Rationale for change
- We were not making use of the Map's value (true/false). Avatars stored in componentContent contained unused values {"girl": true, "robot": true}, and all fields were set to true
- Array vs Map performance is negligible with N being small (6 items)

## Why not Set?
- Set does not serialize with JSON.stringify without extra work. 
   - e.g. JSON.stringify(new Set()) returns {}.
- Set does not parse with JSON.parse without extra work, and it's hard to know which fields should be instantiated as Set.

## Test
- Change componentContent.computerAvatarSettings.ids from object {"girl":true,"robot":true} to array ["girl", "robot"]
- Test that DG avatar authoring and DG avatar student selection work as before 