### PR TITLE
refactor(Dialog Guidance Avatar)

### DIFF
--- a/src/assets/wise5/components/dialogGuidance/dialogGuidanceService.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialogGuidanceService.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { ComputerAvatarService } from '../../services/computerAvatarService';
 import { StudentDataService } from '../../services/studentDataService';
 import { UtilService } from '../../services/utilService';
 import { ComponentService } from '../componentService';
@@ -6,10 +7,11 @@ import { ComponentService } from '../componentService';
 @Injectable()
 export class DialogGuidanceService extends ComponentService {
   constructor(
-    protected StudentDataService: StudentDataService,
-    protected UtilService: UtilService
+    protected computerAvatarService: ComputerAvatarService,
+    protected studentDataService: StudentDataService,
+    protected utilService: UtilService
   ) {
-    super(StudentDataService, UtilService);
+    super(studentDataService, utilService);
   }
 
   getComponentTypeLabel(): string {
@@ -23,6 +25,7 @@ export class DialogGuidanceService extends ComponentService {
     component.feedbackRules = [];
     component.isComputerAvatarEnabled = false;
     component.computerAvatarSettings = {
+      ids: this.computerAvatarService.getAvatars().map((avatar) => avatar.id),
       label: $localize`Thought Buddy`,
       prompt: $localize`Discuss your answer with a thought buddy!`,
       initialResponse: $localize`Hi there! It's nice to meet you. What do you think about...`

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html
@@ -50,11 +50,6 @@
             i18n>
           Select None
         </button>
-        <div *ngIf="numSelectedComputerAvatars === 0"
-            class="warn"
-            i18n>
-          You must select at least one computer avatar
-        </div>
       </div>
       <div fxLayout="row wrap">
         <mat-button-toggle-group fxLayout="row wrap"

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.spec.ts
@@ -91,16 +91,15 @@ describe('EditDialogGuidanceComputerAvatarComponent', () => {
   });
 
   it('should create with initial values', () => {
-    component.computerAvatarSettings.ids = null;
+    component.computerAvatarSettings.ids = ['robot', 'monkey', 'girl'];
     component.ngOnInit();
     expect(component.allComputerAvatars).toEqual(allComputerAvatars);
     expect(isAllComputerAvatarsSelected(component.allComputerAvatars)).toBeTrue();
   });
 
   it('should select all computer avatars', () => {
-    component.computerAvatarSettings.ids = [];
-    component.computerAvatarSettings.ids[component.allComputerAvatars[0].id] = true;
-    component.allComputerAvatars[0].isSelected = true;
+    component.computerAvatarSettings.ids = ['robot'];
+    component.ngOnInit();
     expect(isOnlyFirstComputerAvatarSelected(component.allComputerAvatars)).toEqual(true);
     component.selectAllComputerAvatars();
     expect(isAllComputerAvatarsSelected(component.allComputerAvatars)).toEqual(true);

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.ts
@@ -24,7 +24,6 @@ export class EditDialogGuidanceComputerAvatarComponent implements OnInit {
   ngOnInit(): void {
     this.allComputerAvatars = this.computerAvatarService.getAvatars();
     this.avatarsPath = this.computerAvatarService.getAvatarsPath();
-    this.tryInitializeComputerAvatarIds();
     this.populateAndUpdateNumSelectedComputerAvatars();
   }
 
@@ -32,13 +31,6 @@ export class EditDialogGuidanceComputerAvatarComponent implements OnInit {
     this.populateSelectedComputerAvatars();
     this.updateNumSelectedComputerAvatars();
     this.componentChanged();
-  }
-
-  private tryInitializeComputerAvatarIds(): void {
-    if (this.computerAvatarSettings.ids == null) {
-      this.computerAvatarSettings.ids = [];
-      this.selectAllComputerAvatars();
-    }
   }
 
   private populateSelectedComputerAvatars(): void {

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.ts
@@ -14,7 +14,6 @@ export class EditDialogGuidanceComputerAvatarComponent implements OnInit {
 
   allComputerAvatars: ComputerAvatar[];
   avatarsPath: string;
-  numSelectedComputerAvatars: number;
 
   constructor(
     private computerAvatarService: ComputerAvatarService,
@@ -24,12 +23,7 @@ export class EditDialogGuidanceComputerAvatarComponent implements OnInit {
   ngOnInit(): void {
     this.allComputerAvatars = this.computerAvatarService.getAvatars();
     this.avatarsPath = this.computerAvatarService.getAvatarsPath();
-    this.populateAndUpdateNumSelectedComputerAvatars();
-  }
-
-  private populateAndUpdateNumSelectedComputerAvatars(): void {
     this.populateSelectedComputerAvatars();
-    this.updateNumSelectedComputerAvatars();
     this.componentChanged();
   }
 
@@ -45,7 +39,7 @@ export class EditDialogGuidanceComputerAvatarComponent implements OnInit {
     for (const computerAvatar of this.allComputerAvatars) {
       computerAvatar.isSelected = true;
     }
-    this.saveAndUpdateNumComputerAvatars();
+    this.saveSelectedComputerAvatars();
   }
 
   unselectAllComputerAvatars(): void {
@@ -54,31 +48,18 @@ export class EditDialogGuidanceComputerAvatarComponent implements OnInit {
     }
     // select the first avatar to make sure there is always at least one selected
     this.allComputerAvatars[0].isSelected = true;
-    this.saveAndUpdateNumComputerAvatars();
+    this.saveSelectedComputerAvatars();
   }
 
   toggleSelectComputerAvatar(computerAvatar: ComputerAvatar): void {
     if (!this.isLastSelectedComputerAvatar(computerAvatar)) {
       computerAvatar.isSelected = !computerAvatar.isSelected;
-      this.saveAndUpdateNumComputerAvatars();
+      this.saveSelectedComputerAvatars();
     }
   }
 
   isLastSelectedComputerAvatar(computerAvatar: ComputerAvatar): boolean {
-    return computerAvatar.isSelected && this.getNumSelectedComputerAvatars() === 1;
-  }
-
-  private saveAndUpdateNumComputerAvatars(): void {
-    this.saveSelectedComputerAvatars();
-    this.updateNumSelectedComputerAvatars();
-  }
-
-  private updateNumSelectedComputerAvatars(): void {
-    this.numSelectedComputerAvatars = this.getNumSelectedComputerAvatars();
-  }
-
-  private getNumSelectedComputerAvatars(): number {
-    return this.computerAvatarSettings.ids.length;
+    return computerAvatar.isSelected && this.computerAvatarSettings.ids.length === 1;
   }
 
   saveSelectedComputerAvatars(): void {

--- a/src/assets/wise5/vle/computer-avatar-selector/computer-avatar-selector.component.html
+++ b/src/assets/wise5/vle/computer-avatar-selector/computer-avatar-selector.component.html
@@ -12,9 +12,7 @@
         aria-label="Selected avatar"
         i18n-aria-label>
       <ng-container *ngFor="let avatar of avatars">
-        <mat-button-toggle [value]="avatar"
-            (mousedown)="highlightAvatar(avatar)"
-            aria-label="{{ avatar.name }}">
+        <mat-button-toggle [value]="avatar" aria-label="{{ avatar.name }}">
           <img [src]="avatarsPath + avatar.image" alt="{{ avatar.name }}" class="avatar-image" />
           <div class="name"><b>{{ avatar.name }}</b></div>
         </mat-button-toggle>

--- a/src/assets/wise5/vle/computer-avatar-selector/computer-avatar-selector.component.html
+++ b/src/assets/wise5/vle/computer-avatar-selector/computer-avatar-selector.component.html
@@ -12,7 +12,10 @@
         aria-label="Selected avatar"
         i18n-aria-label>
       <ng-container *ngFor="let avatar of avatars">
-        <mat-button-toggle [value]="avatar" aria-label="{{ avatar.name }}">
+        <mat-button-toggle
+            [value]="avatar"
+            (mousedown)="avatarSelected = avatar"
+            aria-label="{{ avatar.name }}">
           <img [src]="avatarsPath + avatar.image" alt="{{ avatar.name }}" class="avatar-image" />
           <div class="name"><b>{{ avatar.name }}</b></div>
         </mat-button-toggle>

--- a/src/assets/wise5/vle/computer-avatar-selector/computer-avatar-selector.component.spec.ts
+++ b/src/assets/wise5/vle/computer-avatar-selector/computer-avatar-selector.component.spec.ts
@@ -31,22 +31,11 @@ describe('ComputerAvatarSelectorComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should highlight avatar', () => {
-    console.log('avatars:' + component.avatars);
-    expect(component.avatarSelected).toEqual(undefined);
-    const firstAvatar = component.avatars[0];
-    component.highlightAvatar(firstAvatar);
-    expect(firstAvatar.isSelected).toBeTrue();
-    expect(component.avatars[1].isSelected).toBeFalsy();
-  });
-
   it('should choose avatar', () => {
     const firstAvatar = component.avatars[0];
-    firstAvatar.isSelected = true;
     component.avatarSelected = firstAvatar;
     const confirmSelectionEmitSpy = spyOn(component.chooseAvatarEvent, 'emit');
     component.chooseAvatar();
-    expect(firstAvatar.isSelected).toEqual(undefined);
     expect(confirmSelectionEmitSpy).toHaveBeenCalled();
   });
 });

--- a/src/assets/wise5/vle/computer-avatar-selector/computer-avatar-selector.component.ts
+++ b/src/assets/wise5/vle/computer-avatar-selector/computer-avatar-selector.component.ts
@@ -36,19 +36,7 @@ export class ComputerAvatarSelectorComponent implements OnInit {
     return allAvatars.filter((avatar) => avatarIdsToUse.includes(avatar.id));
   }
 
-  highlightAvatar(avatarClicked: ComputerAvatar): void {
-    for (const avatar of this.avatars) {
-      if (avatar.id === avatarClicked.id) {
-        avatar.isSelected = true;
-        this.avatarSelected = avatarClicked;
-      } else {
-        avatar.isSelected = false;
-      }
-    }
-  }
-
   chooseAvatar(): void {
-    delete this.avatarSelected.isSelected;
     this.chooseAvatarEvent.emit(this.avatarSelected);
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -8306,7 +8306,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">69</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component.html</context>
@@ -11708,32 +11708,25 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">51,52</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="aa697f2bae032b1c63ef838c9e82c4a7c7998d62" datatype="html">
-        <source> You must select at least one computer avatar </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">56,57</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="51c96f0051a84a0981042239f47b3f38ee2257cf" datatype="html">
         <source>Avatars available to students</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">56</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c0a308497c02864bc2c7cefcf0274368d3e5edc7" datatype="html">
         <source>Toggle <x id="INTERPOLATION" equiv-text="{{ computerAvatar.name }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5f9ab61f40e9053c2e217864b1d0b00b1df5f35f" datatype="html">
         <source>Not selected</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">78</context>
+          <context context-type="linenumber">73</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ac4a8ebf1347b29327308613dd307970ec899941" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -11593,28 +11593,28 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Dialog Guidance</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialogGuidanceService.ts</context>
-          <context context-type="linenumber">16</context>
+          <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6832087445897716825" datatype="html">
         <source>Thought Buddy</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialogGuidanceService.ts</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">29</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7559493123326903347" datatype="html">
         <source>Discuss your answer with a thought buddy!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialogGuidanceService.ts</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="817739684653615188" datatype="html">
         <source>Hi there! It&apos;s nice to meet you. What do you think about...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialogGuidanceService.ts</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5ee734dd4f01e4fdc237a0eac5d1b2942bda22b3" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15456,7 +15456,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source> Continue </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/computer-avatar-selector/computer-avatar-selector.component.html</context>
-          <context context-type="linenumber">30,31</context>
+          <context context-type="linenumber">28,29</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f3bb0234ead15a9bf90c2cb2ed7b48570d6011c5" datatype="html">


### PR DESCRIPTION
## Changes
- Removed hightAvatarFunction: Selecting and highlighting avatar is managed by Angular Material, so
avatar.isSelected field is also not necessary
- In AT
   - initialize new component with all available avatars: eliminate need for null check
   - Remove numSelectedComputerAvatars: this number is never set to 0 anymore
- cleaned up and consolidated functions related to numSelectedComputerAvatars

## Test
- authoring available avatars and selecting avatar as student work as before
- In particular, try creating a new DG avatar component and make sure that all avatars are selected