### PR TITLE
refactor(PeerChat): Remove peerChatWorkgroupIds

### DIFF
--- a/src/assets/wise5/components/peerChat/peer-chat-chat-box/peer-chat-chat-box.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-chat-box/peer-chat-chat-box.component.spec.ts
@@ -43,9 +43,9 @@ describe('PeerChatChatBoxComponent', () => {
 
   it('should create with workgroup infos without teachers', () => {
     expect(component).toBeTruthy();
-    expect(component.workgroupInfosWithoutTeachers).toEqual({
-      2: { isTeacher: false },
-      3: { isTeacher: false }
-    });
+    expect(component.workgroupInfosWithoutTeachers).toEqual([
+      { isTeacher: false },
+      { isTeacher: false }
+    ]);
   });
 });

--- a/src/assets/wise5/components/peerChat/peer-chat-chat-box/peer-chat-chat-box.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-chat-box/peer-chat-chat-box.component.spec.ts
@@ -33,23 +33,17 @@ describe('PeerChatChatBoxComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(PeerChatChatBoxComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-
-  it('should get workgroup infos without teachers', () => {
-    const workgroupInfos = {
+    component.workgroupInfos = {
       1: { isTeacher: true },
       2: { isTeacher: false },
       3: { isTeacher: false }
     };
-    const workgroupInfosWithoutTeachers = component.getWorkgroupInfosWithoutTeachers(
-      workgroupInfos
-    );
-    expect(workgroupInfosWithoutTeachers).toEqual({
+    fixture.detectChanges();
+  });
+
+  it('should create with workgroup infos without teachers', () => {
+    expect(component).toBeTruthy();
+    expect(component.workgroupInfosWithoutTeachers).toEqual({
       2: { isTeacher: false },
       3: { isTeacher: false }
     });

--- a/src/assets/wise5/components/peerChat/peer-chat-chat-box/peer-chat-chat-box.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-chat-box/peer-chat-chat-box.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { any } from 'angular-ui-router';
 import { PeerChatMessage } from '../PeerChatMessage';
 
 @Component({
@@ -25,17 +26,14 @@ export class PeerChatChatBoxComponent implements OnInit {
   submit: EventEmitter<string> = new EventEmitter<string>();
 
   ngOnInit(): void {
-    this.workgroupInfosWithoutTeachers = this.getWorkgroupInfosWithoutTeachers(this.workgroupInfos);
+    this.populateWorkgroupInfosWithoutTeachers();
   }
 
-  getWorkgroupInfosWithoutTeachers(workgroupInfos: any): any {
-    const workgroupInfosWithoutTeachers = {};
-    for (const workgroupId of Object.keys(workgroupInfos)) {
-      const workgroupInfo = workgroupInfos[workgroupId];
-      if (!workgroupInfo.isTeacher) {
-        workgroupInfosWithoutTeachers[workgroupId] = workgroupInfo;
+  private populateWorkgroupInfosWithoutTeachers(): void {
+    for (const [workgroupId, workgroupInfo] of Object.entries(this.workgroupInfos)) {
+      if (!(workgroupInfo as any).isTeacher) {
+        this.workgroupInfosWithoutTeachers[workgroupId] = workgroupInfo;
       }
     }
-    return workgroupInfosWithoutTeachers;
   }
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-chat-box/peer-chat-chat-box.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-chat-box/peer-chat-chat-box.component.ts
@@ -1,5 +1,4 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { any } from 'angular-ui-router';
 import { PeerChatMessage } from '../PeerChatMessage';
 
 @Component({

--- a/src/assets/wise5/components/peerChat/peer-chat-chat-box/peer-chat-chat-box.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-chat-box/peer-chat-chat-box.component.ts
@@ -19,20 +19,16 @@ export class PeerChatChatBoxComponent implements OnInit {
   @Input()
   workgroupInfos: any = {};
 
-  workgroupInfosWithoutTeachers: any = {};
+  workgroupInfosWithoutTeachers: any[];
 
   @Output('onSubmit')
   submit: EventEmitter<string> = new EventEmitter<string>();
 
   ngOnInit(): void {
-    this.populateWorkgroupInfosWithoutTeachers();
+    this.workgroupInfosWithoutTeachers = this.filterOutTeachers(this.workgroupInfos);
   }
 
-  private populateWorkgroupInfosWithoutTeachers(): void {
-    for (const [workgroupId, workgroupInfo] of Object.entries(this.workgroupInfos)) {
-      if (!(workgroupInfo as any).isTeacher) {
-        this.workgroupInfosWithoutTeachers[workgroupId] = workgroupInfo;
-      }
-    }
+  private filterOutTeachers(workgroupInfos: any): any[] {
+    return Object.values(workgroupInfos).filter((workgroupInfo: any) => !workgroupInfo.isTeacher);
   }
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-members/peer-chat-members.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-members/peer-chat-members.component.html
@@ -1,10 +1,9 @@
 <div class="mat-small secondary-text" fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="6px">
   <span i18n>Chat Members:</span>
-  <span *ngFor="let peerChatWorkgroupInfo of peerChatWorkgroupInfos | keyvalue">
-    <mat-icon class="mat-24"
-        [ngStyle]="{'color': peerChatWorkgroupInfo.value.avatarColor}">
+  <span *ngFor="let peerChatWorkgroupInfo of peerChatWorkgroupInfos">
+    <mat-icon class="mat-24" [ngStyle]="{'color': peerChatWorkgroupInfo.avatarColor}">
       account_circle
     </mat-icon>
-    <span class="names">{{ peerChatWorkgroupInfo.value.displayNames }}</span>
+    <span class="names">{{ peerChatWorkgroupInfo.displayNames }}</span>
   </span>
 </div>

--- a/src/assets/wise5/components/peerChat/peer-chat-members/peer-chat-members.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-members/peer-chat-members.component.html
@@ -1,10 +1,10 @@
 <div class="mat-small secondary-text" fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="6px">
   <span i18n>Chat Members:</span>
-  <span *ngFor="let peerChatWorkgroupId of peerChatWorkgroupIds; let last = last;">
+  <span *ngFor="let peerChatWorkgroupInfo of peerChatWorkgroupInfos | keyvalue">
     <mat-icon class="mat-24"
-        [ngStyle]="{'color': peerChatWorkgroupInfos[peerChatWorkgroupId].avatarColor}">
+        [ngStyle]="{'color': peerChatWorkgroupInfo.value.avatarColor}">
       account_circle
     </mat-icon>
-    <span class="names">{{ peerChatWorkgroupInfos[peerChatWorkgroupId].displayNames }}</span>
+    <span class="names">{{ peerChatWorkgroupInfo.value.displayNames }}</span>
   </span>
 </div>

--- a/src/assets/wise5/components/peerChat/peer-chat-members/peer-chat-members.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-members/peer-chat-members.component.spec.ts
@@ -16,7 +16,7 @@ describe('PeerChatMembersComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(PeerChatMembersComponent);
     component = fixture.componentInstance;
-    component.peerChatWorkgroupInfos = {};
+    component.peerChatWorkgroupInfos = [];
     fixture.detectChanges();
   });
 

--- a/src/assets/wise5/components/peerChat/peer-chat-members/peer-chat-members.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-members/peer-chat-members.component.ts
@@ -7,7 +7,7 @@ import { Component, Input, OnInit } from '@angular/core';
 })
 export class PeerChatMembersComponent implements OnInit {
   @Input()
-  peerChatWorkgroupInfos: any;
+  peerChatWorkgroupInfos: any[];
 
   constructor() {}
 

--- a/src/assets/wise5/components/peerChat/peer-chat-members/peer-chat-members.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-members/peer-chat-members.component.ts
@@ -9,11 +9,7 @@ export class PeerChatMembersComponent implements OnInit {
   @Input()
   peerChatWorkgroupInfos: any;
 
-  peerChatWorkgroupIds: number[];
-
   constructor() {}
 
-  ngOnInit(): void {
-    this.peerChatWorkgroupIds = Object.keys(this.peerChatWorkgroupInfos).map(Number);
-  }
+  ngOnInit(): void {}
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.ts
@@ -41,7 +41,7 @@ export class PeerChatShowWorkComponent extends ComponentShowWorkDirective {
     this.peerGroupService
       .retrievePeerGroup(this.componentContent.peerGroupActivityTag, this.workgroupId)
       .pipe(timeout(this.requestTimeout))
-      .subscribe((peerGroup: any) => {
+      .subscribe((peerGroup: PeerGroup) => {
         this.requestChatWorkgroupsSuccess(peerGroup);
       });
   }

--- a/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.ts
@@ -6,6 +6,8 @@ import { ProjectService } from '../../../services/projectService';
 import { PeerChatMessage } from '../PeerChatMessage';
 import { PeerChatService } from '../peerChatService';
 import { PeerGroupService } from '../../../services/peerGroupService';
+import { PeerGroup } from '../PeerGroup';
+import { PeerGroupMember } from '../PeerGroupMember';
 
 @Component({
   selector: 'peer-chat-show-work',
@@ -14,7 +16,7 @@ import { PeerGroupService } from '../../../services/peerGroupService';
 export class PeerChatShowWorkComponent extends ComponentShowWorkDirective {
   isPeerChatWorkgroupsAvailable: boolean = false;
   peerChatMessages: PeerChatMessage[] = [];
-  peerChatWorkgroupIds: Set<number>;
+  peerChatWorkgroupIds: Set<number> = new Set<number>();
   peerChatWorkgroupInfos: any = {};
   requestTimeout: number = 10000;
 
@@ -32,59 +34,52 @@ export class PeerChatShowWorkComponent extends ComponentShowWorkDirective {
 
   ngOnInit(): void {
     super.ngOnInit();
-    this.peerChatWorkgroupIds = new Set<number>();
     this.requestChatWorkgroups();
   }
 
-  requestChatWorkgroups(): void {
+  private requestChatWorkgroups(): void {
     this.peerGroupService
       .retrievePeerGroup(this.componentContent.peerGroupActivityTag, this.workgroupId)
       .pipe(timeout(this.requestTimeout))
-      .subscribe(
-        (peerGroup: any) => {
-          this.requestChatWorkgroupsSuccess(peerGroup);
-        },
-        (error) => {
-          // TODO
-        }
-      );
+      .subscribe((peerGroup: any) => {
+        this.requestChatWorkgroupsSuccess(peerGroup);
+      });
   }
 
-  requestChatWorkgroupsSuccess(peerGroup: any): void {
+  private requestChatWorkgroupsSuccess(peerGroup: PeerGroup): void {
     this.addWorkgroupIdsFromPeerGroup(this.peerChatWorkgroupIds, peerGroup);
     this.addTeacherWorkgroupIds(this.peerChatWorkgroupIds);
     this.retrievePeerChatComponentStates(this.nodeId, this.componentId, this.workgroupId);
   }
 
-  addWorkgroupIdsFromPeerGroup(workgroupIds: Set<number>, peerGroup: any): void {
-    peerGroup.members.forEach((member: any) => {
+  private addWorkgroupIdsFromPeerGroup(workgroupIds: Set<number>, peerGroup: PeerGroup): void {
+    peerGroup.members.forEach((member: PeerGroupMember) => {
       workgroupIds.add(member.id);
     });
   }
 
-  addTeacherWorkgroupIds(workgroupIds: Set<number>): void {
+  private addTeacherWorkgroupIds(workgroupIds: Set<number>): void {
     this.configService.getTeacherWorkgroupIds().forEach((workgroupId) => {
       workgroupIds.add(workgroupId);
     });
   }
 
-  retrievePeerChatComponentStates(nodeId: string, componentId: string, workgroupId: number): void {
+  private retrievePeerChatComponentStates(
+    nodeId: string,
+    componentId: string,
+    workgroupId: number
+  ): void {
     this.peerChatService
       .retrievePeerChatComponentStates(nodeId, componentId, workgroupId)
       .pipe(timeout(this.requestTimeout))
-      .subscribe(
-        (componentStates: any[]) => {
-          this.setPeerChatMessages(componentStates);
-          this.addWorkgroupIdsFromPeerChatMessages(this.peerChatWorkgroupIds, componentStates);
-          this.setPeerChatWorkgroupInfos(Array.from(this.peerChatWorkgroupIds));
-        },
-        (error) => {
-          // TODO
-        }
-      );
+      .subscribe((componentStates: any[]) => {
+        this.setPeerChatMessages(componentStates);
+        this.addWorkgroupIdsFromPeerChatMessages(this.peerChatWorkgroupIds, componentStates);
+        this.setPeerChatWorkgroupInfos(Array.from(this.peerChatWorkgroupIds));
+      });
   }
 
-  setPeerChatMessages(componentStates: any[]): void {
+  private setPeerChatMessages(componentStates: any[]): void {
     this.peerChatMessages = [];
     componentStates.forEach((componentState: any) => {
       this.peerChatMessages.push(
@@ -93,13 +88,16 @@ export class PeerChatShowWorkComponent extends ComponentShowWorkDirective {
     });
   }
 
-  addWorkgroupIdsFromPeerChatMessages(workgroupIds: Set<number>, componentStates: any[]): void {
+  private addWorkgroupIdsFromPeerChatMessages(
+    workgroupIds: Set<number>,
+    componentStates: any[]
+  ): void {
     componentStates.forEach((componentState) => {
       workgroupIds.add(componentState.workgroupId);
     });
   }
 
-  setPeerChatWorkgroupInfos(workgroupIds: number[]): void {
+  private setPeerChatWorkgroupInfos(workgroupIds: number[]): void {
     for (const workgroupId of workgroupIds) {
       this.peerChatWorkgroupInfos[workgroupId] = {
         avatarColor: this.configService.getAvatarColorForWorkgroupId(workgroupId),

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
@@ -145,7 +145,8 @@ export class PeerChatStudentComponent extends ComponentStudent {
         avatarColor: this.ConfigService.getAvatarColorForWorkgroupId(workgroupId),
         displayNames: this.ConfigService.isTeacherWorkgroupId(workgroupId)
           ? $localize`Teacher`
-          : this.ConfigService.getUsernamesStringByWorkgroupId(workgroupId)
+          : this.ConfigService.getUsernamesStringByWorkgroupId(workgroupId),
+        isTeacher: this.ConfigService.isTeacherWorkgroupId(workgroupId)
       };
     }
     this.isPeerChatWorkgroupsAvailable = true;

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -7350,13 +7350,6 @@
           <context context-type="linenumber">5</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="26599a3f0d31f31c0a993b352609d6f10af5ccdf" datatype="html">
-        <source>Visit the WISE Community</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/discourse-recent-activity/discourse-recent-activity.component.html</context>
-          <context context-type="linenumber">8</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="4c49a9bb7a99a9da256c6e678cbb49baa70e268a" datatype="html">
         <source>Edit Classroom Unit</source>
         <context-group purpose="location">
@@ -14643,20 +14636,6 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">138</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1cd15276840c64f5eae40ef3fb51ff81f84f278b" datatype="html">
-        <source>Chat Members:</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-members/peer-chat-members.component.html</context>
-          <context context-type="linenumber">2</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="939b4d44088b8ece0fd394a0eb0e9c43d632b99c" datatype="html">
-        <source> Send </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-message-input/peer-chat-message-input.component.html</context>
-          <context context-type="linenumber">17,18</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="375ead964bf5b0ae938bb0b600db793ac0d32683" datatype="html">
         <source> This Peer Chat activity is not yet available. Please check back later or wait for a notification to return. </source>
         <context-group purpose="location">
@@ -14672,6 +14651,13 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">2,3</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1cd15276840c64f5eae40ef3fb51ff81f84f278b" datatype="html">
+        <source>Chat Members:</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-members/peer-chat-members.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="939b4d44088b8ece0fd394a0eb0e9c43d632b99c" datatype="html">
         <source> Send </source>
         <context-group purpose="location">
@@ -14683,7 +14669,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.ts</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">105</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts</context>


### PR DESCRIPTION
## Changes
- Use iterate over peerChatWorkgroupInfos in PeerChatMembers. This eliminates need for peerChatWorkgroupIds
- Change getWorkgroupInfosWithoutTeachers() to filterOutTeachers()
- Add private to function signatures and PeerGroup types to parameters
- Fix issue where teacher was showing up as member in student mode

## Test
- Peer Chat works as before

Closes #517 