### PR TITLE
feat(Open Response): Save CRater ideas in annotation

### DIFF
--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
@@ -407,6 +407,9 @@ export class OpenResponseStudent extends ComponentStudent {
     if (data.scores != null) {
       autoScoreAnnotationData.scores = data.scores;
     }
+    if (data.ideas != null) {
+      autoScoreAnnotationData.ideas = data.ideas;
+    }
 
     let autoScoreAnnotation = this.createAutoScoreAnnotation(autoScoreAnnotationData);
     let annotationGroupForScore = null;


### PR DESCRIPTION
## Changes

CRater ideas are now saved in the CRater score annotation for Open Response.

## Test

As a student, submit an Open Response that has a CRater Item ID that analyzes ideas. Here is an Item ID that analyzes ideas

```CarOnAColdDay_score-ki_idea-ki_nonscorable```

Make sure the ideas are saved in the annotation.

Closes #536