### PR TITLE
perf(Teacher Peer Chat): Retrieve messages only when needed

### DIFF
--- a/src/assets/wise5/components/component-show-work.directive.ts
+++ b/src/assets/wise5/components/component-show-work.directive.ts
@@ -27,4 +27,8 @@ export abstract class ComponentShowWorkDirective {
   }
 
   ngOnDestroy(): void {}
+
+  isForThisComponent(object: any): boolean {
+    return object.nodeId === this.nodeId && object.componentId === this.componentId;
+  }
 }

--- a/src/assets/wise5/components/component-show-work.directive.ts
+++ b/src/assets/wise5/components/component-show-work.directive.ts
@@ -27,8 +27,4 @@ export abstract class ComponentShowWorkDirective {
   }
 
   ngOnDestroy(): void {}
-
-  isForThisComponent(object: any): boolean {
-    return object.nodeId === this.nodeId && object.componentId === this.componentId;
-  }
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.ts
@@ -1,5 +1,4 @@
-import { Component, Input } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { Component } from '@angular/core';
 import { ComponentState } from '../../../../../app/domain/componentState';
 import { ConfigService } from '../../../services/configService';
 import { NotificationService } from '../../../services/notificationService';
@@ -19,8 +18,6 @@ import { PeerGroup } from '../PeerGroup';
 })
 export class PeerChatGradingComponent extends PeerChatShowWorkComponent {
   peerGroup: PeerGroup;
-
-  subscriptions: Subscription = new Subscription();
 
   constructor(
     protected configService: ConfigService,
@@ -42,18 +39,6 @@ export class PeerChatGradingComponent extends PeerChatShowWorkComponent {
       .subscribe((peerGroup) => {
         this.peerGroup = peerGroup;
       });
-    this.subscriptions.add(
-      this.teacherWebSocketService.newStudentWorkReceived$.subscribe(({ studentWork }) => {
-        if (this.isForThisPeerGroup(studentWork)) {
-          this.retrievePeerChatComponentStates();
-        }
-      })
-    );
-  }
-
-  ngOnDestroy(): void {
-    super.ngOnDestroy();
-    this.subscriptions.unsubscribe();
   }
 
   submitTeacherResponse(response: string): void {
@@ -103,13 +88,5 @@ export class PeerChatGradingComponent extends PeerChatShowWorkComponent {
       workgroupId: this.configService.getWorkgroupId(),
       peerGroupId: this.peerGroup.id
     };
-  }
-
-  private isForThisPeerGroup(studentWork: any): boolean {
-    return this.isForThisComponent(studentWork) && this.isPeerGroupMember(studentWork.workgroupId);
-  }
-
-  private isPeerGroupMember(workgroupId: number): boolean {
-    return this.peerGroup.members.some((member) => member.id === workgroupId);
   }
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.ts
@@ -18,9 +18,6 @@ import { PeerGroup } from '../PeerGroup';
   styleUrls: ['./peer-chat-grading.component.scss']
 })
 export class PeerChatGradingComponent extends PeerChatShowWorkComponent {
-  @Input()
-  workgroupId: number;
-
   peerGroup: PeerGroup;
 
   subscriptions: Subscription = new Subscription();
@@ -46,8 +43,10 @@ export class PeerChatGradingComponent extends PeerChatShowWorkComponent {
         this.peerGroup = peerGroup;
       });
     this.subscriptions.add(
-      this.teacherWebSocketService.newStudentWorkReceived$.subscribe(() => {
-        this.ngOnInit();
+      this.teacherWebSocketService.newStudentWorkReceived$.subscribe(({ studentWork }) => {
+        if (this.isForThisPeerGroup(studentWork)) {
+          this.retrievePeerChatComponentStates();
+        }
       })
     );
   }
@@ -104,5 +103,13 @@ export class PeerChatGradingComponent extends PeerChatShowWorkComponent {
       workgroupId: this.configService.getWorkgroupId(),
       peerGroupId: this.peerGroup.id
     };
+  }
+
+  private isForThisPeerGroup(studentWork: any): boolean {
+    return this.isForThisComponent(studentWork) && this.isPeerGroupMember(studentWork.workgroupId);
+  }
+
+  private isPeerGroupMember(workgroupId: number): boolean {
+    return this.peerGroup.members.some((member) => member.id === workgroupId);
   }
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.ts
@@ -64,7 +64,7 @@ export class PeerChatShowWorkComponent extends ComponentShowWorkDirective {
     });
   }
 
-  protected retrievePeerChatComponentStates(): void {
+  private retrievePeerChatComponentStates(): void {
     this.peerChatService
       .retrievePeerChatComponentStates(this.nodeId, this.componentId, this.workgroupId)
       .pipe(timeout(this.requestTimeout))

--- a/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.ts
@@ -21,7 +21,7 @@ export class PeerChatShowWorkComponent extends ComponentShowWorkDirective {
   requestTimeout: number = 10000;
 
   @Input()
-  workgroupId: any;
+  workgroupId: number;
 
   constructor(
     protected configService: ConfigService,
@@ -49,7 +49,7 @@ export class PeerChatShowWorkComponent extends ComponentShowWorkDirective {
   private requestChatWorkgroupsSuccess(peerGroup: PeerGroup): void {
     this.addWorkgroupIdsFromPeerGroup(this.peerChatWorkgroupIds, peerGroup);
     this.addTeacherWorkgroupIds(this.peerChatWorkgroupIds);
-    this.retrievePeerChatComponentStates(this.nodeId, this.componentId, this.workgroupId);
+    this.retrievePeerChatComponentStates();
   }
 
   private addWorkgroupIdsFromPeerGroup(workgroupIds: Set<number>, peerGroup: PeerGroup): void {
@@ -64,13 +64,9 @@ export class PeerChatShowWorkComponent extends ComponentShowWorkDirective {
     });
   }
 
-  private retrievePeerChatComponentStates(
-    nodeId: string,
-    componentId: string,
-    workgroupId: number
-  ): void {
+  protected retrievePeerChatComponentStates(): void {
     this.peerChatService
-      .retrievePeerChatComponentStates(nodeId, componentId, workgroupId)
+      .retrievePeerChatComponentStates(this.nodeId, this.componentId, this.workgroupId)
       .pipe(timeout(this.requestTimeout))
       .subscribe((componentStates: any[]) => {
         this.setPeerChatMessages(componentStates);

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -14933,7 +14933,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.ts</context>
-          <context context-type="linenumber">105</context>
+          <context context-type="linenumber">101</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts</context>


### PR DESCRIPTION
## Changes
- Ensure that newly-arrived StudentWork is for the PeerGroup that teacher is viewing
   - Behavior before this PR: the teacher will fetch the PeerGroup's chat messages when any new student work comes in for any step from any student. This results in needless computation and could lead to performance issues

- Change type of workgroupId from any to number

## Test
- Teacher PeerChat works as before: new messages are displayed as they come in
- Teacher only makes request for new messages when the new message is for the PeerGroup that they are viewing

## Note
Right now, a call to this.retrievePeerChatComponentStates() is needed, instead of just calling this.peerChatMessages.push(studentWork) in the code below:

```
if (this.isForThisPeerGroup(studentWork)) {
    this.retrievePeerChatComponentStates();
}
```

If we use the push method, new messages from another student in the PeerGroup (but not the same student that you're viewing in the grading tool) will not appear.

I think this could be looked at again in the future for better optimization, since retrievePeerChatComponentStates() makes a GET request. But for now, this PR would be a significant improvement over the current behavior.

Closes #542