### PR TITLE
feat(notifications): Add clear notifications buttons

### DIFF
--- a/src/app/student/top-bar/top-bar.component.ts
+++ b/src/app/student/top-bar/top-bar.component.ts
@@ -126,7 +126,8 @@ export class TopBarComponent {
   viewAlerts($event: any): void {
     $event.stopPropagation();
     this.dialog.open(NotificationsDialogComponent, {
-      panelClass: 'dialog-sm'
+      panelClass: 'dialog-sm',
+      autoFocus: false
     });
   }
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/notificationsMenu/notificationsMenu.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/notificationsMenu/notificationsMenu.ts
@@ -61,7 +61,8 @@ const NotificationsMenu = {
             <md-toolbar md-theme="light" class="account-menu__info md-subhead md-whiteframe-1dp" layout="row" layout-align="start center">
                 <span class="accent account-menu__info__title" layout="row" layout-align="start center"><md-icon class="accent"> notifications </md-icon>&nbsp;<span translate="ALERTS"></span></span>
                 <span flex></span>
-                  <md-button class="md-icon-button"
+                  <md-button ng-if="$ctrl.newNotifications.length"
+                             class="md-icon-button"
                              aria-label="Clear all notifications"
                              md-prevent-menu-close="md-prevent-menu-close"
                              ng-disabled="$ctrl.newNotifications.length < 1"

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/notificationsMenu/notificationsMenu.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/notificationsMenu/notificationsMenu.ts
@@ -61,12 +61,12 @@ const NotificationsMenu = {
             <md-toolbar md-theme="light" class="account-menu__info md-subhead md-whiteframe-1dp" layout="row" layout-align="start center">
                 <span class="accent account-menu__info__title" layout="row" layout-align="start center"><md-icon class="accent"> notifications </md-icon>&nbsp;<span translate="ALERTS"></span></span>
                 <span flex></span>
-                <!--<md-button class="md-icon-button"
-                           aria-label="Clear all notifications"
-                           md-prevent-menu-close="md-prevent-menu-close"
-                           ng-disabled="$ctrl.newNotifications.length < 1"
-                           ng-click="$ctrl.confirmDismissAllNotifications($event)">
-                    <md-icon> clear_all </md-icon>-->
+                  <md-button class="md-icon-button"
+                             aria-label="Clear all notifications"
+                             md-prevent-menu-close="md-prevent-menu-close"
+                             ng-disabled="$ctrl.newNotifications.length < 1"
+                             ng-click="$ctrl.confirmDismissAllNotifications($event)">
+                  <md-icon> clear_all </md-icon>
                 </md-button>
             </md-toolbar>
             <md-content class="account-menu__actions" flex>

--- a/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.html
+++ b/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.html
@@ -7,7 +7,7 @@
   <span fxFlex></span>
   <button *ngIf="newNotifications.length > 0"
       mat-icon-button
-      (click)="dismissAll($event)"
+      (click)="dismissAll()"
       matTooltip="Dismiss all alerts"
       matTooltipPosition="before"
       i18n-matTooltip>
@@ -23,7 +23,7 @@
   <mat-list *ngIf="hasNewNotifications()">
     <mat-list-item *ngFor="let notificationAggregate of newNotifications; let last = last;" class="notification-item">
       <p matLine class="mat-body-1">
-        <a (click)="dismissNotificationAggregateAndVisitNode($event, notificationAggregate)"
+        <a (click)="dismissNotificationAggregateAndVisitNode(notificationAggregate)"
             tabindex="0"
             aria-label="View alert"
             i18n-aria-label>
@@ -41,7 +41,7 @@
         {{ reportItem.title }}
       </p>
       <button mat-icon-button
-          (click)="dismissNotificationAggregate($event, notificationAggregate); $event.stopPropagation();"
+          (click)="dismissNotificationAggregate(notificationAggregate); $event.stopPropagation();"
           aria-label="Dismiss"
           i18n-aria-label>
         <mat-icon class="text-secondary">clear</mat-icon>

--- a/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.html
+++ b/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.html
@@ -4,6 +4,15 @@
     fxLayoutGap="4px">
   <mat-icon color="accent">notifications</mat-icon>
   <span i18n>Alerts</span>
+  <span fxFlex></span>
+  <button *ngIf="newNotifications.length > 0"
+      mat-icon-button
+      (click)="dismissAll($event)"
+      matTooltip="Dismiss all alerts"
+      matTooltipPosition="before"
+      i18n-matTooltip>
+    <mat-icon class="text-secondary">clear_all</mat-icon>
+  </button>
 </h3>
 <mat-dialog-content class="dialog-content-scroll notifications">
   <p *ngIf="!hasNewNotifications()"
@@ -42,5 +51,5 @@
   </mat-list>
 </mat-dialog-content>
 <mat-dialog-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="end" fxLayoutGap="8px">
-  <button mat-flat-button color="primary" [mat-dialog-close] i18n>Close</button>
+  <button mat-button [mat-dialog-close] i18n>Close</button>
 </mat-dialog-actions>

--- a/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.spec.ts
+++ b/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.spec.ts
@@ -26,6 +26,7 @@ describe('NotificationsMenuComponent', () => {
   let notification2: any;
   let notification3: any;
   let notificationAggregate1: any;
+  let notificationAggregate2: any;
   const teacherToStudentType = 'teacherToStudent';
 
   beforeEach(async () => {
@@ -68,6 +69,10 @@ describe('NotificationsMenuComponent', () => {
       notification1,
       notification2
     ]);
+    notificationAggregate2 = createNotificationAggregate(nodeId1, 'Hello', [
+      notification1,
+      notification3
+    ]);
     dismissNotificationSpy = spyOn(TestBed.inject(NotificationService), 'dismissNotification');
     fixture.detectChanges();
   });
@@ -96,32 +101,38 @@ describe('NotificationsMenuComponent', () => {
     };
   }
 
-  it('should dismiss notification that does not require dismiss code', () => {
-    component.dismissNotification({}, notification1);
-    expect(dismissNotificationSpy).toHaveBeenCalled();
-  });
-
-  it('should dismiss notification that does require dismiss code', () => {
-    const broadcastViewCurrentAmbientNotificationSpy = spyOn(
-      TestBed.inject(NotificationService),
-      'broadcastViewCurrentAmbientNotification'
-    );
-    component.dismissNotification({}, notification3);
-    expect(broadcastViewCurrentAmbientNotificationSpy).toHaveBeenCalled();
-  });
-
   it('should dismiss notification aggregate and visit node', () => {
     const endCurrentNodeAndSetCurrentNodeByNodeIdSpy = spyOn(
       TestBed.inject(StudentDataService),
       'endCurrentNodeAndSetCurrentNodeByNodeId'
     ).and.callFake(() => {});
-    component.dismissNotificationAggregateAndVisitNode({}, notificationAggregate1);
+    component.dismissNotificationAggregateAndVisitNode(notificationAggregate1);
     expect(dismissNotificationSpy).toHaveBeenCalledTimes(2);
     expect(endCurrentNodeAndSetCurrentNodeByNodeIdSpy).toHaveBeenCalledWith(nodeId1);
   });
 
-  it('should dismiss notification aggregate', () => {
-    component.dismissNotificationAggregate({}, notificationAggregate1);
+  it('should dismiss notification aggregate that does not require dismiss code', () => {
+    component.dismissNotificationAggregate(notificationAggregate1);
     expect(dismissNotificationSpy).toHaveBeenCalledTimes(2);
   });
+
+  it('should dismiss notification aggregate that does require dismiss code', () => {
+    const broadcastViewCurrentAmbientNotificationSpy = spyOn(
+      TestBed.inject(NotificationService),
+      'broadcastViewCurrentAmbientNotification'
+    );
+    component.dismissNotificationAggregate(notificationAggregate2);
+    expect(dismissNotificationSpy).toHaveBeenCalledTimes(1);
+    expect(broadcastViewCurrentAmbientNotificationSpy).toHaveBeenCalled();
+  });
+
+  it('should dismiss all notifications', () => {
+    component.newNotifications = [notificationAggregate1, notificationAggregate2];
+    const dismissNotificationAggregateSpy = spyOn(component, 'dismissNotificationAggregate');
+    spyOn(window, 'confirm').and.callFake(function () {
+      return true;
+    });
+    component.dismissAll();
+    expect(dismissNotificationAggregateSpy).toHaveBeenCalledTimes(2);
+  })
 });

--- a/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.ts
+++ b/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.ts
@@ -87,8 +87,10 @@ export class NotificationsDialogComponent implements OnInit {
   }
 
   dismissAll(event: any): void {
-    for (const notificationAggregate of this.newNotifications) {
-      this.dismissNotificationAggregate(event, notificationAggregate, false);
+    if (confirm($localize`Are you sure you want to dismiss all your alerts?`)) {
+      for (const notificationAggregate of this.newNotifications) {
+        this.dismissNotificationAggregate(event, notificationAggregate, false);
+      }
     }
   }
 

--- a/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.ts
+++ b/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.ts
@@ -40,13 +40,13 @@ export class NotificationsDialogComponent implements OnInit {
     return this.newNotifications.length > 0;
   }
 
-  dismissNotificationAggregateAndVisitNode(event: any, notificationAggregate: any): void {
+  dismissNotificationAggregateAndVisitNode(notificationAggregate: any): void {
     if (notificationAggregate != null && notificationAggregate.notifications != null) {
       for (const notification of notificationAggregate.notifications) {
         if (notification.data == null || notification.data.dismissCode == null) {
           // only dismiss notifications that don't require a dismiss code,
           // but still allow them to move to the node
-          this.dismissNotification(event, notification);
+          this.dismissNotification(notification);
         }
       }
     }
@@ -64,13 +64,12 @@ export class NotificationsDialogComponent implements OnInit {
     }
   }
 
-  dismissNotification(event: any, notification: Notification, showDismissCode: boolean = true): any {
+  private dismissNotification(notification: Notification, showDismissCode: boolean = true): any {
     if (this.canDismissWithoutCode(notification)) {
       this.notificationService.dismissNotification(notification);
     } else if (showDismissCode) {
       // ask user to input dismiss code before dismissing it
       let args = {
-        event: event,
         notification: notification
       };
       this.notificationService.broadcastViewCurrentAmbientNotification(args);
@@ -78,10 +77,10 @@ export class NotificationsDialogComponent implements OnInit {
     }
   }
 
-  dismissNotificationAggregate(event: any, notificationAggregate: any, showDismissCode: boolean = true): void {
+  dismissNotificationAggregate(notificationAggregate: any, showDismissCode: boolean = true): void {
     if (notificationAggregate != null && notificationAggregate.notifications != null) {
       for (const notification of notificationAggregate.notifications) {
-        this.dismissNotification(event, notification, showDismissCode);
+        this.dismissNotification(notification, showDismissCode);
       }
     }
   }
@@ -89,7 +88,7 @@ export class NotificationsDialogComponent implements OnInit {
   dismissAll(event: any): void {
     if (confirm($localize`Are you sure you want to dismiss all your alerts?`)) {
       for (const notificationAggregate of this.newNotifications) {
-        this.dismissNotificationAggregate(event, notificationAggregate, false);
+        this.dismissNotificationAggregate(notificationAggregate, false);
       }
     }
   }
@@ -98,7 +97,7 @@ export class NotificationsDialogComponent implements OnInit {
     return this.projectService.getNodePositionAndTitleByNodeId(nodeId);
   }
 
-  canDismissWithoutCode(notification: Notification): boolean {
+  private canDismissWithoutCode(notification: Notification): boolean {
     return notification.data == null || notification.data.dismissCode == null;
   }
 }

--- a/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.ts
+++ b/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.ts
@@ -64,10 +64,10 @@ export class NotificationsDialogComponent implements OnInit {
     }
   }
 
-  dismissNotification(event: any, notification: Notification): any {
-    if (notification.data == null || notification.data.dismissCode == null) {
+  dismissNotification(event: any, notification: Notification, showDismissCode: boolean = true): any {
+    if (this.canDismissWithoutCode(notification)) {
       this.notificationService.dismissNotification(notification);
-    } else {
+    } else if (showDismissCode) {
       // ask user to input dismiss code before dismissing it
       let args = {
         event: event,
@@ -78,15 +78,25 @@ export class NotificationsDialogComponent implements OnInit {
     }
   }
 
-  dismissNotificationAggregate(event: any, notificationAggregate: any): void {
+  dismissNotificationAggregate(event: any, notificationAggregate: any, showDismissCode: boolean = true): void {
     if (notificationAggregate != null && notificationAggregate.notifications != null) {
       for (const notification of notificationAggregate.notifications) {
-        this.dismissNotification(event, notification);
+        this.dismissNotification(event, notification, showDismissCode);
       }
+    }
+  }
+
+  dismissAll(event: any): void {
+    for (const notificationAggregate of this.newNotifications) {
+      this.dismissNotificationAggregate(event, notificationAggregate, false);
     }
   }
 
   getNodePositionAndTitleByNodeId(nodeId: string): string {
     return this.projectService.getNodePositionAndTitleByNodeId(nodeId);
+  }
+
+  canDismissWithoutCode(notification: Notification): boolean {
+    return notification.data == null || notification.data.dismissCode == null;
   }
 }

--- a/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.ts
+++ b/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.ts
@@ -85,7 +85,7 @@ export class NotificationsDialogComponent implements OnInit {
     }
   }
 
-  dismissAll(event: any): void {
+  dismissAll(): void {
     if (confirm($localize`Are you sure you want to dismiss all your alerts?`)) {
       for (const notificationAggregate of this.newNotifications) {
         this.dismissNotificationAggregate(notificationAggregate, false);

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15694,6 +15694,13 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="9025871139272246057" datatype="html">
+        <source>Are you sure you want to dismiss all your alerts?</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.ts</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="b9311730cc705aa91140b247c6e4fb58a10174dd" datatype="html">
         <source>(Team <x id="INTERPOLATION" equiv-text="{{ workgroupId }}"/>)</source>
         <context-group purpose="location">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -292,7 +292,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">54</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/studentAsset/student-assets-dialog/student-assets-dialog.component.html</context>
@@ -311,7 +311,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.html</context>
-          <context context-type="linenumber">36</context>
+          <context context-type="linenumber">45</context>
         </context-group>
       </trans-unit>
       <trans-unit id="69410cfd03d0c317234765d99d86c2c9e88bb915" datatype="html">
@@ -14403,14 +14403,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>This will replace your existing recording. Is this OK?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">774</context>
+          <context context-type="linenumber">706</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8057349329324626950" datatype="html">
         <source>Are you sure you want to delete your recording?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">818</context>
+          <context context-type="linenumber">750</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5623290610025495479" datatype="html">
@@ -15621,7 +15621,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Invalid dismiss code. Please try again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.ts</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">24</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f3bb0234ead15a9bf90c2cb2ed7b48570d6011c5" datatype="html">
@@ -15673,18 +15673,25 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">6</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="e4c201ad39e5fa4658b22a707c94012bc30e0846" datatype="html">
+        <source>Dismiss all alerts</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="eae1bb3f81534953df4c9a2f0e7e24223ec63754" datatype="html">
         <source>Hi there! You currently have no alerts.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.html</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
       <trans-unit id="89ff62ce83b0b07cc05847d8dd1ce15df94e6e20" datatype="html">
         <source>View alert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.html</context>
-          <context context-type="linenumber">19</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b9311730cc705aa91140b247c6e4fb58a10174dd" datatype="html">


### PR DESCRIPTION
## Changes
- Adds clear all button to student notifications dialog
- Re-enables clear all button in teacher notifications dialog

Closes #548.

## Test
- Ensure clear all notifications buttons work for both student and teacher.
- Student clear all button should clear all notifications that don't require a dismiss code.
- Make sure clearing single notifications still works.