### PR TITLE
build(Fabric): Use v3.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "dom-autoscroller": "^2.3.4",
         "drawing-tool": "^2.1.2",
         "eventemitter2": "^5.0.1",
-        "fabric": "^3.6.6",
+        "fabric": "3.6.3",
         "highcharts": "^9.3.3",
         "highcharts-angular": "^2.10.0",
         "html2canvas": "^0.5.0-beta4",
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/@angular-builders/custom-webpack/node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1175,12 +1175,13 @@
       }
     },
     "node_modules/@babel/core/node_modules/@ampproject/remapping": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.0"
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -3509,10 +3510,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-1.0.0.tgz",
       "integrity": "sha512-9oLAnygRMi8Q5QkYEU4XWK04B+nuoXoxjRvRxgjuChkLZFBja0YPSgdZ7dZtwhncLBcQe/I/E+fLuk5qxcYVJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+      "integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
@@ -4245,9 +4268,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "12.20.49",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.49.tgz",
-      "integrity": "sha512-5e6QNb9bkeh4Hni4ktLqUZuUqnGTX/kou2aZkXyxtuYaHXgBm+In1SHR9V+7kDzWzjB08KC2uqt2doDi7cuAAA==",
+      "version": "12.20.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.50.tgz",
+      "integrity": "sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -4270,9 +4293,9 @@
       "dev": true
     },
     "node_modules/@types/retry": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
     },
     "node_modules/@types/selenium-webdriver": {
@@ -4647,6 +4670,15 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/agentkeepalive/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/aggregate-error": {
@@ -5756,24 +5788,27 @@
       "dev": true
     },
     "node_modules/body-parser": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.2.tgz",
-      "integrity": "sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "1.8.1",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
-        "on-finished": "~2.3.0",
-        "qs": "6.9.7",
-        "raw-body": "2.4.3",
-        "type-is": "~1.6.18"
+        "on-finished": "2.4.1",
+        "qs": "6.10.3",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/body-parser/node_modules/debug": {
@@ -7442,9 +7477,9 @@
       }
     },
     "node_modules/cosmiconfig-typescript-loader/node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true,
       "optional": true,
       "bin": {
@@ -9414,12 +9449,12 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/dependency-graph": {
@@ -9444,10 +9479,14 @@
       "dev": true
     },
     "node_modules/destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
     },
     "node_modules/detect-file": {
       "version": "1.0.0",
@@ -9692,138 +9731,10 @@
         "jquery": ">= 2.1.3"
       }
     },
-    "node_modules/drawing-tool/node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "optional": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/drawing-tool/node_modules/cssom": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
-      "optional": true
-    },
-    "node_modules/drawing-tool/node_modules/cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-      "optional": true,
-      "dependencies": {
-        "cssom": "~0.3.6"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/drawing-tool/node_modules/cssstyle/node_modules/cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-      "optional": true
-    },
     "node_modules/drawing-tool/node_modules/eventemitter2": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
-    },
-    "node_modules/drawing-tool/node_modules/fabric": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/fabric/-/fabric-3.6.3.tgz",
-      "integrity": "sha512-PwJKZG7Zbst+B1PSmt2OddK8UJ9tQ23a9gslodCSrXCzj8S+1RcOaQuA9gbpoQWpXYUB0qsBhdBvAVyOi7oM9g==",
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "canvas": "^2.6.1",
-        "jsdom": "^15.1.0"
-      }
-    },
-    "node_modules/drawing-tool/node_modules/jsdom": {
-      "version": "15.2.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
-      "integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
-      "optional": true,
-      "dependencies": {
-        "abab": "^2.0.0",
-        "acorn": "^7.1.0",
-        "acorn-globals": "^4.3.2",
-        "array-equal": "^1.0.0",
-        "cssom": "^0.4.1",
-        "cssstyle": "^2.0.0",
-        "data-urls": "^1.1.0",
-        "domexception": "^1.0.1",
-        "escodegen": "^1.11.1",
-        "html-encoding-sniffer": "^1.0.2",
-        "nwsapi": "^2.2.0",
-        "parse5": "5.1.0",
-        "pn": "^1.1.0",
-        "request": "^2.88.0",
-        "request-promise-native": "^1.0.7",
-        "saxes": "^3.1.9",
-        "symbol-tree": "^3.2.2",
-        "tough-cookie": "^3.0.1",
-        "w3c-hr-time": "^1.0.1",
-        "w3c-xmlserializer": "^1.1.2",
-        "webidl-conversions": "^4.0.2",
-        "whatwg-encoding": "^1.0.5",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^7.0.0",
-        "ws": "^7.0.0",
-        "xml-name-validator": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "canvas": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/drawing-tool/node_modules/tough-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-      "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
-      "optional": true,
-      "dependencies": {
-        "ip-regex": "^2.1.0",
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/drawing-tool/node_modules/ws": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "optional": true,
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
@@ -9901,9 +9812,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.119",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.119.tgz",
-      "integrity": "sha512-HPEmKy+d0xK8oCfEHc5t6wDsSAi1WmE3Ld08QrBjAPxaAzfuKP66VJ77lcTqxTt7GJmSE279s75mhW64Xh+4kw==",
+      "version": "1.4.123",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.123.tgz",
+      "integrity": "sha512-0pHGE53WkYoFbsgwYcVKEpWa6jbzlvkohIEA2CUoZ9b5KC+w/zlMiQHvW/4IBcOh7YoEFqRNavgTk02TBoUTUw==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -11141,44 +11052,54 @@
       }
     },
     "node_modules/express": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.3.tgz",
-      "integrity": "sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.0.tgz",
+      "integrity": "sha512-EJEXxiTQJS3lIPrU1AE2vRuT7X7E+0KBbpm5GSoK524yl0K8X+er8zS2P14E64eqsVNoWbMCT7MpmQ+ErAhgRg==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.19.2",
+        "body-parser": "1.20.0",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.4.2",
+        "cookie": "0.5.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "~1.1.2",
+        "finalhandler": "1.2.0",
         "fresh": "0.5.2",
+        "http-errors": "2.0.0",
         "merge-descriptors": "1.0.1",
         "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.9.7",
+        "qs": "6.10.3",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.17.2",
-        "serve-static": "1.14.2",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
         "setprototypeof": "1.2.0",
-        "statuses": "~1.5.0",
+        "statuses": "2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -11188,6 +11109,24 @@
       "dev": true,
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/finalhandler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/express/node_modules/ms": {
@@ -11215,6 +11154,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/express/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/ext": {
       "version": "1.6.0",
@@ -11371,9 +11319,9 @@
       ]
     },
     "node_modules/fabric": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/fabric/-/fabric-3.6.6.tgz",
-      "integrity": "sha512-+sEwsgLSLIHQ32INuvV4CvWtqYOLyDKify/FfDteZvYQSoWRILLqzpCRt6AkEySsLToohkcygkD/unEOzV38wQ==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/fabric/-/fabric-3.6.3.tgz",
+      "integrity": "sha512-PwJKZG7Zbst+B1PSmt2OddK8UJ9tQ23a9gslodCSrXCzj8S+1RcOaQuA9gbpoQWpXYUB0qsBhdBvAVyOi7oM9g==",
       "engines": {
         "node": ">=8.0.0"
       },
@@ -11656,6 +11604,18 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "node_modules/finalhandler/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/find-cache-dir": {
       "version": "3.3.1",
@@ -13324,9 +13284,9 @@
       }
     },
     "node_modules/gulp-replace/node_modules/@types/node": {
-      "version": "14.18.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.15.tgz",
-      "integrity": "sha512-hzzmpfqOhsFmvQ9nu87qNQJ8ksofJLBIKkgaYWFapV+W8UGHCxtg5uf69ZtlDSS8rb4ax3lMgpqBnLUQETjCJA==",
+      "version": "14.18.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.16.tgz",
+      "integrity": "sha512-X3bUMdK/VmvrWdoTkz+VCn6nwKwrKCFTHtqwBIaQJNx4RUIBBUFXM00bqPz/DsDd+Icjmzm6/tyYZzeGVqb6/Q==",
       "dev": true
     },
     "node_modules/gulp-sass": {
@@ -13852,19 +13812,28 @@
       "dev": true
     },
     "node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "dev": true,
       "dependencies": {
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "2.0.1",
         "toidentifier": "1.0.1"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/http-parser-js": {
@@ -18461,9 +18430,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-8.7.0.tgz",
-      "integrity": "sha512-fOSunmSa1K3dBv4YFoX54wew3PC6aYYDMGWBAonWRO4Yc7smYtk3nLrCda6+dtkTJwA8D4Tv/0wmnpYNgf5VFw==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.8.0.tgz",
+      "integrity": "sha512-MDHVaj0zrinLkshylII8pT46VCkAUqQfYRS+pyuuZZtBZRRphH/IG5HC1YbIc77AX5FmLUWGvu23Kah5fscIbw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -18544,19 +18513,19 @@
         "@npmcli/ci-detect": "^2.0.0",
         "@npmcli/config": "^4.1.0",
         "@npmcli/fs": "^2.1.0",
-        "@npmcli/map-workspaces": "^2.0.2",
+        "@npmcli/map-workspaces": "^2.0.3",
         "@npmcli/package-json": "^2.0.0",
         "@npmcli/run-script": "^3.0.1",
         "abbrev": "~1.1.1",
         "archy": "~1.0.0",
-        "cacache": "^16.0.4",
+        "cacache": "^16.0.6",
         "chalk": "^4.1.2",
         "chownr": "^2.0.0",
         "cli-columns": "^4.0.0",
-        "cli-table3": "^0.6.1",
+        "cli-table3": "^0.6.2",
         "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.12",
-        "glob": "^7.2.0",
+        "glob": "^8.0.1",
         "graceful-fs": "^4.2.10",
         "hosted-git-info": "^5.0.0",
         "ini": "^3.0.0",
@@ -18586,21 +18555,21 @@
         "npm-install-checks": "^5.0.0",
         "npm-package-arg": "^9.0.2",
         "npm-pick-manifest": "^7.0.1",
-        "npm-profile": "^6.0.2",
-        "npm-registry-fetch": "^13.1.0",
+        "npm-profile": "^6.0.3",
+        "npm-registry-fetch": "^13.1.1",
         "npm-user-validate": "^1.0.1",
-        "npmlog": "^6.0.1",
+        "npmlog": "^6.0.2",
         "opener": "^1.5.2",
         "pacote": "^13.1.1",
         "parse-conflict-json": "^2.0.2",
         "proc-log": "^2.0.1",
         "qrcode-terminal": "^0.12.0",
         "read": "~1.0.7",
-        "read-package-json": "^5.0.0",
+        "read-package-json": "^5.0.1",
         "read-package-json-fast": "^2.0.3",
         "readdir-scoped-modules": "^1.1.0",
         "rimraf": "^3.0.2",
-        "semver": "^7.3.6",
+        "semver": "^7.3.7",
         "ssri": "^9.0.0",
         "tar": "^6.1.11",
         "text-table": "~0.2.0",
@@ -18729,6 +18698,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/npm/node_modules/@gar/promisify": {
       "version": "1.1.3",
       "dev": true,
@@ -18744,7 +18724,7 @@
       "peer": true
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "5.0.6",
+      "version": "5.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18752,7 +18732,7 @@
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/installed-package-contents": "^1.0.7",
-        "@npmcli/map-workspaces": "^2.0.0",
+        "@npmcli/map-workspaces": "^2.0.3",
         "@npmcli/metavuln-calculator": "^3.0.1",
         "@npmcli/move-file": "^2.0.0",
         "@npmcli/name-from-folder": "^1.0.1",
@@ -18760,7 +18740,7 @@
         "@npmcli/package-json": "^2.0.0",
         "@npmcli/run-script": "^3.0.0",
         "bin-links": "^3.0.0",
-        "cacache": "^16.0.0",
+        "cacache": "^16.0.6",
         "common-ancestor-path": "^1.0.1",
         "json-parse-even-better-errors": "^2.3.1",
         "json-stringify-nice": "^1.1.4",
@@ -18771,7 +18751,7 @@
         "npm-package-arg": "^9.0.0",
         "npm-pick-manifest": "^7.0.0",
         "npm-registry-fetch": "^13.0.0",
-        "npmlog": "^6.0.1",
+        "npmlog": "^6.0.2",
         "pacote": "^13.0.5",
         "parse-conflict-json": "^2.0.1",
         "proc-log": "^2.0.0",
@@ -18780,7 +18760,7 @@
         "read-package-json-fast": "^2.0.2",
         "readdir-scoped-modules": "^1.1.0",
         "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "ssri": "^9.0.0",
         "treeverse": "^2.0.0",
         "walk-up-path": "^1.0.0"
@@ -18888,19 +18868,19 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
       "dependencies": {
         "@npmcli/name-from-folder": "^1.0.1",
-        "glob": "^7.2.0",
+        "glob": "^8.0.1",
         "minimatch": "^5.0.1",
         "read-package-json-fast": "^2.0.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
@@ -19168,7 +19148,7 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "16.0.4",
+      "version": "16.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19178,7 +19158,7 @@
         "@npmcli/move-file": "^2.0.0",
         "chownr": "^2.0.0",
         "fs-minipass": "^2.1.0",
-        "glob": "^7.2.0",
+        "glob": "^8.0.1",
         "infer-owner": "^1.0.4",
         "lru-cache": "^7.7.1",
         "minipass": "^3.1.6",
@@ -19262,7 +19242,7 @@
       }
     },
     "node_modules/npm/node_modules/cli-table3": {
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19274,7 +19254,7 @@
         "node": "10.* || >= 12.*"
       },
       "optionalDependencies": {
-        "colors": "1.4.0"
+        "@colors/colors": "1.5.0"
       }
     },
     "node_modules/npm/node_modules/clone": {
@@ -19328,17 +19308,6 @@
       "peer": true,
       "bin": {
         "color-support": "bin.js"
-      }
-    },
-    "node_modules/npm/node_modules/colors": {
-      "version": "1.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.1.90"
       }
     },
     "node_modules/npm/node_modules/columnify": {
@@ -19549,7 +19518,7 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "7.2.0",
+      "version": "8.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19558,39 +19527,15 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^5.0.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
       "engines": {
-        "node": "*"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/npm/node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/npm/node_modules/graceful-fs": {
@@ -19935,7 +19880,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "4.0.3",
+      "version": "4.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19947,7 +19892,7 @@
         "chalk": "^4.1.0",
         "mkdirp-infer-owner": "^2.0.0",
         "npm-package-arg": "^9.0.1",
-        "npmlog": "^6.0.1",
+        "npmlog": "^6.0.2",
         "pacote": "^13.0.5",
         "proc-log": "^2.0.0",
         "read": "^1.0.7",
@@ -20015,7 +19960,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20024,7 +19969,7 @@
         "normalize-package-data": "^4.0.0",
         "npm-package-arg": "^9.0.1",
         "npm-registry-fetch": "^13.0.0",
-        "semver": "^7.1.3",
+        "semver": "^7.3.7",
         "ssri": "^9.0.0"
       },
       "engines": {
@@ -20059,7 +20004,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "3.0.3",
+      "version": "3.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20069,14 +20014,14 @@
         "@npmcli/run-script": "^3.0.0",
         "json-parse-even-better-errors": "^2.3.1",
         "proc-log": "^2.0.0",
-        "semver": "^7.3.5"
+        "semver": "^7.3.7"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "7.7.3",
+      "version": "7.8.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20311,6 +20256,51 @@
         "node": "^12.22 || ^14.13 || >=16"
       }
     },
+    "node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/glob": {
+      "version": "7.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/npm/node_modules/nopt": {
       "version": "5.0.0",
       "dev": true,
@@ -20402,13 +20392,13 @@
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
-      "version": "5.0.0",
+      "version": "5.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
       "dependencies": {
-        "glob": "^7.2.0",
+        "glob": "^8.0.1",
         "ignore-walk": "^5.0.1",
         "npm-bundled": "^1.1.2",
         "npm-normalize-package-bin": "^1.0.1"
@@ -20437,21 +20427,21 @@
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "6.0.2",
+      "version": "6.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
       "dependencies": {
-        "npm-registry-fetch": "^13.0.0",
+        "npm-registry-fetch": "^13.0.1",
         "proc-log": "^2.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "13.1.0",
+      "version": "13.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20477,7 +20467,7 @@
       "peer": true
     },
     "node_modules/npm/node_modules/npmlog": {
-      "version": "6.0.1",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20485,11 +20475,11 @@
       "dependencies": {
         "are-we-there-yet": "^3.0.0",
         "console-control-strings": "^1.1.0",
-        "gauge": "^4.0.0",
+        "gauge": "^4.0.3",
         "set-blocking": "^2.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/once": {
@@ -20683,19 +20673,19 @@
       }
     },
     "node_modules/npm/node_modules/read-package-json": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
       "dependencies": {
-        "glob": "^7.2.0",
+        "glob": "^8.0.1",
         "json-parse-even-better-errors": "^2.3.1",
         "normalize-package-data": "^4.0.0",
         "npm-normalize-package-bin": "^1.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
@@ -20766,6 +20756,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/npm/node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/npm/node_modules/safe-buffer": {
       "version": "5.2.1",
       "dev": true,
@@ -20796,19 +20831,32 @@
       "peer": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.3.6",
+      "version": "7.3.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
       "dependencies": {
-        "lru-cache": "^7.4.0"
+        "lru-cache": "^6.0.0"
       },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
-        "node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/set-blocking": {
@@ -21373,9 +21421,9 @@
       "dev": true
     },
     "node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dev": true,
       "dependencies": {
         "ee-first": "1.1.1"
@@ -21761,12 +21809,12 @@
       }
     },
     "node_modules/p-retry": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-      "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "dev": true,
       "dependencies": {
-        "@types/retry": "^0.12.0",
+        "@types/retry": "0.12.0",
         "retry": "^0.13.1"
       },
       "engines": {
@@ -25388,10 +25436,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
       "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
       "engines": {
         "node": ">=0.6"
       },
@@ -25475,13 +25526,13 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.3.tgz",
-      "integrity": "sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
-        "http-errors": "1.8.1",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       },
@@ -26344,9 +26395,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.50.1.tgz",
-      "integrity": "sha512-noTnY41KnlW2A9P8sdwESpDmo+KBNkukI1i8+hOK3footBUcohNHtdOJbckp46XO95nuvcHDDZ+4tmOnpK3hjw==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.51.0.tgz",
+      "integrity": "sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -26768,24 +26819,24 @@
       }
     },
     "node_modules/send": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
-      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
       "dev": true,
       "dependencies": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.8.1",
+        "http-errors": "2.0.0",
         "mime": "1.6.0",
         "ms": "2.1.3",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
+        "statuses": "2.0.1"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -26824,6 +26875,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "node_modules/send/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -26860,6 +26920,15 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/serve-index/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/serve-index/node_modules/http-errors": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -26894,15 +26963,15 @@
       "dev": true
     },
     "node_modules/serve-static": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
-      "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
       "dev": true,
       "dependencies": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.17.2"
+        "send": "0.18.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -28709,9 +28778,9 @@
       "dev": true
     },
     "node_modules/tinymce": {
-      "version": "5.10.3",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.3.tgz",
-      "integrity": "sha512-O59ssHNnujWvSk5Gt8hIGrdNCMKVWVQv9F8siAgLTRgTh0t3NDHrP1UlLtCxArUi9DPWZvlBeUz8D5fJTu7vnA=="
+      "version": "5.10.4",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.4.tgz",
+      "integrity": "sha512-L0ivAhGu7bEo6cUBrCzhtKlkIQqG2sTcL+uu7soMSxrECQIC5VwUnzp9HCEf+fRl36q6zavLV48lf8jelj+gXA=="
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -31196,9 +31265,9 @@
       }
     },
     "node_modules/webpack/node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -31680,9 +31749,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+          "version": "8.7.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+          "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
           "dev": true
         },
         "acorn-walk": {
@@ -32361,12 +32430,13 @@
       },
       "dependencies": {
         "@ampproject/remapping": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-          "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+          "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
           "dev": true,
           "requires": {
-            "@jridgewell/trace-mapping": "^0.3.0"
+            "@jridgewell/gen-mapping": "^0.1.0",
+            "@jridgewell/trace-mapping": "^0.3.9"
           }
         },
         "@babel/generator": {
@@ -34057,10 +34127,26 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@jridgewell/resolve-uri": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-1.0.0.tgz",
       "integrity": "sha512-9oLAnygRMi8Q5QkYEU4XWK04B+nuoXoxjRvRxgjuChkLZFBja0YPSgdZ7dZtwhncLBcQe/I/E+fLuk5qxcYVJA==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+      "integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
@@ -34686,9 +34772,9 @@
       "peer": true
     },
     "@types/node": {
-      "version": "12.20.49",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.49.tgz",
-      "integrity": "sha512-5e6QNb9bkeh4Hni4ktLqUZuUqnGTX/kou2aZkXyxtuYaHXgBm+In1SHR9V+7kDzWzjB08KC2uqt2doDi7cuAAA==",
+      "version": "12.20.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.50.tgz",
+      "integrity": "sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -34711,9 +34797,9 @@
       "dev": true
     },
     "@types/retry": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
     },
     "@types/selenium-webdriver": {
@@ -35056,6 +35142,14 @@
         "debug": "^4.1.0",
         "depd": "^1.1.2",
         "humanize-ms": "^1.2.1"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+          "dev": true
+        }
       }
     },
     "aggregate-error": {
@@ -35906,21 +36000,23 @@
       "dev": true
     },
     "body-parser": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.2.tgz",
-      "integrity": "sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
       "dev": true,
       "requires": {
         "bytes": "3.1.2",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "1.8.1",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
-        "on-finished": "~2.3.0",
-        "qs": "6.9.7",
-        "raw-body": "2.4.3",
-        "type-is": "~1.6.18"
+        "on-finished": "2.4.1",
+        "qs": "6.10.3",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -37235,9 +37331,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+          "version": "8.7.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+          "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
           "dev": true,
           "optional": true
         },
@@ -38650,9 +38746,9 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true
     },
     "dependency-graph": {
@@ -38674,9 +38770,9 @@
       "dev": true
     },
     "destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "dev": true
     },
     "detect-file": {
@@ -38877,100 +38973,10 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
-        "acorn": {
-          "version": "7.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-          "optional": true
-        },
-        "cssom": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-          "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
-          "optional": true
-        },
-        "cssstyle": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-          "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-          "optional": true,
-          "requires": {
-            "cssom": "~0.3.6"
-          },
-          "dependencies": {
-            "cssom": {
-              "version": "0.3.8",
-              "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-              "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-              "optional": true
-            }
-          }
-        },
         "eventemitter2": {
           "version": "0.4.14",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
           "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
-        },
-        "fabric": {
-          "version": "3.6.3",
-          "resolved": "https://registry.npmjs.org/fabric/-/fabric-3.6.3.tgz",
-          "integrity": "sha512-PwJKZG7Zbst+B1PSmt2OddK8UJ9tQ23a9gslodCSrXCzj8S+1RcOaQuA9gbpoQWpXYUB0qsBhdBvAVyOi7oM9g==",
-          "requires": {
-            "canvas": "^2.6.1",
-            "jsdom": "^15.1.0"
-          }
-        },
-        "jsdom": {
-          "version": "15.2.1",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
-          "integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
-          "optional": true,
-          "requires": {
-            "abab": "^2.0.0",
-            "acorn": "^7.1.0",
-            "acorn-globals": "^4.3.2",
-            "array-equal": "^1.0.0",
-            "cssom": "^0.4.1",
-            "cssstyle": "^2.0.0",
-            "data-urls": "^1.1.0",
-            "domexception": "^1.0.1",
-            "escodegen": "^1.11.1",
-            "html-encoding-sniffer": "^1.0.2",
-            "nwsapi": "^2.2.0",
-            "parse5": "5.1.0",
-            "pn": "^1.1.0",
-            "request": "^2.88.0",
-            "request-promise-native": "^1.0.7",
-            "saxes": "^3.1.9",
-            "symbol-tree": "^3.2.2",
-            "tough-cookie": "^3.0.1",
-            "w3c-hr-time": "^1.0.1",
-            "w3c-xmlserializer": "^1.1.2",
-            "webidl-conversions": "^4.0.2",
-            "whatwg-encoding": "^1.0.5",
-            "whatwg-mimetype": "^2.3.0",
-            "whatwg-url": "^7.0.0",
-            "ws": "^7.0.0",
-            "xml-name-validator": "^3.0.0"
-          }
-        },
-        "tough-cookie": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-          "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
-          "optional": true,
-          "requires": {
-            "ip-regex": "^2.1.0",
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
-          }
-        },
-        "ws": {
-          "version": "7.5.7",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-          "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-          "optional": true,
-          "requires": {}
         }
       }
     },
@@ -39045,9 +39051,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.119",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.119.tgz",
-      "integrity": "sha512-HPEmKy+d0xK8oCfEHc5t6wDsSAi1WmE3Ld08QrBjAPxaAzfuKP66VJ77lcTqxTt7GJmSE279s75mhW64Xh+4kw==",
+      "version": "1.4.123",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.123.tgz",
+      "integrity": "sha512-0pHGE53WkYoFbsgwYcVKEpWa6jbzlvkohIEA2CUoZ9b5KC+w/zlMiQHvW/4IBcOh7YoEFqRNavgTk02TBoUTUw==",
       "dev": true
     },
     "emoji-regex": {
@@ -39967,43 +39973,50 @@
       }
     },
     "express": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.3.tgz",
-      "integrity": "sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.0.tgz",
+      "integrity": "sha512-EJEXxiTQJS3lIPrU1AE2vRuT7X7E+0KBbpm5GSoK524yl0K8X+er8zS2P14E64eqsVNoWbMCT7MpmQ+ErAhgRg==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.19.2",
+        "body-parser": "1.20.0",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.4.2",
+        "cookie": "0.5.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "~1.1.2",
+        "finalhandler": "1.2.0",
         "fresh": "0.5.2",
+        "http-errors": "2.0.0",
         "merge-descriptors": "1.0.1",
         "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.9.7",
+        "qs": "6.10.3",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.17.2",
-        "serve-static": "1.14.2",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
         "setprototypeof": "1.2.0",
-        "statuses": "~1.5.0",
+        "statuses": "2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "cookie": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+          "dev": true
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -40011,6 +40024,21 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "finalhandler": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+          "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "on-finished": "2.4.1",
+            "parseurl": "~1.3.3",
+            "statuses": "2.0.1",
+            "unpipe": "~1.0.0"
           }
         },
         "ms": {
@@ -40023,6 +40051,12 @@
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
           "dev": true
         }
       }
@@ -40153,9 +40187,9 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fabric": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/fabric/-/fabric-3.6.6.tgz",
-      "integrity": "sha512-+sEwsgLSLIHQ32INuvV4CvWtqYOLyDKify/FfDteZvYQSoWRILLqzpCRt6AkEySsLToohkcygkD/unEOzV38wQ==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/fabric/-/fabric-3.6.3.tgz",
+      "integrity": "sha512-PwJKZG7Zbst+B1PSmt2OddK8UJ9tQ23a9gslodCSrXCzj8S+1RcOaQuA9gbpoQWpXYUB0qsBhdBvAVyOi7oM9g==",
       "requires": {
         "canvas": "^2.6.1",
         "jsdom": "^15.1.0"
@@ -40375,6 +40409,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+          "dev": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
         }
       }
     },
@@ -41710,9 +41753,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.15.tgz",
-          "integrity": "sha512-hzzmpfqOhsFmvQ9nu87qNQJ8ksofJLBIKkgaYWFapV+W8UGHCxtg5uf69ZtlDSS8rb4ax3lMgpqBnLUQETjCJA==",
+          "version": "14.18.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.16.tgz",
+          "integrity": "sha512-X3bUMdK/VmvrWdoTkz+VCn6nwKwrKCFTHtqwBIaQJNx4RUIBBUFXM00bqPz/DsDd+Icjmzm6/tyYZzeGVqb6/Q==",
           "dev": true
         }
       }
@@ -42131,16 +42174,24 @@
       "dev": true
     },
     "http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "dev": true,
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "2.0.1",
         "toidentifier": "1.0.1"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+          "dev": true
+        }
       }
     },
     "http-parser-js": {
@@ -45674,9 +45725,9 @@
       }
     },
     "npm": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-8.7.0.tgz",
-      "integrity": "sha512-fOSunmSa1K3dBv4YFoX54wew3PC6aYYDMGWBAonWRO4Yc7smYtk3nLrCda6+dtkTJwA8D4Tv/0wmnpYNgf5VFw==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.8.0.tgz",
+      "integrity": "sha512-MDHVaj0zrinLkshylII8pT46VCkAUqQfYRS+pyuuZZtBZRRphH/IG5HC1YbIc77AX5FmLUWGvu23Kah5fscIbw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -45685,19 +45736,19 @@
         "@npmcli/ci-detect": "^2.0.0",
         "@npmcli/config": "^4.1.0",
         "@npmcli/fs": "^2.1.0",
-        "@npmcli/map-workspaces": "^2.0.2",
+        "@npmcli/map-workspaces": "^2.0.3",
         "@npmcli/package-json": "^2.0.0",
         "@npmcli/run-script": "^3.0.1",
         "abbrev": "~1.1.1",
         "archy": "~1.0.0",
-        "cacache": "^16.0.4",
+        "cacache": "^16.0.6",
         "chalk": "^4.1.2",
         "chownr": "^2.0.0",
         "cli-columns": "^4.0.0",
-        "cli-table3": "^0.6.1",
+        "cli-table3": "^0.6.2",
         "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.12",
-        "glob": "^7.2.0",
+        "glob": "^8.0.1",
         "graceful-fs": "^4.2.10",
         "hosted-git-info": "^5.0.0",
         "ini": "^3.0.0",
@@ -45727,21 +45778,21 @@
         "npm-install-checks": "^5.0.0",
         "npm-package-arg": "^9.0.2",
         "npm-pick-manifest": "^7.0.1",
-        "npm-profile": "^6.0.2",
-        "npm-registry-fetch": "^13.1.0",
+        "npm-profile": "^6.0.3",
+        "npm-registry-fetch": "^13.1.1",
         "npm-user-validate": "^1.0.1",
-        "npmlog": "^6.0.1",
+        "npmlog": "^6.0.2",
         "opener": "^1.5.2",
         "pacote": "^13.1.1",
         "parse-conflict-json": "^2.0.2",
         "proc-log": "^2.0.1",
         "qrcode-terminal": "^0.12.0",
         "read": "~1.0.7",
-        "read-package-json": "^5.0.0",
+        "read-package-json": "^5.0.1",
         "read-package-json-fast": "^2.0.3",
         "readdir-scoped-modules": "^1.1.0",
         "rimraf": "^3.0.2",
-        "semver": "^7.3.6",
+        "semver": "^7.3.7",
         "ssri": "^9.0.0",
         "tar": "^6.1.11",
         "text-table": "~0.2.0",
@@ -45752,6 +45803,13 @@
         "write-file-atomic": "^4.0.1"
       },
       "dependencies": {
+        "@colors/colors": {
+          "version": "1.5.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
         "@gar/promisify": {
           "version": "1.1.3",
           "bundled": true,
@@ -45765,14 +45823,14 @@
           "peer": true
         },
         "@npmcli/arborist": {
-          "version": "5.0.6",
+          "version": "5.1.1",
           "bundled": true,
           "dev": true,
           "peer": true,
           "requires": {
             "@isaacs/string-locale-compare": "^1.1.0",
             "@npmcli/installed-package-contents": "^1.0.7",
-            "@npmcli/map-workspaces": "^2.0.0",
+            "@npmcli/map-workspaces": "^2.0.3",
             "@npmcli/metavuln-calculator": "^3.0.1",
             "@npmcli/move-file": "^2.0.0",
             "@npmcli/name-from-folder": "^1.0.1",
@@ -45780,7 +45838,7 @@
             "@npmcli/package-json": "^2.0.0",
             "@npmcli/run-script": "^3.0.0",
             "bin-links": "^3.0.0",
-            "cacache": "^16.0.0",
+            "cacache": "^16.0.6",
             "common-ancestor-path": "^1.0.1",
             "json-parse-even-better-errors": "^2.3.1",
             "json-stringify-nice": "^1.1.4",
@@ -45791,7 +45849,7 @@
             "npm-package-arg": "^9.0.0",
             "npm-pick-manifest": "^7.0.0",
             "npm-registry-fetch": "^13.0.0",
-            "npmlog": "^6.0.1",
+            "npmlog": "^6.0.2",
             "pacote": "^13.0.5",
             "parse-conflict-json": "^2.0.1",
             "proc-log": "^2.0.0",
@@ -45800,7 +45858,7 @@
             "read-package-json-fast": "^2.0.2",
             "readdir-scoped-modules": "^1.1.0",
             "rimraf": "^3.0.2",
-            "semver": "^7.3.5",
+            "semver": "^7.3.7",
             "ssri": "^9.0.0",
             "treeverse": "^2.0.0",
             "walk-up-path": "^1.0.0"
@@ -45875,13 +45933,13 @@
           }
         },
         "@npmcli/map-workspaces": {
-          "version": "2.0.2",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true,
           "peer": true,
           "requires": {
             "@npmcli/name-from-folder": "^1.0.1",
-            "glob": "^7.2.0",
+            "glob": "^8.0.1",
             "minimatch": "^5.0.1",
             "read-package-json-fast": "^2.0.3"
           }
@@ -46080,7 +46138,7 @@
           }
         },
         "cacache": {
-          "version": "16.0.4",
+          "version": "16.0.6",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -46089,7 +46147,7 @@
             "@npmcli/move-file": "^2.0.0",
             "chownr": "^2.0.0",
             "fs-minipass": "^2.1.0",
-            "glob": "^7.2.0",
+            "glob": "^8.0.1",
             "infer-owner": "^1.0.4",
             "lru-cache": "^7.7.1",
             "minipass": "^3.1.6",
@@ -46147,12 +46205,12 @@
           }
         },
         "cli-table3": {
-          "version": "0.6.1",
+          "version": "0.6.2",
           "bundled": true,
           "dev": true,
           "peer": true,
           "requires": {
-            "colors": "1.4.0",
+            "@colors/colors": "1.5.0",
             "string-width": "^4.2.0"
           }
         },
@@ -46190,13 +46248,6 @@
           "version": "1.1.3",
           "bundled": true,
           "dev": true,
-          "peer": true
-        },
-        "colors": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
           "peer": true
         },
         "columnify": {
@@ -46359,7 +46410,7 @@
           }
         },
         "glob": {
-          "version": "7.2.0",
+          "version": "8.0.1",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -46367,30 +46418,9 @@
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.4",
+            "minimatch": "^5.0.1",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
-          },
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.11",
-              "bundled": true,
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "minimatch": {
-              "version": "3.1.2",
-              "bundled": true,
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            }
           }
         },
         "graceful-fs": {
@@ -46646,7 +46676,7 @@
           }
         },
         "libnpmexec": {
-          "version": "4.0.3",
+          "version": "4.0.5",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -46657,7 +46687,7 @@
             "chalk": "^4.1.0",
             "mkdirp-infer-owner": "^2.0.0",
             "npm-package-arg": "^9.0.1",
-            "npmlog": "^6.0.1",
+            "npmlog": "^6.0.2",
             "pacote": "^13.0.5",
             "proc-log": "^2.0.0",
             "read": "^1.0.7",
@@ -46706,7 +46736,7 @@
           }
         },
         "libnpmpublish": {
-          "version": "6.0.3",
+          "version": "6.0.4",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -46714,7 +46744,7 @@
             "normalize-package-data": "^4.0.0",
             "npm-package-arg": "^9.0.1",
             "npm-registry-fetch": "^13.0.0",
-            "semver": "^7.1.3",
+            "semver": "^7.3.7",
             "ssri": "^9.0.0"
           }
         },
@@ -46738,7 +46768,7 @@
           }
         },
         "libnpmversion": {
-          "version": "3.0.3",
+          "version": "3.0.4",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -46747,11 +46777,11 @@
             "@npmcli/run-script": "^3.0.0",
             "json-parse-even-better-errors": "^2.3.1",
             "proc-log": "^2.0.0",
-            "semver": "^7.3.5"
+            "semver": "^7.3.7"
           }
         },
         "lru-cache": {
-          "version": "7.7.3",
+          "version": "7.8.1",
           "bundled": true,
           "dev": true,
           "peer": true
@@ -46917,6 +46947,41 @@
             "semver": "^7.3.5",
             "tar": "^6.1.2",
             "which": "^2.0.2"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "glob": {
+              "version": "7.2.0",
+              "bundled": true,
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.1.2",
+              "bundled": true,
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
           }
         },
         "nopt": {
@@ -46985,12 +47050,12 @@
           }
         },
         "npm-packlist": {
-          "version": "5.0.0",
+          "version": "5.0.2",
           "bundled": true,
           "dev": true,
           "peer": true,
           "requires": {
-            "glob": "^7.2.0",
+            "glob": "^8.0.1",
             "ignore-walk": "^5.0.1",
             "npm-bundled": "^1.1.2",
             "npm-normalize-package-bin": "^1.0.1"
@@ -47009,17 +47074,17 @@
           }
         },
         "npm-profile": {
-          "version": "6.0.2",
+          "version": "6.0.3",
           "bundled": true,
           "dev": true,
           "peer": true,
           "requires": {
-            "npm-registry-fetch": "^13.0.0",
+            "npm-registry-fetch": "^13.0.1",
             "proc-log": "^2.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "13.1.0",
+          "version": "13.1.1",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -47040,14 +47105,14 @@
           "peer": true
         },
         "npmlog": {
-          "version": "6.0.1",
+          "version": "6.0.2",
           "bundled": true,
           "dev": true,
           "peer": true,
           "requires": {
             "are-we-there-yet": "^3.0.0",
             "console-control-strings": "^1.1.0",
-            "gauge": "^4.0.0",
+            "gauge": "^4.0.3",
             "set-blocking": "^2.0.0"
           }
         },
@@ -47186,12 +47251,12 @@
           "peer": true
         },
         "read-package-json": {
-          "version": "5.0.0",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "peer": true,
           "requires": {
-            "glob": "^7.2.0",
+            "glob": "^8.0.1",
             "json-parse-even-better-errors": "^2.3.1",
             "normalize-package-data": "^4.0.0",
             "npm-normalize-package-bin": "^1.0.1"
@@ -47243,6 +47308,41 @@
           "peer": true,
           "requires": {
             "glob": "^7.1.3"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "glob": {
+              "version": "7.2.0",
+              "bundled": true,
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.1.2",
+              "bundled": true,
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
           }
         },
         "safe-buffer": {
@@ -47259,12 +47359,23 @@
           "peer": true
         },
         "semver": {
-          "version": "7.3.6",
+          "version": "7.3.7",
           "bundled": true,
           "dev": true,
           "peer": true,
           "requires": {
-            "lru-cache": "^7.4.0"
+            "lru-cache": "^6.0.0"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "6.0.0",
+              "bundled": true,
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
           }
         },
         "set-blocking": {
@@ -47791,9 +47902,9 @@
       "dev": true
     },
     "on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dev": true,
       "requires": {
         "ee-first": "1.1.1"
@@ -48073,12 +48184,12 @@
       "peer": true
     },
     "p-retry": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-      "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "dev": true,
       "requires": {
-        "@types/retry": "^0.12.0",
+        "@types/retry": "0.12.0",
         "retry": "^0.13.1"
       }
     },
@@ -50805,10 +50916,13 @@
       "dev": true
     },
     "qs": {
-      "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
-      "dev": true
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "dev": true,
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "query-string": {
       "version": "4.3.4",
@@ -50859,13 +50973,13 @@
       "dev": true
     },
     "raw-body": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.3.tgz",
-      "integrity": "sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
       "dev": true,
       "requires": {
         "bytes": "3.1.2",
-        "http-errors": "1.8.1",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       }
@@ -51534,9 +51648,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.50.1.tgz",
-      "integrity": "sha512-noTnY41KnlW2A9P8sdwESpDmo+KBNkukI1i8+hOK3footBUcohNHtdOJbckp46XO95nuvcHDDZ+4tmOnpK3hjw==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.51.0.tgz",
+      "integrity": "sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -51852,24 +51966,24 @@
       "peer": true
     },
     "send": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
-      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.8.1",
+        "http-errors": "2.0.0",
         "mime": "1.6.0",
         "ms": "2.1.3",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
+        "statuses": "2.0.1"
       },
       "dependencies": {
         "debug": {
@@ -51899,6 +52013,12 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
           "dev": true
         }
       }
@@ -51936,6 +52056,12 @@
             "ms": "2.0.0"
           }
         },
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+          "dev": true
+        },
         "http-errors": {
           "version": "1.6.3",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -51969,15 +52095,15 @@
       }
     },
     "serve-static": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
-      "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
       "dev": true,
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.17.2"
+        "send": "0.18.0"
       }
     },
     "set-blocking": {
@@ -53411,9 +53537,9 @@
       "dev": true
     },
     "tinymce": {
-      "version": "5.10.3",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.3.tgz",
-      "integrity": "sha512-O59ssHNnujWvSk5Gt8hIGrdNCMKVWVQv9F8siAgLTRgTh0t3NDHrP1UlLtCxArUi9DPWZvlBeUz8D5fJTu7vnA=="
+      "version": "5.10.4",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.4.tgz",
+      "integrity": "sha512-L0ivAhGu7bEo6cUBrCzhtKlkIQqG2sTcL+uu7soMSxrECQIC5VwUnzp9HCEf+fRl36q6zavLV48lf8jelj+gXA=="
     },
     "tmp": {
       "version": "0.0.33",
@@ -54574,9 +54700,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+          "version": "8.7.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+          "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
           "dev": true
         },
         "acorn-import-assertions": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "dom-autoscroller": "^2.3.4",
     "drawing-tool": "^2.1.2",
     "eventemitter2": "^5.0.1",
-    "fabric": "^3.6.6",
+    "fabric": "3.6.3",
     "highcharts": "^9.3.3",
     "highcharts-angular": "^2.10.0",
     "html2canvas": "^0.5.0-beta4",


### PR DESCRIPTION
## Changes
Label and Draw were using different versions of Fabric. Since Draw is an external library that uses 3.6.3, we opt to fix Fabric version to 3.6.3.

## Before Test
- run ```npm install``` to get latest deps

## Test
- Label and Draw components work as before. 
- Open dev tools and make sure that there is only one Fabric that is loaded, and it is v3.6.3.

Closes #567