### PR TITLE
refactor(Discussion): Retrieve classmate work from Discussion endpoint

### DIFF
--- a/src/app/services/discussionService.spec.ts
+++ b/src/app/services/discussionService.spec.ts
@@ -1,5 +1,5 @@
 import { DiscussionService } from '../../assets/wise5/components/discussion/discussionService';
-import { TestBed } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
@@ -25,10 +25,11 @@ class MockTeacherDataService {
 
 let service: DiscussionService;
 let http: HttpTestingController;
-let configService: ConfigService;
 let studentDataService: StudentDataService;
 const componentId = 'component1';
 const nodeId = 'node1';
+const periodId = 2;
+const runId = 1;
 
 describe('DiscussionService', () => {
   beforeEach(() => {
@@ -55,13 +56,13 @@ describe('DiscussionService', () => {
 
     http = TestBed.inject(HttpTestingController);
     service = TestBed.inject(DiscussionService);
-    configService = TestBed.inject(ConfigService);
     studentDataService = TestBed.inject(StudentDataService);
   });
 
   checkThatAComponentStateHasStudentWorkWhenStudentOnlyAttachedAFile();
   componentStateHasStudentWork();
   createComponent();
+  getClassmateResponsesFromComponents();
   getClassmateResponses();
   hasShowWorkConnectedComponentThatHasWork();
   hasNodeEnteredEvent();
@@ -206,21 +207,61 @@ function hasNodeEnteredEvent() {
   });
 }
 
-function getClassmateResponses() {
-  it('should get classmate responses', () => {
-    spyOn(configService, 'getConfigParam').and.returnValue('/student/data');
-    service
-      .getClassmateResponses(1, 2, [{ nodeId: 'node1', componentId: 'component1' }])
-      .then((data: any) => {
-        expect(data.studentWorkList[0].studentData.response).toEqual('Hello World');
-      });
-    const expectedRequest =
-      '/student/data?runId=1&periodId=2&getStudentWork=true&getAnnotations=' +
-      'true&components=%7B%22nodeId%22:%22node1%22,%22componentId%22:%22component1%22%7D';
-    http
-      .expectOne(expectedRequest)
-      .flush({ studentWorkList: [{ studentData: { response: 'Hello World' } }] });
+function getClassmateResponsesFromComponents() {
+  it('should get classmate responses from components', () => {
+    waitForAsync(() => {
+      const componentState1 = { studentData: { response: 'Hello World' } };
+      const componentState2 = { studentData: { response: 'Hello World 2' } };
+      const annotation1 = { data: { action: 'Delete' } };
+      const annotation2 = { data: { action: 'Undelete' } };
+      const componentStates = [componentState1, componentState2];
+      const annotations = [annotation1, annotation2];
+      service
+        .getClassmateResponsesFromComponents(runId, periodId, [
+          { nodeId: nodeId, componentId: componentId }
+        ])
+        .subscribe((response: any) => {
+          expect(response.studentWork).toEqual(componentStates);
+          expect(response.annotations).toEqual(annotations);
+        });
+      http
+        .expectOne(
+          `/api/classmate/discussion/student-work/${runId}/${periodId}/${nodeId}/${componentId}`
+        )
+        .flush(componentStates);
+      http
+        .expectOne(
+          `/api/classmate/discussion/annotations/${runId}/${periodId}/${nodeId}/${componentId}`
+        )
+        .flush(annotations);
+    });
   });
+}
+
+function getClassmateResponses() {
+  it(
+    'should get classmate responses',
+    waitForAsync(() => {
+      const componentState1 = { studentData: { response: 'Hello World' } };
+      const annotation1 = { data: { action: 'Delete' } };
+      service
+        .getClassmateResponses(runId, periodId, nodeId, componentId)
+        .subscribe((response: any) => {
+          expect(response.studentWork).toEqual([componentState1]);
+          expect(response.annotations).toEqual([annotation1]);
+        });
+      http
+        .expectOne(
+          `/api/classmate/discussion/student-work/${runId}/${periodId}/${nodeId}/${componentId}`
+        )
+        .flush([componentState1]);
+      http
+        .expectOne(
+          `/api/classmate/discussion/annotations/${runId}/${periodId}/${nodeId}/${componentId}`
+        )
+        .flush([annotation1]);
+    })
+  );
 }
 
 function isTopLevelPost() {

--- a/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.spec.ts
+++ b/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { BrowserModule } from '@angular/platform-browser';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { of } from 'rxjs';
 import { AnnotationService } from '../../../services/annotationService';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
@@ -289,8 +290,8 @@ function getClassmateResponses() {
       'should get classmate responses',
       waitForAsync(() => {
         spyOn(TestBed.inject(DiscussionService), 'getClassmateResponses').and.callFake(() => {
-          return Promise.resolve({
-            studentWorkList: [componentState1, componentState2],
+          return of({
+            studentWork: [componentState1, componentState2],
             annotations: []
           });
         });

--- a/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.ts
+++ b/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.ts
@@ -99,7 +99,7 @@ export class DiscussionStudent extends ComponentStudent {
             componentId: this.componentId
           });
         }
-        this.getClassmateResponses(retrieveWorkFromTheseComponents);
+        this.getClassmateResponsesFromComponents(retrieveWorkFromTheseComponents);
       } else {
         if (this.isClassmateResponsesGated()) {
           const componentState = this.componentState;
@@ -319,14 +319,29 @@ export class DiscussionStudent extends ComponentStudent {
     return this.isForThisComponent(componentState);
   }
 
-  getClassmateResponses(components = [{ nodeId: this.nodeId, componentId: this.componentId }]) {
+  getClassmateResponsesFromComponents(components: any[] = []): void {
     const runId = this.ConfigService.getRunId();
     const periodId = this.ConfigService.getPeriodId();
-    this.DiscussionService.getClassmateResponses(runId, periodId, components).then(
-      (result: any) => {
-        this.setClassResponses(result.studentWorkList, result.annotations);
-      }
-    );
+    this.DiscussionService.getClassmateResponsesFromComponents(
+      runId,
+      periodId,
+      components
+    ).subscribe((response: any) => {
+      this.setClassResponses(response.studentWork, response.annotations);
+    });
+  }
+
+  getClassmateResponses(): void {
+    const runId = this.ConfigService.getRunId();
+    const periodId = this.ConfigService.getPeriodId();
+    this.DiscussionService.getClassmateResponses(
+      runId,
+      periodId,
+      this.nodeId,
+      this.componentId
+    ).subscribe((response: any) => {
+      this.setClassResponses(response.studentWork, response.annotations);
+    });
   }
 
   submitButtonClicked() {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12013,7 +12013,7 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Discussion</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/discussionService.ts</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fa8877ba0986b7bb88ec902a4a0dab94371354c0" datatype="html">


### PR DESCRIPTION
## Changes

Discussion student component now retrieves classmate posts using the Discussion API endpoint instead of the general student data API endpoint.

## Test

- Make sure classmate posts and annotations (delete and undelete) are retrieved for a Discussion component in the VLE
- Make sure classmate posts and annotations are retrieved when a Discussion component imports posts from other Discussions (using connected components) in the VLE

Closes #573