### PR TITLE
fix(VLE): disable close for open response c-rater dialog

### DIFF
--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
@@ -350,7 +350,8 @@ export class OpenResponseStudent extends ComponentStudent {
       data: {
         content: $localize`We are scoring your work...`,
         title: $localize`Please Wait`
-      }
+      },
+      disableClose: true
     });
     this.CRaterService.makeCRaterScoringRequest(
       this.CRaterService.getCRaterItemId(this.componentContent),

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -14371,21 +14371,21 @@ Are you ready to submit this answer?</source>
 If this problem continues, let your teacher know and move on to the next activity. Your work will still be saved.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">373</context>
+          <context context-type="linenumber">374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5445965000497851580" datatype="html">
         <source>This will replace your existing recording. Is this OK?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">705</context>
+          <context context-type="linenumber">706</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8057349329324626950" datatype="html">
         <source>Are you sure you want to delete your recording?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">749</context>
+          <context context-type="linenumber">750</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5623290610025495479" datatype="html">


### PR DESCRIPTION
## Test
Make sure user can't close (with esc key or clicking outside the dialog) the dialog that appears when c-rater is scoring a response to an Open Response item.

Closes #576. 