### PR TITLE
fix(Peer Chat): Null pointer when manual assignment and not grouped

### DIFF
--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
@@ -97,11 +97,13 @@ export class PeerChatStudentComponent extends ComponentStudent {
       .subscribe(
         (peerGroup: PeerGroup) => {
           this.isPeerChatWorkgroupsResponseReceived = true;
-          this.peerGroup = peerGroup;
-          const peerGroupWorkgroupIds = this.getPeerGroupWorkgroupIds(peerGroup);
-          this.addTeacherWorkgroupIds(peerGroupWorkgroupIds);
-          this.setPeerChatWorkgroups(peerGroupWorkgroupIds);
-          this.getPeerChatComponentStates(peerGroup);
+          if (peerGroup != null) {
+            this.peerGroup = peerGroup;
+            const peerGroupWorkgroupIds = this.getPeerGroupWorkgroupIds(peerGroup);
+            this.addTeacherWorkgroupIds(peerGroupWorkgroupIds);
+            this.setPeerChatWorkgroups(peerGroupWorkgroupIds);
+            this.getPeerChatComponentStates(peerGroup);
+          }
         },
         (error) => {
           this.isPeerChatWorkgroupsResponseReceived = true;

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15014,7 +15014,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>You have new chat messages</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts</context>
-          <context context-type="linenumber">209</context>
+          <context context-type="linenumber">211</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6310961320545154131" datatype="html">


### PR DESCRIPTION
## Changes

Added null check for Peer Group in the response when student retrieves Peer Group.

## Test

1. Create a Peer Chat that uses manual assignment
2. Log in as a student and go to the Peer Chat (do not have that teacher manually assign them to a group)
3. The browser console used to display the error below but now should not

```
core.mjs:6485 ERROR TypeError: Cannot read properties of null (reading 'members')
    at PeerChatStudentComponent.getPeerGroupWorkgroupIds (peer-chat-student.component.ts:117:22)
    at SafeSubscriber.peerGroupService.retrievePeerGroup.pipe.subscribe.isPeerChatWorkgroupsResponseReceived [as _next] (peer-chat-student.component.ts:101:46)
    at SafeSubscriber.__tryOrUnsub (Subscriber.js:183:1)
```

Closes #594