### PR TITLE
refactor(ConceptMapService): Remove NodeService dependency

### DIFF
--- a/src/app/services/conceptMapService.spec.ts
+++ b/src/app/services/conceptMapService.spec.ts
@@ -9,7 +9,6 @@ import { UtilService } from '../../assets/wise5/services/utilService';
 import { ConceptMapService } from '../../assets/wise5/components/conceptMap/conceptMapService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { SessionService } from '../../assets/wise5/services/sessionService';
-import { NodeService } from '../../assets/wise5/services/nodeService';
 import { MatDialogModule } from '@angular/material/dialog';
 
 let service: ConceptMapService;
@@ -42,8 +41,6 @@ const link2SourceNodeInstanceId = 'studentNode1';
 const link2DestinationNodeOriginalId = 'node2';
 const link2DestinationNodeInstanceId = 'studentNode2';
 
-export class MockService {}
-
 describe('ConceptMapService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -52,7 +49,6 @@ describe('ConceptMapService', () => {
         AnnotationService,
         ConceptMapService,
         ConfigService,
-        { provide: NodeService, useClass: MockService },
         ProjectService,
         SessionService,
         StudentAssetService,

--- a/src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts
+++ b/src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts
@@ -1473,7 +1473,16 @@ export class ConceptMapStudent extends ComponentStudent {
    * @return a component state with the merged student responses
    */
   createMergedComponentState(componentStates: any[]): any {
-    let componentStateToMergeInto: any = this.ConceptMapService.createComponentStateObject();
+    let componentStateToMergeInto: any = this.NodeService.createNewComponentState();
+    componentStateToMergeInto.studentData = {
+      conceptMapData: {
+        background: null,
+        backgroundPath: null,
+        links: [],
+        nodes: [],
+        stretchBackground: null
+      }
+    };
     for (const componentState of componentStates) {
       if (componentState.componentType === 'ConceptMap') {
         this.mergeConceptMapComponentState(componentStateToMergeInto, componentState);

--- a/src/assets/wise5/components/conceptMap/conceptMapService.ts
+++ b/src/assets/wise5/components/conceptMap/conceptMapService.ts
@@ -9,13 +9,11 @@ import ConceptMapNode from './conceptMapNode';
 import ConceptMapLink from './conceptMapLink';
 import { Injectable } from '@angular/core';
 import { UtilService } from '../../services/utilService';
-import { NodeService } from '../../services/nodeService';
 
 @Injectable()
 export class ConceptMapService extends ComponentService {
   constructor(
     private ConfigService: ConfigService,
-    private NodeService: NodeService,
     private StudentAssetService: StudentAssetService,
     protected UtilService: UtilService
   ) {
@@ -59,20 +57,6 @@ export class ConceptMapService extends ComponentService {
     component.showAutoFeedback = false;
     component.showNodeLabels = true;
     return component;
-  }
-
-  createComponentStateObject(): any {
-    const componentState = this.NodeService.createNewComponentState();
-    componentState.studentData = {
-      conceptMapData: {
-        background: null,
-        backgroundPath: null,
-        links: [],
-        nodes: [],
-        stretchBackground: null
-      }
-    };
-    return componentState;
   }
 
   isCompleted(component: any, componentStates: any[], nodeEvents: any[], node: any) {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -11644,7 +11644,7 @@ Are you ready to receive feedback on this answer?</source>
         <source>Concept Map</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/conceptMapService.ts</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">24</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4d5d5b4e6b3c3a79914e4c5a72054018599ac2c4" datatype="html">


### PR DESCRIPTION
## Changes
- Before: use NodeService to create a component state in the cm-student-component (component -> CMService -> NodeService). 
- After: call NodeService directly from cm-student-component (cm-student-component -> NodeService)

This will remove the circular dependency when we create ComponentServiceLookupService. Right now with the NodeService dependency, it will look like this: 
CMService -> NodeService -> StudentDataService -> ComponentServiceLookupService -> CMService.

## Test
- ConceptMap connected component works as before (the code that calls ```createMergedComponentState()```). For example, import Draw -> ConceptMap. 


Closes #601