### PR TITLE
refactor(Summary): Use summary endpoint

### DIFF
--- a/src/app/services/studentDataService.spec.ts
+++ b/src/app/services/studentDataService.spec.ts
@@ -112,8 +112,6 @@ describe('StudentDataService', () => {
   shouldCheckIsCompleted();
   shouldGetLatestComponentStatesByNodeId();
   shouldGetLatestComponentStateByNodeId();
-  shouldGetClassmateStudentWork();
-  shouldGetClassmateScores();
   shouldGetStudentWorkById();
   shouldGetMaxScore();
   shouldEvaluateCriterias();
@@ -1366,34 +1364,6 @@ function shouldGetLatestComponentStateByNodeId() {
     };
     const componentState = service.getLatestComponentStateByNodeId('node1');
     expect(componentState.id).toEqual(2);
-  });
-}
-
-function shouldGetClassmateStudentWork() {
-  it('should get classmate student work', () => {
-    spyOn(configService, 'getRunId').and.returnValue(1);
-    spyOn(configService, 'getConfigParam').withArgs('studentDataURL').and.returnValue('/student');
-    service.getClassmateStudentWork('node1', 'component1', 10);
-    http
-      .expectOne(
-        '/student?runId=1&nodeId=node1&componentId=component1&getStudentWork=true&' +
-          'getEvents=false&getAnnotations=false&onlyGetLatest=true&periodId=10'
-      )
-      .flush({});
-  });
-}
-
-function shouldGetClassmateScores() {
-  it('should get classmate scores', () => {
-    spyOn(configService, 'getRunId').and.returnValue(1);
-    spyOn(configService, 'getConfigParam').withArgs('studentDataURL').and.returnValue('/student');
-    service.getClassmateScores('node1', 'component1', 10);
-    http
-      .expectOne(
-        '/student?runId=1&nodeId=node1&componentId=component1&getStudentWork=false&' +
-          'getEvents=false&getAnnotations=true&onlyGetLatest=false&periodId=10'
-      )
-      .flush({});
   });
 }
 

--- a/src/app/services/summaryService.spec.ts
+++ b/src/app/services/summaryService.spec.ts
@@ -2,13 +2,19 @@ import { TestBed } from '@angular/core/testing';
 import { SummaryService } from '../../assets/wise5/components/summary/summaryService';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { UtilService } from '../../assets/wise5/services/utilService';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
 import { TagService } from '../../assets/wise5/services/tagService';
 import { SessionService } from '../../assets/wise5/services/sessionService';
 
+const componentId = 'component1';
+let http: HttpTestingController;
+const nodeId = 'node1';
+const periodId = 10;
+const periodSource = 'period';
+const runId = 1;
 let service;
 const summaryAllowedComponentTypes = [
   'Animation',
@@ -43,11 +49,16 @@ describe('SummaryService', () => {
       ]
     });
     service = TestBed.get(SummaryService);
+    http = TestBed.get(HttpTestingController);
+    spyOn(TestBed.inject(ConfigService), 'getRunId').and.returnValue(runId);
+    spyOn(TestBed.inject(ConfigService), 'getPeriodId').and.returnValue(periodId);
   });
   createComponent();
   isComponentTypeAllowed();
   isScoresSummaryAvailableForComponentType();
   isResponsesSummaryAvailableForComponentType();
+  getLatestClassmateStudentWork();
+  getLatestClassmateScores();
 });
 
 function createComponent() {
@@ -116,5 +127,37 @@ function isResponsesSummaryAvailableForComponentType() {
       ],
       false
     );
+  });
+}
+
+function getLatestClassmateStudentWork() {
+  it('should get latest classmate student work', () => {
+    const expectedStudentWork = [{ id: 1 }];
+    service
+      .getLatestClassmateStudentWork(nodeId, componentId, periodSource)
+      .subscribe((studentWork: any[]) => {
+        expect(studentWork).toEqual(expectedStudentWork);
+      });
+    http
+      .expectOne(
+        `/api/classmate/summary/student-work/${runId}/${periodId}/${nodeId}/${componentId}/${periodSource}`
+      )
+      .flush(expectedStudentWork);
+  });
+}
+
+function getLatestClassmateScores() {
+  it('should get latest classmate scores', () => {
+    const expectedScores = [{ id: 2 }];
+    service
+      .getLatestClassmateScores(nodeId, componentId, periodSource)
+      .subscribe((scores: any[]) => {
+        expect(scores).toEqual(expectedScores);
+      });
+    http
+      .expectOne(
+        `/api/classmate/summary/scores/${runId}/${periodId}/${nodeId}/${componentId}/${periodSource}`
+      )
+      .flush(expectedScores);
   });
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/nodeInfo/nodeInfo.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/nodeInfo/nodeInfo.ts
@@ -13,6 +13,7 @@ class NodeInfoController {
   nodeContent: any;
   nodeId: string;
   periodId: number;
+  source: string;
   static $inject = [
     '$injector',
     'AnnotationService',
@@ -33,6 +34,11 @@ class NodeInfoController {
     const currentPeriod = this.TeacherDataService.getCurrentPeriod();
     if (currentPeriod != null) {
       this.periodId = currentPeriod.periodId;
+      if (this.periodId === -1) {
+        this.source = 'allPeriods';
+      } else {
+        this.source = 'period';
+      }
     }
   }
 
@@ -161,6 +167,7 @@ const NodeInfo = {
                         <summary-display ng-if='component.type === "MultipleChoice"'
                                 [node-id]='::$ctrl.nodeId' [component-id]='::component.id'
                                 [period-id]='$ctrl.periodId' [student-data-type]='"responses"'
+                                [source]='$ctrl.source'
                                 [highlight-correct-answer]='$ctrl.componentHasCorrectAnswer(component)'
                                 [chart-type]='"column"'
                                 [do-render]='true'>
@@ -170,6 +177,7 @@ const NodeInfo = {
                             $ctrl.componentHasScoreAnnotation(component.id)'>
                         <summary-display [node-id]='::$ctrl.nodeId' [component-id]='::component.id'
                                 [period-id]='$ctrl.periodId' [student-data-type]='"scores"'
+                                [source]='$ctrl.source'
                                 [chart-type]='"column"'
                                 [do-render]='true'>
                         </summary-display>

--- a/src/assets/wise5/components/summary/summaryService.ts
+++ b/src/assets/wise5/components/summary/summaryService.ts
@@ -3,13 +3,20 @@
 import { ComponentService } from '../componentService';
 import { UtilService } from '../../services/utilService';
 import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { ConfigService } from '../../services/configService';
+import { Observable } from 'rxjs';
 
 @Injectable()
 export class SummaryService extends ComponentService {
   componentsWithScoresSummary: string[];
   componentsWithResponsesSummary: string[];
 
-  constructor(protected UtilService: UtilService) {
+  constructor(
+    private configService: ConfigService,
+    private http: HttpClient,
+    protected UtilService: UtilService
+  ) {
     super(UtilService);
     this.componentsWithScoresSummary = [
       'Animation',
@@ -60,5 +67,25 @@ export class SummaryService extends ComponentService {
 
   isResponsesSummaryAvailableForComponentType(componentType) {
     return this.componentsWithResponsesSummary.indexOf(componentType) != -1;
+  }
+
+  getLatestClassmateStudentWork(
+    nodeId: string,
+    componentId: string,
+    source: string
+  ): Observable<any> {
+    const runId = this.configService.getRunId();
+    const periodId = this.configService.getPeriodId();
+    return this.http.get(
+      `/api/classmate/summary/student-work/${runId}/${periodId}/${nodeId}/${componentId}/${source}`
+    );
+  }
+
+  getLatestClassmateScores(nodeId: string, componentId: string, source: string): Observable<any> {
+    const runId = this.configService.getRunId();
+    const periodId = this.configService.getPeriodId();
+    return this.http.get(
+      `/api/classmate/summary/scores/${runId}/${periodId}/${nodeId}/${componentId}/${source}`
+    );
   }
 }

--- a/src/assets/wise5/directives/summaryDisplay/summary-display.component.spec.ts
+++ b/src/assets/wise5/directives/summaryDisplay/summary-display.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { SummaryService } from '../../components/summary/summaryService';
 import { AnnotationService } from '../../services/annotationService';
 import { ConfigService } from '../../services/configService';
 import { ProjectService } from '../../services/projectService';
@@ -25,6 +26,7 @@ describe('SummaryDisplayComponent', () => {
         ProjectService,
         SessionService,
         StudentDataService,
+        SummaryService,
         TagService,
         UtilService
       ],
@@ -53,7 +55,8 @@ describe('SummaryDisplayComponent', () => {
   filterLatestScoreAnnotations();
   getChartColors();
   getDataPointColor();
-  getGraphTitle();
+  getGraphForSelf();
+  getGraphTitleForPeriod();
   getGraphTitleForClass();
   getIndexByName();
   getPercentOfClassRespondedText();
@@ -63,7 +66,6 @@ describe('SummaryDisplayComponent', () => {
   getTotalWorkgroups();
   hasCorrectAnswer();
   initializeOtherComponent();
-  initializePeriodId();
   setCustomLabelColors();
   setLatestAnnotationIfNewer();
   setNumDummySamples();
@@ -224,23 +226,6 @@ function initializeOtherComponent() {
       component.initializeOtherComponent();
       expect(component.otherComponent).toEqual(otherComponent);
       expect(component.otherComponentType).toEqual(otherComponentType);
-    });
-  });
-}
-
-function initializePeriodId() {
-  describe('initializePeriodId', () => {
-    it('should initialize period id', () => {
-      spyOn(component, 'isClassroomMonitor').and.returnValue(true);
-      spyOn(component, 'isSourcePeriod').and.returnValue(true);
-      const periodId = 10;
-      component.dataService = {
-        currentPeriod: {
-          periodId: periodId
-        }
-      };
-      component.initializePeriodId();
-      expect(component.periodId).toEqual(periodId);
     });
   });
 }
@@ -473,37 +458,52 @@ function getChartColors() {
   });
 }
 
-function getGraphTitleForClass() {
-  describe('getGraphTitleForClass', () => {
-    it('should get graph title for class when student data type is responses', () => {
-      expectGraphTitleForClass('responses');
+function getGraphTitleForPeriod() {
+  describe('getGraphTitleForPeriod', () => {
+    it('should get graph title for period when student data type is responses', () => {
+      expectGraphTitleForX('Period', 'responses');
     });
-    it('should get graph title for class when student data type is scores', () => {
-      expectGraphTitleForClass('scores');
+    it('should get graph title for period when student data type is scores', () => {
+      expectGraphTitleForX('Period', 'scores');
     });
   });
 }
 
-function expectGraphTitleForClass(studentDataType: string) {
-  setResponseNumbers(component);
-  component.studentDataType = studentDataType;
-  const title = component.getGraphTitleForClass();
-  const upperCaseStudentDataType = studentDataType[0].toUpperCase() + studentDataType.substring(1);
-  expect(title).toEqual(`Class ${upperCaseStudentDataType} | 60% Responded (6/10)`);
+function getGraphTitleForClass() {
+  describe('getGraphTitleForClass', () => {
+    it('should get graph title for class when student data type is responses', () => {
+      expectGraphTitleForX('Class', 'responses');
+    });
+    it('should get graph title for class when student data type is scores', () => {
+      expectGraphTitleForX('Class', 'scores');
+    });
+  });
 }
 
-function getGraphTitle() {
+function expectGraphTitleForX(source: string, studentDataType: string) {
+  setResponseNumbers(component);
+  component.studentDataType = studentDataType;
+  let title: string;
+  if (source === 'Period') {
+    title = component.getGraphTitleForPeriod();
+  } else {
+    title = component.getGraphTitleForClass();
+  }
+  const upperCaseStudentDataType = studentDataType[0].toUpperCase() + studentDataType.substring(1);
+  expect(title).toEqual(`${source} ${upperCaseStudentDataType} | 60% Responded (6/10)`);
+}
+
+function getGraphForSelf() {
   describe('getGraphTitle', () => {
-    it('should get graph title when source is self', () => {
+    it('should get graph title for self when student data type is responses', () => {
       component.source = 'self';
+      component.studentDataType = 'responses';
       expect(component.getGraphTitle()).toEqual('Your Response');
     });
-    it('should get graph title when source is class', () => {
-      component.source = 'period';
-      setResponseNumbers(component);
-      component.studentDataType = 'responses';
-      const title = component.getGraphTitle();
-      expect(title).toEqual(`Class Responses | 60% Responded (6/10)`);
+    it('should get graph title for self when student data type is scores', () => {
+      component.source = 'self';
+      component.studentDataType = 'scores';
+      expect(component.getGraphTitle()).toEqual('Your Score');
     });
   });
 }

--- a/src/assets/wise5/directives/summaryDisplay/summary-display.component.ts
+++ b/src/assets/wise5/directives/summaryDisplay/summary-display.component.ts
@@ -1,12 +1,15 @@
 import * as Highcharts from 'highcharts';
 import { Component, Input, SimpleChanges } from '@angular/core';
 import { UpgradeModule } from '@angular/upgrade/static';
-import { Subscription } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { AnnotationService } from '../../services/annotationService';
 import { ConfigService } from '../../services/configService';
 import { ProjectService } from '../../services/projectService';
 import { StudentDataService } from '../../services/studentDataService';
 import { UtilService } from '../../services/utilService';
+import { SummaryService } from '../../components/summary/summaryService';
+import { from, of } from 'rxjs';
+import { tap } from 'rxjs/operators';
 
 @Component({
   selector: 'summary-display',
@@ -68,6 +71,7 @@ export class SummaryDisplay {
     private ConfigService: ConfigService,
     private ProjectService: ProjectService,
     private StudentDataService: StudentDataService,
+    private summaryService: SummaryService,
     private upgrade: UpgradeModule,
     private UtilService: UtilService
   ) {}
@@ -76,7 +80,6 @@ export class SummaryDisplay {
     this.setNumDummySamples();
     this.initializeOtherComponent();
     this.initializeDataService();
-    this.initializePeriodId();
     this.initializeCustomLabelColors();
     this.initializeChangeListeners();
     if (this.doRender) {
@@ -113,12 +116,6 @@ export class SummaryDisplay {
       this.dataService = this.upgrade.$injector.get('StudentDataService');
     } else if (this.isClassroomMonitor() || this.isAuthoringPreview()) {
       this.dataService = this.upgrade.$injector.get('TeacherDataService');
-    }
-  }
-
-  initializePeriodId() {
-    if (this.isClassroomMonitor() && this.isSourcePeriod()) {
-      this.periodId = this.dataService.currentPeriod.periodId;
     }
   }
 
@@ -209,27 +206,33 @@ export class SummaryDisplay {
   }
 
   renderClassResponses() {
-    this.getComponentStates(this.nodeId, this.componentId, this.periodId).then(
+    this.getLatestStudentWork(this.nodeId, this.componentId, this.source, this.periodId).subscribe(
       (componentStates = []) => {
         this.processComponentStates(componentStates);
       }
     );
   }
 
-  getScores(nodeId, componentId, periodId) {
+  getLatestScores(
+    nodeId: string,
+    componentId: string,
+    source: string,
+    periodId: number
+  ): Observable<any[]> {
     if (this.isVLEPreview()) {
-      return this.getDummyStudentScoresForVLEPreview(nodeId, componentId);
+      return this.getDummyStudentScoresForVLEPreview();
     } else if (this.isAuthoringPreview()) {
       return this.getDummyStudentScoresForAuthoringPreview();
     } else if (this.isStudentRun()) {
-      return this.dataService
-        .getClassmateScores(nodeId, componentId, periodId)
-        .then((annotations) => {
-          return this.filterLatestScoreAnnotations(annotations);
-        });
+      return this.summaryService.getLatestClassmateScores(nodeId, componentId, source).pipe(
+        tap((scoreAnnotations) => {
+          return this.filterLatestScoreAnnotations(scoreAnnotations);
+        })
+      );
     } else if (this.isClassroomMonitor()) {
-      const annotations = this.dataService.getAnnotationsByNodeIdAndPeriodId(nodeId, periodId);
-      return this.resolveData(this.filterLatestScoreAnnotations(annotations));
+      const periodIdValue = this.getPeriodIdValue(periodId);
+      const annotations = this.dataService.getAnnotationsByNodeIdAndPeriodId(nodeId, periodIdValue);
+      return of(this.filterLatestScoreAnnotations(annotations));
     }
   }
 
@@ -271,9 +274,11 @@ export class SummaryDisplay {
 
   renderClassScores() {
     this.setMaxScore(this.otherComponent);
-    this.getScores(this.nodeId, this.componentId, this.periodId).then((annotations) => {
-      this.processScoreAnnotations(annotations);
-    });
+    this.getLatestScores(this.nodeId, this.componentId, this.source, this.periodId).subscribe(
+      (annotations) => {
+        this.processScoreAnnotations(annotations);
+      }
+    );
   }
 
   setMaxScore(component) {
@@ -284,20 +289,32 @@ export class SummaryDisplay {
     }
   }
 
-  getComponentStates(nodeId, componentId, periodId) {
+  getLatestStudentWork(
+    nodeId: string,
+    componentId: string,
+    source: string,
+    periodId: number
+  ): Observable<any> {
     if (this.isVLEPreview()) {
       return this.getDummyStudentWorkForVLEPreview(nodeId, componentId);
     } else if (this.isAuthoringPreview()) {
       return this.getDummyStudentWorkForAuthoringPreview();
     } else if (this.isStudentRun()) {
-      return this.dataService.getClassmateStudentWork(nodeId, componentId, periodId);
+      return this.summaryService.getLatestClassmateStudentWork(nodeId, componentId, source);
     } else if (this.isClassroomMonitor()) {
-      return this.dataService.retrieveLatestStudentDataByNodeIdAndComponentIdAndPeriodId(
-        nodeId,
-        componentId,
-        periodId
+      const periodIdValue = this.getPeriodIdValue(periodId);
+      return from(
+        this.dataService.retrieveLatestStudentDataByNodeIdAndComponentIdAndPeriodId(
+          nodeId,
+          componentId,
+          periodIdValue
+        )
       );
     }
+  }
+
+  getPeriodIdValue(periodId: number): number {
+    return periodId === -1 ? null : periodId;
   }
 
   filterLatestScoreAnnotations(annotations) {
@@ -324,7 +341,7 @@ export class SummaryDisplay {
     });
   }
 
-  getDummyStudentWorkForVLEPreview(nodeId, componentId) {
+  getDummyStudentWorkForVLEPreview(nodeId: string, componentId: string): Observable<any> {
     const componentStates = this.createDummyComponentStates();
     const componentState = this.dataService.getLatestComponentStateByNodeIdAndComponentId(
       nodeId,
@@ -333,32 +350,24 @@ export class SummaryDisplay {
     if (componentState != null) {
       componentStates.push(componentState);
     }
-    return this.resolveData(componentStates);
+    return of(componentStates);
   }
 
-  getDummyStudentScoresForVLEPreview(nodeId, componentId) {
+  getDummyStudentScoresForVLEPreview(): Observable<any> {
     const annotations = this.createDummyScoreAnnotations();
     const annotation = this.getLatestScoreAnnotationForWorkgroup();
     if (annotation != null) {
       annotations.push(annotation);
     }
-    return this.resolveData(annotations);
+    return of(annotations);
   }
 
-  getDummyStudentWorkForAuthoringPreview() {
-    return this.resolveData(this.createDummyComponentStates());
+  getDummyStudentWorkForAuthoringPreview(): Observable<any> {
+    return of(this.createDummyComponentStates());
   }
 
-  getDummyStudentScoresForAuthoringPreview() {
-    return this.resolveData(this.createDummyScoreAnnotations());
-  }
-
-  resolveData(data) {
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        resolve(data);
-      });
-    });
+  getDummyStudentScoresForAuthoringPreview(): Observable<any> {
+    return of(this.createDummyScoreAnnotations());
   }
 
   createDummyComponentStates() {
@@ -718,21 +727,51 @@ export class SummaryDisplay {
   getGraphTitle() {
     if (this.isSourceSelf()) {
       return this.getGraphTitleForSelf();
+    } else if (this.isSourcePeriod()) {
+      return this.getGraphTitleForPeriod();
     } else {
       return this.getGraphTitleForClass();
     }
   }
 
   getGraphTitleForSelf() {
-    return 'Your Response';
+    if (this.isStudentDataTypeResponses()) {
+      return 'Your Response';
+    } else if (this.isStudentDataTypeScores()) {
+      return 'Your Score';
+    }
+  }
+
+  getGraphTitleForPeriod() {
+    if (this.isStudentDataTypeResponses()) {
+      return this.getGraphTitleWithLabelAndPercent(
+        $localize`Period Responses`,
+        this.getPercentOfClassRespondedText()
+      );
+    } else if (this.isStudentDataTypeScores()) {
+      return this.getGraphTitleWithLabelAndPercent(
+        $localize`Period Scores`,
+        this.getPercentOfClassRespondedText()
+      );
+    }
   }
 
   getGraphTitleForClass() {
     if (this.isStudentDataTypeResponses()) {
-      return $localize`Class Responses` + ' | ' + this.getPercentOfClassRespondedText();
+      return this.getGraphTitleWithLabelAndPercent(
+        $localize`Class Responses`,
+        this.getPercentOfClassRespondedText()
+      );
     } else if (this.isStudentDataTypeScores()) {
-      return $localize`Class Scores` + ' | ' + this.getPercentOfClassRespondedText();
+      return this.getGraphTitleWithLabelAndPercent(
+        $localize`Class Scores`,
+        this.getPercentOfClassRespondedText()
+      );
     }
+  }
+
+  getGraphTitleWithLabelAndPercent(label: string, percentDisplayText: string): string {
+    return `${label} | ${percentDisplayText}`;
   }
 
   getPercentOfClassRespondedText(): string {

--- a/src/assets/wise5/directives/summaryDisplay/summary-display.component.ts
+++ b/src/assets/wise5/directives/summaryDisplay/summary-display.component.ts
@@ -736,9 +736,9 @@ export class SummaryDisplay {
 
   getGraphTitleForSelf() {
     if (this.isStudentDataTypeResponses()) {
-      return 'Your Response';
+      return $localize`Your Response`;
     } else if (this.isStudentDataTypeScores()) {
-      return 'Your Score';
+      return $localize`Your Score`;
     }
   }
 

--- a/src/assets/wise5/services/studentDataService.ts
+++ b/src/assets/wise5/services/studentDataService.ts
@@ -1394,52 +1394,6 @@ export class StudentDataService extends DataService {
     }
   }
 
-  getClassmateStudentWork(nodeId, componentId, periodId) {
-    let params = new HttpParams()
-      .set('runId', this.ConfigService.getRunId())
-      .set('nodeId', nodeId + '')
-      .set('componentId', componentId + '')
-      .set('getStudentWork', true + '')
-      .set('getEvents', false + '')
-      .set('getAnnotations', false + '')
-      .set('onlyGetLatest', true + '');
-    if (periodId != null) {
-      params = params.set('periodId', periodId);
-    }
-    const options = {
-      params: params
-    };
-    return this.http
-      .get(this.ConfigService.getConfigParam('studentDataURL'), options)
-      .toPromise()
-      .then((resultData: any) => {
-        return resultData.studentWorkList;
-      });
-  }
-
-  getClassmateScores(nodeId, componentId, periodId) {
-    let params = new HttpParams()
-      .set('runId', this.ConfigService.getRunId())
-      .set('nodeId', nodeId + '')
-      .set('componentId', componentId + '')
-      .set('getStudentWork', false + '')
-      .set('getEvents', false + '')
-      .set('getAnnotations', true + '')
-      .set('onlyGetLatest', false + '');
-    if (periodId != null) {
-      params = params.set('periodId', periodId);
-    }
-    const options = {
-      params: params
-    };
-    return this.http
-      .get(this.ConfigService.getConfigParam('studentDataURL'), options)
-      .toPromise()
-      .then((resultData: any) => {
-        return resultData.annotations;
-      });
-  }
-
   getStudentWorkById(id) {
     const params = new HttpParams()
       .set('runId', this.ConfigService.getRunId())

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -14112,11 +14112,11 @@ Warning: This will delete all existing choices and buckets in this component.</s
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summaryDisplay/summary-display.component.ts</context>
-          <context context-type="linenumber">596</context>
+          <context context-type="linenumber">605</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summaryDisplay/summary-display.component.ts</context>
-          <context context-type="linenumber">706</context>
+          <context context-type="linenumber">715</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2496818939481806999" datatype="html">
@@ -14127,11 +14127,11 @@ Warning: This will delete all existing choices and buckets in this component.</s
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summaryDisplay/summary-display.component.ts</context>
-          <context context-type="linenumber">596</context>
+          <context context-type="linenumber">605</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summaryDisplay/summary-display.component.ts</context>
-          <context context-type="linenumber">710</context>
+          <context context-type="linenumber">719</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6619869754055745168" datatype="html">
@@ -15331,7 +15331,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Summary</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summaryService.ts</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f7d15493b0e51d441ca4b60ff28151b6de9b9ee2" datatype="html">
@@ -15772,35 +15772,63 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>The student will see a graph of their individual data here.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summaryDisplay/summary-display.component.ts</context>
-          <context context-type="linenumber">187</context>
+          <context context-type="linenumber">184</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="629070935308008546" datatype="html">
+        <source>Your Response</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/directives/summaryDisplay/summary-display.component.ts</context>
+          <context context-type="linenumber">739</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="610707389788117365" datatype="html">
+        <source>Your Score</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/directives/summaryDisplay/summary-display.component.ts</context>
+          <context context-type="linenumber">741</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1159047178964534522" datatype="html">
+        <source>Period Responses</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/directives/summaryDisplay/summary-display.component.ts</context>
+          <context context-type="linenumber">748</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6903542619561738551" datatype="html">
+        <source>Period Scores</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/directives/summaryDisplay/summary-display.component.ts</context>
+          <context context-type="linenumber">753</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2142002953999044695" datatype="html">
         <source>Class Responses</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summaryDisplay/summary-display.component.ts</context>
-          <context context-type="linenumber">732</context>
+          <context context-type="linenumber">762</context>
         </context-group>
       </trans-unit>
       <trans-unit id="489297649750722424" datatype="html">
         <source>Class Scores</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summaryDisplay/summary-display.component.ts</context>
-          <context context-type="linenumber">734</context>
+          <context context-type="linenumber">767</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4270887249744454870" datatype="html">
         <source><x id="PH" equiv-text="this.percentResponded"/>% Responded (<x id="PH_1" equiv-text="this.numResponses"/>/<x id="PH_2" equiv-text="this.totalWorkgroups"/>)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summaryDisplay/summary-display.component.ts</context>
-          <context context-type="linenumber">739</context>
+          <context context-type="linenumber">778</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8177873832400820695" datatype="html">
         <source>Count</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summaryDisplay/summary-display.component.ts</context>
-          <context context-type="linenumber">856</context>
+          <context context-type="linenumber">895</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d53b401d14b43833857138029db823612e52f518" datatype="html">


### PR DESCRIPTION
You should test this with https://github.com/WISE-Community/WISE-API/pull/131

## Changes

- Retrieve summary data from summary endpoint instead of generic student data endpoint
- Fixed properly displaying data from period or all periods in classroom monitor based upon which period is currently selected
- Fixed the graph title based upon self, period, or class

# Test

- Summary works for VLE preview
- Summary works for Authoring preview
- In student VLE, Summary properly shows data depending on whether it is authored to show data from self, period, or all periods
- Summary works for Classroom Monitor (when you click Node Info on a step that contains a Multiple Choice component or a component with any scores)
- In Classroom Monitor, Summary properly shows data depending on which period is selected or all periods are selected
- The summary graph title properly displays the text "Your", "Period", or "Class"

#592