### PR TITLE
fix(VLE): Make components full width on small screens

### DIFF
--- a/src/assets/wise5/vle/node/node.component.html
+++ b/src/assets/wise5/vle/node/node.component.html
@@ -18,6 +18,7 @@
     <div *ngFor="let component of components"
         id="component_{{ component.id }}"
         class="component"
+        fxFlex="100"
         fxFlex.gt-sm="{{component.componentWidth ? component.componentWidth : 100}}">
       <div *ngIf="isShowComponentRubric(component)" class="component__rubric">
         <help-icon

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1541,7 +1541,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/node/node.component.html</context>
-          <context context-type="linenumber">59</context>
+          <context context-type="linenumber">60</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6178733511992894634" datatype="html">
@@ -5834,7 +5834,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/node/node.component.html</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">50</context>
         </context-group>
       </trans-unit>
       <trans-unit id="044703276ff14d0a94f05154d5bc032872465a0d" datatype="html">
@@ -16413,7 +16413,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/node/node.component.html</context>
-          <context context-type="linenumber">51,53</context>
+          <context context-type="linenumber">52,54</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dc390b4facb4c5f5fb7d88cac9db7fe350393640" datatype="html">
@@ -16631,14 +16631,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Teaching Tips</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/node/node.component.html</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b570c9b6f5d96fb6f6969cb9397019829c34e82c" datatype="html">
         <source> Submit </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/node/node.component.html</context>
-          <context context-type="linenumber">61,63</context>
+          <context context-type="linenumber">62,64</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9fe218829514884cdd0ca2300573a4e0428c324f" datatype="html">


### PR DESCRIPTION
## Changes
Ensures that components take up the full page width on smaller screens.

Closes #604.

## Test
- Make sure all component types take up the full width of the available page space when browser window is less than 900px wide.
- Make sure to test with embedded components.