### PR TITLE
refactor(ComponentServiceLookupService): Replace $injector.get(componentService)

### DIFF
--- a/src/app/common-hybrid-angular.module.ts
+++ b/src/app/common-hybrid-angular.module.ts
@@ -80,6 +80,7 @@ import { EditNotebookItemDialogModule } from '../assets/wise5/themes/default/not
 import { ComputerAvatarService } from '../assets/wise5/services/computerAvatarService';
 import { StudentStatusService } from '../assets/wise5/services/studentStatusService';
 import { OpenResponseCompletionCriteriaService } from '../assets/wise5/components/openResponse/openResponseCompletionCriteriaService';
+import { ComponentServiceLookupService } from '../assets/wise5/services/componentServiceLookupService';
 
 @Component({ template: `` })
 export class EmptyComponent {}
@@ -135,6 +136,7 @@ export class EmptyComponent {}
     AudioRecorderService,
     ConceptMapService,
     ComponentService,
+    ComponentServiceLookupService,
     ComputerAvatarService,
     ConfigService,
     CRaterService,

--- a/src/assets/wise5/authoringTool/node/nodeAuthoringComponent.ts
+++ b/src/assets/wise5/authoringTool/node/nodeAuthoringComponent.ts
@@ -12,6 +12,7 @@ import { NotificationService } from '../../services/notificationService';
 import { Subscription } from 'rxjs';
 import { Directive } from '@angular/core';
 import { Node } from '../../common/Node';
+import { ComponentServiceLookupService } from '../../services/componentServiceLookupService';
 
 @Directive()
 class NodeAuthoringController {
@@ -50,13 +51,13 @@ class NodeAuthoringController {
   static $inject = [
     '$anchorScroll',
     '$filter',
-    '$injector',
     '$mdDialog',
     '$state',
     '$stateParams',
     '$timeout',
     'ConfigService',
     'CopyComponentService',
+    'ComponentServiceLookupService',
     'InsertComponentService',
     'NodeService',
     'NotificationService',
@@ -68,13 +69,13 @@ class NodeAuthoringController {
   constructor(
     private $anchorScroll: any,
     $filter: any,
-    private $injector: any,
     private $mdDialog: any,
     private $state: any,
     private $stateParams: any,
     private $timeout: any,
     private ConfigService: ConfigService,
     private CopyComponentService: CopyComponentService,
+    private componentServiceLookupService: ComponentServiceLookupService,
     private InsertComponentService: InsertComponentService,
     private NodeService: NodeService,
     private NotificationService: NotificationService,
@@ -183,7 +184,7 @@ class NodeAuthoringController {
 
   hideAllComponentSaveButtons() {
     for (const component of this.components) {
-      const service = this.$injector.get(component.type + 'Service');
+      const service = this.componentServiceLookupService.getService(component.type);
       if (service.componentUsesSaveButton()) {
         component.showSaveButton = false;
       }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/nodeInfo/nodeInfo.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/nodeInfo/nodeInfo.ts
@@ -5,6 +5,7 @@ import { SummaryService } from '../../../../components/summary/summaryService';
 import { TeacherDataService } from '../../../../services/teacherDataService';
 import { UtilService } from '../../../../services/utilService';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
+import { ComponentServiceLookupService } from '../../../../services/componentServiceLookupService';
 
 class NodeInfoController {
   color: any;
@@ -14,8 +15,8 @@ class NodeInfoController {
   nodeId: string;
   periodId: number;
   static $inject = [
-    '$injector',
     'AnnotationService',
+    'ComponentServiceLookupService',
     'ProjectService',
     'SummaryService',
     'TeacherDataService',
@@ -23,8 +24,8 @@ class NodeInfoController {
   ];
 
   constructor(
-    private $injector: any,
     private AnnotationService: AnnotationService,
+    private componentServiceLookupService: ComponentServiceLookupService,
     private ProjectService: TeacherProjectService,
     private SummaryService: SummaryService,
     private TeacherDataService: TeacherDataService,
@@ -109,8 +110,8 @@ class NodeInfoController {
     );
   }
 
-  componentHasCorrectAnswer(component) {
-    const service = this.$injector.get(component.type + 'Service');
+  componentHasCorrectAnswer(component: any): boolean {
+    const service = this.componentServiceLookupService.getService(component.type);
     return service.componentHasCorrectAnswer(component);
   }
 }

--- a/src/assets/wise5/classroomMonitor/dataExport/data-export-module.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/data-export-module.ts
@@ -1,5 +1,6 @@
 import { downgradeInjectable } from '@angular/upgrade/static';
 import * as angular from 'angular';
+import { ComponentServiceLookupService } from '../../services/componentServiceLookupService';
 import { DataExportService } from '../../services/dataExportService';
 import DataExportController from './dataExportController';
 import ExportController from './exportController';
@@ -8,6 +9,7 @@ import ExportVisitsController from './exportVisitsController';
 export default angular
   .module('dataExport', ['ngFileSaver'])
   .factory('DataExportService', downgradeInjectable(DataExportService))
+  .factory('ComponentServiceLookupService', downgradeInjectable(ComponentServiceLookupService))
   .controller('DataExportController', DataExportController)
   .controller('ExportController', ExportController)
   .controller('ExportVisitsController', ExportVisitsController)

--- a/src/assets/wise5/classroomMonitor/dataExport/dataExportController.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/dataExportController.ts
@@ -8,6 +8,7 @@ import { TeacherDataService } from '../../services/teacherDataService';
 import { UtilService } from '../../services/utilService';
 import * as angular from 'angular';
 import { TeacherProjectService } from '../../services/teacherProjectService';
+import { ComponentServiceLookupService } from '../../services/componentServiceLookupService';
 
 class DataExportController {
   $translate: any;
@@ -45,7 +46,6 @@ class DataExportController {
     'Submit Count'
   ];
   canViewStudentNames: boolean = false;
-  componentTypeToComponentService: any = {};
   dialogGuidanceComputerResponseLabel: string = 'Computer Response';
   dialogGuidanceRevisionLabel: string = 'Revision';
   embeddedTableKeyToValue = {
@@ -86,10 +86,10 @@ class DataExportController {
 
   static $inject = [
     '$filter',
-    '$injector',
     '$mdDialog',
     '$state',
     'AnnotationService',
+    'ComponentServiceLookupService',
     'ConfigService',
     'DataExportService',
     'FileSaver',
@@ -101,10 +101,10 @@ class DataExportController {
 
   constructor(
     $filter: any,
-    private $injector: any,
     private $mdDialog: any,
     private $state: any,
     private AnnotationService: AnnotationService,
+    private componentServiceLookupService: ComponentServiceLookupService,
     private ConfigService: ConfigService,
     private DataExportService: DataExportService,
     private FileSaver: any,
@@ -688,7 +688,7 @@ class DataExportController {
      */
     let studentDataString = ' ';
     let componentType = componentState.componentType;
-    let componentService = this.getComponentService(componentType);
+    let componentService = this.componentServiceLookupService.getService(componentType);
     if (componentService != null && componentService.getStudentDataString != null) {
       studentDataString = componentService.getStudentDataString(componentState);
       studentDataString = this.UtilService.removeHTMLTags(studentDataString);
@@ -2341,23 +2341,6 @@ class DataExportController {
     topRows.push(columnIdRow);
     topRows.push(descriptionRow);
     return topRows;
-  }
-
-  /**
-   * Get the component service for a component type
-   * @param componentType the component type
-   * @return the component service or null if it doesn't exist
-   */
-  getComponentService(componentType) {
-    let componentService = null;
-    if (componentType != null) {
-      componentService = this.componentTypeToComponentService[componentType];
-      if (componentService == null) {
-        componentService = this.$injector.get(componentType + 'Service');
-        this.componentTypeToComponentService[componentType] = componentService;
-      }
-    }
-    return componentService;
   }
 
   /**

--- a/src/assets/wise5/services/componentServiceLookupService.ts
+++ b/src/assets/wise5/services/componentServiceLookupService.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@angular/core';
+import { AnimationService } from '../components/animation/animationService';
+import { AudioOscillatorService } from '../components/audioOscillator/audioOscillatorService';
+import { ConceptMapService } from '../components/conceptMap/conceptMapService';
+import { DialogGuidanceService } from '../components/dialogGuidance/dialogGuidanceService';
+import { DiscussionService } from '../components/discussion/discussionService';
+import { DrawService } from '../components/draw/drawService';
+import { EmbeddedService } from '../components/embedded/embeddedService';
+import { GraphService } from '../components/graph/graphService';
+import { HTMLService } from '../components/html/htmlService';
+import { LabelService } from '../components/label/labelService';
+import { MatchService } from '../components/match/matchService';
+import { MultipleChoiceService } from '../components/multipleChoice/multipleChoiceService';
+import { OpenResponseService } from '../components/openResponse/openResponseService';
+import { OutsideURLService } from '../components/outsideURL/outsideURLService';
+import { PeerChatService } from '../components/peerChat/peerChatService';
+import { ShowGroupWorkService } from '../components/showGroupWork/showGroupWorkService';
+import { ShowMyWorkService } from '../components/showMyWork/showMyWorkService';
+import { SummaryService } from '../components/summary/summaryService';
+import { TableService } from '../components/table/tableService';
+
+@Injectable()
+export class ComponentServiceLookupService {
+  services = new Map<string, any>();
+
+  constructor(
+    private animationService: AnimationService,
+    private audioOscillatorService: AudioOscillatorService,
+    private conceptMapService: ConceptMapService,
+    private dialogGuidanceService: DialogGuidanceService,
+    private discussionService: DiscussionService,
+    private drawService: DrawService,
+    private embeddedService: EmbeddedService,
+    private graphService: GraphService,
+    private labelService: LabelService,
+    private matchService: MatchService,
+    private multipleChoiceService: MultipleChoiceService,
+    private openResponseService: OpenResponseService,
+    private outsideURLService: OutsideURLService,
+    private peerChatService: PeerChatService,
+    private htmlService: HTMLService,
+    private showGroupWorkService: ShowGroupWorkService,
+    private showMyWorkService: ShowMyWorkService,
+    private summaryService: SummaryService,
+    private tableService: TableService
+  ) {
+    this.services.set('Animation', this.animationService);
+    this.services.set('AudioOscillator', this.audioOscillatorService);
+    this.services.set('ConceptMap', this.conceptMapService);
+    this.services.set('DialogGuidance', this.dialogGuidanceService);
+    this.services.set('Discussion', this.discussionService);
+    this.services.set('Draw', this.drawService);
+    this.services.set('Embedded', this.embeddedService);
+    this.services.set('Graph', this.graphService);
+    this.services.set('Label', this.labelService);
+    this.services.set('Match', this.matchService);
+    this.services.set('MultipleChoice', this.multipleChoiceService);
+    this.services.set('OpenResponse', this.openResponseService);
+    this.services.set('OutsideURL', this.outsideURLService);
+    this.services.set('PeerChat', this.peerChatService);
+    this.services.set('HTML', this.htmlService);
+    this.services.set('ShowGroupWork', this.showGroupWorkService);
+    this.services.set('ShowMyWork', this.showMyWorkService);
+    this.services.set('Summary', this.summaryService);
+    this.services.set('Table', this.tableService);
+  }
+
+  getService(componentType: string): any {
+    return this.services.get(componentType);
+  }
+}


### PR DESCRIPTION
## Changes
- Create ComponentServiceLookupService
- Replace $injector.get(componentType + 'Service') with ComponentServiceLookupService.getService(componentType)
- Remove dependencies to $injector where possible
- Note: not all instances of $injector.get(componentService) were replaceable at this time (e.g. StudentDataService, UtilService) because it would have created circular dependencies. Those classes will first need to be refactored.

## Test
- MC Summary in CM via the "Step Tools" dialog: should call NodeInfo.componentHasCorrectAnswer() which calls ComponentServiceLookupService.getService()
- Node Authoring: deleting a component should call hideAllComponentSaveButtons() which calls ComponentServiceLookupService.getService()
- Data export should work as before and use ComponentServiceLookupService to look up component services 

Closes #606