### PR TITLE
refactor(Component Type Label): move function into new ComponentTypeService

### DIFF
--- a/src/app/authoring-tool/add-component/choose-new-component-location/choose-new-component-location.component.spec.ts
+++ b/src/app/authoring-tool/add-component/choose-new-component-location/choose-new-component-location.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { ComponentTypeService } from '../../../../assets/wise5/services/componentTypeService';
 import { ConfigService } from '../../../../assets/wise5/services/configService';
 import { TeacherDataService } from '../../../../assets/wise5/services/teacherDataService';
 import { TeacherProjectService } from '../../../../assets/wise5/services/teacherProjectService';
@@ -41,6 +42,8 @@ class MockUpgradeModule {
   };
 }
 
+class MockComponentTypeService {}
+
 let component: ChooseNewComponentLocation;
 let teacherProjectService: TeacherProjectService;
 
@@ -50,6 +53,7 @@ describe('ChooseNewComponentLocation', () => {
       imports: [HttpClientTestingModule],
       providers: [
         ChooseNewComponentLocation,
+        { provide: ComponentTypeService, useClass: MockComponentTypeService },
         ConfigService,
         { provide: TeacherProjectService, useClass: MockProjectService },
         { provide: TeacherDataService, useClass: MockTeacherDataService },

--- a/src/app/authoring-tool/add-component/choose-new-component-location/choose-new-component-location.component.ts
+++ b/src/app/authoring-tool/add-component/choose-new-component-location/choose-new-component-location.component.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { ComponentTypeService } from '../../../../assets/wise5/services/componentTypeService';
 import { ConfigService } from '../../../../assets/wise5/services/configService';
 import { TeacherDataService } from '../../../../assets/wise5/services/teacherDataService';
 import { TeacherProjectService } from '../../../../assets/wise5/services/teacherProjectService';
-import { UtilService } from '../../../../assets/wise5/services/utilService';
 
 @Component({
   selector: 'choose-new-component-location',
@@ -15,10 +15,10 @@ export class ChooseNewComponentLocation {
 
   constructor(
     private upgrade: UpgradeModule,
+    private componentTypeService: ComponentTypeService,
     private ConfigService: ConfigService,
     private TeacherProjectService: TeacherProjectService,
-    private TeacherDataService: TeacherDataService,
-    private UtilService: UtilService
+    private TeacherDataService: TeacherDataService
   ) {}
 
   ngOnInit() {
@@ -27,7 +27,7 @@ export class ChooseNewComponentLocation {
   }
 
   getComponentTypeLabel(componentType) {
-    return this.UtilService.getComponentTypeLabel(componentType);
+    return this.componentTypeService.getComponentTypeLabel(componentType);
   }
 
   insertComponentAsFirst() {

--- a/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.ts
+++ b/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { UpgradeModule } from '@angular/upgrade/static';
-import { UtilService } from '../../../../assets/wise5/services/utilService';
+import { ComponentTypeService } from '../../../../assets/wise5/services/componentTypeService';
 
 @Component({
   selector: 'choose-new-component',
@@ -11,10 +11,10 @@ export class ChooseNewComponent {
   componentTypes: any[];
   selectedComponentType: string;
 
-  constructor(private upgrade: UpgradeModule, private UtilService: UtilService) {}
+  constructor(private upgrade: UpgradeModule, private componentTypeService: ComponentTypeService) {}
 
   ngOnInit() {
-    this.componentTypes = this.UtilService.getComponentTypes();
+    this.componentTypes = this.componentTypeService.getComponentTypes();
     this.selectedComponentType = this.upgrade.$injector.get('$stateParams').componentType;
   }
 

--- a/src/app/classroom-monitor/component-select/component-select.component.ts
+++ b/src/app/classroom-monitor/component-select/component-select.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ComponentTypeService } from '../../../assets/wise5/services/componentTypeService';
 import { TeacherProjectService } from '../../../assets/wise5/services/teacherProjectService';
-import { UtilService } from '../../../assets/wise5/services/utilService';
 
 @Component({
   selector: 'component-select',
@@ -18,7 +18,10 @@ export class ComponentSelectComponent {
 
   selectedComponents: any[];
 
-  constructor(private ProjectService: TeacherProjectService, private UtilService: UtilService) {}
+  constructor(
+    private componentTypeService: ComponentTypeService,
+    private ProjectService: TeacherProjectService
+  ) {}
 
   ngOnInit() {
     this.components = this.ProjectService.getComponentsByNodeId(this.nodeId).filter((component) => {
@@ -30,7 +33,7 @@ export class ComponentSelectComponent {
   }
 
   getComponentTypeLabel(componentType) {
-    return this.UtilService.getComponentTypeLabel(componentType);
+    return this.componentTypeService.getComponentTypeLabel(componentType);
   }
 
   getSelectedText() {

--- a/src/app/common-hybrid-angular.module.ts
+++ b/src/app/common-hybrid-angular.module.ts
@@ -81,6 +81,7 @@ import { ComputerAvatarService } from '../assets/wise5/services/computerAvatarSe
 import { StudentStatusService } from '../assets/wise5/services/studentStatusService';
 import { OpenResponseCompletionCriteriaService } from '../assets/wise5/components/openResponse/openResponseCompletionCriteriaService';
 import { ComponentServiceLookupService } from '../assets/wise5/services/componentServiceLookupService';
+import { ComponentTypeService } from '../assets/wise5/services/componentTypeService';
 
 @Component({ template: `` })
 export class EmptyComponent {}
@@ -137,6 +138,7 @@ export class EmptyComponent {}
     ConceptMapService,
     ComponentService,
     ComponentServiceLookupService,
+    ComponentTypeService,
     ComputerAvatarService,
     ConfigService,
     CRaterService,

--- a/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.ts
@@ -2,7 +2,7 @@ import { Component, ElementRef, ViewChild } from '@angular/core';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { FormControl, FormGroup, Validators, FormBuilder } from '@angular/forms';
-import { UtilService } from '../../../services/utilService';
+import { ComponentTypeService } from '../../../services/componentTypeService';
 
 @Component({
   styleUrls: ['add-your-own-node.component.scss'],
@@ -18,12 +18,12 @@ export class AddYourOwnNode {
 
   constructor(
     private upgrade: UpgradeModule,
-    private UtilService: UtilService,
+    private componentTypeService: ComponentTypeService,
     private fb: FormBuilder
   ) {}
 
   ngOnInit() {
-    this.componentTypes = this.UtilService.getComponentTypes();
+    this.componentTypes = this.componentTypeService.getComponentTypes();
   }
 
   @ViewChild('titleField') titleField: ElementRef;

--- a/src/assets/wise5/authoringTool/importComponent/choose-component-location.component.ts
+++ b/src/assets/wise5/authoringTool/importComponent/choose-component-location.component.ts
@@ -3,7 +3,7 @@ import { ImportComponentService } from '../../services/importComponentService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { TeacherDataService } from '../../services/teacherDataService';
 import { ProjectAssetService } from '../../../../app/services/projectAssetService';
-import { UtilService } from '../../services/utilService';
+import { ComponentTypeService } from '../../services/componentTypeService';
 
 class ChooseComponentLocationController {
   components: any = [];
@@ -12,23 +12,23 @@ class ChooseComponentLocationController {
   static $inject = [
     '$state',
     '$stateParams',
+    'ComponentTypeService',
     'ConfigService',
     'ImportComponentService',
     'ProjectAssetService',
     'ProjectService',
-    'TeacherDataService',
-    'UtilService'
+    'TeacherDataService'
   ];
 
   constructor(
     private $state: any,
     private $stateParams: any,
+    private componentTypeService: ComponentTypeService,
     private ConfigService: ConfigService,
     private ImportComponentService: ImportComponentService,
     private ProjectAssetService: ProjectAssetService,
     private ProjectService: TeacherProjectService,
-    private TeacherDataService: TeacherDataService,
-    private UtilService: UtilService
+    private TeacherDataService: TeacherDataService
   ) {}
 
   $onInit() {
@@ -37,7 +37,7 @@ class ChooseComponentLocationController {
   }
 
   getComponentTypeLabel(componentType) {
-    return this.UtilService.getComponentTypeLabel(componentType);
+    return this.componentTypeService.getComponentTypeLabel(componentType);
   }
 
   insertComponentAsFirst() {

--- a/src/assets/wise5/authoringTool/node/nodeAuthoringComponent.ts
+++ b/src/assets/wise5/authoringTool/node/nodeAuthoringComponent.ts
@@ -13,6 +13,7 @@ import { Subscription } from 'rxjs';
 import { Directive } from '@angular/core';
 import { Node } from '../../common/Node';
 import { ComponentServiceLookupService } from '../../services/componentServiceLookupService';
+import { ComponentTypeService } from '../../services/componentTypeService';
 
 @Directive()
 class NodeAuthoringController {
@@ -58,6 +59,7 @@ class NodeAuthoringController {
     'ConfigService',
     'CopyComponentService',
     'ComponentServiceLookupService',
+    'ComponentTypeService',
     'InsertComponentService',
     'NodeService',
     'NotificationService',
@@ -76,6 +78,7 @@ class NodeAuthoringController {
     private ConfigService: ConfigService,
     private CopyComponentService: CopyComponentService,
     private componentServiceLookupService: ComponentServiceLookupService,
+    private componentTypeService: ComponentTypeService,
     private InsertComponentService: InsertComponentService,
     private NodeService: NodeService,
     private NotificationService: NotificationService,
@@ -535,7 +538,7 @@ class NodeAuthoringController {
   }
 
   getComponentTypeLabel(componentType) {
-    return this.UtilService.getComponentTypeLabel(componentType);
+    return this.componentTypeService.getComponentTypeLabel(componentType);
   }
 
   /**

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneWorkgroupItem/milestoneWorkgroupItem.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestoneWorkgroupItem/milestoneWorkgroupItem.ts
@@ -2,9 +2,9 @@
 
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
 import * as angular from 'angular';
-import { UtilService } from '../../../../services/utilService';
 import { WorkgroupItemController } from '../../nodeGrading/workgroupItem/workgroupItem';
 import { Subscription } from 'rxjs';
+import { ComponentTypeService } from '../../../../services/componentTypeService';
 
 class MilestoneWorkgroupItemController extends WorkgroupItemController {
   $translate: any;
@@ -34,14 +34,14 @@ class MilestoneWorkgroupItemController extends WorkgroupItemController {
   subscriptions: Subscription = new Subscription();
   workgroupId: number;
 
-  static $inject = ['$filter', 'ProjectService', 'UtilService'];
+  static $inject = ['$filter', 'ComponentTypeService', 'ProjectService'];
 
   constructor(
     $filter: any,
-    protected ProjectService: TeacherProjectService,
-    protected UtilService: UtilService
+    protected componentTypeService: ComponentTypeService,
+    protected ProjectService: TeacherProjectService
   ) {
-    super($filter, ProjectService, UtilService);
+    super($filter, componentTypeService, ProjectService);
   }
 
   $onInit() {
@@ -117,10 +117,6 @@ class MilestoneWorkgroupItemController extends WorkgroupItemController {
 
   $onDestroy() {
     this.subscriptions.unsubscribe();
-  }
-
-  getComponentTypeLabel(componentType) {
-    return this.UtilService.getComponentTypeLabel(componentType);
   }
 
   getNodePosition(nodeId: string): string {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroupItem/workgroupItem.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroupItem/workgroupItem.ts
@@ -2,7 +2,7 @@
 
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
 import * as angular from 'angular';
-import { UtilService } from '../../../../services/utilService';
+import { ComponentTypeService } from '../../../../services/componentTypeService';
 
 export class WorkgroupItemController {
   $translate: any;
@@ -23,12 +23,12 @@ export class WorkgroupItemController {
   statusClass: any;
   statusText: string;
   workgroupId: number;
-  static $inject = ['$filter', 'ProjectService', 'UtilService'];
+  static $inject = ['$filter', 'ComponentTypeService', 'ProjectService'];
 
   constructor(
     $filter: any,
-    protected ProjectService: TeacherProjectService,
-    protected UtilService: UtilService
+    protected componentTypeService: ComponentTypeService,
+    protected ProjectService: TeacherProjectService
   ) {
     this.$translate = $filter('translate');
   }
@@ -77,7 +77,7 @@ export class WorkgroupItemController {
   }
 
   getComponentTypeLabel(componentType) {
-    return this.UtilService.getComponentTypeLabel(componentType);
+    return this.componentTypeService.getComponentTypeLabel(componentType);
   }
 
   update() {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.spec.ts
@@ -76,8 +76,6 @@ describe('PeerGroupDialogComponent', () => {
       { periodId: 1, periodName: '1' },
       { id: 2, periodName: '2' }
     ]);
-    spyOn(TestBed.inject(ProjectService), 'getComponentType').and.returnValue('PeerChat');
-    spyOn(TestBed.inject(UtilService), 'getComponentTypeLabel').and.returnValue('Peer Chat');
     spyOn(TestBed.inject(WorkgroupService), 'getWorkgroupsInPeriod').and.returnValue(new Map());
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/nodeInfo/nodeInfo.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/nodeInfo/nodeInfo.ts
@@ -3,9 +3,9 @@
 import { AnnotationService } from '../../../../services/annotationService';
 import { SummaryService } from '../../../../components/summary/summaryService';
 import { TeacherDataService } from '../../../../services/teacherDataService';
-import { UtilService } from '../../../../services/utilService';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
 import { ComponentServiceLookupService } from '../../../../services/componentServiceLookupService';
+import { ComponentTypeService } from '../../../../services/componentTypeService';
 
 class NodeInfoController {
   color: any;
@@ -18,19 +18,19 @@ class NodeInfoController {
   static $inject = [
     'AnnotationService',
     'ComponentServiceLookupService',
+    'ComponentTypeService',
     'ProjectService',
     'SummaryService',
-    'TeacherDataService',
-    'UtilService'
+    'TeacherDataService'
   ];
 
   constructor(
     private AnnotationService: AnnotationService,
     private componentServiceLookupService: ComponentServiceLookupService,
+    private componentTypeService: ComponentTypeService,
     private ProjectService: TeacherProjectService,
     private SummaryService: SummaryService,
-    private TeacherDataService: TeacherDataService,
-    private UtilService: UtilService
+    private TeacherDataService: TeacherDataService
   ) {
     const currentPeriod = this.TeacherDataService.getCurrentPeriod();
     if (currentPeriod != null) {
@@ -97,7 +97,7 @@ class NodeInfoController {
    * @return string of the component type label
    */
   getComponentTypeLabel(componentType) {
-    return this.UtilService.getComponentTypeLabel(componentType);
+    return this.componentTypeService.getComponentTypeLabel(componentType);
   }
 
   isResponsesSummaryAvailableForComponentType(componentType) {

--- a/src/assets/wise5/common-angular-js-module.ts
+++ b/src/assets/wise5/common-angular-js-module.ts
@@ -76,6 +76,7 @@ import { NotebookNotesComponent } from '../../app/notebook/notebook-notes/notebo
 import { NotebookReportComponent } from '../../app/notebook/notebook-report/notebook-report.component';
 import { NotebookReportAnnotationsComponent } from '../../app/notebook/notebook-report-annotations/notebook-report-annotations.component';
 import { ComputerAvatarService } from './services/computerAvatarService';
+import { ComponentTypeService } from './services/componentTypeService';
 
 angular
   .module('common', [
@@ -143,6 +144,7 @@ angular
   .factory('ConfigService', downgradeInjectable(ConfigService))
   .factory('ComponentService', downgradeInjectable(ComponentService))
   .factory('ComputerAvatarService', downgradeInjectable(ComputerAvatarService))
+  .factory('ComponentTypeService', downgradeInjectable(ComponentTypeService))
   .factory('CRaterService', downgradeInjectable(CRaterService))
   .service('HttpInterceptor', HttpInterceptor)
   .service('NodeService', downgradeInjectable(NodeService))

--- a/src/assets/wise5/services/componentTypeService.ts
+++ b/src/assets/wise5/services/componentTypeService.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { ComponentServiceLookupService } from './componentServiceLookupService';
+
+@Injectable()
+export class ComponentTypeService {
+  constructor(private componentServiceLookupService: ComponentServiceLookupService) {}
+
+  getComponentTypes(): any[] {
+    return [
+      { type: 'Animation', name: this.getComponentTypeLabel('Animation') },
+      { type: 'AudioOscillator', name: this.getComponentTypeLabel('AudioOscillator') },
+      { type: 'ConceptMap', name: this.getComponentTypeLabel('ConceptMap') },
+      { type: 'DialogGuidance', name: this.getComponentTypeLabel('DialogGuidance') },
+      { type: 'Discussion', name: this.getComponentTypeLabel('Discussion') },
+      { type: 'Draw', name: this.getComponentTypeLabel('Draw') },
+      { type: 'Embedded', name: this.getComponentTypeLabel('Embedded') },
+      { type: 'Graph', name: this.getComponentTypeLabel('Graph') },
+      { type: 'Label', name: this.getComponentTypeLabel('Label') },
+      { type: 'Match', name: this.getComponentTypeLabel('Match') },
+      { type: 'MultipleChoice', name: this.getComponentTypeLabel('MultipleChoice') },
+      { type: 'OpenResponse', name: this.getComponentTypeLabel('OpenResponse') },
+      { type: 'OutsideURL', name: this.getComponentTypeLabel('OutsideURL') },
+      { type: 'PeerChat', name: this.getComponentTypeLabel('PeerChat') },
+      { type: 'HTML', name: this.getComponentTypeLabel('HTML') },
+      { type: 'ShowGroupWork', name: this.getComponentTypeLabel('ShowGroupWork') },
+      { type: 'ShowMyWork', name: this.getComponentTypeLabel('ShowMyWork') },
+      { type: 'Summary', name: this.getComponentTypeLabel('Summary') },
+      { type: 'Table', name: this.getComponentTypeLabel('Table') }
+    ];
+  }
+
+  private getComponentTypeLabel(componentType: string): string {
+    return this.componentServiceLookupService.getService(componentType).getComponentTypeLabel();
+  }
+}

--- a/src/assets/wise5/services/componentTypeService.ts
+++ b/src/assets/wise5/services/componentTypeService.ts
@@ -29,7 +29,7 @@ export class ComponentTypeService {
     ];
   }
 
-  private getComponentTypeLabel(componentType: string): string {
+  getComponentTypeLabel(componentType: string): string {
     return this.componentServiceLookupService.getService(componentType).getComponentTypeLabel();
   }
 }

--- a/src/assets/wise5/services/utilService.ts
+++ b/src/assets/wise5/services/utilService.ts
@@ -391,30 +391,6 @@ export class UtilService {
     return '';
   }
 
-  getComponentTypes(): any[] {
-    return [
-      { type: 'Animation', name: this.getComponentTypeLabel('Animation') },
-      { type: 'AudioOscillator', name: this.getComponentTypeLabel('AudioOscillator') },
-      { type: 'ConceptMap', name: this.getComponentTypeLabel('ConceptMap') },
-      { type: 'DialogGuidance', name: this.getComponentTypeLabel('DialogGuidance') },
-      { type: 'Discussion', name: this.getComponentTypeLabel('Discussion') },
-      { type: 'Draw', name: this.getComponentTypeLabel('Draw') },
-      { type: 'Embedded', name: this.getComponentTypeLabel('Embedded') },
-      { type: 'Graph', name: this.getComponentTypeLabel('Graph') },
-      { type: 'Label', name: this.getComponentTypeLabel('Label') },
-      { type: 'Match', name: this.getComponentTypeLabel('Match') },
-      { type: 'MultipleChoice', name: this.getComponentTypeLabel('MultipleChoice') },
-      { type: 'OpenResponse', name: this.getComponentTypeLabel('OpenResponse') },
-      { type: 'OutsideURL', name: this.getComponentTypeLabel('OutsideURL') },
-      { type: 'PeerChat', name: this.getComponentTypeLabel('PeerChat') },
-      { type: 'HTML', name: this.getComponentTypeLabel('HTML') },
-      { type: 'ShowGroupWork', name: this.getComponentTypeLabel('ShowGroupWork') },
-      { type: 'ShowMyWork', name: this.getComponentTypeLabel('ShowMyWork') },
-      { type: 'Summary', name: this.getComponentTypeLabel('Summary') },
-      { type: 'Table', name: this.getComponentTypeLabel('Table') }
-    ];
-  }
-
   getComponentTypeLabel(componentType) {
     let label = this.componentTypeToLabel[componentType];
     if (label == null) {

--- a/src/assets/wise5/services/utilService.ts
+++ b/src/assets/wise5/services/utilService.ts
@@ -7,7 +7,6 @@ import '../lib/jquery/jquery-global';
 
 @Injectable()
 export class UtilService {
-  componentTypeToLabel = {};
   CHARS = [
     'a',
     'b',
@@ -389,21 +388,6 @@ export class UtilService {
       return date.toDateString() + ' ' + date.toLocaleTimeString();
     }
     return '';
-  }
-
-  getComponentTypeLabel(componentType) {
-    let label = this.componentTypeToLabel[componentType];
-    if (label == null) {
-      let componentService = this.upgrade.$injector.get(componentType + 'Service');
-      if (componentService != null && componentService.getComponentTypeLabel != null) {
-        label = componentService.getComponentTypeLabel();
-        this.componentTypeToLabel[componentType] = label;
-      }
-    }
-    if (label == null) {
-      label = componentType;
-    }
-    return label;
   }
 
   /**

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1182,7 +1182,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Showing <x id="PH" equiv-text="this.selectedComponents.length"/>/<x id="PH_1" equiv-text="this.components.length"/> items</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/classroom-monitor/component-select/component-select.component.ts</context>
-          <context context-type="linenumber">37</context>
+          <context context-type="linenumber">40</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e9f75e02d7db72cd425f81c273a721c62a617dc4" datatype="html">


### PR DESCRIPTION
## Changes
- Create ComponentTypeService and moved getComponentTypes() and getComponentTypeLabel() from UtilService
- Use ComponentServiceLookupService to look up service instead of upgrade.$injector.get(ComponentService)
- Update existing calls 
   - UtilService.getComponentTypes() -> ComponentTypeService.getComponentTypes()
   - UtilService.getComponentTypeLabel() -> ComponentTypeService.getComponentTypeLabel()

## Test

Component labels appear in the following pages:
- Authoring
   - Add new step
   - Add new component
   - Choose component location
- CM
   - Milestone
   - Step Info

Closes #619