### PR TITLE
fix(Peer Chat/Dialog Guidance): Set isCompleted true when work is saved

### DIFF
--- a/src/assets/wise5/components/dialogGuidance/dialogGuidanceService.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialogGuidanceService.ts
@@ -39,4 +39,8 @@ export class DialogGuidanceService extends ComponentService {
   getDefaultComputerAvatarLabel(): string {
     return $localize`Thought Buddy`;
   }
+
+  isCompleted(component: any, componentStates: any[], nodeEvents: any[], node: any) {
+    return componentStates.length > 0;
+  }
 }

--- a/src/assets/wise5/components/peerChat/peerChatService.ts
+++ b/src/assets/wise5/components/peerChat/peerChatService.ts
@@ -69,4 +69,8 @@ export class PeerChatService extends ComponentService {
       peerChatMessages.push(this.convertComponentStateToPeerChatMessage(componentState));
     });
   }
+
+  isCompleted(component: any, componentStates: any[], nodeEvents: any[], node: any) {
+    return componentStates.length > 0;
+  }
 }


### PR DESCRIPTION
## Changes

- Peer Chat now checks for student work to determine if isCompleted
- Dialog Guidance now checks for student work to determine if isCompleted

## Test

- Make sure Peer Chat is only set to completed if the student saved work
- Make sure Dialog Guidance is only set to completed if the student saved work

Closes #630