### PR TITLE
fix(Peer Grouping): Remove grouping logic authoring from most components

### DIFF
--- a/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.html
+++ b/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.html
@@ -22,8 +22,6 @@
   </edit-component-rubric>
   <edit-component-tags [authoringComponentContent]="authoringComponentContent">
   </edit-component-tags>
-  <edit-component-peer-grouping-tag [authoringComponentContent]="authoringComponentContent">
-  </edit-component-peer-grouping-tag>
 </div>
 <edit-connected-components
     [nodeId]="nodeId"

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-advanced/edit-dialog-guidance-advanced.component.html
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-advanced/edit-dialog-guidance-advanced.component.html
@@ -1,3 +1,1 @@
-<edit-component-peer-grouping-tag [authoringComponentContent]="authoringComponentContent">
-</edit-component-peer-grouping-tag>
 <edit-component-json [nodeId]="nodeId" [componentId]="componentId"></edit-component-json>

--- a/src/assets/wise5/components/discussion/edit-discussion-advanced/edit-discussion-advanced.component.html
+++ b/src/assets/wise5/components/discussion/edit-discussion-advanced/edit-discussion-advanced.component.html
@@ -4,8 +4,6 @@
   <edit-component-width [authoringComponentContent]="authoringComponentContent"></edit-component-width>
   <edit-component-rubric [authoringComponentContent]="authoringComponentContent"></edit-component-rubric>
   <edit-component-tags [authoringComponentContent]="authoringComponentContent"></edit-component-tags>
-  <edit-component-peer-grouping-tag [authoringComponentContent]="authoringComponentContent">
-  </edit-component-peer-grouping-tag>
 </div>
 <edit-discussion-connected-components
     [nodeId]="nodeId"

--- a/src/assets/wise5/components/draw/edit-draw-advanced/edit-draw-advanced.component.html
+++ b/src/assets/wise5/components/draw/edit-draw-advanced/edit-draw-advanced.component.html
@@ -26,8 +26,6 @@
   </edit-component-rubric>
   <edit-component-tags [authoringComponentContent]="authoringComponentContent">
   </edit-component-tags>
-  <edit-component-peer-grouping-tag [authoringComponentContent]="authoringComponentContent">
-  </edit-component-peer-grouping-tag>
 </div>
 <edit-draw-connected-components
     [nodeId]="nodeId"

--- a/src/assets/wise5/components/label/edit-label-advanced/edit-label-advanced.component.html
+++ b/src/assets/wise5/components/label/edit-label-advanced/edit-label-advanced.component.html
@@ -26,8 +26,6 @@
   </edit-component-rubric>
   <edit-component-tags [authoringComponentContent]="authoringComponentContent">
   </edit-component-tags>
-  <edit-component-peer-grouping-tag [authoringComponentContent]="authoringComponentContent">
-  </edit-component-peer-grouping-tag>
 </div>
 <edit-label-connected-components
     [nodeId]="nodeId"

--- a/src/assets/wise5/components/match/edit-match-advanced/edit-match-advanced.component.html
+++ b/src/assets/wise5/components/match/edit-match-advanced/edit-match-advanced.component.html
@@ -42,8 +42,6 @@
   </edit-component-rubric>
   <edit-component-tags [authoringComponentContent]="authoringComponentContent">
   </edit-component-tags>
-  <edit-component-peer-grouping-tag [authoringComponentContent]="authoringComponentContent">
-  </edit-component-peer-grouping-tag>
 </div>
 <edit-match-connected-components
     [nodeId]="nodeId"

--- a/src/assets/wise5/components/multipleChoice/edit-multiple-choice-advanced/edit-multiple-choice-advanced.component.html
+++ b/src/assets/wise5/components/multipleChoice/edit-multiple-choice-advanced/edit-multiple-choice-advanced.component.html
@@ -31,8 +31,6 @@
   </edit-component-rubric>
   <edit-component-tags [authoringComponentContent]="authoringComponentContent">
   </edit-component-tags>
-  <edit-component-peer-grouping-tag [authoringComponentContent]="authoringComponentContent">
-  </edit-component-peer-grouping-tag>
 </div>
 <edit-multiple-choice-connected-components
     [nodeId]="nodeId"

--- a/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html
+++ b/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html
@@ -163,8 +163,6 @@
   </edit-component-rubric>
   <edit-component-tags [authoringComponentContent]="authoringComponentContent">
   </edit-component-tags>
-  <edit-component-peer-grouping-tag [authoringComponentContent]="authoringComponentContent">
-  </edit-component-peer-grouping-tag>
 </div>
 <edit-table-connected-components
     [nodeId]="nodeId"


### PR DESCRIPTION
## Changes

Removed grouping logic authoring from all components except Peer Chat and Show Group Work.

## Test

Make sure the grouping logic authoring only shows up for Peer Chat and Show Group Work.

Closes #632