### PR TITLE
test(Peer Chat): Fix test that was failing because toLowerCase of null

### DIFF
--- a/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.spec.ts
@@ -87,6 +87,9 @@ describe('PeerChatGradingComponent', () => {
     spyOn(TestBed.inject(PeerGroupService), 'retrievePeerGroup').and.callFake(() => {
       return of(peerGroup);
     });
+    spyOn(TestBed.inject(NotificationService), 'saveNotificationToServer').and.callFake(() => {
+      return Promise.resolve();
+    });
     component = fixture.componentInstance;
     fixture.detectChanges();
   });


### PR DESCRIPTION
## Changes

Fixed a PeerChatGrading test that was throwing the error
```TypeError: Cannot read properties of null (reading 'toLowerCase')```

## Test

Make sure this error does not occur anymore when running the tests

```
TypeError: Cannot read properties of null (reading 'toLowerCase')
    at HttpXsrfInterceptor.intercept (http://localhost:9876/_karma_webpack_/vendor.js:317381:31)
```

Closes #635