### PR TITLE
Issue 637 place upgrade module get component service with component service lookup service

### DIFF
--- a/src/app/authoring-tool/edit-advanced-component/edit-component-default-feedback/edit-component-default-feedback.component.spec.ts
+++ b/src/app/authoring-tool/edit-advanced-component/edit-component-default-feedback/edit-component-default-feedback.component.spec.ts
@@ -5,6 +5,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { ComponentServiceLookupServiceModule } from '../../../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../../assets/wise5/services/configService';
 import { CopyNodesService } from '../../../../assets/wise5/services/copyNodesService';
 import { SessionService } from '../../../../assets/wise5/services/sessionService';
@@ -22,6 +23,7 @@ describe('EditComponentDefaultFeedback', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatIconModule,

--- a/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.spec.ts
+++ b/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.spec.ts
@@ -9,6 +9,7 @@ import { MatInputModule } from '@angular/material/input';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../assets/wise5/services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../assets/wise5/services/configService';
 import { NotificationService } from '../../../assets/wise5/services/notificationService';
 import { ProjectService } from '../../../assets/wise5/services/projectService';
@@ -36,6 +37,7 @@ describe('EditCommonAdvancedComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatCheckboxModule,

--- a/src/app/authoring-tool/edit-component-add-to-notebook-button/edit-component-add-to-notebook-button.component.spec.ts
+++ b/src/app/authoring-tool/edit-component-add-to-notebook-button/edit-component-add-to-notebook-button.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../assets/wise5/services/configService';
 import { SessionService } from '../../../assets/wise5/services/sessionService';
 import { TeacherProjectService } from '../../../assets/wise5/services/teacherProjectService';
@@ -16,7 +17,13 @@ describe('EditComponentAddToNotebookButtonComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FormsModule, HttpClientTestingModule, MatCheckboxModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        FormsModule,
+        HttpClientTestingModule,
+        MatCheckboxModule,
+        UpgradeModule
+      ],
       declarations: [EditComponentAddToNotebookButtonComponent],
       providers: [ConfigService, SessionService, TeacherProjectService, UtilService]
     }).compileComponents();

--- a/src/app/authoring-tool/edit-component-peer-grouping-tag/edit-component-peer-grouping-tag.component.spec.ts
+++ b/src/app/authoring-tool/edit-component-peer-grouping-tag/edit-component-peer-grouping-tag.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PeerGroupingTestingModule } from '../../../assets/wise5/authoringTool/peer-grouping/peer-grouping-testing.module';
 import { SelectPeerGroupingAuthoringComponent } from '../../../assets/wise5/authoringTool/peer-grouping/select-peer-grouping-authoring/select-peer-grouping-authoring.component';
+import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
 import { TeacherProjectService } from '../../../assets/wise5/services/teacherProjectService';
 import { EditComponentPeerGroupingTagComponent } from './edit-component-peer-grouping-tag.component';
 
@@ -13,7 +14,7 @@ const tag2: string = 'tag2';
 describe('EditComponentPeerGroupingTagComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PeerGroupingTestingModule],
+      imports: [ComponentServiceLookupServiceModule, PeerGroupingTestingModule],
       declarations: [EditComponentPeerGroupingTagComponent, SelectPeerGroupingAuthoringComponent],
       providers: []
     }).compileComponents();

--- a/src/app/authoring-tool/edit-connected-component-component-select/edit-connected-component-component-select.component.spec.ts
+++ b/src/app/authoring-tool/edit-connected-component-component-select/edit-connected-component-component-select.component.spec.ts
@@ -11,6 +11,7 @@ import { SessionService } from '../../../assets/wise5/services/sessionService';
 import { UtilService } from '../../../assets/wise5/services/utilService';
 import { EditConnectedComponentComponentSelectComponent } from './edit-connected-component-component-select.component';
 import { createConnectedComponentObject } from '../../../app/authoring-tool/edit-connected-components/edit-connected-components.component.spec';
+import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
 
 describe('EditConnectedComponentComponentSelectComponent', () => {
   let component: EditConnectedComponentComponentSelectComponent;
@@ -22,6 +23,7 @@ describe('EditConnectedComponentComponentSelectComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientModule,
         MatFormFieldModule,

--- a/src/app/authoring-tool/edit-connected-component-node-select/edit-connected-component-node-select.component.spec.ts
+++ b/src/app/authoring-tool/edit-connected-component-node-select/edit-connected-component-node-select.component.spec.ts
@@ -11,6 +11,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule } from '@angular/forms';
+import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
 
 describe('EditConnectedComponentNodeSelectComponent', () => {
   let component: EditConnectedComponentNodeSelectComponent;
@@ -22,6 +23,7 @@ describe('EditConnectedComponentNodeSelectComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientModule,
         MatFormFieldModule,

--- a/src/app/authoring-tool/edit-connected-components-with-background/edit-connected-components-with-background.component.spec.ts
+++ b/src/app/authoring-tool/edit-connected-components-with-background/edit-connected-components-with-background.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../assets/wise5/services/configService';
 import { ProjectService } from '../../../assets/wise5/services/projectService';
 import { SessionService } from '../../../assets/wise5/services/sessionService';
@@ -18,7 +19,12 @@ const importWorkType = 'importWork';
 describe('EditConnectedComponentsWithBackgroundComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatIconModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatIconModule,
+        UpgradeModule
+      ],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditConnectedComponentsWithBackgroundComponent

--- a/src/app/authoring-tool/edit-connected-components/edit-connected-components.component.spec.ts
+++ b/src/app/authoring-tool/edit-connected-components/edit-connected-components.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../assets/wise5/services/configService';
 import { ProjectService } from '../../../assets/wise5/services/projectService';
 import { SessionService } from '../../../assets/wise5/services/sessionService';
@@ -22,7 +23,12 @@ const importWorkType = 'importWork';
 describe('EditConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatIconModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatIconModule,
+        UpgradeModule
+      ],
       declarations: [EditConnectedComponentsAddButtonComponent, EditConnectedComponentsComponent],
       providers: [ConfigService, ProjectService, SessionService, UtilService]
     }).compileComponents();

--- a/src/app/notebook/notebook-item/notebook-item.component.spec.ts
+++ b/src/app/notebook/notebook-item/notebook-item.component.spec.ts
@@ -4,6 +4,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { Subscription } from 'rxjs';
 import { AnnotationService } from '../../../assets/wise5/services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../assets/wise5/services/configService';
 import { NotebookService } from '../../../assets/wise5/services/notebookService';
 import { ProjectService } from '../../../assets/wise5/services/projectService';
@@ -19,7 +20,12 @@ let component: NotebookItemComponent;
 describe('NotebookItemComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       declarations: [NotebookItemComponent],
       providers: [
         AnnotationService,

--- a/src/app/notebook/notebook-notes/notebook-notes.component.spec.ts
+++ b/src/app/notebook/notebook-notes/notebook-notes.component.spec.ts
@@ -3,6 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../assets/wise5/services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../assets/wise5/services/configService';
 import { NotebookService } from '../../../assets/wise5/services/notebookService';
 import { ProjectService } from '../../../assets/wise5/services/projectService';
@@ -18,7 +19,12 @@ let component: NotebookNotesComponent;
 describe('NotebookNotesComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       declarations: [NotebookNotesComponent],
       providers: [
         AnnotationService,

--- a/src/app/notebook/notebook-report-annotations/notebook-report-annotations.component.spec.ts
+++ b/src/app/notebook/notebook-report-annotations/notebook-report-annotations.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../assets/wise5/services/configService';
 import { ProjectService } from '../../../assets/wise5/services/projectService';
 import { SessionService } from '../../../assets/wise5/services/sessionService';
@@ -13,7 +14,7 @@ let component: NotebookReportAnnotationsComponent;
 describe('NotebookReportAnnotationsComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       declarations: [NotebookReportAnnotationsComponent],
       providers: [ConfigService, ProjectService, SessionService, UtilService, VLEProjectService]
     });

--- a/src/app/notebook/notebook-report/notebook-report.component.spec.ts
+++ b/src/app/notebook/notebook-report/notebook-report.component.spec.ts
@@ -12,13 +12,19 @@ import { StudentDataService } from '../../../assets/wise5/services/studentDataSe
 import { TagService } from '../../../assets/wise5/services/tagService';
 import { UtilService } from '../../../assets/wise5/services/utilService';
 import { NotebookReportComponent } from './notebook-report.component';
+import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
 
 let component: NotebookReportComponent;
 
 describe('NotebookReportComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       declarations: [NotebookReportComponent],
       providers: [
         AnnotationService,

--- a/src/app/services/annotationService.spec.ts
+++ b/src/app/services/annotationService.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
 import { SessionService } from '../../assets/wise5/services/sessionService';
@@ -33,7 +34,7 @@ const annotations = [
 describe('AnnotationService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       providers: [ProjectService, ConfigService, SessionService, AnnotationService, UtilService]
     });
     utilService = TestBed.inject(UtilService);

--- a/src/app/services/classroomStatusService.spec.ts
+++ b/src/app/services/classroomStatusService.spec.ts
@@ -7,6 +7,7 @@ import { UpgradeModule } from '@angular/upgrade/static';
 import { ProjectService } from '../../assets/wise5/services/projectService';
 import { UtilService } from '../../assets/wise5/services/utilService';
 import { SessionService } from '../../assets/wise5/services/sessionService';
+import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 
 let configService: ConfigService;
 let service: ClassroomStatusService;
@@ -15,7 +16,7 @@ let http: HttpTestingController;
 describe('ClassroomStatusService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/data.service.spec.ts
+++ b/src/app/services/data.service.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
 import { SessionService } from '../../assets/wise5/services/sessionService';
@@ -14,7 +15,7 @@ let projectService: ProjectService;
 describe('DataService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       providers: [ConfigService, ProjectService, SessionService, UtilService]
     });
     service = TestBed.inject(DataService);

--- a/src/app/services/dataExportService.spec.ts
+++ b/src/app/services/dataExportService.spec.ts
@@ -17,6 +17,7 @@ import { TeacherProjectService } from '../../assets/wise5/services/teacherProjec
 import { TeacherWebSocketService } from '../../assets/wise5/services/teacherWebSocketService';
 import { UtilService } from '../../assets/wise5/services/utilService';
 import { MatDialogModule } from '@angular/material/dialog';
+import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 
 let service: DataExportService;
 let configService: ConfigService;
@@ -44,7 +45,12 @@ describe('DataExportService', () => {
         TeacherWebSocketService,
         UtilService
       ],
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule]
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ]
     });
     service = TestBed.inject(DataExportService);
     configService = TestBed.inject(ConfigService);

--- a/src/app/services/deleteNodeService.spec.ts
+++ b/src/app/services/deleteNodeService.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { CopyNodesService } from '../../assets/wise5/services/copyNodesService';
 import { DeleteNodeService } from '../../assets/wise5/services/deleteNodeService';
@@ -16,7 +17,7 @@ let service: DeleteNodeService;
 describe('DeleteNodeService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       providers: [
         ConfigService,
         CopyNodesService,

--- a/src/app/services/milestoneService.spec.ts
+++ b/src/app/services/milestoneService.spec.ts
@@ -18,6 +18,7 @@ import { ClassroomStatusService } from '../../assets/wise5/services/classroomSta
 import { SessionService } from '../../assets/wise5/services/sessionService';
 import { CopyNodesService } from '../../assets/wise5/services/copyNodesService';
 import { MatDialogModule } from '@angular/material/dialog';
+import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 
 let service: MilestoneService;
 let achievementService: AchievementService;
@@ -82,7 +83,12 @@ const reportSettingsCustomScoreValuesSample = {
 describe('MilestoneService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       providers: [
         AchievementService,
         AnnotationService,

--- a/src/app/services/notebookService.spec.ts
+++ b/src/app/services/notebookService.spec.ts
@@ -15,6 +15,7 @@ import demoPublicNotebookItems_import from './sampleData/sample_publicNotebookIt
 import demoProject_import from './sampleData/curriculum/Demo.project.json';
 import { SessionService } from '../../assets/wise5/services/sessionService';
 import { MatDialogModule } from '@angular/material/dialog';
+import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 
 let http: HttpTestingController;
 let configService: ConfigService;
@@ -34,7 +35,12 @@ const teacherNotebookURL = 'http://localhost:8080/teacher/notebook/run/1';
 describe('NotebookService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       providers: [
         NotebookService,
         AnnotationService,

--- a/src/app/services/notificationService.spec.ts
+++ b/src/app/services/notificationService.spec.ts
@@ -11,6 +11,7 @@ import { HttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 import { Notification } from '../domain/notification';
 import { MatDialogModule } from '@angular/material/dialog';
+import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 
 let configService: ConfigService;
 let http: HttpTestingController;
@@ -40,7 +41,12 @@ const retrieveNotificationsURL = `/notifications/${runId1}`;
 describe('NotificationService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/peerGroupingAuthoringService.spec.ts
+++ b/src/app/services/peerGroupingAuthoringService.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { PeerGroupingAuthoringService } from '../../assets/wise5/services/peerGroupingAuthoringService';
 import { SessionService } from '../../assets/wise5/services/sessionService';
@@ -30,7 +31,7 @@ const tag2: string = 'tag2';
 describe('PeerGroupingAuthoringService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       providers: [
         ConfigService,
         PeerGroupingAuthoringService,

--- a/src/app/services/projectAssetService.spec.ts
+++ b/src/app/services/projectAssetService.spec.ts
@@ -6,6 +6,7 @@ import { UtilService } from '../../assets/wise5/services/utilService';
 import { ProjectAssetService } from './projectAssetService';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { SessionService } from '../../assets/wise5/services/sessionService';
+import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 let service: ProjectAssetService;
 let configService: ConfigService;
 let http: HttpTestingController;
@@ -14,7 +15,7 @@ let spongeBobAndPatrickAssets: any;
 describe('ProjectAssetService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       providers: [ConfigService, ProjectAssetService, ProjectService, SessionService, UtilService]
     });
     http = TestBed.get(HttpTestingController);

--- a/src/app/services/projectService.spec.ts
+++ b/src/app/services/projectService.spec.ts
@@ -10,6 +10,7 @@ import scootersProjectJSON_import from './sampleData/curriculum/SelfPropelledVeh
 import twoStepsProjectJSON_import from './sampleData/curriculum/TwoSteps.project.json';
 import { SessionService } from '../../assets/wise5/services/sessionService';
 import { PeerGrouping } from '../domain/peerGrouping';
+import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 
 const projectIdDefault = 1;
 const projectBaseURL = 'http://localhost:8080/curriculum/12345/';
@@ -29,7 +30,7 @@ let twoStepsProjectJSON: any;
 describe('ProjectService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       providers: [ProjectService, ConfigService, SessionService, UtilService]
     });
     http = TestBed.get(HttpTestingController);

--- a/src/app/services/spaceService.spec.ts
+++ b/src/app/services/spaceService.spec.ts
@@ -7,13 +7,14 @@ import { UtilService } from '../../assets/wise5/services/utilService';
 import { SessionService } from '../../assets/wise5/services/sessionService';
 import { TeacherProjectService } from '../../assets/wise5/services/teacherProjectService';
 import { CopyNodesService } from '../../assets/wise5/services/copyNodesService';
+import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 let service: SpaceService;
 let teacherProjectService: TeacherProjectService;
 
 describe('SpaceService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       providers: [
         ConfigService,
         CopyNodesService,

--- a/src/app/services/studentDataService.spec.ts
+++ b/src/app/services/studentDataService.spec.ts
@@ -8,6 +8,7 @@ import { ProjectService } from '../../assets/wise5/services/projectService';
 import { UtilService } from '../../assets/wise5/services/utilService';
 import { TagService } from '../../assets/wise5/services/tagService';
 import { SessionService } from '../../assets/wise5/services/sessionService';
+import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 
 let $injector, $rootScope;
 let http: HttpTestingController;
@@ -24,7 +25,7 @@ let criteria2: any;
 describe('StudentDataService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/studentStatusService.spec.ts
+++ b/src/app/services/studentStatusService.spec.ts
@@ -12,6 +12,7 @@ import { StudentStatusService } from '../../assets/wise5/services/studentStatusS
 import { TagService } from '../../assets/wise5/services/tagService';
 import { UtilService } from '../../assets/wise5/services/utilService';
 import { of } from 'rxjs';
+import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 
 let configService: ConfigService;
 let http: HttpClient;
@@ -35,7 +36,7 @@ const studentStatusUrl = '/api/studentStatus';
 describe('StudentStatusService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/tagService.spec.ts
+++ b/src/app/services/tagService.spec.ts
@@ -6,6 +6,7 @@ import { ConfigService } from '../../assets/wise5/services/configService';
 import { UtilService } from '../../assets/wise5/services/utilService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
 import { SessionService } from '../../assets/wise5/services/sessionService';
+import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 
 let configService: ConfigService;
 let projectService: ProjectService;
@@ -16,7 +17,7 @@ let service: TagService;
 describe('TagService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       providers: [ConfigService, ProjectService, SessionService, TagService, UtilService]
     });
     http = TestBed.get(HttpTestingController);

--- a/src/app/services/teacherProjectService.spec.ts
+++ b/src/app/services/teacherProjectService.spec.ts
@@ -8,6 +8,7 @@ import demoProjectJSON_import from './sampleData/curriculum/Demo.project.json';
 import scootersProjectJSON_import from './sampleData/curriculum/SelfPropelledVehiclesChallenge.project.json';
 import teacherProjctJSON_import from './sampleData/curriculum/TeacherProjectServiceSpec.project.json';
 import { SessionService } from '../../assets/wise5/services/sessionService';
+import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 let service: TeacherProjectService;
 let configService: ConfigService;
 let utilService: UtilService;
@@ -29,7 +30,7 @@ const wiseBaseURL = '/wise';
 describe('TeacherProjectService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       providers: [TeacherProjectService, ConfigService, SessionService, UtilService]
     });
     http = TestBed.inject(HttpTestingController);

--- a/src/app/services/vleProjectService.spec.ts
+++ b/src/app/services/vleProjectService.spec.ts
@@ -5,6 +5,7 @@ import { VLEProjectService } from '../../assets/wise5/vle/vleProjectService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { UtilService } from '../../assets/wise5/services/utilService';
 import { SessionService } from '../../assets/wise5/services/sessionService';
+import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 let service: VLEProjectService;
 let configService: ConfigService;
 let sessionService: SessionService;
@@ -14,7 +15,7 @@ let http: HttpTestingController;
 describe('VLEProjectService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       providers: [VLEProjectService, ConfigService, SessionService, UtilService]
     });
     http = TestBed.get(HttpTestingController);

--- a/src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.spec.ts
@@ -18,6 +18,7 @@ import { TeacherWebSocketService } from '../../../../services/teacherWebSocketSe
 import { UtilService } from '../../../../services/utilService';
 import { NodeAdvancedConstraintAuthoringComponent } from './node-advanced-constraint-authoring.component';
 import { MatDialogModule } from '@angular/material/dialog';
+import { ComponentServiceLookupServiceModule } from '../../../../services/componentServiceLookupServiceModule';
 
 describe('NodeAdvancedConstraintAuthoringComponent', () => {
   let component: NodeAdvancedConstraintAuthoringComponent;
@@ -27,6 +28,7 @@ describe('NodeAdvancedConstraintAuthoringComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
+        ComponentServiceLookupServiceModule,
         HttpClientTestingModule,
         MatDialogModule,
         MatFormFieldModule,

--- a/src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.spec.ts
@@ -18,6 +18,7 @@ import { TeacherWebSocketService } from '../../../../services/teacherWebSocketSe
 import { UtilService } from '../../../../services/utilService';
 import { NodeAdvancedPathAuthoringComponent } from './node-advanced-path-authoring.component';
 import { MatDialogModule } from '@angular/material/dialog';
+import { ComponentServiceLookupServiceModule } from '../../../../services/componentServiceLookupServiceModule';
 
 describe('NodeAdvancedPathAuthoringComponent', () => {
   let component: NodeAdvancedPathAuthoringComponent;
@@ -27,6 +28,7 @@ describe('NodeAdvancedPathAuthoringComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
+        ComponentServiceLookupServiceModule,
         HttpClientTestingModule,
         MatDialogModule,
         MatFormFieldModule,

--- a/src/assets/wise5/authoringTool/peer-grouping/create-new-peer-grouping-dialog/create-new-peer-grouping-dialog.component.spec.ts
+++ b/src/assets/wise5/authoringTool/peer-grouping/create-new-peer-grouping-dialog/create-new-peer-grouping-dialog.component.spec.ts
@@ -3,6 +3,7 @@ import { MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { of } from 'rxjs';
 import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { PeerGroupingAuthoringService } from '../../../services/peerGroupingAuthoringService';
 import { PeerGroupingTestingModule } from '../peer-grouping-testing.module';
 import { CreateNewPeerGroupingDialogComponent } from './create-new-peer-grouping-dialog.component';
@@ -14,7 +15,7 @@ const tag1: string = 'tag1';
 describe('CreateNewPeerGroupingDialogComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MatSnackBarModule, PeerGroupingTestingModule],
+      imports: [ComponentServiceLookupServiceModule, MatSnackBarModule, PeerGroupingTestingModule],
       declarations: [CreateNewPeerGroupingDialogComponent],
       providers: []
     }).compileComponents();

--- a/src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.spec.ts
+++ b/src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.spec.ts
@@ -5,6 +5,7 @@ import { PeerGroupingAuthoringService } from '../../../services/peerGroupingAuth
 import { PeerGroupingTestingModule } from '../peer-grouping-testing.module';
 import { EditPeerGroupingDialogComponent } from './edit-peer-grouping-dialog.component';
 import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 
 let component: EditPeerGroupingDialogComponent;
 let dialogCloseSpy: jasmine.Spy;
@@ -13,7 +14,7 @@ let fixture: ComponentFixture<EditPeerGroupingDialogComponent>;
 describe('EditPeerGroupingDialogComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PeerGroupingTestingModule],
+      imports: [ComponentServiceLookupServiceModule, PeerGroupingTestingModule],
       declarations: [EditPeerGroupingDialogComponent],
       providers: [
         {

--- a/src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-authoring/select-peer-grouping-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-authoring/select-peer-grouping-authoring.component.spec.ts
@@ -4,6 +4,7 @@ import { SelectPeerGroupingAuthoringComponent } from './select-peer-grouping-aut
 import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
 import { MatDialog } from '@angular/material/dialog';
 import { PeerGroupingAuthoringService } from '../../../services/peerGroupingAuthoringService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 
 let component: SelectPeerGroupingAuthoringComponent;
 let fixture: ComponentFixture<SelectPeerGroupingAuthoringComponent>;
@@ -13,7 +14,7 @@ const tag1: string = 'tag1';
 describe('SelectPeerGroupingAuthoringComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PeerGroupingTestingModule],
+      imports: [ComponentServiceLookupServiceModule, PeerGroupingTestingModule],
       declarations: [SelectPeerGroupingAuthoringComponent],
       providers: [PeerGroupingAuthoringService]
     }).compileComponents();

--- a/src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-dialog/select-peer-grouping-dialog.component.spec.ts
+++ b/src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-dialog/select-peer-grouping-dialog.component.spec.ts
@@ -5,6 +5,7 @@ import { PeerGroupingTestingModule } from '../peer-grouping-testing.module';
 import { SelectPeerGroupingDialogComponent } from './select-peer-grouping-dialog.component';
 import { getDialogOpenSpy } from '../peer-grouping-testing-helper';
 import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 
 let component: SelectPeerGroupingDialogComponent;
 let fixture: ComponentFixture<SelectPeerGroupingDialogComponent>;
@@ -16,7 +17,7 @@ const tag2: string = 'tag2';
 describe('SelectPeerGroupingDialogComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PeerGroupingTestingModule],
+      imports: [ComponentServiceLookupServiceModule, PeerGroupingTestingModule],
       declarations: [SelectPeerGroupingDialogComponent],
       providers: []
     }).compileComponents();

--- a/src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-option/select-peer-grouping-option.component.spec.ts
+++ b/src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-option/select-peer-grouping-option.component.spec.ts
@@ -3,6 +3,7 @@ import { PeerGroupingTestingModule } from '../peer-grouping-testing.module';
 import { SelectPeerGroupingOptionComponent } from './select-peer-grouping-option.component';
 import { getDialogOpenSpy } from '../peer-grouping-testing-helper';
 import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 
 let component: SelectPeerGroupingOptionComponent;
 let deleteEventSpy: jasmine.Spy;
@@ -13,7 +14,7 @@ const tag1: string = 'tag1';
 describe('SelectPeerGroupingOptionComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PeerGroupingTestingModule],
+      imports: [ComponentServiceLookupServiceModule, PeerGroupingTestingModule],
       declarations: [SelectPeerGroupingOptionComponent]
     }).compileComponents();
   });

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/grading-edit-component-max-score/grading-edit-component-max-score.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/grading-edit-component-max-score/grading-edit-component-max-score.component.spec.ts
@@ -8,6 +8,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ConfigService } from '../../../services/configService';
 import { SessionService } from '../../../services/sessionService';
 import { CopyNodesService } from '../../../services/copyNodesService';
+import { ComponentServiceLookupServiceModule } from '../../../../wise5/services/componentServiceLookupServiceModule';
 
 let component: GradingEditComponentMaxScoreComponent;
 let fixture: ComponentFixture<GradingEditComponentMaxScoreComponent>;
@@ -20,7 +21,7 @@ class MockService {}
 describe('GradingEditComponentMaxScoreComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       declarations: [GradingEditComponentMaxScoreComponent],
       providers: [
         { provide: ConfigService, useClass: MockService },

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.spec.ts
@@ -23,6 +23,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CommonModule } from '@angular/common';
 import { ClassroomStatusService } from '../../../../services/classroomStatusService';
 import { PeerGrouping } from '../../../../../../app/domain/peerGrouping';
+import { ComponentServiceLookupServiceModule } from '../../../../services/componentServiceLookupServiceModule';
 
 describe('PeerGroupDialogComponent', () => {
   let component: PeerGroupDialogComponent;
@@ -34,6 +35,7 @@ describe('PeerGroupDialogComponent', () => {
       imports: [
         BrowserAnimationsModule,
         CommonModule,
+        ComponentServiceLookupServiceModule,
         HttpClientTestingModule,
         MatDialogModule,
         MatSelectModule

--- a/src/assets/wise5/common/stepTools/step-tools.component.spec.ts
+++ b/src/assets/wise5/common/stepTools/step-tools.component.spec.ts
@@ -20,6 +20,7 @@ import { TeacherProjectService } from '../../services/teacherProjectService';
 import { TeacherWebSocketService } from '../../services/teacherWebSocketService';
 import { UtilService } from '../../services/utilService';
 import { StepToolsComponent } from './step-tools.component';
+import { ComponentServiceLookupServiceModule } from '../../services/componentServiceLookupServiceModule';
 
 const nodeId1 = 'node1';
 const nodeId2 = 'node2';
@@ -53,6 +54,7 @@ describe('StepTools', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatDialogModule,

--- a/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.spec.ts
+++ b/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.spec.ts
@@ -10,6 +10,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-component-prompt/edit-component-prompt.component';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { ProjectService } from '../../../services/projectService';
@@ -30,6 +31,7 @@ describe('AnimationAuthoring', () => {
       imports: [
         BrowserAnimationsModule,
         BrowserModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatFormFieldModule,

--- a/src/assets/wise5/components/animation/animation-student/animation-student.component.spec.ts
+++ b/src/assets/wise5/components/animation/animation-student/animation-student.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
@@ -54,7 +55,12 @@ const object1 = {
 describe('AnimationStudent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       declarations: [AnimationStudent],
       providers: [
         AnimationService,

--- a/src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.spec.ts
+++ b/src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.spec.ts
@@ -8,6 +8,7 @@ import { UpgradeModule } from '@angular/upgrade/static';
 import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-component-prompt/edit-component-prompt.component';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { ProjectService } from '../../../services/projectService';
@@ -29,6 +30,7 @@ describe('AudioOscillatorAuthoring', () => {
     TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatCheckboxModule,

--- a/src/assets/wise5/components/audioOscillator/audio-oscillator-show-work/audio-oscillator-show-work.component.spec.ts
+++ b/src/assets/wise5/components/audioOscillator/audio-oscillator-show-work/audio-oscillator-show-work.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { ProjectService } from '../../../services/projectService';
 import { SessionService } from '../../../services/sessionService';
@@ -14,7 +15,7 @@ let fixture: ComponentFixture<AudioOscillatorShowWorkComponent>;
 describe('AudioOscillatorShowWorkComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       declarations: [AudioOscillatorShowWorkComponent],
       providers: [ConfigService, SessionService, ProjectService, UtilService],
       schemas: []

--- a/src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.spec.ts
+++ b/src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.spec.ts
@@ -26,6 +26,7 @@ import { ComponentService } from '../../componentService';
 import { AudioOscillatorService } from '../audioOscillatorService';
 import { AudioOscillatorStudent } from './audio-oscillator-student.component';
 import { AudioOscillatorStudentData } from '../AudioOscillatorStudentData';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 
 export class MockService {}
 
@@ -50,6 +51,7 @@ describe('AudioOscillatorStudent', () => {
       imports: [
         BrowserAnimationsModule,
         BrowserModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatDialogModule,

--- a/src/assets/wise5/components/component-student.component.spec.ts
+++ b/src/assets/wise5/components/component-student.component.spec.ts
@@ -15,6 +15,7 @@ import { ComponentService } from './componentService';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MatDialogModule } from '@angular/material/dialog';
+import { ComponentServiceLookupServiceModule } from '../services/componentServiceLookupServiceModule';
 
 let component: ComponentStudent;
 let fixture: ComponentFixture<ComponentStudent>;
@@ -30,7 +31,12 @@ class ComponentStudentImpl extends ComponentStudent {}
 describe('ComponentStudentComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       declarations: [ComponentStudentImpl],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/conceptMap/concept-map-authoring/concept-map-authoring.component.spec.ts
+++ b/src/assets/wise5/components/conceptMap/concept-map-authoring/concept-map-authoring.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { ConceptMapAuthoring } from './concept-map-authoring.component';
 import { ConceptMapAuthoringModule } from './concept-map-authoring.module';
@@ -80,7 +81,12 @@ const componentContent = {
 describe('ConceptMapAuthoringComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [BrowserAnimationsModule, ConceptMapAuthoringModule, HttpClientTestingModule]
+      imports: [
+        BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
+        ConceptMapAuthoringModule,
+        HttpClientTestingModule
+      ]
     });
     fixture = TestBed.createComponent(ConceptMapAuthoring);
     component = fixture.componentInstance;

--- a/src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.spec.ts
+++ b/src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
@@ -46,7 +47,12 @@ let nodeInstanceId2 = 'studentNode2';
 describe('ConceptMapStudent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       declarations: [ConceptMapStudent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.spec.ts
+++ b/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.spec.ts
@@ -20,6 +20,7 @@ import { EditComponentWidthComponent } from '../../../../../app/authoring-tool/e
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { EditConnectedComponentsComponent } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
@@ -48,6 +49,7 @@ describe('EditConceptMapAdvancedComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatCheckboxModule,

--- a/src/assets/wise5/components/conceptMap/edit-concept-map-connected-components/edit-concept-map-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/conceptMap/edit-concept-map-connected-components/edit-concept-map-connected-components.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { ProjectService } from '../../../services/projectService';
 import { SessionService } from '../../../services/sessionService';
@@ -17,7 +18,12 @@ const nodeId1 = 'nodeId1';
 describe('EditConceptMapConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatIconModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatIconModule,
+        UpgradeModule
+      ],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditConceptMapConnectedComponentsComponent

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
@@ -11,6 +11,7 @@ import { UpgradeModule } from '@angular/upgrade/static';
 import { PossibleScoreComponent } from '../../../../app/possible-score/possible-score.component';
 import { ComponentHeader } from '../../directives/component-header/component-header.component';
 import { AnnotationService } from '../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../services/componentServiceLookupServiceModule';
 import { ComputerAvatarService } from '../../services/computerAvatarService';
 import { ConfigService } from '../../services/configService';
 import { CRaterService } from '../../services/cRaterService';
@@ -110,6 +111,7 @@ describe('DialogGuidanceFeedbackRuleEvaluator', () => {
       ],
       imports: [
         BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatCardModule,

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { DialogGuidanceAuthoringComponent } from './dialog-guidance-authoring.component';
 import { DialogGuidanceAuthoringModule } from './dialog-guidance-authoring.module';
@@ -21,7 +22,12 @@ describe('DialogGuidanceAuthoringComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [BrowserAnimationsModule, DialogGuidanceAuthoringModule, HttpClientTestingModule]
+      imports: [
+        BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
+        DialogGuidanceAuthoringModule,
+        HttpClientTestingModule
+      ]
     });
     fixture = TestBed.createComponent(DialogGuidanceAuthoringComponent);
     component = fixture.componentInstance;

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-show-work/dialog-guidance-show-work.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-show-work/dialog-guidance-show-work.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ComputerAvatarService } from '../../../services/computerAvatarService';
 import { ConfigService } from '../../../services/configService';
 import { ProjectService } from '../../../services/projectService';
@@ -15,7 +16,7 @@ describe('DialogGuidanceShowWorkComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       declarations: [DialogGuidanceShowWorkComponent, DialogResponsesComponent],
       providers: [ConfigService, ComputerAvatarService, ProjectService, SessionService, UtilService]
     }).compileComponents();

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.spec.ts
@@ -12,6 +12,7 @@ import { PossibleScoreComponent } from '../../../../../app/possible-score/possib
 import { ComputerAvatar } from '../../../common/ComputerAvatar';
 import { ComponentHeader } from '../../../directives/component-header/component-header.component';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ComputerAvatarService } from '../../../services/computerAvatarService';
 import { ConfigService } from '../../../services/configService';
 import { CRaterService } from '../../../services/cRaterService';
@@ -51,6 +52,7 @@ describe('DialogGuidanceStudentComponent', () => {
       ],
       imports: [
         BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatCardModule,

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.spec.ts
@@ -13,6 +13,7 @@ import { UpgradeModule } from '@angular/upgrade/static';
 import { Observable, Subject } from 'rxjs';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { ComputerAvatar } from '../../../common/ComputerAvatar';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ComputerAvatarService } from '../../../services/computerAvatarService';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
@@ -39,6 +40,7 @@ describe('EditDialogGuidanceComputerAvatarComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
         DragDropModule,
         FormsModule,
         HttpClientTestingModule,

--- a/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.spec.ts
+++ b/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.spec.ts
@@ -6,6 +6,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { of } from 'rxjs';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
@@ -40,7 +41,13 @@ let saveNotificationToServerSpy;
 describe('DiscussionStudentComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [BrowserModule, HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        BrowserModule,
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       declarations: [DiscussionStudent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/discussion/edit-discussion-connected-components/edit-discussion-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/discussion/edit-discussion-connected-components/edit-discussion-connected-components.component.spec.ts
@@ -9,6 +9,7 @@ import { SessionService } from '../../../services/sessionService';
 import { UtilService } from '../../../services/utilService';
 import { EditDiscussionConnectedComponentsComponent } from './edit-discussion-connected-components.component';
 import { createConnectedComponentObject } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component.spec';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 
 let component: EditDiscussionConnectedComponentsComponent;
 let fixture: ComponentFixture<EditDiscussionConnectedComponentsComponent>;
@@ -16,7 +17,12 @@ let fixture: ComponentFixture<EditDiscussionConnectedComponentsComponent>;
 describe('EditDiscussionConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatIconModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatIconModule,
+        UpgradeModule
+      ],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditDiscussionConnectedComponentsComponent

--- a/src/assets/wise5/components/draw/draw-authoring/draw-authoring.component.spec.ts
+++ b/src/assets/wise5/components/draw/draw-authoring/draw-authoring.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { DrawAuthoring } from './draw-authoring.component';
 import { DrawAuthoringModule } from './draw-authoring.module';
@@ -43,7 +44,12 @@ const componentContent = {
 describe('DrawAuthoringComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [BrowserAnimationsModule, DrawAuthoringModule, HttpClientTestingModule]
+      imports: [
+        BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
+        DrawAuthoringModule,
+        HttpClientTestingModule
+      ]
     });
     fixture = TestBed.createComponent(DrawAuthoring);
     component = fixture.componentInstance;

--- a/src/assets/wise5/components/draw/draw-student/draw-student.component.spec.ts
+++ b/src/assets/wise5/components/draw/draw-student/draw-student.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
@@ -32,7 +33,12 @@ const starterDrawData =
 describe('DrawStudentComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       declarations: [DrawStudent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/draw/edit-draw-connected-components/edit-draw-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/draw/edit-draw-connected-components/edit-draw-connected-components.component.spec.ts
@@ -9,6 +9,7 @@ import { SessionService } from '../../../services/sessionService';
 import { UtilService } from '../../../services/utilService';
 import { EditDrawConnectedComponentsComponent } from './edit-draw-connected-components.component';
 import { createConnectedComponentObject } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component.spec';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 
 let component: EditDrawConnectedComponentsComponent;
 let fixture: ComponentFixture<EditDrawConnectedComponentsComponent>;
@@ -20,7 +21,12 @@ const componentId2 = 'component2';
 describe('EditDrawConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatIconModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatIconModule,
+        UpgradeModule
+      ],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditDrawConnectedComponentsComponent

--- a/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.spec.ts
+++ b/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { EmbeddedAuthoring } from './embedded-authoring.component';
 import { EmbeddedAuthoringModule } from './embedded-authoring.module';
@@ -13,7 +14,12 @@ let fixture: ComponentFixture<EmbeddedAuthoring>;
 describe('EmbeddedAuthoringComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [BrowserAnimationsModule, EmbeddedAuthoringModule, HttpClientTestingModule]
+      imports: [
+        BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
+        EmbeddedAuthoringModule,
+        HttpClientTestingModule
+      ]
     });
     fixture = TestBed.createComponent(EmbeddedAuthoring);
     component = fixture.componentInstance;

--- a/src/assets/wise5/components/embedded/embedded-show-work/embedded-show-work.component.ts
+++ b/src/assets/wise5/components/embedded/embedded-show-work/embedded-show-work.component.ts
@@ -1,5 +1,7 @@
 import { Component } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
+import { AnnotationService } from '../../../services/annotationService';
+import { ConfigService } from '../../../services/configService';
 import { ProjectService } from '../../../services/projectService';
 import { TeacherDataService } from '../../../services/teacherDataService';
 import { UtilService } from '../../../services/utilService';
@@ -18,6 +20,8 @@ export class EmbeddedShowWorkComponent extends ComponentShowWorkDirective {
   messageEventListener: any;
 
   constructor(
+    private AnnotationService: AnnotationService,
+    private ConfigService: ConfigService,
     private EmbeddedService: EmbeddedService,
     protected ProjectService: ProjectService,
     protected TeacherDataService: TeacherDataService,
@@ -111,10 +115,25 @@ export class EmbeddedShowWorkComponent extends ComponentShowWorkDirective {
   }
 
   handleGetLatestAnnotationsMessage(): void {
-    this.EmbeddedService.handleGetLatestAnnotationsMessage(
-      this.embeddedApplicationIFrameId,
+    const workgroupId = this.ConfigService.getWorkgroupId();
+    const type = 'any';
+    const latestScoreAnnotation = this.AnnotationService.getLatestScoreAnnotation(
       this.nodeId,
-      this.componentId
+      this.componentId,
+      workgroupId,
+      type
     );
+    const latestCommentAnnotation = this.AnnotationService.getLatestCommentAnnotation(
+      this.nodeId,
+      this.componentId,
+      workgroupId,
+      type
+    );
+    const message = {
+      messageType: 'latestAnnotations',
+      latestScoreAnnotation: latestScoreAnnotation,
+      latestCommentAnnotation: latestCommentAnnotation
+    };
+    this.sendMessageToApplication(message);
   }
 }

--- a/src/assets/wise5/components/embedded/embedded-student/embedded-student.component.spec.ts
+++ b/src/assets/wise5/components/embedded/embedded-student/embedded-student.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
@@ -51,7 +52,12 @@ const spongebobName = 'Spongebob';
 describe('EmbeddedStudentComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       declarations: [EmbeddedStudent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/embedded/embedded-student/embedded-student.component.ts
+++ b/src/assets/wise5/components/embedded/embedded-student/embedded-student.component.ts
@@ -237,11 +237,26 @@ export class EmbeddedStudent extends ComponentStudent {
   }
 
   handleGetLatestAnnotationsMessage(): void {
-    this.EmbeddedService.handleGetLatestAnnotationsMessage(
-      this.embeddedApplicationIFrameId,
+    const workgroupId = this.ConfigService.getWorkgroupId();
+    const type = 'any';
+    const latestScoreAnnotation = this.AnnotationService.getLatestScoreAnnotation(
       this.nodeId,
-      this.componentId
+      this.componentId,
+      workgroupId,
+      type
     );
+    const latestCommentAnnotation = this.AnnotationService.getLatestCommentAnnotation(
+      this.nodeId,
+      this.componentId,
+      workgroupId,
+      type
+    );
+    const message = {
+      messageType: 'latestAnnotations',
+      latestScoreAnnotation: latestScoreAnnotation,
+      latestCommentAnnotation: latestCommentAnnotation
+    };
+    this.sendMessageToApplication(message);
   }
 
   handleStudentWorkSavedToServerAdditionalProcessing(componentState: any): void {

--- a/src/assets/wise5/components/embedded/embeddedService.ts
+++ b/src/assets/wise5/components/embedded/embeddedService.ts
@@ -7,7 +7,6 @@ import { StudentAssetService } from '../../services/studentAssetService';
 import { Injectable } from '@angular/core';
 import { UtilService } from '../../services/utilService';
 import { ConfigService } from '../../services/configService';
-import { AnnotationService } from '../../services/annotationService';
 
 @Injectable()
 export class EmbeddedService extends ComponentService {
@@ -16,7 +15,6 @@ export class EmbeddedService extends ComponentService {
   iframePrefix: string = 'embedded-application-iframe-';
 
   constructor(
-    protected AnnotationService: AnnotationService,
     protected ConfigService: ConfigService,
     protected StudentAssetService: StudentAssetService,
     protected UtilService: UtilService
@@ -142,29 +140,6 @@ export class EmbeddedService extends ComponentService {
     const message = {
       messageType: 'parameters',
       parameters: parameters
-    };
-    this.sendMessageToApplication(iframeId, message);
-  }
-
-  handleGetLatestAnnotationsMessage(iframeId: string, nodeId: string, componentId: string): void {
-    const workgroupId = this.ConfigService.getWorkgroupId();
-    const type = 'any';
-    const latestScoreAnnotation = this.AnnotationService.getLatestScoreAnnotation(
-      nodeId,
-      componentId,
-      workgroupId,
-      type
-    );
-    const latestCommentAnnotation = this.AnnotationService.getLatestCommentAnnotation(
-      nodeId,
-      componentId,
-      workgroupId,
-      type
-    );
-    const message = {
-      messageType: 'latestAnnotations',
-      latestScoreAnnotation: latestScoreAnnotation,
-      latestCommentAnnotation: latestCommentAnnotation
     };
     this.sendMessageToApplication(iframeId, message);
   }

--- a/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.spec.ts
+++ b/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.spec.ts
@@ -21,6 +21,7 @@ import { EditComponentWidthComponent } from '../../../../../app/authoring-tool/e
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { EditConnectedComponentsComponent } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
@@ -48,6 +49,7 @@ describe('EditGraphAdvancedComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatCheckboxModule,

--- a/src/assets/wise5/components/graph/edit-graph-connected-components/edit-graph-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/graph/edit-graph-connected-components/edit-graph-connected-components.component.spec.ts
@@ -9,6 +9,7 @@ import { SessionService } from '../../../services/sessionService';
 import { UtilService } from '../../../services/utilService';
 import { EditGraphConnectedComponentsComponent } from './edit-graph-connected-components.component';
 import { createConnectedComponentObject } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component.spec';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 
 let component: EditGraphConnectedComponentsComponent;
 let fixture: ComponentFixture<EditGraphConnectedComponentsComponent>;
@@ -18,7 +19,12 @@ const componentId1 = 'component1';
 describe('EditGraphConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatIconModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatIconModule,
+        UpgradeModule
+      ],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditGraphConnectedComponentsComponent

--- a/src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.spec.ts
+++ b/src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.spec.ts
@@ -14,6 +14,7 @@ import { UpgradeModule } from '@angular/upgrade/static';
 import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-component-prompt/edit-component-prompt.component';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { ProjectService } from '../../../services/projectService';
@@ -38,6 +39,7 @@ describe('GraphAuthoringComponent', () => {
       imports: [
         BrowserAnimationsModule,
         BrowserModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatCheckboxModule,

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
@@ -22,6 +22,7 @@ import { ComponentService } from '../../componentService';
 import { GraphService } from '../graphService';
 import { GraphStudent } from './graph-student.component';
 import { of } from 'rxjs';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 
 class MockNotebookService {
   addNote() {}
@@ -49,6 +50,7 @@ describe('GraphStudentComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         BrowserModule,
+        ComponentServiceLookupServiceModule,
         HighchartsChartModule,
         HttpClientTestingModule,
         MatDialogModule,

--- a/src/assets/wise5/components/label/edit-label-connected-components/edit-label-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/label/edit-label-connected-components/edit-label-connected-components.component.spec.ts
@@ -9,6 +9,7 @@ import { SessionService } from '../../../services/sessionService';
 import { UtilService } from '../../../services/utilService';
 import { EditLabelConnectedComponentsComponent } from './edit-label-connected-components.component';
 import { createConnectedComponentObject } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component.spec';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 
 let component: EditLabelConnectedComponentsComponent;
 let fixture: ComponentFixture<EditLabelConnectedComponentsComponent>;
@@ -18,7 +19,12 @@ const componentId1 = 'component1';
 describe('EditLabelConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatIconModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatIconModule,
+        UpgradeModule
+      ],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditLabelConnectedComponentsComponent

--- a/src/assets/wise5/components/label/label-student/label-student.component.spec.ts
+++ b/src/assets/wise5/components/label/label-student/label-student.component.spec.ts
@@ -17,6 +17,7 @@ import { UtilService } from '../../../services/utilService';
 import { ComponentService } from '../../componentService';
 import { LabelService } from '../labelService';
 import { LabelStudent } from './label-student.component';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 
 export class MockService {}
 
@@ -26,7 +27,12 @@ let fixture: ComponentFixture<LabelStudent>;
 describe('LabelStudentComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       declarations: [LabelStudent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/match/edit-match-connected-components/edit-match-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/match/edit-match-connected-components/edit-match-connected-components.component.spec.ts
@@ -9,6 +9,7 @@ import { SessionService } from '../../../services/sessionService';
 import { UtilService } from '../../../services/utilService';
 import { EditMatchConnectedComponentsComponent } from './edit-match-connected-components.component';
 import { createConnectedComponentObject } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component.spec';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 
 let component: EditMatchConnectedComponentsComponent;
 let fixture: ComponentFixture<EditMatchConnectedComponentsComponent>;
@@ -18,7 +19,12 @@ const nodeId1 = 'nodeId1';
 describe('EditMatchConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatIconModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatIconModule,
+        UpgradeModule
+      ],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditMatchConnectedComponentsComponent

--- a/src/assets/wise5/components/match/match-student/match-student.component.spec.ts
+++ b/src/assets/wise5/components/match/match-student/match-student.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
@@ -64,7 +65,12 @@ let starterBucketLabel = 'Starter Choices';
 describe('MatchStudentComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       declarations: [MatchStudent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.spec.ts
@@ -9,6 +9,7 @@ import { SessionService } from '../../../services/sessionService';
 import { UtilService } from '../../../services/utilService';
 import { EditMultipleChoiceConnectedComponentsComponent } from './edit-multiple-choice-connected-components.component';
 import { createConnectedComponentObject } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component.spec';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 
 let component: EditMultipleChoiceConnectedComponentsComponent;
 let fixture: ComponentFixture<EditMultipleChoiceConnectedComponentsComponent>;
@@ -18,7 +19,12 @@ const nodeId1 = 'nodeId1';
 describe('EditMultipleChoiceConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatIconModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatIconModule,
+        UpgradeModule
+      ],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditMultipleChoiceConnectedComponentsComponent

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.spec.ts
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.spec.ts
@@ -10,6 +10,7 @@ import { UpgradeModule } from '@angular/upgrade/static';
 import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
 import { ComponentHeader } from '../../../directives/component-header/component-header.component';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
@@ -127,6 +128,7 @@ describe('MultipleChoiceStudentComponent', () => {
       imports: [
         BrowserAnimationsModule,
         BrowserModule,
+        ComponentServiceLookupServiceModule,
         HttpClientTestingModule,
         MatCheckboxModule,
         MatDialogModule,

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
@@ -21,6 +21,7 @@ import { EditComponentWidthComponent } from '../../../../../app/authoring-tool/e
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { EditConnectedComponentsComponent } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { CRaterService } from '../../../services/cRaterService';
 import { NodeService } from '../../../services/nodeService';
@@ -52,6 +53,7 @@ describe('EditOpenResponseAdvancedComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatCheckboxModule,

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.spec.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.spec.ts
@@ -13,6 +13,7 @@ import { ComponentHeader } from '../../../directives/component-header/component-
 import { ComponentSaveSubmitButtons } from '../../../directives/component-save-submit-buttons/component-save-submit-buttons.component';
 import { AnnotationService } from '../../../services/annotationService';
 import { AudioRecorderService } from '../../../services/audioRecorderService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { CRaterService } from '../../../services/cRaterService';
 import { NodeService } from '../../../services/nodeService';
@@ -51,6 +52,7 @@ describe('OpenResponseStudent', () => {
         BrowserAnimationsModule,
         BrowserModule,
         CommonModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatDialogModule,

--- a/src/assets/wise5/components/outsideURL/outside-url-student/outside-url-student.component.spec.ts
+++ b/src/assets/wise5/components/outsideURL/outside-url-student/outside-url-student.component.spec.ts
@@ -9,6 +9,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
 import { AudioRecorderService } from '../../../services/audioRecorderService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { CRaterService } from '../../../services/cRaterService';
 import { NodeService } from '../../../services/nodeService';
@@ -45,6 +46,7 @@ describe('OutsideUrlStudentComponent', () => {
         BrowserAnimationsModule,
         BrowserModule,
         CommonModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatDialogModule,

--- a/src/assets/wise5/components/peerChat/edit-peer-chat-advanced-component/edit-peer-chat-advanced-component.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/edit-peer-chat-advanced-component/edit-peer-chat-advanced-component.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
@@ -27,7 +28,12 @@ describe('EditPeerChatAdvancedComponentComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       declarations: [EditPeerChatAdvancedComponentComponent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.spec.ts
@@ -24,6 +24,7 @@ import { PeerGroupMember } from '../PeerGroupMember';
 import { PeerChatGradingComponent } from './peer-chat-grading.component';
 import { of } from 'rxjs';
 import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 
 let component: PeerChatGradingComponent;
 let fixture: ComponentFixture<PeerChatGradingComponent>;
@@ -46,7 +47,12 @@ const peerGroup = new PeerGroup(
 describe('PeerChatGradingComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       declarations: [PeerChatGradingComponent],
       providers: [
         AchievementService,

--- a/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.spec.ts
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.spec.ts
@@ -18,6 +18,7 @@ import { UtilService } from '../../../services/utilService';
 import { ShowGroupWorkAuthoringComponent } from './show-group-work-authoring.component';
 import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-component-prompt/edit-component-prompt.component';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 
 describe('ShowGroupWorkAuthoringComponent', () => {
   let component: ShowGroupWorkAuthoringComponent;
@@ -29,6 +30,7 @@ describe('ShowGroupWorkAuthoringComponent', () => {
       imports: [
         BrowserAnimationsModule,
         BrowserModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatCheckboxModule,

--- a/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.spec.ts
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.spec.ts
@@ -4,6 +4,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
@@ -60,7 +61,7 @@ let studentWork;
 describe('ShowGroupWorkStudentComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       declarations: [ShowGroupWorkStudentComponent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/showMyWork/show-my-work-authoring/show-my-work-authoring.component.spec.ts
+++ b/src/assets/wise5/components/showMyWork/show-my-work-authoring/show-my-work-authoring.component.spec.ts
@@ -10,6 +10,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-component-prompt/edit-component-prompt.component';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { ProjectService } from '../../../services/projectService';
@@ -39,6 +40,7 @@ describe('ShowMyWorkAuthoringComponent', () => {
       imports: [
         BrowserAnimationsModule,
         BrowserModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatDialogModule,

--- a/src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.spec.ts
+++ b/src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.spec.ts
@@ -4,6 +4,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
@@ -37,7 +38,12 @@ describe('ShowMyWorkStudentComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatCardModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatCardModule,
+        UpgradeModule
+      ],
       declarations: [ShowMyWorkStudentComponent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.spec.ts
+++ b/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.spec.ts
@@ -14,6 +14,7 @@ import { UpgradeModule } from '@angular/upgrade/static';
 import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-component-prompt/edit-component-prompt.component';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupService } from '../../../services/componentServiceLookupService';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { ProjectService } from '../../../services/projectService';
@@ -27,6 +28,15 @@ import { SummaryService } from '../summaryService';
 import { SummaryAuthoring } from './summary-authoring.component';
 
 export class MockConfigService {}
+export class MockComponentServiceLookupService {
+  getService(componentType: string) {
+    return {
+      componentHasCorrectAnswer() {
+        return true;
+      }
+    };
+  }
+}
 
 let component: SummaryAuthoring;
 let fixture: ComponentFixture<SummaryAuthoring>;
@@ -53,6 +63,7 @@ describe('SummaryAuthoringComponent', () => {
       declarations: [EditComponentPrompt, SummaryAuthoring],
       providers: [
         AnnotationService,
+        { provide: ComponentServiceLookupService, useClass: MockComponentServiceLookupService },
         ConfigService,
         { provide: NodeService, useClass: MockNodeService },
         ProjectAssetService,
@@ -75,11 +86,6 @@ describe('SummaryAuthoringComponent', () => {
       'getComponentByNodeIdAndComponentId'
     );
     getComponentByNodeIdAndComponentIdSpy.and.returnValue(componentContent);
-    spyOn(TestBed.inject(TeacherProjectService), 'getComponentService').and.returnValue({
-      componentHasCorrectAnswer: () => {
-        return true;
-      }
-    });
     spyOn(component, 'componentChanged');
     fixture.detectChanges();
   });

--- a/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.spec.ts
+++ b/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.spec.ts
@@ -14,7 +14,7 @@ import { UpgradeModule } from '@angular/upgrade/static';
 import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-component-prompt/edit-component-prompt.component';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { AnnotationService } from '../../../services/annotationService';
-import { ComponentServiceLookupService } from '../../../services/componentServiceLookupService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { ProjectService } from '../../../services/projectService';
@@ -28,15 +28,6 @@ import { SummaryService } from '../summaryService';
 import { SummaryAuthoring } from './summary-authoring.component';
 
 export class MockConfigService {}
-export class MockComponentServiceLookupService {
-  getService(componentType: string) {
-    return {
-      componentHasCorrectAnswer() {
-        return true;
-      }
-    };
-  }
-}
 
 let component: SummaryAuthoring;
 let fixture: ComponentFixture<SummaryAuthoring>;
@@ -49,6 +40,7 @@ describe('SummaryAuthoringComponent', () => {
         BrowserAnimationsModule,
         BrowserModule,
         CommonModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatCheckboxModule,
@@ -63,7 +55,6 @@ describe('SummaryAuthoringComponent', () => {
       declarations: [EditComponentPrompt, SummaryAuthoring],
       providers: [
         AnnotationService,
-        { provide: ComponentServiceLookupService, useClass: MockComponentServiceLookupService },
         ConfigService,
         { provide: NodeService, useClass: MockNodeService },
         ProjectAssetService,

--- a/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.ts
+++ b/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.ts
@@ -3,10 +3,10 @@
 import { Component } from '@angular/core';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { ComponentAuthoring } from '../../../authoringTool/components/component-authoring.component';
+import { ComponentServiceLookupService } from '../../../services/componentServiceLookupService';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
-import { UtilService } from '../../../services/utilService';
 import { SummaryService } from '../summaryService';
 
 @Component({
@@ -21,12 +21,12 @@ export class SummaryAuthoring extends ComponentAuthoring {
   stepNodesDetails: string[];
 
   constructor(
+    private componentServiceLookupService: ComponentServiceLookupService,
     protected ConfigService: ConfigService,
     protected NodeService: NodeService,
     protected ProjectAssetService: ProjectAssetService,
     protected ProjectService: TeacherProjectService,
-    private SummaryService: SummaryService,
-    private UtilService: UtilService
+    private SummaryService: SummaryService
   ) {
     super(ConfigService, NodeService, ProjectAssetService, ProjectService);
     this.stepNodesDetails = this.ProjectService.getStepNodesDetailsInOrder();
@@ -142,7 +142,7 @@ export class SummaryAuthoring extends ComponentAuthoring {
     if (nodeId != null && componentId != null) {
       const component = this.ProjectService.getComponentByNodeIdAndComponentId(nodeId, componentId);
       if (component != null) {
-        const componentService = this.ProjectService.getComponentService(component.type);
+        const componentService = this.componentServiceLookupService.getService(component.type);
         return componentService.componentHasCorrectAnswer(component);
       }
     }

--- a/src/assets/wise5/components/summary/summary-student/summary-student.component.spec.ts
+++ b/src/assets/wise5/components/summary/summary-student/summary-student.component.spec.ts
@@ -6,6 +6,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
@@ -39,6 +40,7 @@ describe('SummaryStudentComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         BrowserModule,
+        ComponentServiceLookupServiceModule,
         HttpClientTestingModule,
         MatDialogModule,
         NoopAnimationsModule,

--- a/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.spec.ts
+++ b/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.spec.ts
@@ -22,6 +22,7 @@ import { EditComponentWidthComponent } from '../../../../../app/authoring-tool/e
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { EditConnectedComponentsComponent } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
@@ -50,6 +51,7 @@ describe('EditTableAdvancedComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatCheckboxModule,

--- a/src/assets/wise5/components/table/edit-table-connected-components/edit-table-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/table/edit-table-connected-components/edit-table-connected-components.component.spec.ts
@@ -9,6 +9,7 @@ import { SessionService } from '../../../services/sessionService';
 import { UtilService } from '../../../services/utilService';
 import { EditTableConnectedComponentsComponent } from './edit-table-connected-components.component';
 import { createConnectedComponentObject } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component.spec';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 
 let component: EditTableConnectedComponentsComponent;
 let fixture: ComponentFixture<EditTableConnectedComponentsComponent>;
@@ -18,7 +19,12 @@ const nodeId1 = 'nodeId1';
 describe('EditTableConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatIconModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatIconModule,
+        UpgradeModule
+      ],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditTableConnectedComponentsComponent

--- a/src/assets/wise5/components/table/table-show-work/table-show-work.component.spec.ts
+++ b/src/assets/wise5/components/table/table-show-work/table-show-work.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { ProjectService } from '../../../services/projectService';
 import { SessionService } from '../../../services/sessionService';
@@ -13,7 +14,7 @@ let component: TableShowWorkComponent;
 describe('TableShowWorkComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       declarations: [TableShowWorkComponent],
       providers: [ConfigService, ProjectService, SessionService, UpgradeModule, UtilService]
     });

--- a/src/assets/wise5/components/table/table-student/table-student.component.spec.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.spec.ts
@@ -6,6 +6,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
@@ -46,6 +47,7 @@ describe('TableStudentComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         BrowserModule,
+        ComponentServiceLookupServiceModule,
         HttpClientTestingModule,
         MatDialogModule,
         NoopAnimationsModule,

--- a/src/assets/wise5/directives/generate-image-dialog/generate-image-dialog.component.spec.ts
+++ b/src/assets/wise5/directives/generate-image-dialog/generate-image-dialog.component.spec.ts
@@ -12,6 +12,7 @@ import { GraphService } from '../../components/graph/graphService';
 import { LabelService } from '../../components/label/labelService';
 import { TableService } from '../../components/table/tableService';
 import { AnnotationService } from '../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../services/configService';
 import { NodeService } from '../../services/nodeService';
 import { NotebookService } from '../../services/notebookService';
@@ -43,7 +44,13 @@ describe('GenerateImageDialogComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, MatProgressSpinnerModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        MatProgressSpinnerModule,
+        UpgradeModule
+      ],
       declarations: [ComponentComponent, GenerateImageDialogComponent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/directives/summaryDisplay/summary-display.component.spec.ts
+++ b/src/assets/wise5/directives/summaryDisplay/summary-display.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { SummaryService } from '../../components/summary/summaryService';
 import { AnnotationService } from '../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../services/configService';
 import { ProjectService } from '../../services/projectService';
 import { SessionService } from '../../services/sessionService';
@@ -18,7 +19,7 @@ let fixture: ComponentFixture<SummaryDisplay>;
 describe('SummaryDisplayComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       declarations: [SummaryDisplay],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/directives/wise-link/wise-link.component.spec.ts
+++ b/src/assets/wise5/directives/wise-link/wise-link.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../services/configService';
 import { NotebookService } from '../../services/notebookService';
 import { ProjectService } from '../../services/projectService';
@@ -20,7 +21,12 @@ describe('WiseLinkComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       declarations: [WiseLinkComponent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component.spec.ts
+++ b/src/assets/wise5/directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component.spec.ts
@@ -4,6 +4,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { ProjectAssetService } from '../../../../app/services/projectAssetService';
 import { AnnotationService } from '../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../services/configService';
 import { CopyNodesService } from '../../services/copyNodesService';
 import { NotebookService } from '../../services/notebookService';
@@ -23,7 +24,12 @@ describe('WiseAuthoringTinymceEditorComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [WiseAuthoringTinymceEditorComponent],
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.spec.ts
+++ b/src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.spec.ts
@@ -4,6 +4,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { ProjectAssetService } from '../../../../app/services/projectAssetService';
 import { AnnotationService } from '../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../services/configService';
 import { NotebookService } from '../../services/notebookService';
 import { ProjectService } from '../../services/projectService';
@@ -21,7 +22,12 @@ describe('WiseTinymceEditorComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [WiseTinymceEditorComponent],
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [
+        ComponentServiceLookupServiceModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        UpgradeModule
+      ],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/assets/wise5/services/componentServiceLookupServiceModule.ts
+++ b/src/assets/wise5/services/componentServiceLookupServiceModule.ts
@@ -1,0 +1,59 @@
+import { NgModule } from '@angular/core';
+import { AnimationService } from '../components/animation/animationService';
+import { AudioOscillatorService } from '../components/audioOscillator/audioOscillatorService';
+import { ConceptMapService } from '../components/conceptMap/conceptMapService';
+import { DialogGuidanceService } from '../components/dialogGuidance/dialogGuidanceService';
+import { DiscussionService } from '../components/discussion/discussionService';
+import { DrawService } from '../components/draw/drawService';
+import { EmbeddedService } from '../components/embedded/embeddedService';
+import { GraphService } from '../components/graph/graphService';
+import { HTMLService } from '../components/html/htmlService';
+import { LabelService } from '../components/label/labelService';
+import { MatchService } from '../components/match/matchService';
+import { MultipleChoiceService } from '../components/multipleChoice/multipleChoiceService';
+import { OpenResponseCompletionCriteriaService } from '../components/openResponse/openResponseCompletionCriteriaService';
+import { OpenResponseService } from '../components/openResponse/openResponseService';
+import { OutsideURLService } from '../components/outsideURL/outsideURLService';
+import { PeerChatService } from '../components/peerChat/peerChatService';
+import { ShowGroupWorkService } from '../components/showGroupWork/showGroupWorkService';
+import { ShowMyWorkService } from '../components/showMyWork/showMyWorkService';
+import { SummaryService } from '../components/summary/summaryService';
+import { TableService } from '../components/table/tableService';
+import { ComponentServiceLookupService } from './componentServiceLookupService';
+import { ComputerAvatarService } from './computerAvatarService';
+import { ConfigService } from './configService';
+import { StudentAssetService } from './studentAssetService';
+import { UtilService } from './utilService';
+
+@NgModule({
+  declarations: [],
+  imports: [],
+  providers: [
+    AnimationService,
+    AudioOscillatorService,
+    ComputerAvatarService,
+    ComponentServiceLookupService,
+    ConceptMapService,
+    ConfigService,
+    DialogGuidanceService,
+    DiscussionService,
+    DrawService,
+    EmbeddedService,
+    GraphService,
+    LabelService,
+    MatchService,
+    MultipleChoiceService,
+    OpenResponseCompletionCriteriaService,
+    OpenResponseService,
+    OutsideURLService,
+    PeerChatService,
+    HTMLService,
+    ShowGroupWorkService,
+    ShowMyWorkService,
+    StudentAssetService,
+    SummaryService,
+    TableService,
+    UtilService
+  ]
+})
+export class ComponentServiceLookupServiceModule {}

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -3,12 +3,12 @@
 import { ConfigService } from './configService';
 import { UtilService } from './utilService';
 import { Injectable } from '@angular/core';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { SessionService } from './sessionService';
 import { Observable, Subject } from 'rxjs';
 import { Node } from '../common/Node';
 import { PeerGrouping } from '../../../app/domain/peerGrouping';
+import { ComponentServiceLookupService } from './componentServiceLookupService';
 
 @Injectable()
 export class ProjectService {
@@ -18,7 +18,6 @@ export class ProjectService {
   allPaths: string[] = [];
   applicationNodes: any;
   branchesCache: any;
-  componentServices: any = {};
   filters: any[] = [{ name: 'all', label: 'All' }];
   flattenedProjectAsNodeIds: any = null;
   groupNodes: any[];
@@ -43,7 +42,7 @@ export class ProjectService {
   public snipImage$: Observable<any> = this.snipImageSource.asObservable();
 
   constructor(
-    protected upgrade: UpgradeModule,
+    protected componentServiceLookupService: ComponentServiceLookupService,
     protected http: HttpClient,
     protected ConfigService: ConfigService,
     protected SessionService: SessionService,
@@ -2431,27 +2430,8 @@ export class ProjectService {
    * @return whether the component generates work
    */
   componentHasWork(component) {
-    const componentType = component.type;
-    const componentService = this.getComponentService(componentType);
-    if (componentService != null) {
-      return componentService.componentHasWork(component);
-    }
-    return false;
-  }
-
-  /**
-   * Get a component service
-   * @param componentType the component type
-   * @return the component service
-   */
-  getComponentService(componentType) {
-    const componentServiceName = componentType + 'Service';
-    let componentService = this.componentServices[componentServiceName];
-    if (componentService == null) {
-      componentService = this.upgrade.$injector.get(componentServiceName);
-      this.componentServices[componentServiceName] = componentService;
-    }
-    return componentService;
+    const componentService = this.componentServiceLookupService.getService(component.type);
+    return componentService.componentHasWork(component);
   }
 
   getComponentType(nodeId: string, componentId: string): string {

--- a/src/assets/wise5/services/studentDataService.ts
+++ b/src/assets/wise5/services/studentDataService.ts
@@ -11,6 +11,7 @@ import * as angular from 'angular';
 import { TagService } from './tagService';
 import { Observable, Subject } from 'rxjs';
 import { DataService } from '../../../app/services/data.service';
+import { ComponentServiceLookupService } from './componentServiceLookupService';
 
 @Injectable()
 export class StudentDataService extends DataService {
@@ -111,8 +112,9 @@ export class StudentDataService extends DataService {
     private upgrade: UpgradeModule,
     public http: HttpClient,
     private AnnotationService: AnnotationService,
+    private componentServiceLookupService: ComponentServiceLookupService,
     private ConfigService: ConfigService,
-    ProjectService: ProjectService,
+    protected ProjectService: ProjectService,
     private TagService: TagService,
     private UtilService: UtilService
   ) {
@@ -552,16 +554,12 @@ export class StudentDataService extends DataService {
   }
 
   evaluateChoiceChosenCriteria(criteria: any): boolean {
-    const serviceName = 'MultipleChoiceService';
-    if (this.upgrade.$injector.has(serviceName)) {
-      const service = this.upgrade.$injector.get(serviceName);
-      const latestComponentState = this.getLatestComponentStateByNodeIdAndComponentId(
-        criteria.params.nodeId,
-        criteria.params.componentId
-      );
-      return latestComponentState != null && service.choiceChosen(criteria, latestComponentState);
-    }
-    return false;
+    const service = this.componentServiceLookupService.getService('MultipleChoice');
+    const latestComponentState = this.getLatestComponentStateByNodeIdAndComponentId(
+      criteria.params.nodeId,
+      criteria.params.componentId
+    );
+    return latestComponentState != null && service.choiceChosen(criteria, latestComponentState);
   }
 
   evaluateScoreCriteria(criteria: any): boolean {
@@ -669,7 +667,7 @@ export class StudentDataService extends DataService {
     const requiredNumberOfFilledRows = params.requiredNumberOfFilledRows;
     const tableHasHeaderRow = params.tableHasHeaderRow;
     const requireAllCellsInARowToBeFilled = params.requireAllCellsInARowToBeFilled;
-    const tableService = this.upgrade.$injector.get('TableService');
+    const tableService = this.componentServiceLookupService.getService('Table');
     const componentState = this.getLatestComponentStateByNodeIdAndComponentId(nodeId, componentId);
     return (
       componentState != null &&
@@ -1279,7 +1277,7 @@ export class StudentDataService extends DataService {
     if (component != null) {
       const node = this.ProjectService.getNodeById(nodeId);
       const componentType = component.type;
-      const service = this.upgrade.$injector.get(componentType + 'Service');
+      const service = this.componentServiceLookupService.getService(componentType);
       if (['OpenResponse', 'Discussion'].includes(componentType)) {
         return service.isCompletedV2(node, component, this.studentData);
       } else {

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -9,6 +9,7 @@ import { UpgradeModule } from '@angular/upgrade/static';
 import { HttpClient } from '@angular/common/http';
 import { Observable, Subject } from 'rxjs';
 import { SessionService } from './sessionService';
+import { ComponentServiceLookupService } from './componentServiceLookupService';
 
 @Injectable()
 export class TeacherProjectService extends ProjectService {
@@ -33,12 +34,13 @@ export class TeacherProjectService extends ProjectService {
 
   constructor(
     protected upgrade: UpgradeModule,
+    protected componentServiceLookupService: ComponentServiceLookupService,
     protected http: HttpClient,
     protected ConfigService: ConfigService,
     protected SessionService: SessionService,
     protected UtilService: UtilService
   ) {
-    super(upgrade, http, ConfigService, SessionService, UtilService);
+    super(componentServiceLookupService, http, ConfigService, SessionService, UtilService);
   }
 
   getNewProjectTemplate() {
@@ -604,7 +606,7 @@ export class TeacherProjectService extends ProjectService {
 
   turnOnSaveButtonForAllComponents(node) {
     for (const component of node.components) {
-      const service = this.upgrade.$injector.get(component.type + 'Service');
+      const service = this.componentServiceLookupService.getService(component.type);
       if (service.componentUsesSaveButton()) {
         component.showSaveButton = true;
       }
@@ -613,7 +615,7 @@ export class TeacherProjectService extends ProjectService {
 
   turnOffSaveButtonForAllComponents(node) {
     for (const component of node.components) {
-      const service = this.upgrade.$injector.get(component.type + 'Service');
+      const service = this.componentServiceLookupService.getService(component.type);
       if (service.componentUsesSaveButton()) {
         component.showSaveButton = false;
       }
@@ -1809,7 +1811,7 @@ export class TeacherProjectService extends ProjectService {
    */
   createComponent(nodeId, componentType, insertAfterComponentId = null) {
     const node = this.getNodeById(nodeId);
-    const service = this.upgrade.$injector.get(componentType + 'Service');
+    const service = this.componentServiceLookupService.getService(componentType);
     const component = service.createComponent();
     if (service.componentHasWork(component)) {
       if (node.showSaveButton == false) {
@@ -1832,7 +1834,7 @@ export class TeacherProjectService extends ProjectService {
   doesAnyComponentHaveWork(nodeId) {
     const node = this.getNodeById(nodeId);
     for (const component of node.components) {
-      const service = this.upgrade.$injector.get(component.type + 'Service');
+      const service = this.componentServiceLookupService.getService(component.type);
       if (service != null && service.componentHasWork(component)) {
         return true;
       }

--- a/src/assets/wise5/themes/default/navigation/navigation.component.spec.ts
+++ b/src/assets/wise5/themes/default/navigation/navigation.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { ProjectService } from '../../../services/projectService';
 import { SessionService } from '../../../services/sessionService';
@@ -25,7 +26,7 @@ describe('NavigationComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       declarations: [NavigationComponent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/themes/default/notebook/edit-notebook-item-dialog/edit-notebook-item-dialog.component.spec.ts
+++ b/src/assets/wise5/themes/default/notebook/edit-notebook-item-dialog/edit-notebook-item-dialog.component.spec.ts
@@ -10,6 +10,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { WiseLinkComponent } from '../../../../directives/wise-link/wise-link.component';
 import { AnnotationService } from '../../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../../services/configService';
 import { NotebookService } from '../../../../services/notebookService';
 import { ProjectService } from '../../../../services/projectService';
@@ -29,6 +30,7 @@ describe('EditNotebookItemDialogComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatDialogModule,

--- a/src/assets/wise5/themes/default/themeComponents/stepTools/step-tools.component.spec.ts
+++ b/src/assets/wise5/themes/default/themeComponents/stepTools/step-tools.component.spec.ts
@@ -7,6 +7,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { NodeIconComponent } from '../../../../classroomMonitor/classroomMonitorComponents/shared/nodeIcon/node-icon.component';
 import { AnnotationService } from '../../../../services/annotationService';
+import { ComponentServiceLookupServiceModule } from '../../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../../services/configService';
 import { NodeService } from '../../../../services/nodeService';
 import { ProjectService } from '../../../../services/projectService';
@@ -40,6 +41,7 @@ describe('StepToolsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatDialogModule,

--- a/src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.spec.ts
+++ b/src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.spec.ts
@@ -14,6 +14,7 @@ import { StudentDataService } from '../../services/studentDataService';
 import { TagService } from '../../services/tagService';
 import { UtilService } from '../../services/utilService';
 import { DismissAmbientNotificationDialogComponent } from './dismiss-ambient-notification-dialog.component';
+import { ComponentServiceLookupServiceModule } from '../../services/componentServiceLookupServiceModule';
 
 let component: DismissAmbientNotificationDialogComponent;
 const DISMISS_CODE: string = 'computer';
@@ -27,6 +28,7 @@ describe('DismissAmbientNotificationDialogComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatDialogModule,

--- a/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.spec.ts
+++ b/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.spec.ts
@@ -16,6 +16,7 @@ import { TagService } from '../../services/tagService';
 import { UtilService } from '../../services/utilService';
 import { NotificationsDialogComponent } from './notifications-dialog.component';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { ComponentServiceLookupServiceModule } from '../../services/componentServiceLookupServiceModule';
 
 describe('NotificationsMenuComponent', () => {
   let component: NotificationsDialogComponent;
@@ -32,6 +33,7 @@ describe('NotificationsMenuComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
+        ComponentServiceLookupServiceModule,
         HttpClientTestingModule,
         MatCardModule,
         MatDialogModule,
@@ -134,5 +136,5 @@ describe('NotificationsMenuComponent', () => {
     });
     component.dismissAll();
     expect(dismissNotificationAggregateSpy).toHaveBeenCalledTimes(2);
-  })
+  });
 });

--- a/src/assets/wise5/vle/student-account-menu/student-account-menu.component.spec.ts
+++ b/src/assets/wise5/vle/student-account-menu/student-account-menu.component.spec.ts
@@ -12,6 +12,7 @@ import { TagService } from '../../services/tagService';
 import { UtilService } from '../../services/utilService';
 import { StudentAccountMenuComponent } from './student-account-menu.component';
 import { MatMenuModule } from '@angular/material/menu';
+import { ComponentServiceLookupServiceModule } from '../../services/componentServiceLookupServiceModule';
 
 class MockProjectService {
   rootNode = {};
@@ -32,6 +33,7 @@ describe('StudentAccountMenuComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
+        ComponentServiceLookupServiceModule,
         HttpClientTestingModule,
         MatDividerModule,
         MatIconModule,

--- a/src/assets/wise5/vle/studentAsset/student-assets/student-assets.component.spec.ts
+++ b/src/assets/wise5/vle/studentAsset/student-assets/student-assets.component.spec.ts
@@ -7,6 +7,7 @@ import { ProjectService } from '../../../services/projectService';
 import { SessionService } from '../../../services/sessionService';
 import { UtilService } from '../../../services/utilService';
 import { StudentAssetService } from '../../../services/studentAssetService';
+import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 
 describe('StudentAssetsComponent', () => {
   let component: StudentAssetsComponent;
@@ -20,7 +21,7 @@ describe('StudentAssetsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
       declarations: [StudentAssetsComponent],
       providers: [ConfigService, ProjectService, SessionService, StudentAssetService, UtilService]
     }).compileComponents();

--- a/src/assets/wise5/vle/vle.component.spec.ts
+++ b/src/assets/wise5/vle/vle.component.spec.ts
@@ -36,6 +36,7 @@ import { NodeStatusIcon } from '../themes/default/themeComponents/nodeStatusIcon
 import { NodeIconComponent } from '../classroomMonitor/classroomMonitorComponents/shared/nodeIcon/node-icon.component';
 import { Node } from '../common/Node';
 import { FormsModule } from '@angular/forms';
+import { ComponentServiceLookupServiceModule } from '../services/componentServiceLookupServiceModule';
 
 let component: VLEComponent;
 let fixture: ComponentFixture<VLEComponent>;
@@ -56,6 +57,7 @@ describe('VLEComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
+        ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
         MatBadgeModule,

--- a/src/assets/wise5/vle/vleProjectService.ts
+++ b/src/assets/wise5/vle/vleProjectService.ts
@@ -3,20 +3,20 @@ import { ProjectService } from '../services/projectService';
 import { ConfigService } from '../services/configService';
 import { UtilService } from '../services/utilService';
 import { Injectable } from '@angular/core';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { HttpClient } from '@angular/common/http';
 import { SessionService } from '../services/sessionService';
+import { ComponentServiceLookupService } from '../services/componentServiceLookupService';
 
 @Injectable()
 export class VLEProjectService extends ProjectService {
   constructor(
-    protected upgrade: UpgradeModule,
+    protected componentServiceLookupService: ComponentServiceLookupService,
     protected http: HttpClient,
     protected ConfigService: ConfigService,
     protected SessionService: SessionService,
     protected UtilService: UtilService
   ) {
-    super(upgrade, http, ConfigService, SessionService, UtilService);
+    super(componentServiceLookupService, http, ConfigService, SessionService, UtilService);
   }
 
   /**
@@ -65,7 +65,7 @@ export class VLEProjectService extends ProjectService {
       annotation.nodeId,
       annotation.componentId
     );
-    const componentService = this.upgrade.$injector.get(component.type + 'Service');
+    const componentService = this.componentServiceLookupService.getService(component.type);
     return componentService.displayAnnotation(component, annotation);
   }
 
@@ -115,10 +115,10 @@ export class VLEProjectService extends ProjectService {
   }
 
   retrieveScript(scriptFilename) {
-    return this.upgrade.$injector
-      .get('$http')
+    return this.http
       .get(`${this.ConfigService.getProjectAssetsDirectoryPath()}/${scriptFilename}`)
-      .then((result) => {
+      .toPromise()
+      .then((result: any) => {
         return result.data;
       });
   }


### PR DESCRIPTION
## Changes

- Replaced this.upgrade.$injector.get(componentType + 'Service') with this.componentServiceLookupService.getService(componentType)
- Add ComponentServiceLookupServiceModule to tests that were failing

## Test

Make sure the VLE, Authoring Tool, and Classroom Monitor work like they used to.

Closes #637