### PR TITLE
feat(Session): Show login page immediate on session expire

### DIFF
--- a/src/app/login/login-home/login-home.component.html
+++ b/src/app/login/login-home/login-home.component.html
@@ -3,6 +3,7 @@
     <form role="form" (submit)="login()">
       <h2 class="standalone__title accent" i18n>Sign in to WISE</h2>
       <p class="warn center standalone__error inactive" [ngClass]="{'active': passwordError}" i18n>Username and password not recognized. Please try again.</p>
+      <p class="warn center standalone__error inactive" *ngIf="isReLoginDueToErrorSavingData" [ngClass]="{'active': isReLoginDueToErrorSavingData}" i18n>There was an error saving data. Please log in again. You may need to re-do your recent work. We apologize for the inconvenience.</p>
       <p *ngIf="isRecaptchaRequired" class="warn center standalone__error inactive" [ngClass]="{'active': isRecaptchaRequired}" i18n>Please try again and verify that you are not a robot.</p>
       <p>
         <mat-form-field appearance="fill" fxFlex>

--- a/src/app/login/login-home/login-home.component.spec.ts
+++ b/src/app/login/login-home/login-home.component.spec.ts
@@ -13,6 +13,9 @@ export class MockUserService {
   isSignedIn(): boolean {
     return false;
   }
+  getRedirectUrl(): string {
+    return '';
+  }
 }
 
 export class MockConfigService {
@@ -35,17 +38,19 @@ export class MockConfigService {
 describe('LoginHomeComponent', () => {
   let component: LoginHomeComponent;
   let fixture: ComponentFixture<LoginHomeComponent>;
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [LoginHomeComponent],
-      imports: [HttpClientTestingModule, RouterTestingModule, RecaptchaModule],
-      providers: [
-        { provide: UserService, useClass: MockUserService },
-        { provide: ConfigService, useClass: MockConfigService }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [LoginHomeComponent],
+        imports: [HttpClientTestingModule, RouterTestingModule, RecaptchaModule],
+        providers: [
+          { provide: UserService, useClass: MockUserService },
+          { provide: ConfigService, useClass: MockConfigService }
+        ],
+        schemas: [NO_ERRORS_SCHEMA]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LoginHomeComponent);

--- a/src/app/login/login-home/login-home.component.ts
+++ b/src/app/login/login-home/login-home.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
 import { Router, ActivatedRoute } from '@angular/router';
 
 import { UserService } from '../../services/user.service';
@@ -15,6 +14,7 @@ export class LoginHomeComponent implements OnInit {
   passwordError: boolean = false;
   processing: boolean = false;
   isGoogleAuthenticationEnabled: boolean = false;
+  isReLoginDueToErrorSavingData: boolean;
   isShowGoogleLogin: boolean = true;
   recaptchaPublicKey: string = '';
   isRecaptchaRequired: boolean = false;
@@ -23,7 +23,6 @@ export class LoginHomeComponent implements OnInit {
 
   constructor(
     private userService: UserService,
-    private http: HttpClient,
     private router: Router,
     private route: ActivatedRoute,
     private configService: ConfigService
@@ -56,6 +55,12 @@ export class LoginHomeComponent implements OnInit {
         this.accessCode = params['accessCode'];
       }
     });
+    this.isReLoginDueToErrorSavingData = this.isRedirectToAppRoutes();
+  }
+
+  private isRedirectToAppRoutes(): boolean {
+    const regExp = RegExp('/student/unit|/teacher/manage|/teacher/edit');
+    return regExp.test(this.getRedirectUrl(''));
   }
 
   login(): boolean {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1989,7 +1989,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/login/login-home/login-home.component.html</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">21</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-student-form/register-student-form.component.html</context>
@@ -2190,7 +2190,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/login/login-home/login-home.component.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">43</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/mobile-menu/mobile-menu.component.html</context>
@@ -2249,7 +2249,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/login/login-home/login-home.component.html</context>
-          <context context-type="linenumber">9</context>
+          <context context-type="linenumber">10</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/student/account/edit-profile/edit-profile.component.html</context>
@@ -4451,7 +4451,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>An error occurred. Please refresh this page and try again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/http-error.interceptor.ts</context>
-          <context context-type="linenumber">53</context>
+          <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="050473ed2d269f07090850ebf8f56f635436869e" datatype="html">
@@ -4469,7 +4469,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/login/login-home/login-home.component.html</context>
-          <context context-type="linenumber">62</context>
+          <context context-type="linenumber">63</context>
         </context-group>
       </trans-unit>
       <trans-unit id="263e1717422fe3b5810e9a2e55b87e477b35d1ed" datatype="html">
@@ -4486,18 +4486,25 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">5</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="953cfa811f8ef112a9c03b68076d16ba25f3060b" datatype="html">
+        <source>There was an error saving data. Please log in again. You may need to re-do your recent work. We apologize for the inconvenience.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/login/login-home/login-home.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="9fb7b860775d8522b9402f7e31392531ec8079d6" datatype="html">
         <source>Please try again and verify that you are not a robot.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/login/login-home/login-home.component.html</context>
-          <context context-type="linenumber">6</context>
+          <context context-type="linenumber">7</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d745a22ae7b825b146ca8185126c482597f1d485" datatype="html">
         <source>Sign in with Google</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/login/login-home/login-home.component.html</context>
-          <context context-type="linenumber">54</context>
+          <context context-type="linenumber">55</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-google-user-already-exists/register-google-user-already-exists.component.html</context>
@@ -4520,7 +4527,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Forgot username or password?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/login/login-home/login-home.component.html</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="acd82db1a5e5f81b87f6a6b1639f028a4d106d49" datatype="html">


### PR DESCRIPTION
## Changes
- When session times out while using VLE, AT, CM, show message indicating an error and prompt user to login again. Upon logging in, they will be redirected to where they where before

## Test
- While using VLE, AT, CM, invalidate the session via Redis-cli ```flushall``` command. Then, try saving work by making changes or going to the next step.
   - They should be redirected to the log in page and see an error message, prompting them to log back in and check recent work
   - When they log in, they should be redirected to where they were before in the app 

Closes #655