### PR TITLE
feat(Run): Add support for 4-digit runcode suffix

### DIFF
--- a/src/app/student/add-project-dialog/add-project-dialog.component.spec.ts
+++ b/src/app/student/add-project-dialog/add-project-dialog.component.spec.ts
@@ -36,14 +36,16 @@ describe('AddProjectDialogComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should detect valid project code', () => {
-    const projectCode = 'Cat123';
-    expect(component.isValidRunCodeSyntax(projectCode)).toEqual(true);
+  it('should detect valid project codes', () => {
+    ['Cat123', 'Cat1234'].forEach((projectCode) => {
+      expect(component.isValidRunCodeSyntax(projectCode)).toEqual(true);
+    });
   });
 
-  it('should detect invalid project code', () => {
-    const projectCode = 'Cat12';
-    expect(component.isValidRunCodeSyntax(projectCode)).toEqual(false);
+  it('should detect invalid project codes', () => {
+    ['Cat12', 'Cat12345'].forEach((projectCode) => {
+      expect(component.isValidRunCodeSyntax(projectCode)).toEqual(false);
+    });
   });
 
   it('should detect invalid run code response', () => {

--- a/src/app/student/add-project-dialog/add-project-dialog.component.ts
+++ b/src/app/student/add-project-dialog/add-project-dialog.component.ts
@@ -10,7 +10,7 @@ import { ActivatedRoute } from '@angular/router';
   styleUrls: ['./add-project-dialog.component.scss']
 })
 export class AddProjectDialogComponent implements OnInit {
-  validRunCodeSyntaxRegEx: any = /^[a-zA-Z]*\d\d\d$/;
+  validRunCodeSyntaxRegEx: any = /^[a-zA-Z]*\d{3,4}$/;
   registerRunRunCode: string = '';
   registerRunPeriods: string[] = [];
   selectedPeriod: string = '';


### PR DESCRIPTION
## Changes
- Add support for 4-digit suffix in runcode

We now support these formats:
[animalName][3-digit-number]. Ex: ant123
[animalName][4-digit-number]. Ex: ant1234

## Note
- Keep the 3-digit runcode for backwards-compatibility support (for existing runs with 3 digit runcodes)

## Test
- Try adding runs using with the 3-digit and 4-digit runcodes. They should be allowed

Closes #658