### PR TITLE
refactor(TeacherProjectService): Remove UpgradeModule dependency

### DIFF
--- a/src/app/authoring-tool/edit-advanced-component/edit-component-default-feedback/edit-component-default-feedback.component.spec.ts
+++ b/src/app/authoring-tool/edit-advanced-component/edit-component-default-feedback/edit-component-default-feedback.component.spec.ts
@@ -4,7 +4,6 @@ import { FormsModule } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ComponentServiceLookupServiceModule } from '../../../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../../assets/wise5/services/configService';
 import { CopyNodesService } from '../../../../assets/wise5/services/copyNodesService';
@@ -28,8 +27,7 @@ describe('EditComponentDefaultFeedback', () => {
         HttpClientTestingModule,
         MatIconModule,
         MatInputModule,
-        NoopAnimationsModule,
-        UpgradeModule
+        NoopAnimationsModule
       ],
       declarations: [EditComponentDefaultFeedback],
       providers: [

--- a/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.spec.ts
+++ b/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.spec.ts
@@ -7,7 +7,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../assets/wise5/services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../assets/wise5/services/configService';
@@ -44,8 +43,7 @@ describe('EditCommonAdvancedComponent', () => {
         MatDialogModule,
         MatFormFieldModule,
         MatIconModule,
-        MatInputModule,
-        UpgradeModule
+        MatInputModule
       ],
       declarations: [
         EditCommonAdvancedComponent,

--- a/src/app/authoring-tool/edit-component-add-to-notebook-button/edit-component-add-to-notebook-button.component.spec.ts
+++ b/src/app/authoring-tool/edit-component-add-to-notebook-button/edit-component-add-to-notebook-button.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../assets/wise5/services/configService';
 import { SessionService } from '../../../assets/wise5/services/sessionService';
@@ -21,8 +20,7 @@ describe('EditComponentAddToNotebookButtonComponent', () => {
         ComponentServiceLookupServiceModule,
         FormsModule,
         HttpClientTestingModule,
-        MatCheckboxModule,
-        UpgradeModule
+        MatCheckboxModule
       ],
       declarations: [EditComponentAddToNotebookButtonComponent],
       providers: [ConfigService, SessionService, TeacherProjectService, UtilService]

--- a/src/app/authoring-tool/edit-connected-component-component-select/edit-connected-component-component-select.component.spec.ts
+++ b/src/app/authoring-tool/edit-connected-component-component-select/edit-connected-component-component-select.component.spec.ts
@@ -4,7 +4,6 @@ import { FormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ConfigService } from '../../../assets/wise5/services/configService';
 import { ProjectService } from '../../../assets/wise5/services/projectService';
 import { SessionService } from '../../../assets/wise5/services/sessionService';
@@ -27,8 +26,7 @@ describe('EditConnectedComponentComponentSelectComponent', () => {
         FormsModule,
         HttpClientModule,
         MatFormFieldModule,
-        MatSelectModule,
-        UpgradeModule
+        MatSelectModule
       ],
       declarations: [EditConnectedComponentComponentSelectComponent],
       providers: [ConfigService, ProjectService, SessionService, UtilService]

--- a/src/app/authoring-tool/edit-connected-component-node-select/edit-connected-component-node-select.component.spec.ts
+++ b/src/app/authoring-tool/edit-connected-component-node-select/edit-connected-component-node-select.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientModule } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ConfigService } from '../../../assets/wise5/services/configService';
 import { ProjectService } from '../../../assets/wise5/services/projectService';
 import { SessionService } from '../../../assets/wise5/services/sessionService';
@@ -27,8 +26,7 @@ describe('EditConnectedComponentNodeSelectComponent', () => {
         FormsModule,
         HttpClientModule,
         MatFormFieldModule,
-        MatSelectModule,
-        UpgradeModule
+        MatSelectModule
       ],
       declarations: [EditConnectedComponentNodeSelectComponent],
       providers: [ConfigService, ProjectService, SessionService, UtilService]

--- a/src/app/authoring-tool/edit-connected-component-type-select/edit-connected-component-type-select.component.spec.ts
+++ b/src/app/authoring-tool/edit-connected-component-type-select/edit-connected-component-type-select.component.spec.ts
@@ -4,7 +4,6 @@ import { FormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ConfigService } from '../../../assets/wise5/services/configService';
 import { ProjectService } from '../../../assets/wise5/services/projectService';
 import { SessionService } from '../../../assets/wise5/services/sessionService';
@@ -25,8 +24,7 @@ describe('EditConnectedComponentTypeSelectComponent', () => {
         FormsModule,
         HttpClientModule,
         MatFormFieldModule,
-        MatSelectModule,
-        UpgradeModule
+        MatSelectModule
       ],
       declarations: [EditConnectedComponentTypeSelectComponent],
       providers: [ConfigService, ProjectService, SessionService, UtilService]

--- a/src/app/authoring-tool/edit-connected-components-with-background/edit-connected-components-with-background.component.spec.ts
+++ b/src/app/authoring-tool/edit-connected-components-with-background/edit-connected-components-with-background.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../assets/wise5/services/configService';
 import { ProjectService } from '../../../assets/wise5/services/projectService';
@@ -19,12 +18,7 @@ const importWorkType = 'importWork';
 describe('EditConnectedComponentsWithBackgroundComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatIconModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatIconModule],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditConnectedComponentsWithBackgroundComponent

--- a/src/app/authoring-tool/edit-connected-components/edit-connected-components.component.spec.ts
+++ b/src/app/authoring-tool/edit-connected-components/edit-connected-components.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../assets/wise5/services/configService';
 import { ProjectService } from '../../../assets/wise5/services/projectService';
@@ -23,12 +22,7 @@ const importWorkType = 'importWork';
 describe('EditConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatIconModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatIconModule],
       declarations: [EditConnectedComponentsAddButtonComponent, EditConnectedComponentsComponent],
       providers: [ConfigService, ProjectService, SessionService, UtilService]
     }).compileComponents();

--- a/src/app/notebook/notebook-item/notebook-item.component.spec.ts
+++ b/src/app/notebook/notebook-item/notebook-item.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { Subscription } from 'rxjs';
 import { AnnotationService } from '../../../assets/wise5/services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
@@ -20,12 +19,7 @@ let component: NotebookItemComponent;
 describe('NotebookItemComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       declarations: [NotebookItemComponent],
       providers: [
         AnnotationService,

--- a/src/app/notebook/notebook-notes/notebook-notes.component.spec.ts
+++ b/src/app/notebook/notebook-notes/notebook-notes.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../assets/wise5/services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../assets/wise5/services/configService';
@@ -19,12 +18,7 @@ let component: NotebookNotesComponent;
 describe('NotebookNotesComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       declarations: [NotebookNotesComponent],
       providers: [
         AnnotationService,

--- a/src/app/notebook/notebook-report-annotations/notebook-report-annotations.component.spec.ts
+++ b/src/app/notebook/notebook-report-annotations/notebook-report-annotations.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ComponentServiceLookupServiceModule } from '../../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../assets/wise5/services/configService';
 import { ProjectService } from '../../../assets/wise5/services/projectService';
@@ -14,7 +13,7 @@ let component: NotebookReportAnnotationsComponent;
 describe('NotebookReportAnnotationsComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       declarations: [NotebookReportAnnotationsComponent],
       providers: [ConfigService, ProjectService, SessionService, UtilService, VLEProjectService]
     });

--- a/src/app/notebook/notebook-report/notebook-report.component.spec.ts
+++ b/src/app/notebook/notebook-report/notebook-report.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../assets/wise5/services/annotationService';
 import { ConfigService } from '../../../assets/wise5/services/configService';
 import { NotebookService } from '../../../assets/wise5/services/notebookService';
@@ -19,12 +18,7 @@ let component: NotebookReportComponent;
 describe('NotebookReportComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       declarations: [NotebookReportComponent],
       providers: [
         AnnotationService,

--- a/src/app/services/animationService.spec.ts
+++ b/src/app/services/animationService.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
@@ -15,7 +14,7 @@ let service: AnimationService;
 describe('AnimationService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         AnimationService,
         AnnotationService,

--- a/src/app/services/annotationService.spec.ts
+++ b/src/app/services/annotationService.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../assets/wise5/services/configService';
@@ -34,7 +33,7 @@ const annotations = [
 describe('AnnotationService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       providers: [ProjectService, ConfigService, SessionService, AnnotationService, UtilService]
     });
     utilService = TestBed.inject(UtilService);

--- a/src/app/services/audioOscillatorService.spec.ts
+++ b/src/app/services/audioOscillatorService.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
@@ -15,7 +14,7 @@ let service: AudioOscillatorService;
 describe('AudioOscillatorService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         AnnotationService,
         AudioOscillatorService,

--- a/src/app/services/classroomStatusService.spec.ts
+++ b/src/app/services/classroomStatusService.spec.ts
@@ -3,7 +3,6 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ClassroomStatusService } from '../../assets/wise5/services/classroomStatusService';
 import { ConfigService } from '../../assets/wise5/services/configService';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ProjectService } from '../../assets/wise5/services/projectService';
 import { UtilService } from '../../assets/wise5/services/utilService';
 import { SessionService } from '../../assets/wise5/services/sessionService';
@@ -16,7 +15,7 @@ let http: HttpTestingController;
 describe('ClassroomStatusService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/conceptMapService.spec.ts
+++ b/src/app/services/conceptMapService.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
 import { StudentAssetService } from '../../assets/wise5/services/studentAssetService';
@@ -44,7 +43,7 @@ const link2DestinationNodeInstanceId = 'studentNode2';
 describe('ConceptMapService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [HttpClientTestingModule, MatDialogModule],
       providers: [
         AnnotationService,
         ConceptMapService,

--- a/src/app/services/copyComponentService.spec.ts
+++ b/src/app/services/copyComponentService.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { CopyComponentService } from '../../assets/wise5/services/copyComponentService';
 import { TeacherProjectService } from '../../assets/wise5/services/teacherProjectService';
 import { UtilService } from '../../assets/wise5/services/utilService';
@@ -21,7 +20,7 @@ let utilService: UtilService;
 describe('CopyComponentService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         CopyComponentService,
         { provide: TeacherProjectService, useClass: MockProjectService },

--- a/src/app/services/copyNodesService.spec.ts
+++ b/src/app/services/copyNodesService.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { CopyNodesService } from '../../assets/wise5/services/copyNodesService';
 import { TeacherProjectService } from '../../assets/wise5/services/teacherProjectService';
@@ -37,7 +36,7 @@ let createNodeAfterSpy, createNodeInsideSpy, getUnusedComponentIdSpy, parseProje
 describe('CopyNodesService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         CopyNodesService,
         { provide: ConfigService, useClass: ConfigServiceStub },

--- a/src/app/services/data.service.spec.ts
+++ b/src/app/services/data.service.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
@@ -15,7 +14,7 @@ let projectService: ProjectService;
 describe('DataService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       providers: [ConfigService, ProjectService, SessionService, UtilService]
     });
     service = TestBed.inject(DataService);

--- a/src/app/services/dataExportService.spec.ts
+++ b/src/app/services/dataExportService.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AchievementService } from '../../assets/wise5/services/achievementService';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ConfigService } from '../../assets/wise5/services/configService';
@@ -47,12 +46,7 @@ describe('DataExportService', () => {
         TeacherWebSocketService,
         UtilService
       ],
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ]
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule]
     });
     service = TestBed.inject(DataExportService);
     configService = TestBed.inject(ConfigService);

--- a/src/app/services/deleteNodeService.spec.ts
+++ b/src/app/services/deleteNodeService.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { CopyNodesService } from '../../assets/wise5/services/copyNodesService';
@@ -17,7 +16,7 @@ let service: DeleteNodeService;
 describe('DeleteNodeService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       providers: [
         ConfigService,
         CopyNodesService,

--- a/src/app/services/discussionService.spec.ts
+++ b/src/app/services/discussionService.spec.ts
@@ -1,7 +1,6 @@
 import { DiscussionService } from '../../assets/wise5/components/discussion/discussionService';
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
@@ -32,7 +31,7 @@ const runId = 1;
 describe('DiscussionService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         AchievementService,
         AnnotationService,

--- a/src/app/services/drawService.spec.ts
+++ b/src/app/services/drawService.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
@@ -18,7 +17,7 @@ let drawDataWithObjects: string = '{"canvas":{"objects":[{}]}}';
 describe('DrawService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/embeddedService.spec.ts
+++ b/src/app/services/embeddedService.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
@@ -15,7 +14,7 @@ let service: EmbeddedService;
 describe('EmbeddedService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/graphService.spec.ts
+++ b/src/app/services/graphService.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
@@ -17,7 +16,7 @@ let service: GraphService;
 describe('GraphService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/htmlService.spec.ts
+++ b/src/app/services/htmlService.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { UtilService } from '../../assets/wise5/services/utilService';
 import { HTMLService } from '../../assets/wise5/components/html/htmlService';
@@ -15,7 +14,7 @@ let service: HTMLService;
 describe('HTMLService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/insertComponentService.spec.ts
+++ b/src/app/services/insertComponentService.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { InsertComponentService } from '../../assets/wise5/services/insertComponentService';
 import { TeacherProjectService } from '../../assets/wise5/services/teacherProjectService';
 
@@ -18,7 +17,7 @@ let node;
 describe('InsertComponentService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         InsertComponentService,
         { provide: TeacherProjectService, useClass: MockProjectService }

--- a/src/app/services/labelService.spec.ts
+++ b/src/app/services/labelService.spec.ts
@@ -1,5 +1,4 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
@@ -39,7 +38,7 @@ let canDeleteBoolean: boolean = true;
 describe('LabelService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/matchService.spec.ts
+++ b/src/app/services/matchService.spec.ts
@@ -1,7 +1,6 @@
 import { MatchService } from '../../assets/wise5/components/match/matchService';
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
@@ -16,7 +15,7 @@ let componentStateBucketWithItem: any;
 describe('MatchService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/multipleChoiceService.spec.ts
+++ b/src/app/services/multipleChoiceService.spec.ts
@@ -1,6 +1,5 @@
 import { MultipleChoiceService } from '../../assets/wise5/components/multipleChoice/multipleChoiceService';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { TestBed } from '@angular/core/testing';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ConfigService } from '../../assets/wise5/services/configService';
@@ -26,7 +25,7 @@ let componentId1: string = 'abcdefghij';
 describe('MultipleChoiceService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/notificationService.spec.ts
+++ b/src/app/services/notificationService.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { NotificationService } from '../../assets/wise5/services/notificationService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
@@ -41,12 +40,7 @@ const retrieveNotificationsURL = `/notifications/${runId1}`;
 describe('NotificationService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/openResponseService.spec.ts
+++ b/src/app/services/openResponseService.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { OpenResponseService } from '../../assets/wise5/components/openResponse/openResponseService';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ConfigService } from '../../assets/wise5/services/configService';
@@ -17,7 +16,7 @@ let completionCriteriaService: OpenResponseCompletionCriteriaService;
 describe('OpenResponseService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/outsideURLService.spec.ts
+++ b/src/app/services/outsideURLService.spec.ts
@@ -2,7 +2,6 @@ import { OutsideURLService } from '../../assets/wise5/components/outsideURL/outs
 import { TestBed } from '@angular/core/testing';
 import { UtilService } from '../../assets/wise5/services/utilService';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
@@ -15,7 +14,7 @@ let http: HttpTestingController;
 describe('OutsideURLService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/peerGroupingAuthoringService.spec.ts
+++ b/src/app/services/peerGroupingAuthoringService.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ComponentServiceLookupServiceModule } from '../../assets/wise5/services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { PeerGroupingAuthoringService } from '../../assets/wise5/services/peerGroupingAuthoringService';
@@ -31,7 +30,7 @@ const tag2: string = 'tag2';
 describe('PeerGroupingAuthoringService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       providers: [
         ConfigService,
         PeerGroupingAuthoringService,

--- a/src/app/services/projectService.spec.ts
+++ b/src/app/services/projectService.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ProjectService } from '../../assets/wise5/services/projectService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { UtilService } from '../../assets/wise5/services/utilService';
@@ -30,7 +29,7 @@ let twoStepsProjectJSON: any;
 describe('ProjectService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       providers: [ProjectService, ConfigService, SessionService, UtilService]
     });
     http = TestBed.get(HttpTestingController);

--- a/src/app/services/spaceService.spec.ts
+++ b/src/app/services/spaceService.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { SpaceService } from '../../assets/wise5/services/spaceService';
@@ -14,7 +13,7 @@ let teacherProjectService: TeacherProjectService;
 describe('SpaceService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       providers: [
         ConfigService,
         CopyNodesService,

--- a/src/app/services/studentStatusService.spec.ts
+++ b/src/app/services/studentStatusService.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { StudentStatus } from '../../assets/wise5/common/StudentStatus';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ConfigService } from '../../assets/wise5/services/configService';
@@ -38,12 +37,7 @@ const studentStatusUrl = '/api/studentStatus';
 describe('StudentStatusService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/summaryService.spec.ts
+++ b/src/app/services/summaryService.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { SummaryService } from '../../assets/wise5/components/summary/summaryService';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { UtilService } from '../../assets/wise5/services/utilService';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { ConfigService } from '../../assets/wise5/services/configService';
@@ -38,7 +37,7 @@ const scoreSummaryDisallowedComponentTypes = summaryDisallowedComponentTypes;
 describe('SummaryService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/tableService.spec.ts
+++ b/src/app/services/tableService.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { TableService } from '../../assets/wise5/components/table/tableService';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { StudentAssetService } from '../../assets/wise5/services/studentAssetService';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ConfigService } from '../../assets/wise5/services/configService';
@@ -15,7 +14,7 @@ let service: TableService;
 describe('TableService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/app/services/tagService.spec.ts
+++ b/src/app/services/tagService.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { TagService } from '../../assets/wise5/services/tagService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { UtilService } from '../../assets/wise5/services/utilService';
@@ -17,7 +16,7 @@ let service: TagService;
 describe('TagService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       providers: [ConfigService, ProjectService, SessionService, TagService, UtilService]
     });
     http = TestBed.get(HttpTestingController);

--- a/src/app/services/teacherDiscussionService.spec.ts
+++ b/src/app/services/teacherDiscussionService.spec.ts
@@ -1,7 +1,6 @@
 import { DiscussionService } from '../../assets/wise5/components/discussion/discussionService';
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../assets/wise5/services/annotationService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
@@ -47,7 +46,7 @@ const nodeId = 'node1';
 describe('TeacherDiscussionService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       providers: [
         AchievementService,
         AnnotationService,

--- a/src/app/services/teacherProjectService.spec.ts
+++ b/src/app/services/teacherProjectService.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { TeacherProjectService } from '../../assets/wise5/services/teacherProjectService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { UtilService } from '../../assets/wise5/services/utilService';
@@ -30,7 +29,7 @@ const wiseBaseURL = '/wise';
 describe('TeacherProjectService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       providers: [TeacherProjectService, ConfigService, SessionService, UtilService]
     });
     http = TestBed.inject(HttpTestingController);

--- a/src/app/services/utilService.spec.ts
+++ b/src/app/services/utilService.spec.ts
@@ -1,12 +1,11 @@
 import { TestBed } from '@angular/core/testing';
 import { UtilService } from '../../assets/wise5/services/utilService';
-import { UpgradeModule } from '@angular/upgrade/static';
 let service: UtilService;
 
 describe('UtilService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [UpgradeModule],
+      imports: [],
       providers: [UtilService]
     });
     service = TestBed.get(UtilService);

--- a/src/app/services/vleProjectService.spec.ts
+++ b/src/app/services/vleProjectService.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { VLEProjectService } from '../../assets/wise5/vle/vleProjectService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { UtilService } from '../../assets/wise5/services/utilService';
@@ -15,7 +14,7 @@ let http: HttpTestingController;
 describe('VLEProjectService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       providers: [VLEProjectService, ConfigService, SessionService, UtilService]
     });
     http = TestBed.get(HttpTestingController);

--- a/src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AchievementService } from '../../../../services/achievementService';
 import { AnnotationService } from '../../../../services/annotationService';
 import { ConfigService } from '../../../../services/configService';
@@ -33,8 +32,7 @@ describe('NodeAdvancedConstraintAuthoringComponent', () => {
         HttpClientTestingModule,
         MatDialogModule,
         MatFormFieldModule,
-        MatIconModule,
-        UpgradeModule
+        MatIconModule
       ],
       declarations: [NodeAdvancedConstraintAuthoringComponent],
       providers: [

--- a/src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AchievementService } from '../../../../services/achievementService';
 import { AnnotationService } from '../../../../services/annotationService';
 import { ConfigService } from '../../../../services/configService';
@@ -33,8 +32,7 @@ describe('NodeAdvancedPathAuthoringComponent', () => {
         HttpClientTestingModule,
         MatDialogModule,
         MatFormFieldModule,
-        MatIconModule,
-        UpgradeModule
+        MatIconModule
       ],
       declarations: [NodeAdvancedPathAuthoringComponent],
       providers: [

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/grading-edit-component-max-score/grading-edit-component-max-score.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/grading-edit-component-max-score/grading-edit-component-max-score.component.spec.ts
@@ -3,7 +3,6 @@ import { GradingEditComponentMaxScoreComponent } from './grading-edit-component-
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { UtilService } from '../../../services/utilService';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ConfigService } from '../../../services/configService';
 import { SessionService } from '../../../services/sessionService';
@@ -21,7 +20,7 @@ class MockService {}
 describe('GradingEditComponentMaxScoreComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       declarations: [GradingEditComponentMaxScoreComponent],
       providers: [
         { provide: ConfigService, useClass: MockService },

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatSelectModule } from '@angular/material/select';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { WorkgroupService } from '../../../../../../app/services/workgroup.service';
 import { AchievementService } from '../../../../services/achievementService';
 import { AnnotationService } from '../../../../services/annotationService';
@@ -57,7 +56,6 @@ describe('PeerGroupDialogComponent', () => {
         TeacherDataService,
         TeacherProjectService,
         TeacherWebSocketService,
-        UpgradeModule,
         UtilService,
         WorkgroupService
       ]

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-period/peer-group-period.component.spec.ts
@@ -6,7 +6,6 @@ import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSelectModule } from '@angular/material/select';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { of } from 'rxjs';
 import { WorkgroupService } from '../../../../../../app/services/workgroup.service';
 import { AchievementService } from '../../../../services/achievementService';
@@ -85,7 +84,6 @@ describe('PeerGroupPeriodComponent', () => {
         TeacherDataService,
         TeacherProjectService,
         TeacherWebSocketService,
-        UpgradeModule,
         UtilService,
         WorkgroupService
       ]

--- a/src/assets/wise5/common/stepTools/step-tools.component.spec.ts
+++ b/src/assets/wise5/common/stepTools/step-tools.component.spec.ts
@@ -4,7 +4,6 @@ import { FormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSelectModule } from '@angular/material/select';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AchievementService } from '../../services/achievementService';
 import { AnnotationService } from '../../services/annotationService';
 import { ConfigService } from '../../services/configService';
@@ -60,8 +59,7 @@ describe('StepTools', () => {
         HttpClientTestingModule,
         MatDialogModule,
         MatIconModule,
-        MatSelectModule,
-        UpgradeModule
+        MatSelectModule
       ],
       declarations: [StepToolsComponent],
       providers: [

--- a/src/assets/wise5/components/animation/animation-student/animation-student.component.spec.ts
+++ b/src/assets/wise5/components/animation/animation-student/animation-student.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
@@ -54,12 +53,7 @@ const object1 = {
 describe('AnimationStudent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       declarations: [AnimationStudent],
       providers: [
         AnimationService,

--- a/src/assets/wise5/components/audioOscillator/audio-oscillator-show-work/audio-oscillator-show-work.component.spec.ts
+++ b/src/assets/wise5/components/audioOscillator/audio-oscillator-show-work/audio-oscillator-show-work.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { ProjectService } from '../../../services/projectService';
@@ -15,7 +14,7 @@ let fixture: ComponentFixture<AudioOscillatorShowWorkComponent>;
 describe('AudioOscillatorShowWorkComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       declarations: [AudioOscillatorShowWorkComponent],
       providers: [ConfigService, SessionService, ProjectService, UtilService],
       schemas: []

--- a/src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.spec.ts
+++ b/src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.spec.ts
@@ -9,7 +9,6 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
 import { ComponentHeader } from '../../../directives/component-header/component-header.component';
 import { AnnotationService } from '../../../services/annotationService';
@@ -58,8 +57,7 @@ describe('AudioOscillatorStudent', () => {
         MatInputModule,
         MatSelectModule,
         MatTooltipModule,
-        ReactiveFormsModule,
-        UpgradeModule
+        ReactiveFormsModule
       ],
       declarations: [AudioOscillatorStudent, ComponentHeader, PossibleScoreComponent],
       providers: [

--- a/src/assets/wise5/components/component-student.component.spec.ts
+++ b/src/assets/wise5/components/component-student.component.spec.ts
@@ -12,7 +12,6 @@ import { StudentDataService } from '../services/studentDataService';
 import { TagService } from '../services/tagService';
 import { UtilService } from '../services/utilService';
 import { ComponentService } from './componentService';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { ComponentServiceLookupServiceModule } from '../services/componentServiceLookupServiceModule';
@@ -31,12 +30,7 @@ class ComponentStudentImpl extends ComponentStudent {}
 describe('ComponentStudentComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       declarations: [ComponentStudentImpl],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.spec.ts
+++ b/src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
@@ -46,12 +45,7 @@ let nodeInstanceId2 = 'studentNode2';
 describe('ConceptMapStudent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       declarations: [ConceptMapStudent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.spec.ts
+++ b/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.spec.ts
@@ -7,7 +7,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { EditCommonAdvancedComponent } from '../../../../../app/authoring-tool/edit-common-advanced/edit-common-advanced.component';
 import { EditComponentExcludeFromTotalScoreComponent } from '../../../../../app/authoring-tool/edit-component-exclude-from-total-score/edit-component-exclude-from-total-score.component';
 import { EditComponentJsonComponent } from '../../../../../app/authoring-tool/edit-component-json/edit-component-json.component';
@@ -56,8 +55,7 @@ describe('EditConceptMapAdvancedComponent', () => {
         MatDialogModule,
         MatFormFieldModule,
         MatIconModule,
-        MatInputModule,
-        UpgradeModule
+        MatInputModule
       ],
       declarations: [
         EditCommonAdvancedComponent,

--- a/src/assets/wise5/components/conceptMap/edit-concept-map-connected-components/edit-concept-map-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/conceptMap/edit-concept-map-connected-components/edit-concept-map-connected-components.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
@@ -18,12 +17,7 @@ const nodeId1 = 'nodeId1';
 describe('EditConceptMapConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatIconModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatIconModule],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditConceptMapConnectedComponentsComponent

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
@@ -7,7 +7,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { PossibleScoreComponent } from '../../../../app/possible-score/possible-score.component';
 import { ComponentHeader } from '../../directives/component-header/component-header.component';
 import { AnnotationService } from '../../services/annotationService';
@@ -117,8 +116,7 @@ describe('DialogGuidanceFeedbackRuleEvaluator', () => {
         MatDialogModule,
         MatFormFieldModule,
         MatIconModule,
-        MatInputModule,
-        UpgradeModule
+        MatInputModule
       ],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-show-work/dialog-guidance-show-work.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-show-work/dialog-guidance-show-work.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ComputerAvatarService } from '../../../services/computerAvatarService';
 import { ConfigService } from '../../../services/configService';
@@ -16,7 +15,7 @@ describe('DialogGuidanceShowWorkComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       declarations: [DialogGuidanceShowWorkComponent, DialogResponsesComponent],
       providers: [ConfigService, ComputerAvatarService, ProjectService, SessionService, UtilService]
     }).compileComponents();

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.spec.ts
@@ -7,7 +7,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
 import { ComputerAvatar } from '../../../common/ComputerAvatar';
 import { ComponentHeader } from '../../../directives/component-header/component-header.component';
@@ -58,8 +57,7 @@ describe('DialogGuidanceStudentComponent', () => {
         MatDialogModule,
         MatFormFieldModule,
         MatIconModule,
-        MatInputModule,
-        UpgradeModule
+        MatInputModule
       ],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.spec.ts
@@ -9,7 +9,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { Observable, Subject } from 'rxjs';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { ComputerAvatar } from '../../../common/ComputerAvatar';
@@ -49,8 +48,7 @@ describe('EditDialogGuidanceComputerAvatarComponent', () => {
         MatDialogModule,
         MatFormFieldModule,
         MatIconModule,
-        MatInputModule,
-        UpgradeModule
+        MatInputModule
       ],
       declarations: [EditDialogGuidanceComputerAvatarComponent],
       providers: [

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.spec.ts
@@ -3,7 +3,6 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { EditDialogGuidanceFeedbackRulesComponent } from './edit-dialog-guidance-feedback-rules.component';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { UtilService } from '../../../services/utilService';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { FeedbackRule } from '../FeedbackRule';
 
 class MockTeacherProjectService {
@@ -20,7 +19,7 @@ describe('EditDialogGuidanceFeedbackRulesComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [UpgradeModule],
+      imports: [],
       declarations: [EditDialogGuidanceFeedbackRulesComponent],
       providers: [
         { provide: TeacherProjectService, useClass: MockTeacherProjectService },

--- a/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.spec.ts
+++ b/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.spec.ts
@@ -3,7 +3,6 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { BrowserModule } from '@angular/platform-browser';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { of } from 'rxjs';
 import { AnnotationService } from '../../../services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
@@ -42,8 +41,7 @@ describe('DiscussionStudentComponent', () => {
         BrowserModule,
         ComponentServiceLookupServiceModule,
         HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
+        MatDialogModule
       ],
       declarations: [DiscussionStudent],
       providers: [

--- a/src/assets/wise5/components/discussion/edit-discussion-connected-components/edit-discussion-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/discussion/edit-discussion-connected-components/edit-discussion-connected-components.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { ConfigService } from '../../../services/configService';
 import { ProjectService } from '../../../services/projectService';
@@ -17,12 +16,7 @@ let fixture: ComponentFixture<EditDiscussionConnectedComponentsComponent>;
 describe('EditDiscussionConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatIconModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatIconModule],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditDiscussionConnectedComponentsComponent

--- a/src/assets/wise5/components/draw/draw-student/draw-student.component.spec.ts
+++ b/src/assets/wise5/components/draw/draw-student/draw-student.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
@@ -32,12 +31,7 @@ const starterDrawData =
 describe('DrawStudentComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       declarations: [DrawStudent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/draw/edit-draw-connected-components/edit-draw-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/draw/edit-draw-connected-components/edit-draw-connected-components.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { ConfigService } from '../../../services/configService';
 import { ProjectService } from '../../../services/projectService';
@@ -21,12 +20,7 @@ const componentId2 = 'component2';
 describe('EditDrawConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatIconModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatIconModule],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditDrawConnectedComponentsComponent

--- a/src/assets/wise5/components/embedded/embedded-student/embedded-student.component.spec.ts
+++ b/src/assets/wise5/components/embedded/embedded-student/embedded-student.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
@@ -46,12 +45,7 @@ const spongebobName = 'Spongebob';
 describe('EmbeddedStudentComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       declarations: [EmbeddedStudent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.spec.ts
+++ b/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.spec.ts
@@ -7,7 +7,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { EditCommonAdvancedComponent } from '../../../../../app/authoring-tool/edit-common-advanced/edit-common-advanced.component';
 import { EditComponentAddToNotebookButtonComponent } from '../../../../../app/authoring-tool/edit-component-add-to-notebook-button/edit-component-add-to-notebook-button.component';
 import { EditComponentExcludeFromTotalScoreComponent } from '../../../../../app/authoring-tool/edit-component-exclude-from-total-score/edit-component-exclude-from-total-score.component';
@@ -56,8 +55,7 @@ describe('EditGraphAdvancedComponent', () => {
         MatDialogModule,
         MatFormFieldModule,
         MatIconModule,
-        MatInputModule,
-        UpgradeModule
+        MatInputModule
       ],
       declarations: [
         EditComponentAddToNotebookButtonComponent,

--- a/src/assets/wise5/components/graph/edit-graph-connected-components/edit-graph-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/graph/edit-graph-connected-components/edit-graph-connected-components.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { ConfigService } from '../../../services/configService';
 import { ProjectService } from '../../../services/projectService';
@@ -19,12 +18,7 @@ const componentId1 = 'component1';
 describe('EditGraphConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatIconModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatIconModule],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditGraphConnectedComponentsComponent

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
@@ -4,7 +4,6 @@ import { ComponentFixture, fakeAsync, TestBed, waitForAsync } from '@angular/cor
 import { MatDialogModule } from '@angular/material/dialog';
 import { BrowserModule } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { Point } from 'highcharts';
 import { HighchartsChartModule } from 'highcharts-angular';
 import { AnnotationService } from '../../../services/annotationService';
@@ -50,8 +49,7 @@ describe('GraphStudentComponent', () => {
         HighchartsChartModule,
         HttpClientTestingModule,
         MatDialogModule,
-        NoopAnimationsModule,
-        UpgradeModule
+        NoopAnimationsModule
       ],
       declarations: [GraphStudent],
       providers: [

--- a/src/assets/wise5/components/label/edit-label-connected-components/edit-label-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/label/edit-label-connected-components/edit-label-connected-components.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { ConfigService } from '../../../services/configService';
 import { ProjectService } from '../../../services/projectService';
@@ -19,12 +18,7 @@ const componentId1 = 'component1';
 describe('EditLabelConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatIconModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatIconModule],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditLabelConnectedComponentsComponent

--- a/src/assets/wise5/components/label/label-student/label-student.component.spec.ts
+++ b/src/assets/wise5/components/label/label-student/label-student.component.spec.ts
@@ -3,7 +3,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
@@ -27,12 +26,7 @@ let fixture: ComponentFixture<LabelStudent>;
 describe('LabelStudentComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       declarations: [LabelStudent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/match/edit-match-connected-components/edit-match-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/match/edit-match-connected-components/edit-match-connected-components.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { ConfigService } from '../../../services/configService';
 import { ProjectService } from '../../../services/projectService';
@@ -19,12 +18,7 @@ const nodeId1 = 'nodeId1';
 describe('EditMatchConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatIconModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatIconModule],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditMatchConnectedComponentsComponent

--- a/src/assets/wise5/components/match/match-student/match-student.component.spec.ts
+++ b/src/assets/wise5/components/match/match-student/match-student.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
@@ -64,12 +63,7 @@ let starterBucketLabel = 'Starter Choices';
 describe('MatchStudentComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       declarations: [MatchStudent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { ConfigService } from '../../../services/configService';
 import { ProjectService } from '../../../services/projectService';
@@ -19,12 +18,7 @@ const nodeId1 = 'nodeId1';
 describe('EditMultipleChoiceConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatIconModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatIconModule],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditMultipleChoiceConnectedComponentsComponent

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.spec.ts
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.spec.ts
@@ -6,7 +6,6 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatRadioModule } from '@angular/material/radio';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
 import { ComponentHeader } from '../../../directives/component-header/component-header.component';
 import { AnnotationService } from '../../../services/annotationService';
@@ -132,8 +131,7 @@ describe('MultipleChoiceStudentComponent', () => {
         MatCheckboxModule,
         MatDialogModule,
         MatRadioModule,
-        ReactiveFormsModule,
-        UpgradeModule
+        ReactiveFormsModule
       ],
       declarations: [ComponentHeader, MultipleChoiceStudent, PossibleScoreComponent],
       providers: [

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
@@ -7,7 +7,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { EditCommonAdvancedComponent } from '../../../../../app/authoring-tool/edit-common-advanced/edit-common-advanced.component';
 import { EditComponentAddToNotebookButtonComponent } from '../../../../../app/authoring-tool/edit-component-add-to-notebook-button/edit-component-add-to-notebook-button.component';
 import { EditComponentExcludeFromTotalScoreComponent } from '../../../../../app/authoring-tool/edit-component-exclude-from-total-score/edit-component-exclude-from-total-score.component';
@@ -60,8 +59,7 @@ describe('EditOpenResponseAdvancedComponent', () => {
         MatDialogModule,
         MatFormFieldModule,
         MatIconModule,
-        MatInputModule,
-        UpgradeModule
+        MatInputModule
       ],
       declarations: [
         EditComponentAddToNotebookButtonComponent,

--- a/src/assets/wise5/components/outsideURL/outside-url-student/outside-url-student.component.spec.ts
+++ b/src/assets/wise5/components/outsideURL/outside-url-student/outside-url-student.component.spec.ts
@@ -6,7 +6,6 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
 import { AudioRecorderService } from '../../../services/audioRecorderService';
 import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
@@ -48,8 +47,7 @@ describe('OutsideUrlStudentComponent', () => {
         HttpClientTestingModule,
         MatDialogModule,
         MatIconModule,
-        ReactiveFormsModule,
-        UpgradeModule
+        ReactiveFormsModule
       ],
       declarations: [OutsideUrlStudent],
       providers: [

--- a/src/assets/wise5/components/peerChat/edit-peer-chat-advanced-component/edit-peer-chat-advanced-component.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/edit-peer-chat-advanced-component/edit-peer-chat-advanced-component.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
@@ -28,12 +27,7 @@ describe('EditPeerChatAdvancedComponentComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       declarations: [EditPeerChatAdvancedComponentComponent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.spec.ts
@@ -7,7 +7,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-component-prompt/edit-component-prompt.component';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { ConfigService } from '../../../services/configService';
@@ -54,8 +53,7 @@ describe('PeerChatAuthoringComponent', () => {
         MatFormFieldModule,
         MatIconModule,
         MatInputModule,
-        MatSelectModule,
-        UpgradeModule
+        MatSelectModule
       ],
       declarations: [EditComponentPrompt, PeerChatAuthoringComponent],
       providers: [

--- a/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AchievementService } from '../../../services/achievementService';
 import { AnnotationService } from '../../../services/annotationService';
 import { ClassroomStatusService } from '../../../services/classroomStatusService';
@@ -48,12 +47,7 @@ const peerGroup = new PeerGroup(
 describe('PeerChatGradingComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       declarations: [PeerChatGradingComponent],
       providers: [
         AchievementService,

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
@@ -132,8 +131,7 @@ describe('PeerChatStudentComponent', () => {
         MatFormFieldModule,
         MatIconModule,
         MatInputModule,
-        PeerChatModule,
-        UpgradeModule
+        PeerChatModule
       ],
       declarations: [ComponentHeader, PeerChatStudentComponent, PossibleScoreComponent],
       providers: [

--- a/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.spec.ts
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialog } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { of } from 'rxjs';
 import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
 import { AnnotationService } from '../../../services/annotationService';
@@ -65,7 +64,7 @@ let studentWork;
 describe('ShowGroupWorkStudentComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       declarations: [ShowGroupWorkStudentComponent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.spec.ts
+++ b/src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatCardModule } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { of } from 'rxjs';
 import { AnnotationService } from '../../../services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
@@ -41,12 +40,7 @@ describe('ShowMyWorkStudentComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatCardModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatCardModule],
       declarations: [ShowMyWorkStudentComponent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/components/summary/summary-student/summary-student.component.spec.ts
+++ b/src/assets/wise5/components/summary/summary-student/summary-student.component.spec.ts
@@ -4,7 +4,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { BrowserModule } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
@@ -40,8 +39,7 @@ describe('SummaryStudentComponent', () => {
         ComponentServiceLookupServiceModule,
         HttpClientTestingModule,
         MatDialogModule,
-        NoopAnimationsModule,
-        UpgradeModule
+        NoopAnimationsModule
       ],
       declarations: [SummaryStudent],
       providers: [

--- a/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.spec.ts
+++ b/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.spec.ts
@@ -8,7 +8,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { EditCommonAdvancedComponent } from '../../../../../app/authoring-tool/edit-common-advanced/edit-common-advanced.component';
 import { EditComponentAddToNotebookButtonComponent } from '../../../../../app/authoring-tool/edit-component-add-to-notebook-button/edit-component-add-to-notebook-button.component';
 import { EditComponentExcludeFromTotalScoreComponent } from '../../../../../app/authoring-tool/edit-component-exclude-from-total-score/edit-component-exclude-from-total-score.component';
@@ -59,8 +58,7 @@ describe('EditTableAdvancedComponent', () => {
         MatFormFieldModule,
         MatIconModule,
         MatInputModule,
-        MatSelectModule,
-        UpgradeModule
+        MatSelectModule
       ],
       declarations: [
         EditComponentAddToNotebookButtonComponent,

--- a/src/assets/wise5/components/table/edit-table-connected-components/edit-table-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/table/edit-table-connected-components/edit-table-connected-components.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { ConfigService } from '../../../services/configService';
 import { ProjectService } from '../../../services/projectService';
@@ -19,12 +18,7 @@ const nodeId1 = 'nodeId1';
 describe('EditTableConnectedComponentsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatIconModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatIconModule],
       declarations: [
         EditConnectedComponentsAddButtonComponent,
         EditTableConnectedComponentsComponent

--- a/src/assets/wise5/components/table/table-show-work/table-show-work.component.spec.ts
+++ b/src/assets/wise5/components/table/table-show-work/table-show-work.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
 import { ProjectService } from '../../../services/projectService';
@@ -16,7 +15,7 @@ describe('TableShowWorkComponent', () => {
     TestBed.configureTestingModule({
       imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       declarations: [TableShowWorkComponent],
-      providers: [ConfigService, ProjectService, SessionService, UpgradeModule, UtilService]
+      providers: [ConfigService, ProjectService, SessionService, UtilService]
     });
     fixture = TestBed.createComponent(TableShowWorkComponent);
     const componentContent = {

--- a/src/assets/wise5/components/table/table-student/table-student.component.spec.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.spec.ts
@@ -4,7 +4,6 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { BrowserModule } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
@@ -46,8 +45,7 @@ describe('TableStudentComponent', () => {
         ComponentServiceLookupServiceModule,
         HttpClientTestingModule,
         MatDialogModule,
-        NoopAnimationsModule,
-        UpgradeModule
+        NoopAnimationsModule
       ],
       declarations: [TableStudent],
       providers: [

--- a/src/assets/wise5/directives/generate-image-dialog/generate-image-dialog.component.spec.ts
+++ b/src/assets/wise5/directives/generate-image-dialog/generate-image-dialog.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { Subject } from 'rxjs';
 import { ConceptMapService } from '../../components/conceptMap/conceptMapService';
 import { DrawService } from '../../components/draw/drawService';
@@ -38,8 +37,7 @@ describe('GenerateImageDialogComponent', () => {
         ComponentServiceLookupServiceModule,
         HttpClientTestingModule,
         MatDialogModule,
-        MatProgressSpinnerModule,
-        UpgradeModule
+        MatProgressSpinnerModule
       ],
       declarations: [GenerateImageDialogComponent],
       providers: [

--- a/src/assets/wise5/directives/student-summary-display/student-summary-display.component.spec.ts
+++ b/src/assets/wise5/directives/student-summary-display/student-summary-display.component.spec.ts
@@ -2,7 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { SummaryService } from '../../components/summary/summaryService';
 import { AnnotationService } from '../../services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../services/componentServiceLookupServiceModule';
@@ -21,12 +20,7 @@ let fixture: ComponentFixture<StudentSummaryDisplay>;
 describe('SummaryDisplayComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       declarations: [StudentSummaryDisplay],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/directives/wise-link/wise-link.component.spec.ts
+++ b/src/assets/wise5/directives/wise-link/wise-link.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../services/configService';
@@ -21,12 +20,7 @@ describe('WiseLinkComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       declarations: [WiseLinkComponent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component.spec.ts
+++ b/src/assets/wise5/directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component.spec.ts
@@ -3,16 +3,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { ProjectAssetService } from '../../../../app/services/projectAssetService';
-import { AnnotationService } from '../../services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../services/configService';
-import { CopyNodesService } from '../../services/copyNodesService';
 import { NotebookService } from '../../services/notebookService';
 import { ProjectService } from '../../services/projectService';
 import { SessionService } from '../../services/sessionService';
-import { StudentAssetService } from '../../services/studentAssetService';
-import { StudentDataService } from '../../services/studentDataService';
-import { TagService } from '../../services/tagService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { UtilService } from '../../services/utilService';
 import { WiseAuthoringTinymceEditorComponent } from './wise-authoring-tinymce-editor.component';
@@ -31,16 +26,11 @@ describe('WiseAuthoringTinymceEditorComponent', () => {
         UpgradeModule
       ],
       providers: [
-        AnnotationService,
         ConfigService,
-        CopyNodesService,
         NotebookService,
         ProjectAssetService,
         ProjectService,
         SessionService,
-        StudentAssetService,
-        StudentDataService,
-        TagService,
         TeacherProjectService,
         UtilService
       ]

--- a/src/assets/wise5/directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component.ts
+++ b/src/assets/wise5/directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component.ts
@@ -1,10 +1,10 @@
 import { Component } from '@angular/core';
 import { ConfigService } from '../../services/configService';
 import { ProjectAssetService } from '../../../../app/services/projectAssetService';
-import { TeacherProjectService } from '../../services/teacherProjectService';
 import { WiseTinymceEditorComponent } from './wise-tinymce-editor.component';
 import { NotebookService } from '../../services/notebookService';
 import 'tinymce';
+import { UpgradeModule } from '@angular/upgrade/static';
 
 declare let tinymce: any;
 
@@ -29,7 +29,7 @@ export class WiseAuthoringTinymceEditorComponent extends WiseTinymceEditorCompon
     private ConfigService: ConfigService,
     NotebookService: NotebookService,
     private ProjectAssetService: ProjectAssetService,
-    private ProjectService: TeacherProjectService
+    private upgrade: UpgradeModule
   ) {
     super(NotebookService);
   }
@@ -40,8 +40,8 @@ export class WiseAuthoringTinymceEditorComponent extends WiseTinymceEditorCompon
     this.initializeTinyMCE();
   }
 
-  initializeInsertWISELinkPlugin(): void {
-    const thisProjectService = this.ProjectService;
+  private initializeInsertWISELinkPlugin(): void {
+    const thisComponent = this;
     tinymce.PluginManager.add('wiselink', function (editor: any, url: string) {
       editor.ui.registry.addIcon(
         'wiselink',
@@ -61,7 +61,7 @@ export class WiseAuthoringTinymceEditorComponent extends WiseTinymceEditorCompon
             componentId: '',
             target: ''
           };
-          thisProjectService.openWISELinkChooser(params).then((result) => {
+          thisComponent.openWISELinkChooser(params).then((result) => {
             let content = '';
             if (result.wiseLinkType === 'link') {
               content =
@@ -78,6 +78,23 @@ export class WiseAuthoringTinymceEditorComponent extends WiseTinymceEditorCompon
           });
         }
       });
+    });
+  }
+
+  private openWISELinkChooser({ projectId, nodeId, componentId, target }): any {
+    const stateParams = {
+      projectId: projectId,
+      nodeId: nodeId,
+      componentId: componentId,
+      target: target
+    };
+    return this.upgrade.$injector.get('$mdDialog').show({
+      templateUrl: 'assets/wise5/authoringTool/wiseLink/wiseLinkAuthoring.html',
+      controller: 'WISELinkAuthoringController',
+      controllerAs: '$ctrl',
+      $stateParams: stateParams,
+      clickOutsideToClose: true,
+      escapeToClose: true
     });
   }
 

--- a/src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.spec.ts
+++ b/src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ProjectAssetService } from '../../../../app/services/projectAssetService';
 import { AnnotationService } from '../../services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../services/componentServiceLookupServiceModule';
@@ -22,12 +21,7 @@ describe('WiseTinymceEditorComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [WiseTinymceEditorComponent],
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       providers: [
         AnnotationService,
         ConfigService,

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -1,11 +1,9 @@
 'use strict';
 import * as angular from 'angular';
-import * as $ from 'jquery';
 import { ConfigService } from '../services/configService';
 import { ProjectService } from './projectService';
 import { UtilService } from '../services/utilService';
 import { Injectable } from '@angular/core';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { HttpClient } from '@angular/common/http';
 import { Observable, Subject } from 'rxjs';
 import { SessionService } from './sessionService';
@@ -33,7 +31,6 @@ export class TeacherProjectService extends ProjectService {
   public savingProject$: Observable<any> = this.savingProjectSource.asObservable();
 
   constructor(
-    protected upgrade: UpgradeModule,
     protected componentServiceLookupService: ComponentServiceLookupService,
     protected http: HttpClient,
     protected ConfigService: ConfigService,
@@ -903,23 +900,6 @@ export class TeacherProjectService extends ProjectService {
         constraint.removalCriteria[0].name === 'teacherRemoval' &&
         constraint.removalCriteria[0].params.periodId === periodId
       );
-    });
-  }
-
-  openWISELinkChooser({ projectId, nodeId, componentId, target }): any {
-    const stateParams = {
-      projectId: projectId,
-      nodeId: nodeId,
-      componentId: componentId,
-      target: target
-    };
-    return this.upgrade.$injector.get('$mdDialog').show({
-      templateUrl: 'assets/wise5/authoringTool/wiseLink/wiseLinkAuthoring.html',
-      controller: 'WISELinkAuthoringController',
-      controllerAs: '$ctrl',
-      $stateParams: stateParams,
-      clickOutsideToClose: true,
-      escapeToClose: true
     });
   }
 

--- a/src/assets/wise5/themes/default/navigation/navigation.component.spec.ts
+++ b/src/assets/wise5/themes/default/navigation/navigation.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../../services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../../services/componentServiceLookupServiceModule';
 import { ConfigService } from '../../../services/configService';
@@ -28,12 +27,7 @@ describe('NavigationComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        ComponentServiceLookupServiceModule,
-        HttpClientTestingModule,
-        MatDialogModule,
-        UpgradeModule
-      ],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, MatDialogModule],
       declarations: [NavigationComponent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/themes/default/notebook/edit-notebook-item-dialog/edit-notebook-item-dialog.component.spec.ts
+++ b/src/assets/wise5/themes/default/notebook/edit-notebook-item-dialog/edit-notebook-item-dialog.component.spec.ts
@@ -7,7 +7,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { WiseLinkComponent } from '../../../../directives/wise-link/wise-link.component';
 import { AnnotationService } from '../../../../services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../../../services/componentServiceLookupServiceModule';
@@ -38,8 +37,7 @@ describe('EditNotebookItemDialogComponent', () => {
         MatIconModule,
         MatInputModule,
         MatToolbarModule,
-        ReactiveFormsModule,
-        UpgradeModule
+        ReactiveFormsModule
       ],
       declarations: [EditNotebookItemDialogComponent, WiseLinkComponent],
       providers: [

--- a/src/assets/wise5/themes/default/themeComponents/stepTools/step-tools.component.spec.ts
+++ b/src/assets/wise5/themes/default/themeComponents/stepTools/step-tools.component.spec.ts
@@ -4,7 +4,6 @@ import { FormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSelectModule } from '@angular/material/select';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { NodeIconComponent } from '../../../../vle/node-icon/node-icon.component';
 import { AnnotationService } from '../../../../services/annotationService';
 import { ComponentServiceLookupServiceModule } from '../../../../services/componentServiceLookupServiceModule';
@@ -47,8 +46,7 @@ describe('StepToolsComponent', () => {
         HttpClientTestingModule,
         MatDialogModule,
         MatIconModule,
-        MatSelectModule,
-        UpgradeModule
+        MatSelectModule
       ],
       declarations: [NodeIconComponent, NodeStatusIcon, StepToolsComponent],
       providers: [

--- a/src/assets/wise5/vle/computer-avatar-selector/computer-avatar-selector.component.spec.ts
+++ b/src/assets/wise5/vle/computer-avatar-selector/computer-avatar-selector.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ComputerAvatar } from '../../common/ComputerAvatar';
 import { DialogGuidanceService } from '../../components/dialogGuidance/dialogGuidanceService';
 import { AnnotationService } from '../../services/annotationService';
@@ -23,7 +22,7 @@ describe('ComputerAvatarSelectorComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, UpgradeModule],
+      imports: [HttpClientTestingModule],
       declarations: [ComputerAvatarSelectorComponent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.spec.ts
+++ b/src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.spec.ts
@@ -5,7 +5,6 @@ import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../services/annotationService';
 import { ConfigService } from '../../services/configService';
 import { ProjectService } from '../../services/projectService';
@@ -35,8 +34,7 @@ describe('DismissAmbientNotificationDialogComponent', () => {
         MatDialogModule,
         MatFormFieldModule,
         MatInputModule,
-        ReactiveFormsModule,
-        UpgradeModule
+        ReactiveFormsModule
       ],
       declarations: [DismissAmbientNotificationDialogComponent],
       providers: [

--- a/src/assets/wise5/vle/node/node.component.spec.ts
+++ b/src/assets/wise5/vle/node/node.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ComponentService } from '../../components/componentService';
 import { AnnotationService } from '../../services/annotationService';
 import { ConfigService } from '../../services/configService';
@@ -21,7 +20,7 @@ let fixture: ComponentFixture<NodeComponent>;
 describe('NodeComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule, UpgradeModule],
+      imports: [HttpClientTestingModule, MatDialogModule],
       declarations: [NodeComponent],
       providers: [
         AnnotationService,

--- a/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.spec.ts
+++ b/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../services/annotationService';
 import { ConfigService } from '../../services/configService';
 import { MatCardModule } from '@angular/material/card';
@@ -38,8 +37,7 @@ describe('NotificationsMenuComponent', () => {
         MatCardModule,
         MatDialogModule,
         MatIconModule,
-        MatToolbarModule,
-        UpgradeModule
+        MatToolbarModule
       ],
       declarations: [NotificationsDialogComponent],
       providers: [

--- a/src/assets/wise5/vle/student-account-menu/student-account-menu.component.spec.ts
+++ b/src/assets/wise5/vle/student-account-menu/student-account-menu.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { AnnotationService } from '../../services/annotationService';
 import { ConfigService } from '../../services/configService';
 import { MatDividerModule } from '@angular/material/divider';
@@ -40,8 +39,7 @@ describe('StudentAccountMenuComponent', () => {
         MatDialogModule,
         MatDividerModule,
         MatIconModule,
-        MatMenuModule,
-        UpgradeModule
+        MatMenuModule
       ],
       declarations: [StudentAccountMenuComponent],
       providers: [

--- a/src/assets/wise5/vle/studentAsset/student-assets/student-assets.component.spec.ts
+++ b/src/assets/wise5/vle/studentAsset/student-assets/student-assets.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { UpgradeModule } from '@angular/upgrade/static';
 import { ConfigService } from '../../../services/configService';
 import { StudentAssetsComponent } from './student-assets.component';
 import { ProjectService } from '../../../services/projectService';
@@ -21,7 +20,7 @@ describe('StudentAssetsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule, UpgradeModule],
+      imports: [ComponentServiceLookupServiceModule, HttpClientTestingModule],
       declarations: [StudentAssetsComponent],
       providers: [ConfigService, ProjectService, SessionService, StudentAssetService, UtilService]
     }).compileComponents();

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15918,7 +15918,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">93</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7975589013595125523" datatype="html">
@@ -15929,11 +15929,11 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">108</context>
+          <context context-type="linenumber">105</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">147</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5946383547512220582" datatype="html">
@@ -15944,11 +15944,11 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">106</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">151</context>
+          <context context-type="linenumber">148</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3177789104763917185" datatype="html">
@@ -15966,7 +15966,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">118</context>
+          <context context-type="linenumber">115</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6590475405017990661" datatype="html">
@@ -15977,7 +15977,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">119</context>
+          <context context-type="linenumber">116</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7008439939460403347" datatype="html">
@@ -15988,7 +15988,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">117</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4200122564420479235" datatype="html">
@@ -16212,103 +16212,103 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>First Lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">59</context>
+          <context context-type="linenumber">56</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2017855920890197640" datatype="html">
         <source>First Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">71</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8104421162933956065" datatype="html">
         <source>Notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">110</context>
+          <context context-type="linenumber">107</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">152</context>
+          <context context-type="linenumber">149</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5668531960608480573" datatype="html">
         <source>Final Report</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">127</context>
+          <context context-type="linenumber">124</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8604167983715964004" datatype="html">
         <source>Final summary report of what you learned in this unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">128</context>
+          <context context-type="linenumber">125</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4419148705442508208" datatype="html">
         <source>Use this space to write your final report using evidence from your notebook.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">129</context>
+          <context context-type="linenumber">126</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2128364009265696768" datatype="html">
         <source>&lt;h3&gt;This is a heading&lt;/h3&gt;&lt;p&gt;This is a paragraph.&lt;/p&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">130</context>
+          <context context-type="linenumber">127</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3712572360135341203" datatype="html">
         <source>Teacher Notebook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">138</context>
+          <context context-type="linenumber">135</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3422550137142657635" datatype="html">
         <source>teacher notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">160</context>
+          <context context-type="linenumber">157</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">161</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2558301014879118031" datatype="html">
         <source>Teacher Notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">162</context>
+          <context context-type="linenumber">159</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">169</context>
+          <context context-type="linenumber">166</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2841850575512700640" datatype="html">
         <source>Notes for the teacher as they&apos;re running the WISE unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">170</context>
+          <context context-type="linenumber">167</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4383493915104232758" datatype="html">
         <source>Use this space to take notes for this unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">171</context>
+          <context context-type="linenumber">168</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8373748870534083811" datatype="html">
         <source>&lt;p&gt;Use this space to take notes for this unit&lt;/p&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">172</context>
+          <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3124371804165766752" datatype="html">


### PR DESCRIPTION
## Changes
- Move openWISELinkChooser() to WiseAuthoringTinymceEditorComponent. This was the only class that used this function
- Remove no-longer-necessary UpgradeModule dependencies from spec files

## Test
- Authoring WISE links works as before

Closes #660