### PR TITLE
fix(Teacher): Do not fetch units in homepage

### DIFF
--- a/src/app/modules/library/community-library/community-library.component.ts
+++ b/src/app/modules/library/community-library/community-library.component.ts
@@ -13,15 +13,19 @@ export class CommunityLibraryComponent extends LibraryComponent {
   projects: LibraryProject[] = [];
   filteredProjects: LibraryProject[] = [];
 
-  constructor(libraryService: LibraryService, public dialog: MatDialog) {
+  constructor(protected libraryService: LibraryService, public dialog: MatDialog) {
     super(libraryService);
-    libraryService.communityLibraryProjectsSource$.subscribe((communityProjects) => {
-      this.projects = communityProjects;
-      this.filterUpdated();
-    });
   }
 
-  ngOnInit() {}
+  ngOnInit() {
+    super.ngOnInit();
+    this.subscriptions.add(
+      this.libraryService.communityLibraryProjectsSource$.subscribe((communityProjects) => {
+        this.projects = communityProjects;
+        this.filterUpdated();
+      })
+    );
+  }
 
   emitNumberOfProjectsVisible(numProjectsVisible: number = null) {
     if (numProjectsVisible) {

--- a/src/app/modules/library/library/library.component.ts
+++ b/src/app/modules/library/library/library.component.ts
@@ -4,6 +4,7 @@ import { LibraryService } from '../../../services/library.service';
 import { Standard } from '../standard';
 import { LibraryProject } from '../libraryProject';
 import { PageEvent, MatPaginator } from '@angular/material/paginator';
+import { Subscription } from 'rxjs';
 
 @Directive()
 export abstract class LibraryComponent implements OnInit {
@@ -18,24 +19,30 @@ export abstract class LibraryComponent implements OnInit {
   peValue = [];
   filterValues: ProjectFilterValues = new ProjectFilterValues();
   showFilters: boolean = false;
+  subscriptions: Subscription = new Subscription();
   pageSizeOptions: number[] = [12, 24, 48, 96];
   pageIndex: number = 0;
   pageSize: number = 12;
   lowIndex: number = 0;
   highIndex: number = 0;
 
-  @Output('update')
-  update: EventEmitter<number> = new EventEmitter<number>();
+  @Output('update') update: EventEmitter<number> = new EventEmitter<number>();
 
   @ViewChildren(MatPaginator) paginators!: QueryList<MatPaginator>;
 
-  constructor(protected libraryService: LibraryService) {
-    libraryService.projectFilterValuesSource$.subscribe((projectFilterValues) => {
-      this.filterUpdated(projectFilterValues);
-    });
+  constructor(protected libraryService: LibraryService) {}
+
+  ngOnInit() {
+    this.subscriptions.add(
+      this.libraryService.projectFilterValuesSource$.subscribe((projectFilterValues) => {
+        this.filterUpdated(projectFilterValues);
+      })
+    );
   }
 
-  ngOnInit() {}
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
+  }
 
   pageChange(event?: PageEvent, scroll?: boolean): void {
     this.pageIndex = event.pageIndex;

--- a/src/app/modules/library/official-library/official-library.component.ts
+++ b/src/app/modules/library/official-library/official-library.component.ts
@@ -12,25 +12,30 @@ import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dial
   encapsulation: ViewEncapsulation.None
 })
 export class OfficialLibraryComponent extends LibraryComponent {
-  @Input()
-  isSplitScreen: boolean = false;
+  @Input() isSplitScreen: boolean = false;
 
   projects: LibraryProject[] = [];
   libraryGroups: LibraryGroup[] = [];
   expandedGroups: object = {};
 
-  constructor(libraryService: LibraryService, public dialog: MatDialog) {
+  constructor(protected libraryService: LibraryService, public dialog: MatDialog) {
     super(libraryService);
-    libraryService.libraryGroupsSource$.subscribe((libraryGroups) => {
-      this.libraryGroups = libraryGroups;
-    });
-    libraryService.officialLibraryProjectsSource$.subscribe((libraryProjects) => {
-      this.projects = libraryProjects;
-      this.filterUpdated();
-    });
   }
 
-  ngOnInit() {}
+  ngOnInit() {
+    super.ngOnInit();
+    this.subscriptions.add(
+      this.libraryService.libraryGroupsSource$.subscribe((libraryGroups) => {
+        this.libraryGroups = libraryGroups;
+      })
+    );
+    this.subscriptions.add(
+      this.libraryService.officialLibraryProjectsSource$.subscribe((libraryProjects) => {
+        this.projects = libraryProjects;
+        this.filterUpdated();
+      })
+    );
+  }
 
   emitNumberOfProjectsVisible(numProjectsVisible: number = null) {
     if (numProjectsVisible) {

--- a/src/app/modules/library/personal-library/personal-library.component.ts
+++ b/src/app/modules/library/personal-library/personal-library.component.ts
@@ -3,7 +3,6 @@ import { LibraryProject } from '../libraryProject';
 import { LibraryService } from '../../../services/library.service';
 import { LibraryComponent } from '../library/library.component';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-personal-library',
@@ -15,14 +14,13 @@ export class PersonalLibraryComponent extends LibraryComponent {
   filteredProjects: LibraryProject[] = [];
   personalProjects: LibraryProject[] = [];
   sharedProjects: LibraryProject[] = [];
-  subscriptions: Subscription = new Subscription();
 
-  constructor(libraryService: LibraryService, private dialog: MatDialog) {
+  constructor(protected libraryService: LibraryService, private dialog: MatDialog) {
     super(libraryService);
-    this.libraryService = libraryService;
   }
 
   ngOnInit() {
+    super.ngOnInit();
     this.subscriptions.add(
       this.libraryService.personalLibraryProjectsSource$.subscribe(
         (personalProjects: LibraryProject[]) => {
@@ -48,10 +46,6 @@ export class PersonalLibraryComponent extends LibraryComponent {
         }
       })
     );
-  }
-
-  ngOnDestroy() {
-    this.subscriptions.unsubscribe();
   }
 
   combinePersonalAndSharedProjects() {

--- a/src/app/modules/library/teacher-project-library/teacher-project-library.component.spec.ts
+++ b/src/app/modules/library/teacher-project-library/teacher-project-library.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { TeacherProjectLibraryComponent } from './teacher-project-library.component';
-import { MatDialogModule } from '@angular/material/dialog';
 import { MatMenuModule } from '@angular/material/menu';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -26,14 +25,16 @@ describe('TeacherProjectLibraryComponent', () => {
   let component: TeacherProjectLibraryComponent;
   let fixture: ComponentFixture<TeacherProjectLibraryComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [MatMenuModule, RouterTestingModule, MatDialogModule],
-      declarations: [TeacherProjectLibraryComponent],
-      providers: [{ provide: LibraryService, useClass: MockLibraryService }],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [MatMenuModule, RouterTestingModule],
+        declarations: [TeacherProjectLibraryComponent],
+        providers: [{ provide: LibraryService, useClass: MockLibraryService }],
+        schemas: [NO_ERRORS_SCHEMA]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TeacherProjectLibraryComponent);

--- a/src/app/modules/library/teacher-project-library/teacher-project-library.component.ts
+++ b/src/app/modules/library/teacher-project-library/teacher-project-library.component.ts
@@ -33,13 +33,10 @@ export class TeacherProjectLibraryComponent implements OnInit {
     this.libraryService.numberOfPersonalProjectsVisible$.subscribe((num) => {
       this.tabs[2].numVisible = num;
     });
-    if (!this.libraryService.hasLoaded) {
-      this.libraryService.getCommunityLibraryProjects();
-      this.libraryService.getOfficialLibraryProjects();
-      this.libraryService.getPersonalLibraryProjects();
-      this.libraryService.getSharedLibraryProjects();
-      this.libraryService.hasLoaded = true;
-    }
+    this.libraryService.getCommunityLibraryProjects();
+    this.libraryService.getOfficialLibraryProjects();
+    this.libraryService.getPersonalLibraryProjects();
+    this.libraryService.getSharedLibraryProjects();
     this.libraryService.newProjectSource$.subscribe((project) => {
       if (project) {
         document.querySelector('.library').scrollIntoView();

--- a/src/app/modules/library/teacher-project-library/teacher-project-library.component.ts
+++ b/src/app/modules/library/teacher-project-library/teacher-project-library.component.ts
@@ -1,8 +1,6 @@
 import { Component, ViewEncapsulation, OnInit } from '@angular/core';
 import { LibraryProject } from '../libraryProject';
 import { LibraryService } from '../../../services/library.service';
-import { MatDialog } from '@angular/material/dialog';
-import { OfficialLibraryDetailsComponent } from '../official-library/official-library.component';
 import { Router } from '@angular/router';
 
 @Component({
@@ -18,36 +16,36 @@ export class TeacherProjectLibraryComponent implements OnInit {
   numberOfPersonalProjectsVisible: number = 0;
   route: String;
   tabs: any[] = [
-    { path: 'library/tested', label: $localize`WISE Tested`, numVisible: 0 },
-    { path: 'library/community', label: $localize`Community Built`, numVisible: 0 },
-    { path: 'library/personal', label: $localize`My Units`, numVisible: 0 }
+    { path: 'tested', label: $localize`WISE Tested`, numVisible: 0 },
+    { path: 'community', label: $localize`Community Built`, numVisible: 0 },
+    { path: 'personal', label: $localize`My Units`, numVisible: 0 }
   ];
 
-  constructor(libraryService: LibraryService, public dialog: MatDialog, private router: Router) {
-    libraryService.numberOfOfficialProjectsVisible$.subscribe((num) => {
+  constructor(private libraryService: LibraryService, private router: Router) {}
+
+  ngOnInit() {
+    this.libraryService.numberOfOfficialProjectsVisible$.subscribe((num) => {
       this.tabs[0].numVisible = num;
     });
-    libraryService.numberOfCommunityProjectsVisible$.subscribe((num) => {
+    this.libraryService.numberOfCommunityProjectsVisible$.subscribe((num) => {
       this.tabs[1].numVisible = num;
     });
-    libraryService.numberOfPersonalProjectsVisible$.subscribe((num) => {
+    this.libraryService.numberOfPersonalProjectsVisible$.subscribe((num) => {
       this.tabs[2].numVisible = num;
     });
-    if (!libraryService.hasLoaded) {
-      libraryService.getCommunityLibraryProjects();
-      libraryService.getOfficialLibraryProjects();
-      libraryService.getPersonalLibraryProjects();
-      libraryService.getSharedLibraryProjects();
-      libraryService.hasLoaded = true;
+    if (!this.libraryService.hasLoaded) {
+      this.libraryService.getCommunityLibraryProjects();
+      this.libraryService.getOfficialLibraryProjects();
+      this.libraryService.getPersonalLibraryProjects();
+      this.libraryService.getSharedLibraryProjects();
+      this.libraryService.hasLoaded = true;
     }
-    libraryService.newProjectSource$.subscribe((project) => {
+    this.libraryService.newProjectSource$.subscribe((project) => {
       if (project) {
         document.querySelector('.library').scrollIntoView();
       }
     });
   }
-
-  ngOnInit() {}
 
   isOfficialRoute(): boolean {
     return this.router.url === '/teacher/home/library/tested';
@@ -59,11 +57,5 @@ export class TeacherProjectLibraryComponent implements OnInit {
 
   isPersonalRoute(): boolean {
     return this.router.url === '/teacher/home/library/personal';
-  }
-
-  showInfo() {
-    this.dialog.open(OfficialLibraryDetailsComponent, {
-      panelClass: 'dialog-sm'
-    });
   }
 }

--- a/src/app/services/library.service.ts
+++ b/src/app/services/library.service.ts
@@ -38,7 +38,6 @@ export class LibraryService {
   public numberOfCommunityProjectsVisible$ = this.numberOfCommunityProjectsVisible.asObservable();
   public numberOfPersonalProjectsVisible = new BehaviorSubject<number>(0);
   public numberOfPersonalProjectsVisible$ = this.numberOfPersonalProjectsVisible.asObservable();
-  public hasLoaded: Boolean = false;
 
   constructor(private http: HttpClient, private router: Router) {
     this.router = router;
@@ -166,6 +165,5 @@ export class LibraryService {
     this.personalLibraryProjectsSource.next([]);
     this.sharedLibraryProjectsSource.next([]);
     this.projectFilterValuesSource.next(new ProjectFilterValues());
-    this.hasLoaded = false;
   }
 }

--- a/src/app/teacher/teacher-home/teacher-home.component.html
+++ b/src/app/teacher/teacher-home/teacher-home.component.html
@@ -18,7 +18,7 @@
       fxFlex.gt-sm="0 0 auto"></discourse-recent-activity>
 </header>
 <section>
-  <nav mat-tab-nav-bar i18n-aria-label aria-label="Teacher home navigation">
+  <nav mat-tab-nav-bar i18n-aria-label aria-label="Teacher home navigation" [tabPanel]="tabPanel">
     <a mat-tab-link
         *ngFor="let tab of tabLinks"
         [routerLink]="[tab.path]"
@@ -32,6 +32,7 @@
       &nbsp;<mat-icon class="text">open_in_browser</mat-icon>
     </a>
   </nav>
-  <app-teacher-run-list [hidden]="!isRunListRoute()"></app-teacher-run-list>
-  <app-teacher-project-library [hidden]="isRunListRoute()"></app-teacher-project-library>
+  <mat-tab-nav-panel #tabPanel>
+    <router-outlet></router-outlet>
+  </mat-tab-nav-panel>
 </section>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -5410,21 +5410,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>WISE Tested</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/teacher-project-library/teacher-project-library.component.ts</context>
-          <context context-type="linenumber">21</context>
+          <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4827877614369437209" datatype="html">
         <source>Community Built</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/teacher-project-library/teacher-project-library.component.ts</context>
-          <context context-type="linenumber">22</context>
+          <context context-type="linenumber">20</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4742841752997470251" datatype="html">
         <source>My Units</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/teacher-project-library/teacher-project-library.component.ts</context>
-          <context context-type="linenumber">23</context>
+          <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a55bfaabb5258f66c2f853ce2383cfead1abd258" datatype="html">


### PR DESCRIPTION
## Changes
- The units (personal, shared, community, library) are only fetched when the teacher accesses the ```/teacher/home/library/*``` routes. Before, we requested it in the run listing page (```/teacher/home/schedule``` route) even though we didn't use it
   - I used [mat-tab-nav-panel](https://material.angular.io/components/tabs/overview#tabs-and-navigation) to make this work 
- Cleaned up code
   - Moved component initialization in TeacherProjectLibraryComponent from constructor to ngOnInit
   - Removed unused code

## Test
- ```/api/project/[personal,shared,community/library]``` routes are *not* requested when teacher loads the home page (run listing page)
- The above routes *are* requested when teacher goes to the "Unit Library" tab
- Both run listing and unit library pages work as before

Closes #663