### PR TITLE
refactor(TeacherRunListItemComponent): Reduce unnecessary computation

### DIFF
--- a/src/app/teacher/create-run-dialog/create-run-dialog.component.spec.ts
+++ b/src/app/teacher/create-run-dialog/create-run-dialog.component.spec.ts
@@ -29,7 +29,7 @@ export class MockTeacherService {
     });
   }
 
-  addNewRun() {}
+  broadcastRunChanges() {}
 
   setTabIndex() {}
 

--- a/src/app/teacher/create-run-dialog/create-run-dialog.component.ts
+++ b/src/app/teacher/create-run-dialog/create-run-dialog.component.ts
@@ -3,11 +3,11 @@ import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dial
 import { FormArray, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { finalize } from 'rxjs/operators';
 import { Project } from '../../domain/project';
-import { Run } from '../../domain/run';
 import { TeacherService } from '../teacher.service';
 import { UserService } from '../../services/user.service';
 import { ConfigService } from '../../services/config.service';
 import { ListClassroomCoursesDialogComponent } from '../list-classroom-courses-dialog/list-classroom-courses-dialog.component';
+import { TeacherRun } from '../teacher-run';
 
 @Component({
   selector: 'create-run-dialog',
@@ -26,7 +26,7 @@ export class CreateRunDialogComponent {
   periodOptions: string[] = [];
   isCreating: boolean = false;
   isCreated: boolean = false;
-  run: Run = null;
+  run: TeacherRun = null;
 
   constructor(
     public dialog: MatDialog,
@@ -125,10 +125,10 @@ export class CreateRunDialogComponent {
           this.isCreating = false;
         })
       )
-      .subscribe((newRun: Run) => {
-        this.run = new Run(newRun);
+      .subscribe((newRun: TeacherRun) => {
+        this.run = new TeacherRun(newRun);
         this.dialogRef.afterClosed().subscribe((result) => {
-          this.teacherService.addNewRun(this.run);
+          this.teacherService.broadcastRunChanges(this.run);
         });
         this.isCreated = true;
       });

--- a/src/app/teacher/run-settings-dialog/run-settings-dialog.component.spec.ts
+++ b/src/app/teacher/run-settings-dialog/run-settings-dialog.component.spec.ts
@@ -3,10 +3,10 @@ import { RunSettingsDialogComponent } from './run-settings-dialog.component';
 import { MatDialogRef, MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { Run } from '../../domain/run';
 import { TeacherService } from '../teacher.service';
 import { Observable } from 'rxjs';
 import { of } from 'rxjs';
+import { TeacherRun } from '../teacher-run';
 
 export class MockTeacherService {
   addPeriodToRun(runId, periodName) {
@@ -66,7 +66,7 @@ describe('RunSettingsDialogComponent', () => {
   };
 
   function createNewRun() {
-    return new Run({
+    return new TeacherRun({
       id: 1,
       name: 'Test Project',
       periods: ['1', '2', '3'],

--- a/src/app/teacher/run-settings-dialog/run-settings-dialog.component.ts
+++ b/src/app/teacher/run-settings-dialog/run-settings-dialog.component.ts
@@ -2,9 +2,9 @@ import { Component, Inject, LOCALE_ID, OnInit } from '@angular/core';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { LibraryProjectDetailsComponent } from '../../modules/library/library-project-details/library-project-details.component';
-import { Run } from '../../domain/run';
 import { TeacherService } from '../teacher.service';
 import { formatDate } from '@angular/common';
+import { TeacherRun } from '../teacher-run';
 
 @Component({
   selector: 'app-run-settings-dialog',
@@ -12,7 +12,7 @@ import { formatDate } from '@angular/common';
   styleUrls: ['./run-settings-dialog.component.scss']
 })
 export class RunSettingsDialogComponent implements OnInit {
-  run: Run;
+  run: TeacherRun;
   newPeriodName: string;
   maxStudentsPerTeam: string;
   startDate: Date;
@@ -94,6 +94,7 @@ export class RunSettingsDialogComponent implements OnInit {
           this.clearNewPeriodInput();
           this.clearErrorMessages();
           this.showConfirmMessage();
+          this.teacherService.broadcastRunChanges(new TeacherRun(this.run));
         } else {
           this.addPeriodMessage = this.translateMessageCode(response.messageCode);
         }
@@ -112,6 +113,7 @@ export class RunSettingsDialogComponent implements OnInit {
             this.updateDataRun(this.run);
             this.clearErrorMessages();
             this.showConfirmMessage();
+            this.teacherService.broadcastRunChanges(new TeacherRun(this.run));
           } else {
             this.deletePeriodMessage = this.translateMessageCode(response.messageCode);
             alert(this.deletePeriodMessage);

--- a/src/app/teacher/share-run-code-dialog/share-run-code-dialog.component.spec.ts
+++ b/src/app/teacher/share-run-code-dialog/share-run-code-dialog.component.spec.ts
@@ -54,7 +54,7 @@ describe('ShareRunCodeDialogComponent', () => {
           { provide: TeacherService, useClass: MockTeacherService },
           { provide: UserService, useClass: MockUserService },
           { provide: MatDialogRef, useValue: {} },
-          { provide: MAT_DIALOG_DATA, useValue: { run: runObj } }
+          { provide: MAT_DIALOG_DATA, useValue: runObj }
         ],
         schemas: [NO_ERRORS_SCHEMA]
       }).compileComponents();

--- a/src/app/teacher/share-run-code-dialog/share-run-code-dialog.component.ts
+++ b/src/app/teacher/share-run-code-dialog/share-run-code-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef, MatDialog } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ConfigService } from '../../services/config.service';
 import { UserService } from '../../services/user.service';
@@ -13,13 +13,11 @@ import { ListClassroomCoursesDialogComponent } from '../list-classroom-courses-d
   styleUrls: ['./share-run-code-dialog.component.scss']
 })
 export class ShareRunCodeDialogComponent {
-  run: TeacherRun;
   code: string;
   link: string;
 
   constructor(
-    private dialogRef: MatDialogRef<ShareRunCodeDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) private data: any,
+    @Inject(MAT_DIALOG_DATA) public run: TeacherRun,
     private dialog: MatDialog,
     private snackBar: MatSnackBar,
     private teacherService: TeacherService,
@@ -28,7 +26,6 @@ export class ShareRunCodeDialogComponent {
   ) {}
 
   ngOnInit() {
-    this.run = new TeacherRun(this.data.run);
     this.code = this.run.runCode;
     const host = this.configService.getWISEHostname() + this.configService.getContextPath();
     this.link = `${host}/login?accessCode=${this.code}`;

--- a/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html
+++ b/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html
@@ -1,7 +1,7 @@
 <ng-template #runInfo>
   <div>
     <span class="more-info"
-          [matTooltip]="periodsString()"
+          [matTooltip]="periodsTooltipText"
           matTooltipPosition="above">
       {{run.periods.length}}
       <ng-container [ngPlural]="run.periods.length">

--- a/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
+++ b/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
@@ -15,12 +15,10 @@ import { ShareRunCodeDialogComponent } from '../share-run-code-dialog/share-run-
   animations: [flash]
 })
 export class TeacherRunListItemComponent implements OnInit {
-  @Input()
-  run: TeacherRun = new TeacherRun();
+  @Input() run: TeacherRun = new TeacherRun();
 
-  editLink: string = '';
-  gradeAndManageLink: string = '';
   manageStudentsLink: string = '';
+  periodsTooltipText: string;
   thumbStyle: SafeStyle;
   animateDuration: string = '0s';
   animateDelay: string = '0s';
@@ -31,28 +29,13 @@ export class TeacherRunListItemComponent implements OnInit {
     private router: Router,
     private elRef: ElementRef,
     private dialog: MatDialog
-  ) {
-    this.sanitizer = sanitizer;
-  }
-
-  getThumbStyle() {
-    const DEFAULT_THUMB = 'assets/img/default-picture.svg';
-    const STYLE = `url(${this.run.project.projectThumb}), url(${DEFAULT_THUMB})`;
-    return this.sanitizer.bypassSecurityTrustStyle(STYLE);
-  }
+  ) {}
 
   ngOnInit() {
     this.run.project.thumbStyle = this.getThumbStyle();
-    const contextPath = this.configService.getContextPath();
-    this.editLink = `${contextPath}/author/authorproject.html?projectId=${this.run.project.id}`;
-    if (this.run.project.wiseVersion === 4) {
-      this.gradeAndManageLink =
-        `${this.configService.getWISE4Hostname()}` +
-        `/teacher/classroomMonitor/classroomMonitor?runId=${this.run.id}&gradingType=monitor`;
-    } else {
-      this.gradeAndManageLink = `${contextPath}/teacher/manage/unit/${this.run.id}`;
-    }
-    this.manageStudentsLink = `${contextPath}/teacher/manage/unit/${this.run.id}/manage-students`;
+    this.manageStudentsLink = `${this.configService.getContextPath()}/teacher/manage/unit/${
+      this.run.id
+    }/manage-students`;
     if (this.run.isHighlighted) {
       this.animateDuration = '2s';
       this.animateDelay = '1s';
@@ -68,15 +51,29 @@ export class TeacherRunListItemComponent implements OnInit {
     }
   }
 
-  launchGradeAndManageTool() {
+  ngOnChanges() {
+    this.periodsTooltipText = this.getPeriodsTooltipText();
+  }
+
+  private getThumbStyle() {
+    const DEFAULT_THUMB = 'assets/img/default-picture.svg';
+    const STYLE = `url(${this.run.project.projectThumb}), url(${DEFAULT_THUMB})`;
+    return this.sanitizer.bypassSecurityTrustStyle(STYLE);
+  }
+
+  launchGradeAndManageTool(): void {
     if (this.run.project.wiseVersion === 4) {
-      window.location.href = this.gradeAndManageLink;
+      window.location.href =
+        `${this.configService.getWISE4Hostname()}` +
+        `/teacher/classroomMonitor/classroomMonitor?runId=${this.run.id}&gradingType=monitor`;
     } else {
-      this.router.navigateByUrl(this.gradeAndManageLink);
+      this.router.navigateByUrl(
+        `${this.configService.getContextPath()}/teacher/manage/unit/${this.run.id}`
+      );
     }
   }
 
-  periodsString() {
+  getPeriodsTooltipText(): string {
     let string = '';
     const length = this.run.periods.length;
     for (let p = 0; p < length; p++) {
@@ -99,9 +96,9 @@ export class TeacherRunListItemComponent implements OnInit {
     return run.isCompleted(this.configService.getCurrentServerTime());
   }
 
-  shareCode() {
+  shareCode(): void {
     this.dialog.open(ShareRunCodeDialogComponent, {
-      data: { run: this.run },
+      data: this.run,
       panelClass: 'dialog-sm'
     });
   }

--- a/src/app/teacher/teacher-run-list/teacher-run-list.component.spec.ts
+++ b/src/app/teacher/teacher-run-list/teacher-run-list.component.spec.ts
@@ -53,7 +53,7 @@ export class MockTeacherService {
       observer.complete();
     });
   }
-  newRunSource$ = fakeAsyncResponse({
+  runs$ = fakeAsyncResponse({
     id: 3,
     name: 'Global Climate Change',
     periods: ['1', '2']

--- a/src/app/teacher/teacher.service.ts
+++ b/src/app/teacher/teacher.service.ts
@@ -7,6 +7,7 @@ import { Teacher } from '../domain/teacher';
 import { Run } from '../domain/run';
 import { Course } from '../domain/course';
 import { CopyProjectDialogComponent } from '../modules/library/copy-project-dialog/copy-project-dialog.component';
+import { TeacherRun } from './teacher-run';
 
 @Injectable()
 export class TeacherService {
@@ -36,8 +37,8 @@ export class TeacherService {
   private addAssignmentUrl = '/api/google-classroom/create-assignment';
   private newProjectSource = new Subject<Project>();
   public newProjectSource$ = this.newProjectSource.asObservable();
-  private newRunSource = new Subject<Run>();
-  public newRunSource$ = this.newRunSource.asObservable();
+  private runs = new Subject<Run>();
+  public runs$ = this.runs.asObservable();
   private updateProfileUrl = '/api/teacher/profile/update';
 
   constructor(private http: HttpClient) {}
@@ -49,14 +50,14 @@ export class TeacherService {
     });
   }
 
-  getRuns(): Observable<Run[]> {
+  getRuns(): Observable<TeacherRun[]> {
     const headers = new HttpHeaders({ 'Cache-Control': 'no-cache' });
-    return this.http.get<Run[]>(this.runsUrl, { headers: headers });
+    return this.http.get<TeacherRun[]>(this.runsUrl, { headers: headers });
   }
 
-  getSharedRuns(): Observable<Run[]> {
+  getSharedRuns(): Observable<TeacherRun[]> {
     const headers = new HttpHeaders({ 'Cache-Control': 'no-cache' });
-    return this.http.get<Run[]>(this.sharedRunsUrl, { headers: headers });
+    return this.http.get<TeacherRun[]>(this.sharedRunsUrl, { headers: headers });
   }
 
   getRun(runId: number): Observable<Run> {
@@ -157,8 +158,8 @@ export class TeacherService {
     return this.http.delete<Object>(url, { headers: headers });
   }
 
-  addNewRun(run: Run) {
-    this.newRunSource.next(run);
+  broadcastRunChanges(run: TeacherRun): void {
+    this.runs.next(run);
   }
 
   updateProfile(

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -7841,42 +7841,42 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>1-3</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.ts</context>
-          <context context-type="linenumber">127</context>
+          <context context-type="linenumber">129</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7492811595508525399" datatype="html">
         <source>Are you sure you want to change the students per team to <x id="maxStudentsPerTeam" equiv-text="maxStudentsPerTeamText"/>?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.ts</context>
-          <context context-type="linenumber">131</context>
+          <context context-type="linenumber">133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="976074716410791729" datatype="html">
         <source>Are you sure you want to change the start date to <x id="startDate" equiv-text="formattedStartDate"/>?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.ts</context>
-          <context context-type="linenumber">162</context>
+          <context context-type="linenumber">164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1070039019925938729" datatype="html">
         <source>Are you sure you want to change the end date to <x id="endDate" equiv-text="formattedEndDate"/>?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.ts</context>
-          <context context-type="linenumber">218</context>
+          <context context-type="linenumber">220</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4810452891345359652" datatype="html">
         <source>Are you sure you want to remove the end date?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.ts</context>
-          <context context-type="linenumber">220</context>
+          <context context-type="linenumber">222</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2262426799118056083" datatype="html">
         <source>Unit settings updated.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-settings-dialog/run-settings-dialog.component.ts</context>
-          <context context-type="linenumber">303</context>
+          <context context-type="linenumber">305</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c76c2eeebe0adc81f3434495d189c56d70899cad" datatype="html">
@@ -7925,7 +7925,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Copied to clipboard.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/share-run-code-dialog/share-run-code-dialog.component.ts</context>
-          <context context-type="linenumber">38</context>
+          <context context-type="linenumber">35</context>
         </context-group>
       </trans-unit>
       <trans-unit id="88d53bd596808b844983e5bb4ec7b23a032ab84b" datatype="html">
@@ -8120,7 +8120,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Class Periods:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2353459e710912ab1e887bf5c0adbeaaf7e6b2af" datatype="html">
@@ -8155,7 +8155,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>All Periods</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list/teacher-run-list.component.ts</context>
-          <context context-type="linenumber">22</context>
+          <context context-type="linenumber">134</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component.ts</context>


### PR DESCRIPTION
## Changes
- Compute gradeAndManageLink only when CM is requested (before: always on component load)
- Compute period strings tooltip ("Class Periods: ...") only on component load and when the run's periods change (before: this was computed in every digest loop)
- Use TeacherService.runs$ observable to send new and updated Runs
- Clean up code

## Test
- You can launch CM via "Teacher Tools" button
- "Class Periods: ..." tooltip displays correctly for each run item
- Class periods tooltip and period filter update correctly when periods are added/deleted from a run
- Search and filter runs work as before

Closes #667