### PR TITLE
fix(UtilService): Handle undefined param in makeCopyOfJSONObject()

### DIFF
--- a/src/app/services/utilService.spec.ts
+++ b/src/app/services/utilService.spec.ts
@@ -85,6 +85,10 @@ function makeCopyOfJSONObjectTests() {
     it('should return null for null input', () => {
       expect(service.makeCopyOfJSONObject(null)).toEqual(null);
     });
+
+    it('should return undefined for undefined input', () => {
+      expect(service.makeCopyOfJSONObject(undefined)).toEqual(undefined);
+    });
   });
 }
 

--- a/src/assets/wise5/services/utilService.ts
+++ b/src/assets/wise5/services/utilService.ts
@@ -62,8 +62,12 @@ export class UtilService {
     return str;
   }
 
-  makeCopyOfJSONObject(jsonObject): any {
-    return JSON.parse(JSON.stringify(jsonObject));
+  makeCopyOfJSONObject(jsonObject: any): any {
+    return this.isUndefined(jsonObject) ? undefined : JSON.parse(JSON.stringify(jsonObject));
+  }
+
+  private isUndefined(value: any): boolean {
+    return typeof value === 'undefined';
   }
 
   getImageObjectFromBase64String(img_b64) {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -16315,21 +16315,21 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">787</context>
+          <context context-type="linenumber">791</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5275881069346355759" datatype="html">
         <source>Auto Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">792</context>
+          <context context-type="linenumber">796</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2692433425768915750" datatype="html">
         <source>Submitted <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">797</context>
+          <context context-type="linenumber">801</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846fecebb7756c6127955bc2c08d2111dce64c3c" datatype="html">


### PR DESCRIPTION
## Changes
- UtilService.makeCopyOfJSONObject(undefined) returns undefined

## Test
- Type in a value in any table cell and save. This should work now. Before it was throwing a js error because UtilService.makeCopyOfJSONObject(undefined) was not properly handled.

Closes #671