### PR TITLE
fix(DataExplorer): Y-axis label text and color inconsistencies

### DIFF
--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
@@ -1846,11 +1846,17 @@ function setYAxisLabelsWhenMultipleYAxes() {
     component.yAxis = [
       {
         title: {
+          style: {
+            color: ''
+          },
           text: ''
         }
       },
       {
         title: {
+          style: {
+            color: ''
+          },
           text: ''
         }
       }

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
@@ -1843,6 +1843,11 @@ function setYAxisLabelsWhenMultipleYAxes() {
   it('should set y axis labels when there are multiple y axes', () => {
     component.yAxis = [
       {
+        labels: {
+          style: {
+            color: ''
+          }
+        },
         title: {
           style: {
             color: ''
@@ -1851,6 +1856,11 @@ function setYAxisLabelsWhenMultipleYAxes() {
         }
       },
       {
+        labels: {
+          style: {
+            color: ''
+          }
+        },
         title: {
           style: {
             color: ''

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -350,6 +350,7 @@ export class GraphStudent extends ComponentStudent {
       for (let [index, yAxis] of Object.entries(this.yAxis)) {
         (yAxis as any).title.text = studentData.dataExplorerYAxisLabels[index];
         (yAxis as any).title.style.color = this.dataExplorerColors[index];
+        (yAxis as any).labels.style.color = this.dataExplorerColors[index];
       }
     }
   }

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -343,12 +343,13 @@ export class GraphStudent extends ComponentStudent {
     return !Array.isArray(yAxis);
   }
 
-  setYAxisLabels(studentData) {
+  setYAxisLabels(studentData: any): void {
     if (this.isSingleYAxis(this.yAxis)) {
       this.yAxis.title.text = studentData.dataExplorerYAxisLabel;
     } else if (studentData.dataExplorerYAxisLabels != null) {
       for (let [index, yAxis] of Object.entries(this.yAxis)) {
         (yAxis as any).title.text = studentData.dataExplorerYAxisLabels[index];
+        (yAxis as any).title.style.color = this.dataExplorerColors[index];
       }
     }
   }

--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -1035,15 +1035,13 @@ export class TableStudent extends ComponentStudent {
     this.studentDataChanged();
   }
 
-  dataExplorerYColumnChanged(index) {
+  dataExplorerYColumnChanged(index: number): void {
     const yColumn = this.dataExplorerSeries[index].yColumn;
     this.dataExplorerSeries[index].name = this.columnNames[yColumn];
     if (!this.isDataExplorerOneYAxis()) {
       this.setDataExplorerSeriesYAxis(index);
     }
-    if (this.isDataExplorerYAxisLabelEmpty(index)) {
-      this.updateDataExplorerYAxisLabel(index, yColumn);
-    }
+    this.updateDataExplorerYAxisLabel(index, yColumn);
     this.studentDataChanged();
   }
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13431,39 +13431,39 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>The series you are trying to add a point to is currently hidden. Please show the series by clicking the series name in the legend and try adding the point again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1071</context>
+          <context context-type="linenumber">1072</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2852989551014711458" datatype="html">
         <source>You can not edit this series. Please choose a series that can be edited.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1085</context>
+          <context context-type="linenumber">1086</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7053114367342967943" datatype="html">
         <source>Are you sure you want to reset the series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1399</context>
+          <context context-type="linenumber">1400</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7889560203726829643" datatype="html">
         <source>Are you sure you want to reset the &quot;<x id="PH" equiv-text="seriesName"/>&quot; series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1401</context>
+          <context context-type="linenumber">1402</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6999515396807067782" datatype="html">
         <source>Trial</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1959</context>
+          <context context-type="linenumber">1960</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">2794</context>
+          <context context-type="linenumber">2795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9070768663485888935" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13431,39 +13431,39 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>The series you are trying to add a point to is currently hidden. Please show the series by clicking the series name in the legend and try adding the point again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1070</context>
+          <context context-type="linenumber">1071</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2852989551014711458" datatype="html">
         <source>You can not edit this series. Please choose a series that can be edited.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1084</context>
+          <context context-type="linenumber">1085</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7053114367342967943" datatype="html">
         <source>Are you sure you want to reset the series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1398</context>
+          <context context-type="linenumber">1399</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7889560203726829643" datatype="html">
         <source>Are you sure you want to reset the &quot;<x id="PH" equiv-text="seriesName"/>&quot; series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1400</context>
+          <context context-type="linenumber">1401</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6999515396807067782" datatype="html">
         <source>Trial</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1958</context>
+          <context context-type="linenumber">1959</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">2793</context>
+          <context context-type="linenumber">2794</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9070768663485888935" datatype="html">


### PR DESCRIPTION
## Changes
- Y-axis label update when choosing different columns
- Y-axis label colors match series color when changing

## Test
- Test selecting different Y-Axis in a Data Explorer activity with multiple y-axis. [Here's an example](https://wise.berkeley.edu/preview/unit/35596/node146). The y-axis label text should update, and its color should match the legend's

Closes #674 