### PR TITLE
feat(TeacherRuns): Combine personal and shared runs requests

### DIFF
--- a/src/app/domain/run.ts
+++ b/src/app/domain/run.ts
@@ -1,6 +1,5 @@
 import { Project } from './project';
 import { User } from './user';
-import { BehaviorSubject } from 'rxjs/internal/BehaviorSubject';
 
 export class Run {
   id: number;
@@ -10,14 +9,12 @@ export class Run {
   endTime: number;
   isLockedAfterEndDate: boolean;
   lastRun: string;
-  projectThumb: string;
   numStudents: number;
   maxStudentsPerTeam: number;
   periods: string[];
   owner: User;
   sharedOwners: User[] = [];
   project: Project;
-  private sharedOwners$: BehaviorSubject<any[]> = new BehaviorSubject<any[]>(this.sharedOwners);
 
   static readonly VIEW_STUDENT_WORK_PERMISSION: number = 1;
   static readonly GRADE_AND_MANAGE_PERMISSION: number = 2;

--- a/src/app/student/student-run-list-item/student-run-list-item.component.spec.ts
+++ b/src/app/student/student-run-list-item/student-run-list-item.component.spec.ts
@@ -59,7 +59,6 @@ describe('StudentRunListItemComponent', () => {
     const owner = new User();
     owner.displayName = 'Mr. Happy';
     run.owner = owner;
-    run.projectThumb = 'Happy.png';
     run.startTime = new Date('2018-10-17T00:00:00.0').getTime();
     const project: Project = new Project();
     project.id = 1;

--- a/src/app/student/student-run-list-item/student-run-list-item.component.ts
+++ b/src/app/student/student-run-list-item/student-run-list-item.component.ts
@@ -17,8 +17,7 @@ import { flash } from '../../animations';
   animations: [flash]
 })
 export class StudentRunListItemComponent implements OnInit {
-  @Input()
-  run: StudentRun = new StudentRun();
+  @Input() run: StudentRun = new StudentRun();
 
   problemLink: string = '';
   thumbStyle: SafeStyle;
@@ -31,14 +30,11 @@ export class StudentRunListItemComponent implements OnInit {
     public dialog: MatDialog,
     private studentService: StudentService,
     private userService: UserService
-  ) {
-    this.sanitizer = sanitizer;
-    this.configService = configService;
-  }
+  ) {}
 
   getThumbStyle() {
     const DEFAULT_THUMB = 'assets/img/default-picture.svg';
-    const STYLE = `url(${this.run.projectThumb}), url(${DEFAULT_THUMB})`;
+    const STYLE = `url(${this.run.project.projectThumb}), url(${DEFAULT_THUMB})`;
     return this.sanitizer.bypassSecurityTrustStyle(STYLE);
   }
 

--- a/src/app/teacher/teacher-run-list/teacher-run-list.component.spec.ts
+++ b/src/app/teacher/teacher-run-list/teacher-run-list.component.spec.ts
@@ -7,6 +7,7 @@ import { TeacherRun } from '../teacher-run';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ConfigService } from '../../services/config.service';
 import { RouterTestingModule } from '@angular/router/testing';
+import { UserService } from '../../services/user.service';
 
 class TeacherScheduleStubComponent {}
 
@@ -46,13 +47,6 @@ export class MockTeacherService {
       observer.complete();
     });
   }
-  getSharedRuns(): Observable<TeacherRun[]> {
-    const runs: TeacherRun[] = [];
-    return Observable.create((observer) => {
-      observer.next(runs);
-      observer.complete();
-    });
-  }
   runs$ = fakeAsyncResponse({
     id: 3,
     name: 'Global Climate Change',
@@ -63,6 +57,12 @@ export class MockTeacherService {
 export class MockConfigService {
   getCurrentServerTime(): number {
     return new Date('2018-08-24T00:00:00.0').getTime();
+  }
+}
+
+export class MockUserService {
+  getUserId(): number {
+    return 1;
   }
 }
 
@@ -81,7 +81,8 @@ describe('TeacherRunListComponent', () => {
         ],
         providers: [
           { provide: TeacherService, useClass: MockTeacherService },
-          { provide: ConfigService, useClass: MockConfigService }
+          { provide: ConfigService, useClass: MockConfigService },
+          { provide: UserService, useClass: MockUserService }
         ],
         schemas: [NO_ERRORS_SCHEMA]
       });

--- a/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
+++ b/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
@@ -42,9 +42,10 @@ export class TeacherRunListComponent implements OnInit {
 
   private getRuns(): void {
     this.teacherService.getRuns().subscribe((runs) => {
+      const userId = this.userService.getUserId();
       this.runs = runs.map((run) => {
         const teacherRun = new TeacherRun(run);
-        teacherRun.shared = !teacherRun.isOwner(this.userService.getUserId());
+        teacherRun.shared = !teacherRun.isOwner(userId);
         return teacherRun;
       });
       this.processRuns();

--- a/src/app/teacher/teacher.service.ts
+++ b/src/app/teacher/teacher.service.ts
@@ -12,7 +12,6 @@ import { TeacherRun } from './teacher-run';
 @Injectable()
 export class TeacherService {
   private runsUrl = '/api/teacher/runs';
-  private sharedRunsUrl = '/api/teacher/sharedruns';
   private registerUrl = '/api/teacher/register';
   private runPermissionUrl = '/api/teacher/run/permission';
   private projectPermissionUrl = '/api/teacher/project/permission';
@@ -53,11 +52,6 @@ export class TeacherService {
   getRuns(): Observable<TeacherRun[]> {
     const headers = new HttpHeaders({ 'Cache-Control': 'no-cache' });
     return this.http.get<TeacherRun[]>(this.runsUrl, { headers: headers });
-  }
-
-  getSharedRuns(): Observable<TeacherRun[]> {
-    const headers = new HttpHeaders({ 'Cache-Control': 'no-cache' });
-    return this.http.get<TeacherRun[]>(this.sharedRunsUrl, { headers: headers });
   }
 
   getRun(runId: number): Observable<Run> {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -8155,7 +8155,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>All Periods</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list/teacher-run-list.component.ts</context>
-          <context context-type="linenumber">134</context>
+          <context context-type="linenumber">132</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component.ts</context>


### PR DESCRIPTION
## Note
- Test this with https://github.com/WISE-Community/WISE-API/pull/154

## Changes
- TeacherRuns: fetch personal and shared runs together in one request to ```/api/teacher/runs```
- StudentRuns: get projectThumb via run.project.projectThumb (before: via run.projectThumb)

## Test
- Teacher run listing works as before. It should now only make one request to ```/api/teacher/runs```, and no request to ```/api/teacher/sharedruns```
- Student run listing works as before and the project thumb appears for each run

Closes #676 
