### PR TITLE
feat(Table): Use Tabulator to display Table component data

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -43,6 +43,7 @@
               { "glob": "**/*", "input": "node_modules/tinymce", "output": "/tinymce/" }
             ],
             "styles": [
+              "./node_modules/tabulator-tables/dist/css/tabulator_semanticui.min.css",
               {
                 "input": "src/style/styles.scss",
                 "bundleName": "siteStyles"

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "sockjs-client": "^1.6.0",
         "svg.draggable.js": "2.2.0",
         "svg.js": "2.7.1",
+        "tabulator-tables": "^5.2.7",
         "tinymce": "^5.10.3",
         "tslib": "^2.3.1",
         "webfontloader": "^1.6.28",
@@ -26452,6 +26453,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/tabulator-tables": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-5.2.7.tgz",
+      "integrity": "sha512-ePCqOdfCm8yas7IkpmUM2ZXvgvGVVo3k4N5Zz9oCuV/Q9ijGlhT+Xgzt6+3FlvGsXgshbiyDkxhy8rOGe7Djyw=="
+    },
     "node_modules/tapable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
@@ -49059,6 +49065,11 @@
           }
         }
       }
+    },
+    "tabulator-tables": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-5.2.7.tgz",
+      "integrity": "sha512-ePCqOdfCm8yas7IkpmUM2ZXvgvGVVo3k4N5Zz9oCuV/Q9ijGlhT+Xgzt6+3FlvGsXgshbiyDkxhy8rOGe7Djyw=="
     },
     "tapable": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "sockjs-client": "^1.6.0",
     "svg.draggable.js": "2.2.0",
     "svg.js": "2.7.1",
+    "tabulator-tables": "^5.2.7",
     "tinymce": "^5.10.3",
     "tslib": "^2.3.1",
     "webfontloader": "^1.6.28",

--- a/src/app/services/sampleData/sample_table_data.json
+++ b/src/app/services/sampleData/sample_table_data.json
@@ -1,0 +1,70 @@
+[
+  [
+    {
+      "text": "Age",
+      "editable": false,
+      "size": null
+    },
+    {
+      "text": "Height",
+      "editable": false,
+      "size": null
+    },
+    {
+      "text": "Hours homework per day",
+      "editable": false,
+      "size": 20
+    }
+  ],
+  [
+    {
+      "text": "6",
+      "editable": false,
+      "size": null
+    },
+    {
+      "text": "36",
+      "editable": true,
+      "size": null
+    },
+    {
+      "text": "",
+      "editable": true,
+      "size": 20
+    }
+  ],
+  [
+    {
+      "text": "10",
+      "editable": false,
+      "size": null
+    },
+    {
+      "text": "",
+      "editable": true,
+      "size": null
+    },
+    {
+      "text": "",
+      "editable": true,
+      "size": 20
+    }
+  ],
+  [
+    {
+      "text": "12",
+      "editable": false,
+      "size": null
+    },
+    {
+      "text": "",
+      "editable": true,
+      "size": null
+    },
+    {
+      "text": "",
+      "editable": true,
+      "size": 20
+    }
+  ]
+]

--- a/src/app/services/tabulatorDataService.spec.ts
+++ b/src/app/services/tabulatorDataService.spec.ts
@@ -1,0 +1,38 @@
+import { TestBed } from '@angular/core/testing';
+import { TabulatorData } from '../../assets/wise5/components/table/TabulatorData';
+import { TabulatorDataService } from '../../assets/wise5/components/table/tabulatorDataService';
+import sampleTableData from './sampleData/sample_table_data.json';
+
+let tabulatorDataService: TabulatorDataService;
+const tableData = sampleTableData;
+const globalCellSize = 10;
+
+describe('TabulatorDataService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      providers: [TabulatorDataService]
+    });
+    tabulatorDataService = TestBed.inject(TabulatorDataService);
+  });
+  convertTableDataToTabulator();
+});
+
+function convertTableDataToTabulator() {
+  describe('convertTableDataToTabulator()', () => {
+    it('should convert table data to TabulatorData', () => {
+      const tabulatorData: TabulatorData = tabulatorDataService.convertTableDataToTabulator(
+        tableData,
+        globalCellSize
+      );
+      expect(tabulatorData.columns.length).toBe(3);
+      expect(tabulatorData.columns[0].title).toBe('Age');
+      expect(tabulatorData.columns[0].field).toBe('0');
+      expect(tabulatorData.columns[2].width).toBe(320);
+      expect(tabulatorData.data.length).toBe(3);
+      expect(tabulatorData.data[1]['0']).toBe('10');
+      expect(tabulatorData.options.maxHeight).toBe('500px');
+      expect(tabulatorData.editableCells[0]).toEqual(['1','2']);
+    });
+  });
+}

--- a/src/app/student-teacher-common-services.module.ts
+++ b/src/app/student-teacher-common-services.module.ts
@@ -45,6 +45,7 @@ import { ComponentServiceLookupService } from '../assets/wise5/services/componen
 import { ComponentTypeService } from '../assets/wise5/services/componentTypeService';
 import { BranchService } from '../assets/wise5/services/branchService';
 import { PathService } from '../assets/wise5/services/pathService';
+import { TabulatorDataService } from '../assets/wise5/components/table/tabulatorDataService';
 
 @NgModule({
   providers: [
@@ -90,6 +91,7 @@ import { PathService } from '../assets/wise5/services/pathService';
     StudentWebSocketService,
     SummaryService,
     TableService,
+    TabulatorDataService,
     TagService,
     UtilService,
     VLEProjectService,

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -304,6 +304,7 @@ export class GraphStudent extends ComponentStudent {
     const graphType = studentData.dataExplorerGraphType;
     this.xAxis.title.text = studentData.dataExplorerXAxisLabel;
     this.setYAxisLabels(studentData);
+    this.setXAxisLabels(studentData);
     this.activeTrial.series = [];
     for (let seriesIndex = 0; seriesIndex < dataExplorerSeries.length; seriesIndex++) {
       const xColumn = dataExplorerSeries[seriesIndex].xColumn;
@@ -362,6 +363,38 @@ export class GraphStudent extends ComponentStudent {
         series.yAxis = 0;
       }
     }
+  }
+
+  setXAxisLabels(studentData: any): void {
+    const thisComponent = this;
+    this.xAxis.labels = {
+      formatter: function () {
+        if (
+          this.value < studentData.tableData.length &&
+          studentData.isDataExplorerEnabled != null &&
+          studentData.dataExplorerSeries != null &&
+          studentData.tableData != null
+        ) {
+          // try to convert the x value number to a category string on the x axis
+          const textValue = thisComponent.getXColumnTextValue(
+            studentData.dataExplorerSeries,
+            studentData.tableData,
+            this.value
+          );
+          if (isNaN(parseFloat(textValue))) {
+            return studentData.tableData[this.value + 1][studentData.dataExplorerSeries[0].xColumn]
+              .text;
+          }
+        }
+        return this.value;
+      }
+    };
+  }
+
+  getXColumnTextValue(dataExplorerSeries: any[], tableData: any[][], value: number): string {
+    const xColumn = dataExplorerSeries[0].xColumn;
+    const dataRow = tableData[value + 1];
+    return dataRow[xColumn].text;
   }
 
   generateDataExplorerSeries(tableData, xColumn, yColumn, graphType, name, color, yAxis) {

--- a/src/assets/wise5/components/graph/graphService.ts
+++ b/src/assets/wise5/components/graph/graphService.ts
@@ -349,7 +349,6 @@ export class GraphService extends ComponentService {
         );
         text += thisGraphService.combineXTextAndYText(xText, yText);
       } else if (thisGraphService.isCategoriesXAxisType(xAxis)) {
-        text = thisGraphService.getSeriesText(this.series);
         const xText = thisGraphService.getXTextForCategoriesGraph(
           this.point,
           this.x,
@@ -357,7 +356,7 @@ export class GraphService extends ComponentService {
           roundValuesTo
         );
         const yText = thisGraphService.getYTextForCategoriesGraph(this.y, roundValuesTo);
-        text += xText + ' ' + yText;
+        text = `<b>${xText}</b><br/>${this.series.name}: <b>${yText}</b>`;
       }
       if (thisGraphService.pointHasCustomTooltip(this.point)) {
         text += '<br/>' + this.point.tooltip;
@@ -389,7 +388,16 @@ export class GraphService extends ComponentService {
     axisObj: any,
     roundValuesTo: string
   ): string {
-    let text = `${this.performRounding(num, roundValuesTo)}`;
+    let text = '';
+    if (
+      series.data[num] != null &&
+      series.data[num].category === num &&
+      series.data[num].name != null
+    ) {
+      text = series.data[num].name;
+    } else {
+      text = `${this.performRounding(num, roundValuesTo)}`;
+    }
     const axisUnits = this.getAxisUnits(series, axisName, axisObj);
     if (axisUnits != null && axisUnits !== '') {
       text += ' ' + axisUnits;
@@ -410,6 +418,8 @@ export class GraphService extends ComponentService {
     const category = this.getCategoryByIndex(point.index, xAxis);
     if (category != null) {
       return category;
+    } else if (point.category === x) {
+      return point.name;
     } else {
       return this.performRounding(x, roundValuesTo);
     }

--- a/src/assets/wise5/components/table/TabulatorData.ts
+++ b/src/assets/wise5/components/table/TabulatorData.ts
@@ -1,0 +1,15 @@
+export class TabulatorData {
+  constructor(
+    public columns: any[] = [], // see http://tabulator.info/docs/5.3/columns
+    public data: any[] = [], // see http://tabulator.info/docs/5.3/data
+    public editableCells: any = {},
+    public options: any = {} // see http://tabulator.info/docs/5.3/options
+  ) {
+    const defaultOptions = {
+      layout: 'fitDataTable',
+      maxHeight: '500px',
+      reactiveData: true
+    };
+    this.options = { ...defaultOptions, ...options };
+  }
+}

--- a/src/assets/wise5/components/table/TabulatorData.ts
+++ b/src/assets/wise5/components/table/TabulatorData.ts
@@ -1,6 +1,6 @@
 export class TabulatorData {
   constructor(
-    public columns: any[] = [], // see http://tabulator.info/docs/5.3/columns
+    public columns: TabulatorColumn[] = [], // see http://tabulator.info/docs/5.3/columns
     public data: any[] = [], // see http://tabulator.info/docs/5.3/data
     public editableCells: any = {},
     public options: any = {} // see http://tabulator.info/docs/5.3/options
@@ -11,5 +11,19 @@ export class TabulatorData {
       reactiveData: true
     };
     this.options = { ...defaultOptions, ...options };
+  }
+}
+
+export class TabulatorColumn {
+  title: string;
+  field: string;
+  width: number | string; // number of pixels or percent of table width (e.g. '20%')
+
+  constructor(jsonObject: any = {}) {
+    for (const key of Object.keys(jsonObject)) {
+      if (jsonObject[key] != null) {
+        this[key] = jsonObject[key];
+      }
+    }
   }
 }

--- a/src/assets/wise5/components/table/TabulatorData.ts
+++ b/src/assets/wise5/components/table/TabulatorData.ts
@@ -1,3 +1,5 @@
+import { Tabulator } from 'tabulator-tables';
+
 export class TabulatorData {
   constructor(
     public columns: TabulatorColumn[] = [], // see http://tabulator.info/docs/5.3/columns
@@ -18,6 +20,11 @@ export class TabulatorColumn {
   title: string;
   field: string;
   width: number | string; // number of pixels or percent of table width (e.g. '20%')
+  editor: string;
+  editable: (cell: Tabulator.CellComponent) => boolean;
+  formatter: (cell: Tabulator.CellComponent) => any;
+  sorter: string;
+  sorterParams: any;
 
   constructor(jsonObject: any = {}) {
     for (const key of Object.keys(jsonObject)) {

--- a/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.ts
+++ b/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.ts
@@ -11,7 +11,7 @@ import { UtilService } from '../../../services/utilService';
   styleUrls: ['edit-table-advanced.component.scss']
 })
 export class EditTableAdvancedComponent extends EditAdvancedComponentComponent {
-  MAX_ALLOWED_CELLS_IN_IMPORT = 500;
+  MAX_ALLOWED_CELLS_IN_IMPORT = 2000;
 
   allowedConnectedComponentTypes = ['Embedded', 'Graph', 'Table'];
   columnNames: string[] = [];

--- a/src/assets/wise5/components/table/table-common.module.ts
+++ b/src/assets/wise5/components/table/table-common.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { TabulatorTableComponent } from './tabulator-table/tabulator-table.component';
+
+@NgModule({
+  declarations: [TabulatorTableComponent],
+  imports: [],
+  exports: [TabulatorTableComponent]
+})
+export class TableCommonModule {}

--- a/src/assets/wise5/components/table/table-grading/table-grading.module.ts
+++ b/src/assets/wise5/components/table/table-grading/table-grading.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
+import { TableCommonModule } from '../table-common.module';
 import { TableShowWorkModule } from '../table-show-work/table-show-work.module';
 import { TableGradingComponent } from './table-grading.component';
 
 @NgModule({
   declarations: [TableGradingComponent],
-  imports: [TableShowWorkModule],
+  imports: [TableShowWorkModule, TableCommonModule],
   exports: [TableGradingComponent]
 })
 export class TableGradingModule {}

--- a/src/assets/wise5/components/table/table-show-work/table-show-work.component.html
+++ b/src/assets/wise5/components/table/table-show-work/table-show-work.component.html
@@ -1,24 +1,9 @@
 <div class="table-container">
-  <table class="table">
-    <tbody>
-      <tr *ngFor="let row of tableData">
-        <td *ngFor="let cell of row"
-          class="table-cell"
-          style="width: {{cell.size || componentContent.globalCellSize}}em; max-width: {{cell.size || componentContent.globalCellSize}}em">
-          <mat-form-field *ngIf="cell.editable"
-              class="cell-input form-field-no-label form-field-no-hint"
-              appearance="outline">
-            <input matInput
-                [ngModel]="cell.text"
-                [disabled]="true"
-                i18n-aria-label
-                aria-label="Cell content"/>
-          </mat-form-field>
-          <ng-container *ngIf="!cell.editable">{{cell.text}}</ng-container>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+  <tabulator-table [editableCells]="tabulatorData.editableCells"
+      [isDisabled]="true"
+      [tabColumns]="tabulatorData.columns"
+      [tabData]="tabulatorData.data"
+      [tabOptions]="tabulatorData.options"></tabulator-table>
 </div>
 <ng-container *ngIf="componentContent.isDataExplorerEnabled">
   <br />

--- a/src/assets/wise5/components/table/table-show-work/table-show-work.component.spec.ts
+++ b/src/assets/wise5/components/table/table-show-work/table-show-work.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { ProjectService } from '../../../services/projectService';
+import { TabulatorDataService } from '../tabulatorDataService';
 import { TableShowWorkComponent } from './table-show-work.component';
 
 let fixture: ComponentFixture<TableShowWorkComponent>;
@@ -26,10 +27,9 @@ describe('TableShowWorkComponent', () => {
     fixture.detectChanges();
     component.componentContent = { globalCellSize: 10 };
   });
-
-  injectCellWidths();
-  calculateCellWidth();
+  
   calculateColumnNames();
+  setupTable();
 });
 
 function createCell(text: string): any {
@@ -42,41 +42,6 @@ function createComponentState(tableData: any): any {
       tableData: tableData
     }
   };
-}
-
-function injectCellWidths() {
-  describe('injectCellWidths', () => {
-    it('should inject cell widths', () => {
-      const tableData: any[] = [
-        [{}, {}],
-        [{}, {}]
-      ];
-      const expectedWidth = 100;
-      expect(tableData[0][0].width).toBeUndefined();
-      expect(tableData[0][1].width).toBeUndefined();
-      expect(tableData[1][0].width).toBeUndefined();
-      expect(tableData[1][1].width).toBeUndefined();
-      component.injectCellWidths(tableData);
-      expect(tableData[0][0].width).toEqual(expectedWidth);
-      expect(tableData[0][1].width).toEqual(expectedWidth);
-      expect(tableData[1][0].width).toEqual(expectedWidth);
-      expect(tableData[1][1].width).toEqual(expectedWidth);
-    });
-  });
-}
-
-function calculateCellWidth() {
-  describe('calculateCellWidth', () => {
-    it('should calculate cell width when it has none', () => {
-      const cell = {};
-      expect(component.calculateCellWidth(cell)).toEqual(100);
-    });
-
-    it('should calculate cell width when it cell has a size set', () => {
-      const cell = { size: 20 };
-      expect(component.calculateCellWidth(cell)).toEqual(200);
-    });
-  });
 }
 
 function calculateColumnNames() {
@@ -93,6 +58,20 @@ function calculateColumnNames() {
       expect(columnNames.length).toEqual(2);
       expect(columnNames[0]).toEqual(columnName1);
       expect(columnNames[1]).toEqual(columnName2);
+    });
+  });
+}
+
+function setupTable() {
+  describe('setupTable', () => {
+    it('should setup table', () => {
+      component.tableData = null;
+      const convertTableDataToTabulatorSpy = spyOn(
+        TestBed.inject(TabulatorDataService),
+        'convertTableDataToTabulator'
+      );
+      component.setupTable();
+      expect(convertTableDataToTabulatorSpy).toHaveBeenCalled();
     });
   });
 }

--- a/src/assets/wise5/components/table/table-show-work/table-show-work.component.ts
+++ b/src/assets/wise5/components/table/table-show-work/table-show-work.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
 import { ProjectService } from '../../../services/projectService';
 import { ComponentShowWorkDirective } from '../../component-show-work.directive';
+import { TableService } from '../tableService';
+import { TabulatorData } from '../TabulatorData';
 
 @Component({
   selector: 'table-show-work',
@@ -19,8 +21,9 @@ export class TableShowWorkComponent extends ComponentShowWorkDirective {
   minCellSize: number = 3;
   cellSizeToPixelsMultiplier: number = 10;
   noneText: string = $localize`(None)`;
+  tabulatorData: TabulatorData;
 
-  constructor(protected ProjectService: ProjectService) {
+  constructor(protected ProjectService: ProjectService, private TableService: TableService) {
     super(ProjectService);
   }
 
@@ -38,6 +41,7 @@ export class TableShowWorkComponent extends ComponentShowWorkDirective {
       this.xColumnIndex = this.calculateXColumnIndex(this.componentState);
       this.columnNames = this.calculateColumnNames(this.componentState);
     }
+    this.tabulatorData = this.TableService.convertTableDataToTabulator(this.tableData);
   }
 
   injectCellWidths(tableData: any[]): any[] {

--- a/src/assets/wise5/components/table/table-show-work/table-show-work.component.ts
+++ b/src/assets/wise5/components/table/table-show-work/table-show-work.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { ProjectService } from '../../../services/projectService';
 import { ComponentShowWorkDirective } from '../../component-show-work.directive';
-import { TableService } from '../tableService';
+import { TabulatorDataService } from '../tabulatorDataService';
 import { TabulatorData } from '../TabulatorData';
 
 @Component({
@@ -10,7 +10,7 @@ import { TabulatorData } from '../TabulatorData';
   styleUrls: ['../table-student/table-student.component.scss', 'table-show-work.component.scss']
 })
 export class TableShowWorkComponent extends ComponentShowWorkDirective {
-  tableData: any[];
+  tableData: any[] = [];
   dataExplorerGraphType: string;
   dataExplorerSeries: any[];
   dataExplorerXAxisLabel: string;
@@ -21,7 +21,7 @@ export class TableShowWorkComponent extends ComponentShowWorkDirective {
   noneText: string = $localize`(None)`;
   tabulatorData: TabulatorData;
 
-  constructor(protected ProjectService: ProjectService, private TableService: TableService) {
+  constructor(protected ProjectService: ProjectService, private TabulatorDataService: TabulatorDataService) {
     super(ProjectService);
   }
 
@@ -38,10 +38,7 @@ export class TableShowWorkComponent extends ComponentShowWorkDirective {
       this.xColumnIndex = this.calculateXColumnIndex(this.componentState);
       this.columnNames = this.calculateColumnNames(this.componentState);
     }
-    this.tabulatorData = this.TableService.convertTableDataToTabulator(
-      this.tableData,
-      this.componentContent.globalCellSize
-    );
+    this.setupTable()
   }
 
   calculateXColumnIndex(componentState: any): number {
@@ -56,5 +53,12 @@ export class TableShowWorkComponent extends ComponentShowWorkDirective {
       columnNames.push(cell.text);
     }
     return columnNames;
+  }
+
+  setupTable(): void {
+    this.tabulatorData = this.TabulatorDataService.convertTableDataToTabulator(
+      this.tableData,
+      this.componentContent.globalCellSize
+    );
   }
 }

--- a/src/assets/wise5/components/table/table-show-work/table-show-work.component.ts
+++ b/src/assets/wise5/components/table/table-show-work/table-show-work.component.ts
@@ -18,8 +18,6 @@ export class TableShowWorkComponent extends ComponentShowWorkDirective {
   dataExplorerYAxisLabels: string[];
   xColumnIndex: number;
   columnNames: string[] = [];
-  minCellSize: number = 3;
-  cellSizeToPixelsMultiplier: number = 10;
   noneText: string = $localize`(None)`;
   tabulatorData: TabulatorData;
 
@@ -31,7 +29,6 @@ export class TableShowWorkComponent extends ComponentShowWorkDirective {
     super.ngOnInit();
     const studentData = this.componentState.studentData;
     this.tableData = studentData.tableData;
-    this.injectCellWidths(this.tableData);
     if (studentData.isDataExplorerEnabled) {
       this.dataExplorerGraphType = studentData.dataExplorerGraphType;
       this.dataExplorerSeries = studentData.dataExplorerSeries;
@@ -41,27 +38,10 @@ export class TableShowWorkComponent extends ComponentShowWorkDirective {
       this.xColumnIndex = this.calculateXColumnIndex(this.componentState);
       this.columnNames = this.calculateColumnNames(this.componentState);
     }
-    this.tabulatorData = this.TableService.convertTableDataToTabulator(this.tableData);
-  }
-
-  injectCellWidths(tableData: any[]): any[] {
-    tableData.forEach((row: any) => {
-      row.forEach((cell: any) => {
-        cell.width = this.calculateCellWidth(cell);
-      });
-    });
-    return tableData;
-  }
-
-  calculateCellWidth(cell: any): number {
-    let size = this.componentContent.globalCellSize;
-    if (cell.size != null) {
-      size = cell.size;
-    }
-    if (size < this.minCellSize) {
-      size = this.minCellSize;
-    }
-    return size * this.cellSizeToPixelsMultiplier;
+    this.tabulatorData = this.TableService.convertTableDataToTabulator(
+      this.tableData,
+      this.componentContent.globalCellSize
+    );
   }
 
   calculateXColumnIndex(componentState: any): number {

--- a/src/assets/wise5/components/table/table-show-work/table-show-work.module.ts
+++ b/src/assets/wise5/components/table/table-show-work/table-show-work.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { StudentTeacherCommonModule } from '../../../../../app/student-teacher-common.module';
+import { TableCommonModule } from '../table-common.module';
 import { TableShowWorkComponent } from './table-show-work.component';
 
 @NgModule({
   declarations: [TableShowWorkComponent],
-  imports: [StudentTeacherCommonModule],
+  imports: [StudentTeacherCommonModule, TableCommonModule],
   exports: [TableShowWorkComponent]
 })
 export class TableShowWorkModule {}

--- a/src/assets/wise5/components/table/table-student/table-student.component.html
+++ b/src/assets/wise5/components/table/table-student/table-student.component.html
@@ -30,7 +30,11 @@
     Import Data
   </button>
 </div>
-<tabulator-table [id]="tableId" [tabData]="tabulatorData"></tabulator-table>
+<tabulator-table [id]="tableId"
+    [editableCells]="tabulatorData.editableCells"
+    [tabColumns]="tabulatorData.columns"
+    [tabData]="tabulatorData.data"
+    [tabOptions]="tabulatorData.options"></tabulator-table>
 <div *ngIf="isDataExplorerEnabled">
   <br/>
   <mat-form-field *ngIf="componentContent.dataExplorerGraphTypes.length > 1" appearance="fill">

--- a/src/assets/wise5/components/table/table-student/table-student.component.html
+++ b/src/assets/wise5/components/table/table-student/table-student.component.html
@@ -34,7 +34,8 @@
     [editableCells]="tabulatorData.editableCells"
     [tabColumns]="tabulatorData.columns"
     [tabData]="tabulatorData.data"
-    [tabOptions]="tabulatorData.options"></tabulator-table>
+    [tabOptions]="tabulatorData.options"
+    (cellChanged)="tabulatorCellChanged($event)"></tabulator-table>
 <div *ngIf="isDataExplorerEnabled">
   <br/>
   <mat-form-field *ngIf="componentContent.dataExplorerGraphTypes.length > 1" appearance="fill">

--- a/src/assets/wise5/components/table/table-student/table-student.component.html
+++ b/src/assets/wise5/components/table/table-student/table-student.component.html
@@ -30,29 +30,7 @@
     Import Data
   </button>
 </div>
-<div class="table-container">
-  <table [id]="tableId" class="table">
-    <tr *ngFor="let row of getTableDataRows()">
-      <td *ngFor="let cell of row"
-          class="table-cell"
-          style="width: {{cell.size || componentContent.globalCellSize}}em; max-width: {{cell.size || componentContent.globalCellSize}}em">
-        <mat-form-field *ngIf="cell.editable"
-            class="cell-input form-field-no-label form-field-no-hint"
-            appearance="outline">
-          <textarea cdkTextareaAutosize
-              matInput
-              type="text"
-              [(ngModel)]="cell.text"
-              (ngModelChange)="studentDataChanged()"
-              [disabled]="isDisabled"
-              i18n-aria-label
-              aria-label="Cell content"></textarea>
-        </mat-form-field>
-        <ng-container *ngIf="!cell.editable">{{cell.text}}</ng-container>
-      </td>
-    </tr>
-  </table>
-</div>
+<tabulator-table [id]="tableId" [tabData]="tabulatorData"></tabulator-table>
 <div *ngIf="isDataExplorerEnabled">
   <br/>
   <mat-form-field *ngIf="componentContent.dataExplorerGraphTypes.length > 1" appearance="fill">

--- a/src/assets/wise5/components/table/table-student/table-student.component.scss
+++ b/src/assets/wise5/components/table/table-student/table-student.component.scss
@@ -1,24 +1,3 @@
 .tools {
   margin-bottom: 8px;
 }
-
-.table-container {
-  overflow-x: auto;
-  margin-top: 16px;
-  padding: 8px 0;
-}
-
-.table {
-  border-spacing: 0;
-  border-collapse: collapse;
-}
-
-.table-cell {
-  border: 1px solid #dddddd;
-  padding: 8px;
-
-}
-
-.cell-input {
-  width: 100%;
-}

--- a/src/assets/wise5/components/table/table-student/table-student.component.spec.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.spec.ts
@@ -8,6 +8,7 @@ import { StudentTeacherCommonServicesModule } from '../../../../../app/student-t
 import { AnnotationService } from '../../../services/annotationService';
 import { ProjectService } from '../../../services/projectService';
 import { UtilService } from '../../../services/utilService';
+import { TabulatorDataService } from '../tabulatorDataService';
 import { TableStudent } from './table-student.component';
 
 let component: TableStudent;
@@ -171,7 +172,12 @@ function setupTable() {
   describe('setupTable', () => {
     it('should setup table', () => {
       component.tableData = null;
+      const convertTableDataToTabulatorSpy = spyOn(
+        TestBed.inject(TabulatorDataService),
+        'convertTableDataToTabulator'
+      );
       component.setupTable();
+      expect(convertTableDataToTabulatorSpy).toHaveBeenCalled();
       expect(component.tableData).toEqual(createTestTableData());
     });
   });
@@ -197,8 +203,13 @@ function resetTable() {
     it('should reset table', () => {
       component.tableData = createTestTableData();
       component.tableData[0][0].text = 'Time2';
+      const convertTableDataToTabulatorSpy = spyOn(
+        TestBed.inject(TabulatorDataService),
+        'convertTableDataToTabulator'
+      );
       component.resetTable();
       expect(component.tableData[0][0].text).toEqual('Time');
+      expect(convertTableDataToTabulatorSpy).toHaveBeenCalled();
     });
   });
 }
@@ -567,8 +578,13 @@ function handleConnectedComponents() {
         }
       ]);
       component.tableData = null;
+      const convertTableDataToTabulatorSpy = spyOn(
+        TestBed.inject(TabulatorDataService),
+        'convertTableDataToTabulator'
+      );
       component.handleConnectedComponents();
       expectTableDataEquals(component.tableData, testTableData, true);
+      expect(convertTableDataToTabulatorSpy).toHaveBeenCalled();
     });
     it('should handle graph connected component', () => {
       spyOn(component, 'getConnectedComponentsAndTheirComponentStates').and.returnValue([

--- a/src/assets/wise5/components/table/table-student/table-student.component.spec.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.spec.ts
@@ -597,6 +597,10 @@ function handleConnectedComponents() {
           ])
         }
       ]);
+      const convertTableDataToTabulatorSpy = spyOn(
+        TestBed.inject(TabulatorDataService),
+        'convertTableDataToTabulator'
+      );
       component.handleConnectedComponents();
       const expectedTableData = createTableData([
         ['Time', 'Position', 'Speed'],
@@ -605,6 +609,7 @@ function handleConnectedComponents() {
         ['2', '20', '10']
       ]);
       expectTableDataEquals(component.tableData, expectedTableData, true);
+      expect(convertTableDataToTabulatorSpy).toHaveBeenCalled();
     });
     it('should handle embedded connected component', () => {
       const tableData = createTableData([
@@ -617,8 +622,13 @@ function handleConnectedComponents() {
           componentState: createEmbeddedComponentState(tableData)
         }
       ]);
+      const convertTableDataToTabulatorSpy = spyOn(
+        TestBed.inject(TabulatorDataService),
+        'convertTableDataToTabulator'
+      );
       component.handleConnectedComponents();
       expectTableDataEquals(component.tableData, tableData, true);
+      expect(convertTableDataToTabulatorSpy).toHaveBeenCalled();
     });
   });
 }

--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -12,6 +12,7 @@ import { ComponentStudent } from '../../component-student.component';
 import { ComponentService } from '../../componentService';
 import { TableService } from '../tableService';
 import { MatDialog } from '@angular/material/dialog';
+import { TabulatorData } from '../TabulatorData';
 
 @Component({
   selector: 'table-student',
@@ -40,6 +41,7 @@ export class TableStudent extends ComponentStudent {
   numDataExplorerSeries: number;
   tableData: any;
   tableId: string;
+  tabulatorData: TabulatorData;
 
   constructor(
     protected AnnotationService: AnnotationService,
@@ -323,6 +325,7 @@ export class TableStudent extends ComponentStudent {
        */
       this.tableData = this.getCopyOfTableData(this.componentContent.tableData);
     }
+    this.tabulatorData = this.TableService.convertTableDataToTabulator(this.tableData);
   }
 
   /**

--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -1168,6 +1168,7 @@ export class TableStudent extends ComponentStudent {
         componentId: this.componentId
       });
     }
+    this.setTabulatorData();
   }
 
   attachStudentAsset(studentAsset: any): void {

--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -14,6 +14,7 @@ import { ComponentService } from '../../componentService';
 import { TableService } from '../tableService';
 import { MatDialog } from '@angular/material/dialog';
 import { TabulatorData } from '../TabulatorData';
+import { TabulatorDataService } from '../tabulatorDataService';
 
 @Component({
   selector: 'table-student',
@@ -55,6 +56,7 @@ export class TableStudent extends ComponentStudent {
     protected StudentAssetService: StudentAssetService,
     protected StudentDataService: StudentDataService,
     private TableService: TableService,
+    private TabulatorDataService: TabulatorDataService,
     protected UtilService: UtilService
   ) {
     super(
@@ -1173,7 +1175,7 @@ export class TableStudent extends ComponentStudent {
   }
 
   private setTabulatorData(): void {
-    this.tabulatorData = this.TableService.convertTableDataToTabulator(
+    this.tabulatorData = this.TabulatorDataService.convertTableDataToTabulator(
       this.tableData,
       this.componentContent.globalCellSize
     );

--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -1,5 +1,6 @@
 import * as html2canvas from 'html2canvas';
 import { Component, ViewEncapsulation } from '@angular/core';
+import { Tabulator } from 'tabulator-tables';
 import { AnnotationService } from '../../../services/annotationService';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
@@ -1168,4 +1169,11 @@ export class TableStudent extends ComponentStudent {
   attachStudentAsset(studentAsset: any): void {
     // TODO: make sure the asset is a csv file then populate the csv data into the table
   }
+
+  tabulatorCellChanged(cell: Tabulator.CellComponent): void {
+    const columnIndex = parseInt(cell.getColumn().getField());
+    const rowIndex = cell.getRow().getPosition() + 1;
+    this.tableData[rowIndex][columnIndex].text = cell.getValue();
+    this.studentDataChanged();
+  };
 }

--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -326,10 +326,7 @@ export class TableStudent extends ComponentStudent {
        */
       this.tableData = this.getCopyOfTableData(this.componentContent.tableData);
     }
-    this.tabulatorData = this.TableService.convertTableDataToTabulator(
-      this.tableData,
-      this.componentContent.globalCellSize
-    );
+    this.setTabulatorData();
   }
 
   /**
@@ -358,6 +355,7 @@ export class TableStudent extends ComponentStudent {
           this.setDataExplorerDataToColumn();
         }
       }
+      this.setTabulatorData();
       this.studentDataChanged();
     }
   }
@@ -930,6 +928,7 @@ export class TableStudent extends ComponentStudent {
       }
     }
     if (isStudentDataChanged) {
+      this.setTabulatorData();
       this.studentDataChanged();
     }
   }
@@ -1171,6 +1170,13 @@ export class TableStudent extends ComponentStudent {
 
   attachStudentAsset(studentAsset: any): void {
     // TODO: make sure the asset is a csv file then populate the csv data into the table
+  }
+
+  private setTabulatorData(): void {
+    this.tabulatorData = this.TableService.convertTableDataToTabulator(
+      this.tableData,
+      this.componentContent.globalCellSize
+    );
   }
 
   tabulatorCellChanged(cell: Tabulator.CellComponent): void {

--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -326,7 +326,10 @@ export class TableStudent extends ComponentStudent {
        */
       this.tableData = this.getCopyOfTableData(this.componentContent.tableData);
     }
-    this.tabulatorData = this.TableService.convertTableDataToTabulator(this.tableData);
+    this.tabulatorData = this.TableService.convertTableDataToTabulator(
+      this.tableData,
+      this.componentContent.globalCellSize
+    );
   }
 
   /**

--- a/src/assets/wise5/components/table/table-student/table-student.module.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.module.ts
@@ -1,11 +1,12 @@
 import { NgModule } from '@angular/core';
 import { StudentTeacherCommonModule } from '../../../../../app/student-teacher-common.module';
 import { StudentComponentModule } from '../../../../../app/student/student.component.module';
+import { TabulatorTableComponent } from '../tabulator-table/tabulator-table.component';
 import { TableStudent } from './table-student.component';
 
 @NgModule({
-  declarations: [TableStudent],
+  declarations: [TableStudent, TabulatorTableComponent],
   imports: [StudentTeacherCommonModule, StudentComponentModule],
-  exports: [TableStudent]
+  exports: [TableStudent, TabulatorTableComponent]
 })
 export class TableStudentModule {}

--- a/src/assets/wise5/components/table/table-student/table-student.module.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.module.ts
@@ -1,12 +1,12 @@
 import { NgModule } from '@angular/core';
 import { StudentTeacherCommonModule } from '../../../../../app/student-teacher-common.module';
 import { StudentComponentModule } from '../../../../../app/student/student.component.module';
-import { TabulatorTableComponent } from '../tabulator-table/tabulator-table.component';
+import { TableCommonModule } from '../table-common.module';
 import { TableStudent } from './table-student.component';
 
 @NgModule({
-  declarations: [TableStudent, TabulatorTableComponent],
-  imports: [StudentTeacherCommonModule, StudentComponentModule],
-  exports: [TableStudent, TabulatorTableComponent]
+  declarations: [TableStudent],
+  imports: [StudentTeacherCommonModule, StudentComponentModule, TableCommonModule],
+  exports: [TableStudent]
 })
 export class TableStudentModule {}

--- a/src/assets/wise5/components/table/tableService.ts
+++ b/src/assets/wise5/components/table/tableService.ts
@@ -5,6 +5,7 @@ import { ComponentService } from '../componentService';
 import { StudentAssetService } from '../../services/studentAssetService';
 import { UtilService } from '../../services/utilService';
 import { Injectable } from '@angular/core';
+import { TabulatorData } from './TabulatorData';
 
 @Injectable()
 export class TableService extends ComponentService {
@@ -275,5 +276,45 @@ export class TableService extends ComponentService {
       }
     }
     return false;
+  }
+
+  convertTableDataToTabulator(tableData): TabulatorData {
+    const content = new TabulatorData();
+    content.columns = this.getTabulatorColumnsFromTable(tableData);
+    for (const [index, row] of tableData.entries()) {
+      if (index > 0) {
+        const rowData = this.getTabulatorRowDataFromTableRow(row, content.columns)
+        content.data.push(rowData.values);
+        content.editableCells[index-1] = rowData.editableCells;
+      }
+    }
+    return content;
+  }
+
+  private getTabulatorColumnsFromTable(tableData: any[]): any {
+    let columns = [];
+    const columnDefs = tableData[0];
+    columnDefs.forEach((columnDef, index) => {
+      columns.push({
+        title: columnDef.text,
+        field: `column-${index}`
+      });
+    });
+    return columns;
+  }
+
+  private getTabulatorRowDataFromTableRow(tableRow, columns): any {
+    let rowData = {
+      values: [],
+      editableCells: []
+    };
+    tableRow.forEach((cell, index) => {
+      const field = columns[index].field;
+      rowData.values[field] = cell.text;
+      if (cell.editable) {
+        rowData.editableCells.push(field);
+      }
+    });
+    return rowData;
   }
 }

--- a/src/assets/wise5/components/table/tableService.ts
+++ b/src/assets/wise5/components/table/tableService.ts
@@ -278,9 +278,9 @@ export class TableService extends ComponentService {
     return false;
   }
 
-  convertTableDataToTabulator(tableData): TabulatorData {
+  convertTableDataToTabulator(tableData: any, globalCellSize: number): TabulatorData {
     const content = new TabulatorData();
-    content.columns = this.getTabulatorColumnsFromTable(tableData);
+    content.columns = this.getTabulatorColumnsFromTable(tableData, globalCellSize);
     for (const [index, row] of tableData.entries()) {
       if (index > 0) {
         const rowData = this.getTabulatorRowDataFromTableRow(row, content.columns)
@@ -291,16 +291,36 @@ export class TableService extends ComponentService {
     return content;
   }
 
-  private getTabulatorColumnsFromTable(tableData: any[]): any {
+  private getTabulatorColumnsFromTable(tableData: any[], globalCellSize: number): any {
     let columns = [];
     const columnDefs = tableData[0];
     columnDefs.forEach((columnDef, index) => {
-      columns.push({
-        title: columnDef.text,
-        field: `column-${index}`
-      });
+      columns.push(this.getTabulatorColumn(columnDef, index, globalCellSize))
     });
     return columns;
+  }
+
+  private getTabulatorColumn(columnDef: any, index: number, globalCellSize: number): any {
+    const column: any = {
+      title: columnDef.text,
+      field: `${index}`
+    };
+    const width: number = this.getTabulatorColumnWidth(columnDef, globalCellSize);
+    if (width) {
+      column.width = width;
+    }
+    return column;
+  }
+
+  private getTabulatorColumnWidth(columnDef: any, globalCellSize: number): number {
+    let width: number = null;
+    const legacyWidth: number = columnDef.size ? columnDef.size : globalCellSize;
+    if (columnDef.width) {
+      width = columnDef.width;
+    } else if (legacyWidth && legacyWidth !== 10) {
+      width = legacyWidth * 16; // approzimate conversion of legacy column size based on em measurements
+    }
+    return width;
   }
 
   private getTabulatorRowDataFromTableRow(tableRow, columns): any {

--- a/src/assets/wise5/components/table/tableService.ts
+++ b/src/assets/wise5/components/table/tableService.ts
@@ -5,12 +5,9 @@ import { ComponentService } from '../componentService';
 import { StudentAssetService } from '../../services/studentAssetService';
 import { UtilService } from '../../services/utilService';
 import { Injectable } from '@angular/core';
-import { TabulatorData } from './TabulatorData';
 
 @Injectable()
 export class TableService extends ComponentService {
-  $translate: any;
-
   constructor(
     private StudentAssetService: StudentAssetService,
     protected UtilService: UtilService
@@ -276,65 +273,5 @@ export class TableService extends ComponentService {
       }
     }
     return false;
-  }
-
-  convertTableDataToTabulator(tableData: any, globalCellSize: number): TabulatorData {
-    const content = new TabulatorData();
-    content.columns = this.getTabulatorColumnsFromTable(tableData, globalCellSize);
-    for (const [index, row] of tableData.entries()) {
-      if (index > 0) {
-        const rowData = this.getTabulatorRowDataFromTableRow(row, content.columns)
-        content.data.push(rowData.values);
-        content.editableCells[index-1] = rowData.editableCells;
-      }
-    }
-    return content;
-  }
-
-  private getTabulatorColumnsFromTable(tableData: any[], globalCellSize: number): any {
-    let columns = [];
-    const columnDefs = tableData[0];
-    columnDefs.forEach((columnDef, index) => {
-      columns.push(this.getTabulatorColumn(columnDef, index, globalCellSize))
-    });
-    return columns;
-  }
-
-  private getTabulatorColumn(columnDef: any, index: number, globalCellSize: number): any {
-    const column: any = {
-      title: columnDef.text,
-      field: `${index}`
-    };
-    const width: number = this.getTabulatorColumnWidth(columnDef, globalCellSize);
-    if (width) {
-      column.width = width;
-    }
-    return column;
-  }
-
-  private getTabulatorColumnWidth(columnDef: any, globalCellSize: number): number {
-    let width: number = null;
-    const legacyWidth: number = columnDef.size ? columnDef.size : globalCellSize;
-    if (columnDef.width) {
-      width = columnDef.width;
-    } else if (legacyWidth && legacyWidth !== 10) {
-      width = legacyWidth * 16; // approzimate conversion of legacy column size based on em measurements
-    }
-    return width;
-  }
-
-  private getTabulatorRowDataFromTableRow(tableRow, columns): any {
-    let rowData = {
-      values: [],
-      editableCells: []
-    };
-    tableRow.forEach((cell, index) => {
-      const field = columns[index].field;
-      rowData.values[field] = cell.text;
-      if (cell.editable) {
-        rowData.editableCells.push(field);
-      }
-    });
-    return rowData;
   }
 }

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.html
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.html
@@ -1,0 +1,1 @@
+<div #table></div>

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.scss
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.scss
@@ -1,0 +1,41 @@
+.tabulator {
+  width: auto;
+  max-width: 100%;
+
+  .tabulator-header {
+    font-weight: 500;
+  }
+}
+
+.tabulator-row .tabulator-cell {
+  min-height: 44px; // temporary hack to fix height for some rows with empty cell values; TODO: investigate and fix
+
+  &.tabulator-cell-editable {
+    &:before {
+      content: "";
+      position: absolute;
+      top: 0.25em;
+      bottom: 0.25em;
+      left: 0.2em;
+      right: 0.2em;
+      border: 1px solid #dddddd;
+      border-radius: 4px;
+    }
+
+    &:hover {
+      &:before {
+        border-color: #000000;
+      }
+    }
+  }
+
+  &.tabulator-editing {
+    border: 0 none;
+    padding: 0.5em;
+
+    &:before {
+      border-width: 2px;
+      border-color: #000000;
+    }
+  }
+}

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.spec.ts
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.spec.ts
@@ -1,0 +1,84 @@
+import { SimpleChange } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TabulatorTableComponent } from './tabulator-table.component';
+import { Tabulator } from 'tabulator-tables';
+
+let component: TabulatorTableComponent;
+let fixture: ComponentFixture<TabulatorTableComponent>;
+let element: Element;
+const editableCells = {
+  0: ['1', '2'],
+  1: ['1', '2'],
+  2: ['1', '2']
+};
+const tabColumns = [
+  {title: 'Age', field: '0'},
+  {title: 'Height', field: '1'},
+  {title: 'Hours homework per day', field: '2', width: 200}
+];
+const tabData = [
+  {0: '6', 1: '36', 2: ''},
+  {0: '10', 1: '', 2: ''},
+  {0: '12', 1: '', 2: ''}
+];
+const tabOptions = {
+  layout: "fitDataTable",
+  maxHeight: "500px",
+  reactiveData: true,
+}
+
+describe('TabulatorTableComponent', () => {
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TabulatorTableComponent);
+    component = fixture.componentInstance;
+    component.tabColumns = tabColumns;
+    component.tabData = tabData;
+    component.tabOptions = tabOptions;
+    component.editableCells = editableCells;
+    element = fixture.nativeElement;
+    fixture.detectChanges();
+  });
+
+  afterViewInit();
+  onChanges();
+});
+
+function afterViewInit() {
+  describe('afterViewInit', () => {
+    it('should create Tabulator table after view is initialized', async () => {
+      component.table.on('tableBuilt', () => {
+        expect(component.table.getRows().length).toBe(3);
+        expect(component.table.getColumns().length).toBe(3);
+        expect(component.table.getRows()[0].getCell(1).getValue()).toBe('36');
+      });
+    });
+  });
+}
+
+function onChanges() {
+  describe('onChanges', () => {
+    it('should update Tabulator columns and data on changes', async () => {
+      component.table = new Tabulator(component.tableEl, {});
+      component.table.on('tableBuilt', () => {
+        const newTabColumns = [
+          { title: 'Age', field: '0' },
+          { title: 'Height', field: '1' }
+        ];
+        const newTabData = [
+          { 0: '10', 1: '', 2: '' },
+          { 0: '12', 1: '', 2: '' }
+        ];
+        component.ngOnChanges({
+          tabColumns: new SimpleChange(null, newTabColumns, false),
+          tabData: new SimpleChange(null, newTabData, false)
+        });
+        component.table.on('dataChanged', function (data) {
+          expect(component.table.getRows().length).toBe(2);
+          expect(component.table.getColumns().length).toBe(2);
+          expect(component.table.getRows()[0].getCell(0).getValue()).toBe('10');
+        });
+        fixture.detectChanges();
+      });
+    });
+  });
+}

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.spec.ts
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.spec.ts
@@ -2,6 +2,7 @@ import { SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TabulatorTableComponent } from './tabulator-table.component';
 import { Tabulator } from 'tabulator-tables';
+import { TabulatorColumn } from '../TabulatorData';
 
 let component: TabulatorTableComponent;
 let fixture: ComponentFixture<TabulatorTableComponent>;
@@ -12,14 +13,14 @@ const editableCells = {
   2: ['1', '2']
 };
 const tabColumns = [
-  {title: 'Age', field: '0'},
-  {title: 'Height', field: '1'},
-  {title: 'Hours homework per day', field: '2', width: 200}
+  new TabulatorColumn({ title: 'Age', field: '0' }),
+  new TabulatorColumn({ title: 'Height', field: '1' }),
+  new TabulatorColumn({ title: 'Hours homework per day', field: '2', width: 200 })
 ];
 const tabData = [
-  {0: '6', 1: '36', 2: ''},
-  {0: '10', 1: '', 2: ''},
-  {0: '12', 1: '', 2: ''}
+  { 0: '6', 1: '36', 2: '' },
+  { 0: '10', 1: '', 2: '' },
+  { 0: '12', 1: '', 2: '' }
 ];
 const tabOptions = {
   layout: "fitDataTable",

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
@@ -11,6 +11,7 @@ import { TabulatorData } from '../TabulatorData';
 })
 export class TabulatorTableComponent implements OnChanges, AfterViewInit {
   @Input() editableCells: any;
+  @Input() isDisabled: boolean;
   @Input() tabColumns: any[]; // see http://tabulator.info/docs/5.3/columns
   @Input() tabData: any[]; // see http://tabulator.info/docs/5.3/data
   @Input() tabOptions: any; // see http://tabulator.info/docs/5.3/options
@@ -61,7 +62,7 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
     columns.forEach((column) => {
       column.editor = 'input';
       column.editable = (cell) => {
-        return this.isCellEditable(cell);
+        return this.isDisabled ? false : this.isCellEditable(cell);
       };
       column.formatter = (cell, formatterParams) => {
         return this.cellFormatter(cell, formatterParams);

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
@@ -17,7 +17,6 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
   @Output() cellChanged = new EventEmitter<Tabulator.CellComponent>();
   @ViewChild('table', { static: false }) tableContainer: ElementRef;
 
-  options: any;
   table: Tabulator;
   tableEl = document.createElement('div');
   subscriptions: Subscription = new Subscription();
@@ -28,13 +27,12 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
   }
  
   ngAfterViewInit(): void {
-    this.options = this.tabOptions;
-    this.options.columns = this.setupColumns(this.tabColumns);
-    this.options.data = this.tabData;
+    this.tabOptions.columns = this.setupColumns(this.tabColumns);
+    this.tabOptions.data = this.tabData;
     this.editableCells = this.editableCells;
-    this.table = new Tabulator(this.tableEl, this.options);
+    this.table = new Tabulator(this.tableEl, this.tabOptions);
     this.table.on('cellEdited', (cell) => {
-      this.cellEdited(cell);
+      this.cellChanged.emit(cell);
     });
     this.tableContainer.nativeElement.appendChild(this.tableEl);
     this.viewInit$.next();
@@ -60,15 +58,14 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
       column.editable = (cell) => {
         return this.isDisabled ? false : this.isCellEditable(cell);
       };
-      column.formatter = (cell, formatterParams) => {
-        return this.cellFormatter(cell, formatterParams);
+      column.formatter = (cell) => {
+        return this.cellFormatter(cell);
       };
       column.sorter = 'alphanum';
       column.sorterParams = {
         alignEmptyValues: 'bottom'
       };
     });
-
     return columns;
   }
 
@@ -80,8 +77,7 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
   }
 
   private cellFormatter(
-    cell: Tabulator.CellComponent,
-    formatterParams: Tabulator.formatterParams
+    cell: Tabulator.CellComponent
   ): any {
     if (this.isCellEditable(cell)) {
       cell.getElement().classList.add('tabulator-cell-editable');
@@ -91,15 +87,10 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
 
   private processChanges(changes: SimpleChanges): void {
     if (changes['tabColumns']) {
-      this.options.columns = this.setupColumns(this.tabColumns);
-      this.table.setColumns(this.tabColumns);
+      this.table.setColumns(this.setupColumns(this.tabColumns));
     }
     if (changes['tabData']) {
       this.table.setData(this.tabData);
     }
-  }
-
-  private cellEdited(cell: Tabulator.CellComponent) {
-    this.cellChanged.emit(cell);
   }
 }

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
@@ -28,7 +28,7 @@ import { TabulatorColumn } from '../TabulatorData';
   encapsulation: ViewEncapsulation.None
 })
 export class TabulatorTableComponent implements OnChanges, AfterViewInit {
-  @Input() editableCells: string[][];
+  @Input() editableCells: any;
   @Input() isDisabled: boolean;
   @Input() tabColumns: TabulatorColumn[]; // see http://tabulator.info/docs/5.3/columns
   @Input() tabData: any[]; // see http://tabulator.info/docs/5.3/data
@@ -76,8 +76,8 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
     this.subscriptions.unsubscribe();
   }
 
-  private setupColumns(columns): any[] {
-    columns.forEach((column) => {
+  private setupColumns(columns: TabulatorColumn[]): TabulatorColumn[] {
+    columns.forEach((column: TabulatorColumn) => {
       column.editor = 'input';
       column.editable = (cell) => {
         return this.isDisabled ? false : this.isCellEditable(cell);
@@ -97,7 +97,7 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
     const rowIndex = cell.getRow().getPosition();
     const field = cell.getColumn().getField();
     const row = this.editableCells[rowIndex];
-    return row && row.indexOf(field) > -1;
+    return row && row.includes(field);
   }
 
   private cellFormatter(cell: Tabulator.CellComponent): any {

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
@@ -1,0 +1,80 @@
+import { AfterViewInit, Component, ElementRef, Input, OnChanges, SimpleChanges, ViewChild, ViewEncapsulation } from '@angular/core';
+import { ReplaySubject, Subscription } from 'rxjs';
+import { Tabulator, EditModule, FormatModule, KeybindingsModule, SortModule } from 'tabulator-tables';
+import { TabulatorData } from '../TabulatorData';
+
+@Component({
+  selector: 'tabulator-table',
+  templateUrl: './tabulator-table.component.html',
+  styleUrls: ['./tabulator-table.component.scss'],
+  encapsulation: ViewEncapsulation.None
+})
+export class TabulatorTableComponent implements OnChanges, AfterViewInit {
+  @Input() tabData: TabulatorData;
+  @ViewChild('table', { static: false }) tableContainer: ElementRef;
+
+  editableCells: any;
+  options: any;
+  tableEl = document.createElement('div');
+  afterViewInitSubscription: Subscription;
+  viewInit$ = new ReplaySubject();
+
+  constructor() {
+    Tabulator.registerModule([EditModule, FormatModule, KeybindingsModule, SortModule]);
+  }
+
+  ngAfterViewInit(): void {
+    this.viewInit$.next();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    this.afterViewInitSubscription = this.viewInit$.subscribe(() => {
+      this.options = this.tabData.options;
+      this.options.columns = this.tabData.columns;
+      this.options.columns.forEach((column) => {
+        column.editor = 'input';
+        column.editable = editCheck;
+        column.formatter = cellFormatter;
+        column.sorter = 'alphanum';
+        column.sorterParams = {
+          alignEmptyValues: 'bottom',
+        }
+      });
+      this.options.data = this.tabData.data;
+      this.editableCells = this.tabData.editableCells;
+      this.drawTable();
+    });
+
+    const cellFormatter = (cell, formatterParams) => {
+      if (this.isCellEditable(cell)) {
+        cell.getElement().classList.add('tabulator-cell-editable');
+      }
+      return cell.getValue();
+    };
+
+    const editCheck = (cell) => {
+      return this.isCellEditable(cell);
+    };
+  }
+
+  isCellEditable(cell) {
+    const rowIndex = cell.getRow().getPosition();
+    const field = cell.getColumn().getField();
+    const row = this.editableCells[rowIndex];
+    if (row && row.indexOf(field) > -1) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.afterViewInitSubscription.unsubscribe();
+  }
+
+  private drawTable(): void {
+    new Tabulator(this.tableEl, this.options);
+    this.tableContainer.nativeElement.innerHtml = '';
+    this.tableContainer.nativeElement.appendChild(this.tableEl);
+  }
+}

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, Input, OnChanges, SimpleChanges, ViewChild, ViewEncapsulation } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewChild, ViewEncapsulation } from '@angular/core';
 import { ReplaySubject, Subscription } from 'rxjs';
 import { Tabulator, EditModule, FormatModule, KeybindingsModule, SortModule } from 'tabulator-tables';
 import { TabulatorData } from '../TabulatorData';
@@ -14,6 +14,7 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
   @Input() tabColumns: any[]; // see http://tabulator.info/docs/5.3/columns
   @Input() tabData: any[]; // see http://tabulator.info/docs/5.3/data
   @Input() tabOptions: any; // see http://tabulator.info/docs/5.3/options
+  @Output() cellChanged = new EventEmitter<Tabulator.CellComponent>();
   @ViewChild('table', { static: false }) tableContainer: ElementRef;
 
   options: any;
@@ -50,6 +51,9 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
     this.options.data = this.tabData;
     this.editableCells = this.editableCells;
     this.table = new Tabulator(this.tableEl, this.options);
+    this.table.on('cellEdited', (cell) => {
+      this.cellEdited(cell);
+    });
     this.tableContainer.nativeElement.appendChild(this.tableEl);
   }
 
@@ -71,7 +75,7 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
     return columns;
   }
 
-  private isCellEditable(cell): boolean {
+  private isCellEditable(cell: Tabulator.CellComponent): boolean {
     const rowIndex = cell.getRow().getPosition();
     const field = cell.getColumn().getField();
     const row = this.editableCells[rowIndex];
@@ -82,7 +86,7 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
     }
   }
 
-  private cellFormatter(cell, formatterParams): any {
+  private cellFormatter(cell: Tabulator.CellComponent, formatterParams: Tabulator.formatterParams): any {
     if (this.isCellEditable(cell)) {
       cell.getElement().classList.add('tabulator-cell-editable');
     }
@@ -97,5 +101,9 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
     if (changes['tabData']) {
       this.table.setData(this.tabData);
     }
+  }
+
+  private cellEdited(cell: Tabulator.CellComponent) {
+    this.cellChanged.emit(cell);
   }
 }

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
@@ -1,6 +1,25 @@
-import { AfterViewInit, Component, ElementRef, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewChild, ViewEncapsulation } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges,
+  ViewChild,
+  ViewEncapsulation
+} from '@angular/core';
 import { ReplaySubject, Subscription } from 'rxjs';
-import { Tabulator, EditModule, FormatModule, KeybindingsModule, ReactiveDataModule, SortModule } from 'tabulator-tables';
+import {
+  Tabulator,
+  EditModule,
+  FormatModule,
+  KeybindingsModule,
+  ReactiveDataModule,
+  SortModule
+} from 'tabulator-tables';
+import { TabulatorColumn } from '../TabulatorData';
 
 @Component({
   selector: 'tabulator-table',
@@ -9,9 +28,9 @@ import { Tabulator, EditModule, FormatModule, KeybindingsModule, ReactiveDataMod
   encapsulation: ViewEncapsulation.None
 })
 export class TabulatorTableComponent implements OnChanges, AfterViewInit {
-  @Input() editableCells: any;
+  @Input() editableCells: string[][];
   @Input() isDisabled: boolean;
-  @Input() tabColumns: any[]; // see http://tabulator.info/docs/5.3/columns
+  @Input() tabColumns: TabulatorColumn[]; // see http://tabulator.info/docs/5.3/columns
   @Input() tabData: any[]; // see http://tabulator.info/docs/5.3/data
   @Input() tabOptions: any; // see http://tabulator.info/docs/5.3/options
   @Output() cellChanged = new EventEmitter<Tabulator.CellComponent>();
@@ -23,13 +42,18 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
   viewInit$ = new ReplaySubject();
 
   constructor() {
-    Tabulator.registerModule([EditModule, FormatModule, KeybindingsModule, ReactiveDataModule, SortModule]);
+    Tabulator.registerModule([
+      EditModule,
+      FormatModule,
+      KeybindingsModule,
+      ReactiveDataModule,
+      SortModule
+    ]);
   }
- 
+
   ngAfterViewInit(): void {
     this.tabOptions.columns = this.setupColumns(this.tabColumns);
     this.tabOptions.data = this.tabData;
-    this.editableCells = this.editableCells;
     this.table = new Tabulator(this.tableEl, this.tabOptions);
     this.table.on('cellEdited', (cell) => {
       this.cellChanged.emit(cell);
@@ -76,9 +100,7 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
     return row && row.indexOf(field) > -1;
   }
 
-  private cellFormatter(
-    cell: Tabulator.CellComponent
-  ): any {
+  private cellFormatter(cell: Tabulator.CellComponent): any {
     if (this.isCellEditable(cell)) {
       cell.getElement().classList.add('tabulator-cell-editable');
     }

--- a/src/assets/wise5/components/table/tabulatorDataService.ts
+++ b/src/assets/wise5/components/table/tabulatorDataService.ts
@@ -1,0 +1,73 @@
+'use strict';
+
+import { Injectable } from '@angular/core';
+import { TabulatorData } from './TabulatorData';
+
+@Injectable()
+export class TabulatorDataService {
+  constructor() {}
+
+  convertTableDataToTabulator(tableData: any[], globalCellSize: number): TabulatorData {
+    const content = new TabulatorData();
+    content.columns = this.getTabulatorColumnsFromTable(tableData, globalCellSize);
+    for (const [index, row] of tableData.entries()) {
+      if (index > 0) {
+        const rowIndex = index - 1;
+        const rowData = this.getTabulatorRowDataFromTableRow(row, content.columns);
+        rowData.values.id = rowIndex;
+        content.data.push(rowData.values);
+        content.editableCells[rowIndex] = rowData.editableCells;
+      }
+    }
+    return content;
+  }
+
+  private getTabulatorColumnsFromTable(tableData: any[], globalCellSize: number): any[] {
+    let columns = [];
+    const columnDefs = tableData[0];
+    if (columnDefs) {
+      columnDefs.forEach((columnDef, index) => {
+        columns.push(this.getTabulatorColumn(columnDef, index, globalCellSize));
+      });
+    }
+    return columns;
+  }
+
+  private getTabulatorColumn(columnDef: any, index: number, globalCellSize: number): any {
+    const column: any = {
+      title: columnDef.text,
+      field: `${index}`
+    };
+    const width: number = this.getTabulatorColumnWidth(columnDef, globalCellSize);
+    if (width) {
+      column.width = width;
+    }
+    return column;
+  }
+
+  private getTabulatorColumnWidth(columnDef: any, globalCellSize: number): number {
+    let width: number = null;
+    const legacyWidth: number = columnDef.size ? columnDef.size : globalCellSize;
+    if (columnDef.width) {
+      width = columnDef.width;
+    } else if (legacyWidth && legacyWidth !== 10) {
+      width = legacyWidth * 16; // approximate conversion of legacy column size (em) to number of px
+    }
+    return width;
+  }
+
+  private getTabulatorRowDataFromTableRow(tableRow: any[], columns: any[]): any {
+    let rowData = {
+      values: {},
+      editableCells: []
+    };
+    tableRow.forEach((cell, index) => {
+      const field = columns[index].field;
+      rowData.values[field] = cell.text;
+      if (cell.editable) {
+        rowData.editableCells.push(field);
+      }
+    });
+    return rowData;
+  }
+}

--- a/src/assets/wise5/components/table/tabulatorDataService.ts
+++ b/src/assets/wise5/components/table/tabulatorDataService.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import { Injectable } from '@angular/core';
-import { TabulatorData } from './TabulatorData';
+import { TabulatorColumn, TabulatorData } from './TabulatorData';
 
 @Injectable()
 export class TabulatorDataService {
@@ -23,7 +23,7 @@ export class TabulatorDataService {
   }
 
   private getTabulatorColumnsFromTable(tableData: any[], globalCellSize: number): any[] {
-    let columns = [];
+    const columns: TabulatorColumn[] = [];
     const columnDefs = tableData[0];
     if (columnDefs) {
       columnDefs.forEach((columnDef, index) => {
@@ -33,11 +33,11 @@ export class TabulatorDataService {
     return columns;
   }
 
-  private getTabulatorColumn(columnDef: any, index: number, globalCellSize: number): any {
-    const column: any = {
+  private getTabulatorColumn(columnDef: any, index: number, globalCellSize: number): TabulatorColumn {
+    const column = new TabulatorColumn({
       title: columnDef.text,
       field: `${index}`
-    };
+    });
     const width: number = this.getTabulatorColumnWidth(columnDef, globalCellSize);
     if (width) {
       column.width = width;
@@ -57,7 +57,7 @@ export class TabulatorDataService {
   }
 
   private getTabulatorRowDataFromTableRow(tableRow: any[], columns: any[]): any {
-    let rowData = {
+    const rowData = {
       values: {},
       editableCells: []
     };

--- a/src/assets/wise5/services/utilService.ts
+++ b/src/assets/wise5/services/utilService.ts
@@ -753,7 +753,7 @@ export class UtilService {
       // Now that we have our value string, let's add
       // it to the data array.
       let finalValue = strMatchedValue;
-      const floatVal = parseFloat(strMatchedValue);
+      const floatVal = parseFloat(strMatchedValue.replace(new RegExp(',', 'g'), ''));
       if (!isNaN(floatVal)) {
         finalValue = floatVal;
       }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15601,7 +15601,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>(None)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.ts</context>
-          <context context-type="linenumber">23</context>
+          <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d56d67fc38809e23fcba86a9acc09bd9e40e8b2a" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15651,7 +15651,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Table</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/tableService.ts</context>
-          <context context-type="linenumber">22</context>
+          <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="13914f9fe459520b280fb4e82a4c44812a6d74ad" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -14994,11 +14994,11 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">62</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1702c8b1dfd9b74fe218322fb3509b227cd41b1b" datatype="html">
@@ -15362,7 +15362,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2c57dd23349e236c076c19356af17d5de965d398" datatype="html">
@@ -15565,7 +15565,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">41</context>
+          <context context-type="linenumber">42</context>
         </context-group>
       </trans-unit>
       <trans-unit id="967a05fa93ce8900222661f7beb6c08924b3a857" datatype="html">
@@ -15583,7 +15583,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">97</context>
+          <context context-type="linenumber">98</context>
         </context-group>
       </trans-unit>
       <trans-unit id="484e9a22dbb7f73c463535f204e1f221b6cbdacb" datatype="html">
@@ -15594,7 +15594,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">110</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f15f150caaef41e4e915900660dae93b053ec897" datatype="html">
@@ -15622,36 +15622,36 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Choose the table data you want to graph:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">53</context>
+          <context context-type="linenumber">54</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a3e2cbd23a21040a6893d669847148041dd03868" datatype="html">
         <source>Y Data <x id="INTERPOLATION" equiv-text="{{ dataExplorerSeries.length &gt; 1 ? seriesIndex + 1 : &quot;&quot;}}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">75</context>
+          <context context-type="linenumber">76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7c0b21d6d77a0c42b3a86c8922b7766ebfaeb4c1" datatype="html">
         <source>Enter Text Here</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">102</context>
+          <context context-type="linenumber">103</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">114</context>
+          <context context-type="linenumber">115</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">131</context>
+          <context context-type="linenumber">132</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2ba0ed2ffebe37a936032b49e9fdf057a9af7d07" datatype="html">
         <source>Y Axis <x id="INTERPOLATION" equiv-text="{{yAxisIndex + 1}}"/> Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">126</context>
+          <context context-type="linenumber">127</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1358239534403218079" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -14994,11 +14994,11 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">61</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1702c8b1dfd9b74fe218322fb3509b227cd41b1b" datatype="html">
@@ -15362,7 +15362,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">56</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2c57dd23349e236c076c19356af17d5de965d398" datatype="html">
@@ -15565,7 +15565,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">37</context>
+          <context context-type="linenumber">41</context>
         </context-group>
       </trans-unit>
       <trans-unit id="967a05fa93ce8900222661f7beb6c08924b3a857" datatype="html">
@@ -15583,7 +15583,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">93</context>
+          <context context-type="linenumber">97</context>
         </context-group>
       </trans-unit>
       <trans-unit id="484e9a22dbb7f73c463535f204e1f221b6cbdacb" datatype="html">
@@ -15594,7 +15594,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">105</context>
+          <context context-type="linenumber">109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f15f150caaef41e4e915900660dae93b053ec897" datatype="html">
@@ -15622,36 +15622,36 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Choose the table data you want to graph:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a3e2cbd23a21040a6893d669847148041dd03868" datatype="html">
         <source>Y Data <x id="INTERPOLATION" equiv-text="{{ dataExplorerSeries.length &gt; 1 ? seriesIndex + 1 : &quot;&quot;}}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">71</context>
+          <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7c0b21d6d77a0c42b3a86c8922b7766ebfaeb4c1" datatype="html">
         <source>Enter Text Here</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">98</context>
+          <context context-type="linenumber">102</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">110</context>
+          <context context-type="linenumber">114</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">127</context>
+          <context context-type="linenumber">131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2ba0ed2ffebe37a936032b49e9fdf057a9af7d07" datatype="html">
         <source>Y Axis <x id="INTERPOLATION" equiv-text="{{yAxisIndex + 1}}"/> Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">122</context>
+          <context context-type="linenumber">126</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1358239534403218079" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -14994,11 +14994,11 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">79</context>
+          <context context-type="linenumber">57</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1702c8b1dfd9b74fe218322fb3509b227cd41b1b" datatype="html">
@@ -15362,7 +15362,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">52</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2c57dd23349e236c076c19356af17d5de965d398" datatype="html">
@@ -15556,10 +15556,6 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
           <context context-type="linenumber">15</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">49</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="c1ac7b8d0d0a0d2e7452433c930cef085486540c" datatype="html">
         <source>Graph Type</source>
@@ -15569,7 +15565,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">59</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="967a05fa93ce8900222661f7beb6c08924b3a857" datatype="html">
@@ -15587,7 +15583,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">111</context>
+          <context context-type="linenumber">93</context>
         </context-group>
       </trans-unit>
       <trans-unit id="484e9a22dbb7f73c463535f204e1f221b6cbdacb" datatype="html">
@@ -15598,7 +15594,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">123</context>
+          <context context-type="linenumber">105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f15f150caaef41e4e915900660dae93b053ec897" datatype="html">
@@ -15626,43 +15622,43 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Choose the table data you want to graph:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">71</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a3e2cbd23a21040a6893d669847148041dd03868" datatype="html">
         <source>Y Data <x id="INTERPOLATION" equiv-text="{{ dataExplorerSeries.length &gt; 1 ? seriesIndex + 1 : &quot;&quot;}}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">91</context>
+          <context context-type="linenumber">71</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7c0b21d6d77a0c42b3a86c8922b7766ebfaeb4c1" datatype="html">
         <source>Enter Text Here</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">116</context>
+          <context context-type="linenumber">98</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">128</context>
+          <context context-type="linenumber">110</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">145</context>
+          <context context-type="linenumber">127</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2ba0ed2ffebe37a936032b49e9fdf057a9af7d07" datatype="html">
         <source>Y Axis <x id="INTERPOLATION" equiv-text="{{yAxisIndex + 1}}"/> Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">140</context>
+          <context context-type="linenumber">122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1358239534403218079" datatype="html">
         <source>Table</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/tableService.ts</context>
-          <context context-type="linenumber">21</context>
+          <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
       <trans-unit id="13914f9fe459520b280fb4e82a4c44812a6d74ad" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15358,7 +15358,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">36</context>
+          <context context-type="linenumber">21</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
@@ -15550,18 +15550,11 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">231</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4dee60f2a97f5dcf1f2edbf2f44961facc5bf1ef" datatype="html">
-        <source>Cell content</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">15</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="c1ac7b8d0d0a0d2e7452433c930cef085486540c" datatype="html">
         <source>Graph Type</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">11</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
@@ -15572,14 +15565,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Y Data <x id="INTERPOLATION" equiv-text="{{dataExplorerSeries.length &gt; 1 ? (i + 1) : &apos;&apos;}}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">48</context>
+          <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b703c5f9773985dca9e4594ae0c3ecb9f3da4462" datatype="html">
         <source>X Axis Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">64</context>
+          <context context-type="linenumber">49</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
@@ -15590,7 +15583,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Y Axis Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">77</context>
+          <context context-type="linenumber">62</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
@@ -15601,14 +15594,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Y Axis <x id="INTERPOLATION" equiv-text="{{i + 1}}"/> Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">94</context>
+          <context context-type="linenumber">79</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8764032794209664551" datatype="html">
         <source>(None)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.ts</context>
-          <context context-type="linenumber">21</context>
+          <context context-type="linenumber">23</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d56d67fc38809e23fcba86a9acc09bd9e40e8b2a" datatype="html">


### PR DESCRIPTION
## Changes
- Use Tabulator to display Table components in the VLE and grading.
- Adds column sorting and table scrolling.

Height is currently set to a max of 500px.
Column widths are automatically set by Tabulator if global cell size is not set or is set to 10 (the default). Column widths are approximated into pixels for Tabulator by multiplying the size set in the authoring tool by 16 (so a cell size of 20 = 320px wide). I'll create a new issue to modify the Table authoring to use pixels for column/cell widths.

Closes #332.

## Test
- Run `npm install` to update dependencies.
- Test that all table components work as before in the VLE using Tabulator.
- Test the students can change the value of editable cells and the changes are saved.
- Test that Reset Table button works.
- Test that connected components that import work to Table components function as before.
- Test that Show My Work and Show Group Work display Table components correctly using Tabulator (and editable cells are disabled).
- Test that Table components display correctly in the Teacher Tools (and editable cells are disabled).