### PR TITLE
fix(Data Explorer): Repopulate categorical x axis labels

### DIFF
--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -144,18 +144,7 @@ export class TableStudent extends ComponentStudent {
 
     this.disableComponentIfNecessary();
 
-    if (
-      this.isDataExplorerEnabled &&
-      this.componentContent.dataExplorerDataToColumn != null &&
-      this.isAllDataExplorerSeriesSpecified()
-    ) {
-      // All the data explorer series have been fixed to display a specific column so we will call
-      // studentDataChanged() immediately to generate the table student data which will then be sent
-      // to the graph component so the graph can immediately be displayed. If we did not do this,
-      // the graph may not ever be displayed since it requires the student to change the table data.
-      // If all the data explorer series have been fixed to display a specific column and all the
-      // table data cells are not editable by the student, the student may not ever be able to
-      // change the table to generate table data to be sent to the graph.
+    if (this.isDataExplorerEnabled && this.componentContent.dataExplorerDataToColumn != null) {
       setTimeout(() => {
         this.studentDataChanged();
       }, 1000);
@@ -1187,5 +1176,5 @@ export class TableStudent extends ComponentStudent {
     const rowIndex = cell.getRow().getPosition() + 1;
     this.tableData[rowIndex][columnIndex].text = cell.getValue();
     this.studentDataChanged();
-  };
+  }
 }


### PR DESCRIPTION
## Changes

Repopulate categorical x axis labels when the student returns to a Data Explorer step

## Test

- As a student, go to a Data Explorer step that lets you choose two or more Y columns to graph and has a column that contains categorical data (like [this step](https://wise.berkeley.edu/preview/unit/38172/node210) that can have X Data set to County)
- Set the X column to the categorical data column (like County)
- Set the first Y column to a numerical column and leave the other Y columns unchosen
- The graph should be rendered and show the categorical data values (like County) in the x axis tick mark labels
- Leave the step
- Go back to the Data Explorer step
- The graph should be rendered and show the categorical data values (like County) in the x axis tick mark labels. Previously, the x axis tick mark labels would not be repopulated with the County names and would only show numbers.

Closes #697