### PR TITLE
refactor(PauseScreen): Move event listener to PauseScreenService

### DIFF
--- a/src/app/services/pauseScreenService.spec.ts
+++ b/src/app/services/pauseScreenService.spec.ts
@@ -1,14 +1,16 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { DialogWithoutCloseComponent } from '../../assets/wise5/directives/dialog-without-close/dialog-without-close.component';
 import { PauseScreenService } from '../../assets/wise5/services/pauseScreenService';
+import { StudentTeacherCommonServicesModule } from '../student-teacher-common-services.module';
 
 let dialog: MatDialog;
 let service: PauseScreenService;
 describe('PauseScreenService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [MatDialogModule],
+      imports: [HttpClientTestingModule, MatDialogModule, StudentTeacherCommonServicesModule],
       providers: [PauseScreenService]
     });
     dialog = TestBed.inject(MatDialog);

--- a/src/app/student-teacher-common-services.module.ts
+++ b/src/app/student-teacher-common-services.module.ts
@@ -46,6 +46,7 @@ import { ComponentTypeService } from '../assets/wise5/services/componentTypeServ
 import { BranchService } from '../assets/wise5/services/branchService';
 import { PathService } from '../assets/wise5/services/pathService';
 import { TabulatorDataService } from '../assets/wise5/components/table/tabulatorDataService';
+import { StompService } from '../assets/wise5/services/stompService';
 
 @NgModule({
   providers: [
@@ -85,6 +86,7 @@ import { TabulatorDataService } from '../assets/wise5/components/table/tabulator
     SessionService,
     ShowGroupWorkService,
     ShowMyWorkService,
+    StompService,
     StudentAssetService,
     StudentDataService,
     StudentStatusService,

--- a/src/assets/wise5/services/initializeVLEService.ts
+++ b/src/assets/wise5/services/initializeVLEService.ts
@@ -7,6 +7,7 @@ import { NotebookService } from './notebookService';
 import { NotificationService } from './notificationService';
 import { PauseScreenService } from './pauseScreenService';
 import { SessionService } from './sessionService';
+import { StompService } from './stompService';
 import { StudentAssetService } from './studentAssetService';
 import { StudentDataService } from './studentDataService';
 import { StudentStatusService } from './studentStatusService';
@@ -25,6 +26,7 @@ export class InitializeVLEService {
     private pauseScreenService: PauseScreenService,
     private projectService: VLEProjectService,
     private sessionService: SessionService,
+    private stompService: StompService,
     private studentAssetService: StudentAssetService,
     private studentDataService: StudentDataService,
     private studentStatusService: StudentStatusService,
@@ -36,24 +38,16 @@ export class InitializeVLEService {
     this.sessionService.initializeSession();
     this.studentStatusService.retrieveStudentStatus();
     await this.projectService.retrieveProject();
+    await this.stompService.initialize();
     this.studentWebSocketService.initialize();
     await this.studentDataService.retrieveStudentData();
     await this.notificationService.retrieveNotifications();
     await this.achievementService.retrieveStudentAchievements();
     await this.studentDataService.retrieveRunStatus();
+    this.pauseScreenService.initialize();
     await this.studentAssetService.retrieveAssets();
     await this.notebookService.retrieveNotebookItems(this.configService.getWorkgroupId());
-
-    if (this.shouldScreenBePaused()) {
-      this.pauseScreenService.pauseScreen();
-    }
     this.intializedSource.next(true);
-  }
-
-  private shouldScreenBePaused(): boolean {
-    const runStatus = this.studentDataService.getRunStatus();
-    const periodId = this.configService.getPeriodId();
-    return runStatus.periods.some((period: any) => period.periodId === periodId && period.paused);
   }
 
   async initializePreview(unitId: string) {

--- a/src/assets/wise5/services/pauseScreenService.ts
+++ b/src/assets/wise5/services/pauseScreenService.ts
@@ -1,10 +1,41 @@
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Message } from '@stomp/stompjs';
 import { DialogWithoutCloseComponent } from '../directives/dialog-without-close/dialog-without-close.component';
+import { ConfigService } from './configService';
+import { StompService } from './stompService';
+import { StudentDataService } from './studentDataService';
 
 @Injectable()
 export class PauseScreenService {
-  constructor(private dialog: MatDialog) {}
+  constructor(
+    private configService: ConfigService,
+    private dialog: MatDialog,
+    private stompService: StompService,
+    private studentDataService: StudentDataService
+  ) {}
+
+  initialize(): void {
+    this.subscribeToPauseEvents();
+    if (this.isPeriodPaused()) {
+      this.pauseScreen();
+    }
+  }
+
+  private subscribeToPauseEvents(): void {
+    this.stompService.rxStomp
+      .watch(
+        `/topic/classroom/${this.configService.getRunId()}/${this.configService.getPeriodId()}`
+      )
+      .subscribe((message: Message) => {
+        const body = JSON.parse(message.body);
+        if (body.type === 'pause') {
+          this.pauseScreen();
+        } else if (body.type === 'unpause') {
+          this.unPauseScreen();
+        }
+      });
+  }
 
   pauseScreen(): void {
     this.dialog.open(DialogWithoutCloseComponent, {
@@ -18,5 +49,11 @@ export class PauseScreenService {
 
   unPauseScreen(): void {
     this.dialog.closeAll();
+  }
+
+  private isPeriodPaused(): boolean {
+    const runStatus = this.studentDataService.getRunStatus();
+    const periodId = this.configService.getPeriodId();
+    return runStatus.periods.some((period: any) => period.periodId === periodId && period.paused);
   }
 }

--- a/src/assets/wise5/services/stompService.ts
+++ b/src/assets/wise5/services/stompService.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { RxStomp } from '@stomp/rx-stomp';
+import { ConfigService } from './configService';
+
+@Injectable()
+export class StompService {
+  rxStomp: RxStomp;
+
+  constructor(private configService: ConfigService) {}
+
+  initialize() {
+    this.rxStomp = new RxStomp();
+    this.rxStomp.configure({
+      brokerURL: this.configService.getWebSocketURL()
+    });
+    this.rxStomp.activate();
+  }
+}

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13424,39 +13424,39 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>The series you are trying to add a point to is currently hidden. Please show the series by clicking the series name in the legend and try adding the point again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">984</context>
+          <context context-type="linenumber">1017</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2852989551014711458" datatype="html">
         <source>You can not edit this series. Please choose a series that can be edited.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">998</context>
+          <context context-type="linenumber">1031</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7053114367342967943" datatype="html">
         <source>Are you sure you want to reset the series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1276</context>
+          <context context-type="linenumber">1309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7889560203726829643" datatype="html">
         <source>Are you sure you want to reset the &quot;<x id="PH" equiv-text="seriesName"/>&quot; series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1278</context>
+          <context context-type="linenumber">1311</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6999515396807067782" datatype="html">
         <source>Trial</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1829</context>
+          <context context-type="linenumber">1862</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">2664</context>
+          <context context-type="linenumber">2697</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9070768663485888935" datatype="html">
@@ -16040,14 +16040,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Your teacher has paused all the screens in the class.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/pauseScreenService.ts</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6670906177291724132" datatype="html">
         <source>Screen Paused</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/pauseScreenService.ts</context>
-          <context context-type="linenumber">13</context>
+          <context context-type="linenumber">44</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4238892785951327020" datatype="html">


### PR DESCRIPTION
## Changes
- Create StompService to handle initial RxStomp initialization and configuration, to be used by StudentWebSocketService and PauseScreenService
- Move pause/unpause event listener from StudentWebSocketService to PauseScreenService

## Test
- Pause/unpause works as before
   - while student is in the unit
   - when student is not in the unit 
- Other websocket events work as before
   - teacher comments/scores, discussion posts 

Closes #699