### PR TITLE
feat(Graph): Replace empty table values with NA string

### DIFF
--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -1710,11 +1710,11 @@ export class GraphStudent extends ComponentStudent {
   addPointFromTableIntoData(xCell: any, yCell: any, data: any[]) {
     let xText = xCell.text;
     if (xText == null || xText === '') {
-      xText = 'NA';
+      xText = 'N/A';
     }
     let yText = yCell.text;
     if (yText == null || yText === '') {
-      yText = 'NA';
+      yText = 'N/A';
     }
     const xNumber = Number(xText);
     const yNumber = Number(yText);

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -1709,11 +1709,11 @@ export class GraphStudent extends ComponentStudent {
 
   addPointFromTableIntoData(xCell: any, yCell: any, data: any[]) {
     let xText = xCell.text;
-    if (xText == null || xText == '') {
+    if (xText === null || xText === '') {
       xText = 'NA';
     }
     let yText = yCell.text;
-    if (yText == null || yText == '') {
+    if (yText === null || yText === '') {
       yText = 'NA';
     }
     const xNumber = Number(xText);

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -361,7 +361,7 @@ export class GraphStudent extends ComponentStudent {
     this.xAxis.labels = {
       formatter: function () {
         if (
-          this.value < studentData.tableData.length &&
+          this.value + 1 < studentData.tableData.length &&
           studentData.isDataExplorerEnabled != null &&
           studentData.dataExplorerSeries != null &&
           studentData.tableData != null
@@ -1707,25 +1707,29 @@ export class GraphStudent extends ComponentStudent {
     }
   }
 
-  addPointFromTableIntoData(xCell, yCell, data) {
+  addPointFromTableIntoData(xCell: any, yCell: any, data: any[]) {
     let xText = xCell.text;
-    let yText = yCell.text;
-    if (xText != null && xText !== '' && yText != null && yText !== '') {
-      const xNumber = Number(xText);
-      const yNumber = Number(yText);
-      const point = [];
-      if (!isNaN(xNumber)) {
-        point.push(xNumber);
-      } else {
-        point.push(xText);
-      }
-      if (!isNaN(yNumber)) {
-        point.push(yNumber);
-      } else {
-        point.push(yText);
-      }
-      data.push(point);
+    if (xText == null || xText == '') {
+      xText = 'NA';
     }
+    let yText = yCell.text;
+    if (yText == null || yText == '') {
+      yText = 'NA';
+    }
+    const xNumber = Number(xText);
+    const yNumber = Number(yText);
+    const point = [];
+    if (!isNaN(xNumber)) {
+      point.push(xNumber);
+    } else {
+      point.push(xText);
+    }
+    if (!isNaN(yNumber)) {
+      point.push(yNumber);
+    } else {
+      point.push(yText);
+    }
+    data.push(point);
   }
 
   setSeriesIds(allSeries) {

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -1709,11 +1709,11 @@ export class GraphStudent extends ComponentStudent {
 
   addPointFromTableIntoData(xCell: any, yCell: any, data: any[]) {
     let xText = xCell.text;
-    if (xText === null || xText === '') {
+    if (xText == null || xText === '') {
       xText = 'NA';
     }
     let yText = yCell.text;
-    if (yText === null || yText === '') {
+    if (yText == null || yText === '') {
       yText = 'NA';
     }
     const xNumber = Number(xText);


### PR DESCRIPTION
## Changes

- When a table is sent to a graph, have the empty values replaced with the 'NA' string
- Fixed a bug that would occur if the x value of a table was equal to the length of the table

## Test

- Make sure sending a table to a graph still works if there are empty cells in the x column
- Make sure sending a table to a graph still works if there are empty cells in the y column
- Make sure sending a table to a graph still works if there are empty cells in the x and y column for a given row
- Create a Data Explorer and set one of the x values equal to the number of data rows for example like this below. There are 3 data rows and a row has 3 for the x column (Cats). Previously this would throw an error and the graph would not render. It should now work without any errors.

![Screen Shot 2022-08-02 at 5 07 41 PM](https://user-images.githubusercontent.com/1036509/182497266-fcc478f0-34ec-40b8-8060-5cef3ee767e0.png)


Closes #703