### PR TITLE
refactor(Notification): Handle messages in new StudentNotificationService

### DIFF
--- a/src/app/student/vle/student-vle.module.ts
+++ b/src/app/student/vle/student-vle.module.ts
@@ -25,6 +25,8 @@ import { StudentComponentModule } from '../student.component.module';
 import { TopBarModule } from '../top-bar/top-bar.module';
 import { StudentVLERoutingModule } from './student-vle-routing.module';
 import { PauseScreenService } from '../../../assets/wise5/services/pauseScreenService';
+import { StudentNotificationService } from '../../../assets/wise5/services/studentNotificationService';
+import { NotificationService } from '../../../assets/wise5/services/notificationService';
 
 @NgModule({
   declarations: [
@@ -53,7 +55,9 @@ import { PauseScreenService } from '../../../assets/wise5/services/pauseScreenSe
     InitializeVLEService,
     PauseScreenService,
     { provide: DataService, useExisting: StudentDataService },
+    { provide: NotificationService, useExisting: StudentNotificationService },
     { provide: ProjectService, useExisting: VLEProjectService },
+    StudentNotificationService,
     VLEProjectService
   ],
   exports: [CommonModule, MatButtonModule, MatDialogModule, MatListModule, VLEComponent]

--- a/src/assets/wise5/services/initializeVLEService.ts
+++ b/src/assets/wise5/services/initializeVLEService.ts
@@ -4,12 +4,12 @@ import { VLEProjectService } from '../vle/vleProjectService';
 import { AchievementService } from './achievementService';
 import { ConfigService } from './configService';
 import { NotebookService } from './notebookService';
-import { NotificationService } from './notificationService';
 import { PauseScreenService } from './pauseScreenService';
 import { SessionService } from './sessionService';
 import { StompService } from './stompService';
 import { StudentAssetService } from './studentAssetService';
 import { StudentDataService } from './studentDataService';
+import { StudentNotificationService } from './studentNotificationService';
 import { StudentStatusService } from './studentStatusService';
 import { StudentWebSocketService } from './studentWebSocketService';
 
@@ -22,7 +22,7 @@ export class InitializeVLEService {
     private achievementService: AchievementService,
     private configService: ConfigService,
     private notebookService: NotebookService,
-    private notificationService: NotificationService,
+    private notificationService: StudentNotificationService,
     private pauseScreenService: PauseScreenService,
     private projectService: VLEProjectService,
     private sessionService: SessionService,
@@ -45,6 +45,7 @@ export class InitializeVLEService {
     await this.achievementService.retrieveStudentAchievements();
     await this.studentDataService.retrieveRunStatus();
     this.pauseScreenService.initialize();
+    this.notificationService.initialize();
     await this.studentAssetService.retrieveAssets();
     await this.notebookService.retrieveNotebookItems(this.configService.getWorkgroupId());
     this.intializedSource.next(true);

--- a/src/assets/wise5/services/notificationService.ts
+++ b/src/assets/wise5/services/notificationService.ts
@@ -24,12 +24,12 @@ export class NotificationService {
   public viewCurrentAmbientNotification$: Observable<any> = this.viewCurrentAmbientNotificationSource.asObservable();
 
   constructor(
-    private annotationService: AnnotationService,
-    private dialog: MatDialog,
-    private http: HttpClient,
-    private ConfigService: ConfigService,
-    private ProjectService: ProjectService,
-    private UtilService: UtilService
+    protected annotationService: AnnotationService,
+    protected dialog: MatDialog,
+    protected http: HttpClient,
+    protected ConfigService: ConfigService,
+    protected ProjectService: ProjectService,
+    protected UtilService: UtilService
   ) {}
 
   /**

--- a/src/assets/wise5/services/pauseScreenService.ts
+++ b/src/assets/wise5/services/pauseScreenService.ts
@@ -16,25 +16,21 @@ export class PauseScreenService {
   ) {}
 
   initialize(): void {
-    this.subscribeToPauseEvents();
+    this.subscribeToPauseMessages();
     if (this.isPeriodPaused()) {
       this.pauseScreen();
     }
   }
 
-  private subscribeToPauseEvents(): void {
-    this.stompService.rxStomp
-      .watch(
-        `/topic/classroom/${this.configService.getRunId()}/${this.configService.getPeriodId()}`
-      )
-      .subscribe((message: Message) => {
-        const body = JSON.parse(message.body);
-        if (body.type === 'pause') {
-          this.pauseScreen();
-        } else if (body.type === 'unpause') {
-          this.unPauseScreen();
-        }
-      });
+  private subscribeToPauseMessages(): void {
+    this.stompService.periodMessage$.subscribe((message: Message) => {
+      const body = JSON.parse(message.body);
+      if (body.type === 'pause') {
+        this.pauseScreen();
+      } else if (body.type === 'unpause') {
+        this.unPauseScreen();
+      }
+    });
   }
 
   pauseScreen(): void {

--- a/src/assets/wise5/services/stompService.ts
+++ b/src/assets/wise5/services/stompService.ts
@@ -1,18 +1,35 @@
 import { Injectable } from '@angular/core';
 import { RxStomp } from '@stomp/rx-stomp';
+import { Message } from '@stomp/stompjs';
+import { Observable } from 'rxjs';
 import { ConfigService } from './configService';
 
 @Injectable()
 export class StompService {
-  rxStomp: RxStomp;
+  rxStomp: RxStomp = new RxStomp();
+  periodMessage$: Observable<Message>;
+  workgroupMessage$: Observable<Message>;
 
   constructor(private configService: ConfigService) {}
 
-  initialize() {
-    this.rxStomp = new RxStomp();
+  initialize(): void {
+    this.initializeStomp();
+    this.subscribeToMessages();
+  }
+
+  private initializeStomp(): void {
     this.rxStomp.configure({
       brokerURL: this.configService.getWebSocketURL()
     });
     this.rxStomp.activate();
+  }
+
+  private subscribeToMessages(): void {
+    this.periodMessage$ = this.rxStomp.watch(
+      `/topic/classroom/${this.configService.getRunId()}/${this.configService.getPeriodId()}`
+    );
+    this.workgroupMessage$ = this.rxStomp.watch(
+      `/topic/workgroup/${this.configService.getWorkgroupId()}`
+    );
   }
 }

--- a/src/assets/wise5/services/studentNotificationService.ts
+++ b/src/assets/wise5/services/studentNotificationService.ts
@@ -1,0 +1,52 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { Message } from '@stomp/stompjs';
+import { AnnotationService } from './annotationService';
+import { ConfigService } from './configService';
+import { Notification } from '../../../app/domain/notification';
+import { NotificationService } from './notificationService';
+import { ProjectService } from './projectService';
+import { StompService } from './stompService';
+import { UtilService } from './utilService';
+import { StudentDataService } from './studentDataService';
+
+@Injectable()
+export class StudentNotificationService extends NotificationService {
+  constructor(
+    protected annotationService: AnnotationService,
+    protected dialog: MatDialog,
+    protected http: HttpClient,
+    protected configService: ConfigService,
+    protected projectService: ProjectService,
+    private stompService: StompService,
+    private studentDataService: StudentDataService,
+    protected utilService: UtilService
+  ) {
+    super(annotationService, dialog, http, configService, projectService, utilService);
+  }
+
+  initialize(): void {
+    this.subscribeToNotificationMessages();
+  }
+
+  private subscribeToNotificationMessages(): void {
+    this.stompService.workgroupMessage$.subscribe((message: Message) => {
+      const body = JSON.parse(message.body);
+      if (body.type === 'notification') {
+        const notification = JSON.parse(body.content);
+        this.addNotification(notification);
+        if (this.isDismissImmediately(notification)) {
+          this.dismissNotification(notification);
+        }
+      }
+    });
+  }
+
+  private isDismissImmediately(notification: Notification): boolean {
+    return (
+      notification.nodeId === this.studentDataService.getCurrentNodeId() &&
+      notification.type === 'PeerChatMessage'
+    );
+  }
+}

--- a/src/assets/wise5/vle/vle.component.spec.ts
+++ b/src/assets/wise5/vle/vle.component.spec.ts
@@ -30,6 +30,7 @@ import { FormsModule } from '@angular/forms';
 import { InitializeVLEService } from '../services/initializeVLEService';
 import { StudentTeacherCommonServicesModule } from '../../../app/student-teacher-common-services.module';
 import { PauseScreenService } from '../services/pauseScreenService';
+import { StudentNotificationService } from '../services/studentNotificationService';
 
 let component: VLEComponent;
 let fixture: ComponentFixture<VLEComponent>;
@@ -68,7 +69,13 @@ describe('VLEComponent', () => {
         TopBarComponent,
         VLEComponent
       ],
-      providers: [InitializeVLEService, PauseScreenService, ProjectService, VLEProjectService]
+      providers: [
+        InitializeVLEService,
+        PauseScreenService,
+        ProjectService,
+        StudentNotificationService,
+        VLEProjectService
+      ]
     }).compileComponents();
   });
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -16040,14 +16040,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Your teacher has paused all the screens in the class.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/pauseScreenService.ts</context>
-          <context context-type="linenumber">43</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6670906177291724132" datatype="html">
         <source>Screen Paused</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/pauseScreenService.ts</context>
-          <context context-type="linenumber">44</context>
+          <context context-type="linenumber">40</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4238892785951327020" datatype="html">


### PR DESCRIPTION
## Changes
- Move notification message listener and handler from StudentWebSocketService to new StudentNotificationService
- Make periodMessage and workgroupMessage into observables in StompService

## Test
- Notifications work as before
   - Teacher -> Student (new scores, comments)
   - Student -> Student (new discussion replies, peer chat messages) 

Closes #705