### PR TITLE
fix(Data Explorer): X axis label now updates when changing x column

### DIFF
--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -185,9 +185,7 @@ export class TableStudent extends ComponentStudent {
     this.dataExplorerSeries[dataExplorerSeriesIndex].xColumn = columnIndex;
     this.dataExplorerXColumn = columnIndex;
     this.setDataExplorerXColumnIsDisabled();
-    if (this.isDataExplorerXAxisLabelEmpty()) {
-      this.updateDataExplorerXAxisLabel(columnIndex);
-    }
+    this.updateDataExplorerXAxisLabel(columnIndex);
   }
 
   isDataExplorerXAxisLabelEmpty(): boolean {
@@ -1045,9 +1043,7 @@ export class TableStudent extends ComponentStudent {
     for (const singleSeries of this.dataExplorerSeries) {
       singleSeries.xColumn = this.dataExplorerXColumn;
     }
-    if (this.isDataExplorerXAxisLabelEmpty()) {
-      this.updateDataExplorerXAxisLabel(this.dataExplorerXColumn);
-    }
+    this.updateDataExplorerXAxisLabel(this.dataExplorerXColumn);
     this.studentDataChanged();
   }
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13452,11 +13452,11 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Trial</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1862</context>
+          <context context-type="linenumber">1866</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">2697</context>
+          <context context-type="linenumber">2701</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9070768663485888935" datatype="html">


### PR DESCRIPTION
## Changes

The X axis label is now always updated when the student changes the X Data column.

## Test

- As a student, go to a Data Explorer step
- Select a column for the X Data
- Select a column for the Y Data
- The graph should get rendered and the X Data name should be displayed as the X axis label
- Change the X Data column to a different option
- The graph should get re-rendered and the new X Data name should be displayed as the X axis label. Previously the X axis label would not change.

Closes #716