### PR TITLE
feat(Table): Set default max width for Tabulator columns

### DIFF
--- a/src/assets/wise5/components/table/TabulatorData.ts
+++ b/src/assets/wise5/components/table/TabulatorData.ts
@@ -10,7 +10,10 @@ export class TabulatorData {
     const defaultOptions = {
       layout: 'fitDataTable',
       maxHeight: '500px',
-      reactiveData: true
+      reactiveData: true,
+      columnDefaults: {
+        maxWidth: 200
+      }
     };
     this.options = { ...defaultOptions, ...options };
   }
@@ -19,6 +22,7 @@ export class TabulatorData {
 export class TabulatorColumn {
   title: string;
   field: string;
+  maxWidth: number | boolean; // number of pixels or false for no
   width: number | string; // number of pixels or percent of table width (e.g. '20%')
   editor: string;
   editable: (cell: Tabulator.CellComponent) => boolean;

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.scss
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.scss
@@ -4,6 +4,10 @@
 
   .tabulator-header {
     font-weight: 500;
+
+    .tabulator-col .tabulator-col-content .tabulator-col-title {
+      white-space: normal;
+    }
   }
 }
 

--- a/src/assets/wise5/components/table/tabulatorDataService.ts
+++ b/src/assets/wise5/components/table/tabulatorDataService.ts
@@ -41,6 +41,7 @@ export class TabulatorDataService {
     const width: number = this.getTabulatorColumnWidth(columnDef, globalCellSize);
     if (width) {
       column.width = width;
+      column.maxWidth = false;
     }
     return column;
   }


### PR DESCRIPTION
## Changes
Sets the default max width for each Tabulator column to 200px. 
This can be overridden by authoring the `globalCellSize` or individual column widths.

Closes #721.

## Test
- Author a Table component with a long column header (1st row) text.
- View table in preview mode or as a student.
- Verify that Tabulator restricts the column width to 200px and wraps the header text.
- Back in authoring, enter a value for 'Global Cell Size", e.g. 20.
- Verify in VLE that the Tabulator columns are wider than 200px (should be 320px for a cell size of 20).
- In authoring, clear Global Cell Size and enter a value for 'Column Cell Size' for the column with the long header.
- Verify in VLE that the column is wider than 200px (should be 320px for a cell size of 20).