### PR TITLE
fix(Table): Make sure correct cells are editable by students

### DIFF
--- a/src/app/services/tabulatorDataService.spec.ts
+++ b/src/app/services/tabulatorDataService.spec.ts
@@ -32,7 +32,7 @@ function convertTableDataToTabulator() {
       expect(tabulatorData.data.length).toBe(3);
       expect(tabulatorData.data[1]['0']).toBe('10');
       expect(tabulatorData.options.maxHeight).toBe('500px');
-      expect(tabulatorData.editableCells[0]).toEqual(['1','2']);
+      expect(tabulatorData.editableCells[1]).toEqual(['1', '2']);
     });
   });
 }

--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -1173,7 +1173,7 @@ export class TableStudent extends ComponentStudent {
 
   tabulatorCellChanged(cell: Tabulator.CellComponent): void {
     const columnIndex = parseInt(cell.getColumn().getField());
-    const rowIndex = cell.getRow().getPosition() + 1;
+    const rowIndex = cell.getRow().getIndex() + 1;
     this.tableData[rowIndex][columnIndex].text = cell.getValue();
     this.studentDataChanged();
   }

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
@@ -94,7 +94,7 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
   }
 
   private isCellEditable(cell: Tabulator.CellComponent): boolean {
-    const rowIndex = cell.getRow().getPosition();
+    const rowIndex = cell.getRow().getIndex() + 1;
     const field = cell.getColumn().getField();
     const row = this.editableCells[rowIndex];
     return row && row.includes(field);

--- a/src/assets/wise5/components/table/tabulatorDataService.ts
+++ b/src/assets/wise5/components/table/tabulatorDataService.ts
@@ -16,7 +16,7 @@ export class TabulatorDataService {
         const rowData = this.getTabulatorRowDataFromTableRow(row, content.columns);
         rowData.values.id = rowIndex;
         content.data.push(rowData.values);
-        content.editableCells[rowIndex] = rowData.editableCells;
+        content.editableCells[index] = rowData.editableCells;
       }
     }
     return content;


### PR DESCRIPTION
## Changes
Correct cells are now editable in student Table components. Previously, checking a cell as editable in the Table authoring would make the corresponding cell in the row above editable and not the checked cell.

PR also fixes a bug that would cause cells in the wrong row to be updated when table had a custom sorting set.

Closes #727.
[Note: Cells in the first row of a Table component (header row) are never editable now that we use Tabulator. We should probably remove the editable checkbox from first row cells in the Table authoring. Could explore adding an option to allow student to edit headers in the future.]

## Test
- Make sure The same cells that are checked as editable in Table authoring are actually editable on the student side.
- Make sure that the correct cell values are saved when you edit a table that has custom sorting applied.