### PR TITLE
refactor(VLEComponent): Extract VLEParentComponent

### DIFF
--- a/src/app/student/vle/student-vle-routing.module.ts
+++ b/src/app/student/vle/student-vle-routing.module.ts
@@ -1,15 +1,18 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { VLEParentComponent } from '../../../assets/wise5/vle/vle-parent/vle-parent.component';
 import { VLEComponent } from '../../../assets/wise5/vle/vle.component';
 
 const routes: Routes = [
   {
     path: '',
-    component: VLEComponent
-  },
-  {
-    path: ':nodeId',
-    component: VLEComponent
+    component: VLEParentComponent,
+    children: [
+      {
+        path: ':nodeId',
+        component: VLEComponent
+      }
+    ]
   }
 ];
 

--- a/src/app/student/vle/student-vle.module.ts
+++ b/src/app/student/vle/student-vle.module.ts
@@ -27,6 +27,7 @@ import { StudentVLERoutingModule } from './student-vle-routing.module';
 import { PauseScreenService } from '../../../assets/wise5/services/pauseScreenService';
 import { StudentNotificationService } from '../../../assets/wise5/services/studentNotificationService';
 import { NotificationService } from '../../../assets/wise5/services/notificationService';
+import { VLEParentComponent } from '../../../assets/wise5/vle/vle-parent/vle-parent.component';
 
 @NgModule({
   declarations: [
@@ -36,7 +37,8 @@ import { NotificationService } from '../../../assets/wise5/services/notification
     NavItemComponent,
     SafeUrl,
     StepToolsComponent,
-    VLEComponent
+    VLEComponent,
+    VLEParentComponent
   ],
   imports: [
     StudentTeacherCommonModule,
@@ -60,6 +62,6 @@ import { NotificationService } from '../../../assets/wise5/services/notification
     StudentNotificationService,
     VLEProjectService
   ],
-  exports: [CommonModule, MatButtonModule, MatDialogModule, MatListModule, VLEComponent]
+  exports: [CommonModule, MatButtonModule, MatDialogModule, MatListModule]
 })
 export class StudentVLEModule {}

--- a/src/assets/wise5/services/initializeVLEService.ts
+++ b/src/assets/wise5/services/initializeVLEService.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Observable, Subject } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { VLEProjectService } from '../vle/vleProjectService';
 import { AchievementService } from './achievementService';
 import { ConfigService } from './configService';
@@ -15,7 +15,7 @@ import { StudentWebSocketService } from './studentWebSocketService';
 
 @Injectable()
 export class InitializeVLEService {
-  private intializedSource: Subject<boolean> = new Subject<boolean>();
+  private intializedSource: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   public initialized$: Observable<boolean> = this.intializedSource.asObservable();
 
   constructor(

--- a/src/assets/wise5/vle/vle-parent/vle-parent.component.html
+++ b/src/assets/wise5/vle/vle-parent/vle-parent.component.html
@@ -1,0 +1,1 @@
+<router-outlet></router-outlet>

--- a/src/assets/wise5/vle/vle-parent/vle-parent.component.spec.ts
+++ b/src/assets/wise5/vle/vle-parent/vle-parent.component.spec.ts
@@ -1,0 +1,58 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogModule } from '@angular/material/dialog';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
+import { InitializeVLEService } from '../../services/initializeVLEService';
+import { PauseScreenService } from '../../services/pauseScreenService';
+import { ProjectService } from '../../services/projectService';
+import { StudentNotificationService } from '../../services/studentNotificationService';
+import { VLEProjectService } from '../vleProjectService';
+import { VLEParentComponent } from './vle-parent.component';
+
+let fixture: ComponentFixture<VLEParentComponent>;
+let initializeVLEService: InitializeVLEService;
+let router: Router;
+
+describe('VLEParentComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        MatDialogModule,
+        RouterTestingModule,
+        StudentTeacherCommonServicesModule
+      ],
+      declarations: [VLEParentComponent],
+      providers: [
+        InitializeVLEService,
+        PauseScreenService,
+        ProjectService,
+        StudentNotificationService,
+        VLEProjectService
+      ]
+    }).compileComponents();
+    fixture = TestBed.createComponent(VLEParentComponent);
+    initializeVLEService = TestBed.inject(InitializeVLEService);
+    router = TestBed.inject(Router);
+  });
+  ngOnInit();
+});
+
+function ngOnInit() {
+  describe('ngOnInit()', () => {
+    it('preview route should initialize preview', () => {
+      spyOnProperty(router, 'url', 'get').and.returnValue('/preview/unit/123');
+      const initPreviewSpy = spyOn(initializeVLEService, 'initializePreview');
+      fixture.detectChanges();
+      expect(initPreviewSpy).toHaveBeenCalledWith('123');
+    });
+    it('student route should initialize student', () => {
+      spyOnProperty(router, 'url', 'get').and.returnValue('/student/unit/123');
+      const initStudentSpy = spyOn(initializeVLEService, 'initializeStudent');
+      fixture.detectChanges();
+      expect(initStudentSpy).toHaveBeenCalledWith('123');
+    });
+  });
+}

--- a/src/assets/wise5/vle/vle-parent/vle-parent.component.ts
+++ b/src/assets/wise5/vle/vle-parent/vle-parent.component.ts
@@ -1,0 +1,47 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { InitializeVLEService } from '../../services/initializeVLEService';
+import { StudentDataService } from '../../services/studentDataService';
+import { VLEProjectService } from '../vleProjectService';
+
+@Component({
+  selector: 'vle-parent',
+  templateUrl: './vle-parent.component.html'
+})
+export class VLEParentComponent implements OnInit {
+  constructor(
+    private initializeVLEService: InitializeVLEService,
+    private projectService: VLEProjectService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private studentDataService: StudentDataService
+  ) {}
+
+  ngOnInit(): void {
+    this.initializeVLEService.initialized$.subscribe((initialized: boolean) => {
+      if (initialized) {
+        const startingNodeId = this.getStartingNodeId();
+        this.studentDataService.setCurrentNodeByNodeId(startingNodeId);
+        this.router.navigate([startingNodeId], { relativeTo: this.route.parent });
+      }
+    });
+    const unitId = this.router.url.match(/unit\/([0-9]*)/)[1];
+    if (this.router.url.includes('/preview/unit')) {
+      this.initializeVLEService.initializePreview(unitId);
+    } else {
+      this.initializeVLEService.initializeStudent(unitId);
+    }
+  }
+
+  private getStartingNodeId(): string {
+    const urlMatch = window.location.href.match(/unit\/[0-9]*\/(.*)/);
+    let nodeId =
+      urlMatch != null
+        ? urlMatch[1]
+        : this.studentDataService.getLatestNodeEnteredEventNodeIdWithExistingNode();
+    if (nodeId == null) {
+      nodeId = this.projectService.getStartNodeId();
+    }
+    return nodeId;
+  }
+}

--- a/src/assets/wise5/vle/vle.component.ts
+++ b/src/assets/wise5/vle/vle.component.ts
@@ -73,19 +73,12 @@ export class VLEComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.initializeVLEService.initialized$.subscribe(() => {
-      this.isInitialized = true;
-      this.initRestOfVLE();
-    });
-    const urlMatch = window.location.href.match(/unit\/([0-9]*)/);
-    if (urlMatch != null) {
-      const unitId = urlMatch[1];
-      if (this.router.url.includes('/preview/unit')) {
-        this.initializeVLEService.initializePreview(unitId);
-      } else {
-        this.initializeVLEService.initializeStudent(unitId);
+    this.initializeVLEService.initialized$.subscribe((initialized: boolean) => {
+      if (initialized) {
+        this.initRestOfVLE();
+        this.isInitialized = true;
       }
-    }
+    });
   }
 
   initRestOfVLE() {
@@ -141,18 +134,6 @@ export class VLEComponent implements OnInit {
 
     this.themePath = this.projectService.getThemePath();
     this.notebookItemPath = this.themePath + '/notebook/notebookItem.html';
-
-    const urlMatch = window.location.href.match(/unit\/[0-9]*\/(.*)/);
-    let nodeId =
-      urlMatch != null
-        ? urlMatch[1]
-        : this.studentDataService.getLatestNodeEnteredEventNodeIdWithExistingNode();
-
-    if (nodeId == null) {
-      nodeId = this.projectService.getStartNodeId();
-    }
-
-    this.studentDataService.setCurrentNodeByNodeId(nodeId);
 
     // TODO: set these variables dynamically from theme settings
     this.layoutView = 'list'; // 'list' or 'card'
@@ -283,7 +264,7 @@ export class VLEComponent implements OnInit {
             eventData
           );
         }
-
+        this.router.navigate([currentNodeId], { relativeTo: this.route.parent });
         this.setLayoutState();
       })
     );
@@ -395,8 +376,6 @@ export class VLEComponent implements OnInit {
         }
       }
     }
-
-    this.router.navigate([this.currentNode.id], { relativeTo: this.route.parent });
     this.layoutState = layoutState;
   }
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -16517,8 +16517,8 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <note priority="1" from="description">Label for note text input</note>
       </trans-unit>
-      <trans-unit id="314315645942131479" datatype="html">
-        <source>Info</source>
+      <trans-unit id="8129802372590365244" datatype="html">
+        <source>Rubric</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/themes/default/themeComponents/helpIcon/help-icon.component.ts</context>
           <context context-type="linenumber">40</context>
@@ -16788,49 +16788,49 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>This unit ended on <x id="PH" equiv-text="endDate"/>. You can no longer save new work.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">113</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2304476742154607725" datatype="html">
         <source>You have been inactive for a long time. Do you want to stay logged in?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">222</context>
+          <context context-type="linenumber">203</context>
         </context-group>
       </trans-unit>
       <trans-unit id="537022937435161177" datatype="html">
         <source>Session Timeout</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">223</context>
+          <context context-type="linenumber">204</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3178064088723974543" datatype="html">
         <source>Sorry, you cannot view this item yet.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">316</context>
+          <context context-type="linenumber">297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="685273827497092928" datatype="html">
         <source>&lt;p&gt;To visit &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt; you need to:&lt;/p&gt;&lt;ul&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">323</context>
+          <context context-type="linenumber">304</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2738912629247967660" datatype="html">
         <source>Item Locked</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">336</context>
+          <context context-type="linenumber">317</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3023661788238273336" datatype="html">
         <source>Error: Data is not being saved! Check your internet connection.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">406</context>
+          <context context-type="linenumber">385</context>
         </context-group>
       </trans-unit>
     </body>


### PR DESCRIPTION
## Changes
- "/[preview|student]/unit/1" is now handled by VLEParentComponent
- "/[preview|student]/unit/1/node2" is now handled by VLEComponent
- Fix issue where snipToNotebook was creating two listeners

## Test
- Preview unit ("/preview/unit/X")
   - without nodeId in url launches with the start node in the unit
   - with nodeId in url launches with the nodeId
- Student unit ("/student/unit/X")
   - without nodeId in url launches
      - start node in the unit, if this is student's first time launching unit
      - last-visited node, if student has launched unit before 
   - with nodeId in url launches with the nodeId
- Snip image in html component only launches 1 note dialog (before, it launched 2 dialogs)

Closes #731