### PR TITLE
feat(Dialog Guidance): Add hasKIScore(num) token expression rule

### DIFF
--- a/src/assets/wise5/components/dialogGuidance/CRaterResponse.ts
+++ b/src/assets/wise5/components/dialogGuidance/CRaterResponse.ts
@@ -18,12 +18,14 @@ export class CRaterResponse {
     return detectedIdeaNames;
   }
 
-  getKIScore() {
-    for (const score of this.scores) {
-      if (score.id === 'ki') {
-        return score.score;
-      }
-    }
+  getKIScore(): number {
+    return this.isSingleScoreItem()
+      ? this.score
+      : this.scores.find((score) => score.id === 'ki').score;
+  }
+
+  private isSingleScoreItem(): boolean {
+    return this.score != null;
   }
 
   isNonScorable(): boolean {

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
@@ -24,8 +24,11 @@ import { FeedbackRule } from './FeedbackRule';
 
 let component: DialogGuidanceStudentComponent;
 let evaluator: DialogGuidanceFeedbackRuleEvaluator;
+const KI_SCORE_0 = new CRaterScore('ki', 0, 0, 1, 5);
 const KI_SCORE_1 = new CRaterScore('ki', 1, 1, 1, 5);
 const KI_SCORE_3 = new CRaterScore('ki', 3, 3, 1, 5);
+const KI_SCORE_5 = new CRaterScore('ki', 5, 5, 1, 5);
+const KI_SCORE_6 = new CRaterScore('ki', 6, 6, 1, 5);
 describe('DialogGuidanceFeedbackRuleEvaluator', () => {
   let fixture: ComponentFixture<DialogGuidanceStudentComponent>;
   const defaultFeedbackRules = [
@@ -40,10 +43,6 @@ describe('DialogGuidanceFeedbackRuleEvaluator', () => {
     {
       expression: 'isNonScorable',
       feedback: 'isNonScorable'
-    },
-    {
-      expression: 'hasKIScore(3)',
-      feedback: 'hasKIScore(3)'
     },
     {
       expression: 'idea1 && idea2',
@@ -179,8 +178,36 @@ function matchRule_MultipleIdeasUsingNotAndOr() {
 }
 
 function matchRule_hasKIScore() {
-  it('should find rule matching hasKIScore() function', () => {
-    expectFeedback([], [KI_SCORE_3], 'hasKIScore(3)');
+  describe('hasKIScore()', () => {
+    beforeEach(() => {
+      component.componentContent.feedbackRules = [
+        {
+          expression: 'hasKIScore(1)',
+          feedback: 'hasKIScore(1)'
+        },
+        {
+          expression: 'hasKIScore(3)',
+          feedback: 'hasKIScore(3)'
+        },
+        {
+          expression: 'hasKIScore(5)',
+          feedback: 'hasKIScore(5)'
+        },
+        {
+          expression: 'isDefault',
+          feedback: 'isDefault'
+        }
+      ];
+    });
+    it('should match rule if KI score is in range [1-5]', () => {
+      expectFeedback([], [KI_SCORE_1], 'hasKIScore(1)');
+      expectFeedback([], [KI_SCORE_3], 'hasKIScore(3)');
+      expectFeedback([], [KI_SCORE_5], 'hasKIScore(5)');
+    });
+    it('should not match rule if KI score is out of range [1-5]', () => {
+      expectFeedback([], [KI_SCORE_0], 'isDefault');
+      expectFeedback([], [KI_SCORE_6], 'isDefault');
+    });
   });
 }
 

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
@@ -24,6 +24,8 @@ import { FeedbackRule } from './FeedbackRule';
 
 let component: DialogGuidanceStudentComponent;
 let evaluator: DialogGuidanceFeedbackRuleEvaluator;
+const KI_SCORE_1 = new CRaterScore('ki', 1, 1, 1, 5);
+const KI_SCORE_3 = new CRaterScore('ki', 3, 3, 1, 5);
 describe('DialogGuidanceFeedbackRuleEvaluator', () => {
   let fixture: ComponentFixture<DialogGuidanceStudentComponent>;
   const defaultFeedbackRules = [
@@ -38,6 +40,10 @@ describe('DialogGuidanceFeedbackRuleEvaluator', () => {
     {
       expression: 'isNonScorable',
       feedback: 'isNonScorable'
+    },
+    {
+      expression: 'hasKIScore(3)',
+      feedback: 'hasKIScore(3)'
     },
     {
       expression: 'idea1 && idea2',
@@ -63,7 +69,6 @@ describe('DialogGuidanceFeedbackRuleEvaluator', () => {
       expression: 'idea1',
       feedback: 'You hit idea1'
     },
-
     {
       expression: '!idea10',
       feedback: '!idea10'
@@ -129,6 +134,7 @@ describe('DialogGuidanceFeedbackRuleEvaluator', () => {
   matchRule_MultipleIdeasUsingOr();
   matchRule_MultipleIdeasUsingAndOr();
   matchRule_MultipleIdeasUsingNotAndOr();
+  matchRule_hasKIScore();
   matchNoRule_ReturnDefault();
   matchNoRule_NoDefaultFeedbackAuthored_ReturnApplicationDefault();
   secondToLastSubmit();
@@ -138,64 +144,70 @@ describe('DialogGuidanceFeedbackRuleEvaluator', () => {
 
 function matchRule_OneIdea() {
   it('should find first rule matching one idea', () => {
-    expectFeedback(['idea1'], [], 'You hit idea1');
+    expectFeedback(['idea1'], [KI_SCORE_1], 'You hit idea1');
   });
 }
 
 function matchRule_MultipleIdeasUsingAnd() {
   it('should find rule matching two ideas using && operator', () => {
-    expectFeedback(['idea1', 'idea2'], [], 'You hit idea1 and idea2');
-    expectFeedback(['idea2', 'idea3', 'idea4'], [], 'You hit idea2, idea3 and idea4');
+    expectFeedback(['idea1', 'idea2'], [KI_SCORE_1], 'You hit idea1 and idea2');
+    expectFeedback(['idea2', 'idea3', 'idea4'], [KI_SCORE_1], 'You hit idea2, idea3 and idea4');
   });
 }
 
 function matchRule_MultipleIdeasUsingOr() {
   it('should find rule matching ideas using || operator', () => {
-    expectFeedback(['idea5'], [], 'You hit idea5 or idea6');
+    expectFeedback(['idea5'], [KI_SCORE_1], 'You hit idea5 or idea6');
   });
 }
 
 function matchRule_MultipleIdeasUsingAndOr() {
   it('should find rule matching ideas using combination of && and || operators', () => {
-    expectFeedback(['idea7', 'idea9'], [], 'You hit idea7 or idea8 and idea9');
-    expectFeedback(['idea8', 'idea9'], [], 'You hit idea7 or idea8 and idea9');
-    expectFeedback(['idea7', 'idea8'], [], 'You hit idea7 and idea8 or idea9');
-    expectFeedback(['idea9'], [], 'You hit idea7 and idea8 or idea9');
+    expectFeedback(['idea7', 'idea9'], [KI_SCORE_1], 'You hit idea7 or idea8 and idea9');
+    expectFeedback(['idea8', 'idea9'], [KI_SCORE_1], 'You hit idea7 or idea8 and idea9');
+    expectFeedback(['idea7', 'idea8'], [KI_SCORE_1], 'You hit idea7 and idea8 or idea9');
+    expectFeedback(['idea9'], [KI_SCORE_1], 'You hit idea7 and idea8 or idea9');
   });
 }
 
 function matchRule_MultipleIdeasUsingNotAndOr() {
   it('should find rule matching ideas using combination of !, && and || operators', () => {
-    expectFeedback([], [], '!idea10');
-    expectFeedback(['idea10'], [], 'idea10 && !idea11');
-    expectFeedback(['idea10', 'idea11', 'idea12'], [], '!idea11 || idea12');
+    expectFeedback([], [KI_SCORE_1], '!idea10');
+    expectFeedback(['idea10'], [KI_SCORE_1], 'idea10 && !idea11');
+    expectFeedback(['idea10', 'idea11', 'idea12'], [KI_SCORE_1], '!idea11 || idea12');
+  });
+}
+
+function matchRule_hasKIScore() {
+  it('should find rule matching hasKIScore() function', () => {
+    expectFeedback([], [KI_SCORE_3], 'hasKIScore(3)');
   });
 }
 
 function matchNoRule_ReturnDefault() {
   it('should return default idea when no rule is matched', () => {
-    expectFeedback(['idea10', 'idea11'], [], 'default feedback');
+    expectFeedback(['idea10', 'idea11'], [KI_SCORE_1], 'default feedback');
   });
 }
 
 function matchNoRule_NoDefaultFeedbackAuthored_ReturnApplicationDefault() {
   it('should return application default rule when no rule is matched and no default is authored', () => {
     component.componentContent.feedbackRules = [];
-    expectFeedback(['idea10', 'idea11'], [], evaluator.defaultFeedback);
+    expectFeedback(['idea10', 'idea11'], [KI_SCORE_1], evaluator.defaultFeedback);
   });
 }
 
 function secondToLastSubmit() {
   it('should return second to last submit rule when there is one submit left', () => {
     component.submitCounter = 4;
-    expectFeedback(['idea1'], [], 'second to last submission');
+    expectFeedback(['idea1'], [KI_SCORE_1], 'second to last submission');
   });
 }
 
 function finalSubmit() {
   it('should return final submit rule when no more submits left', () => {
     component.submitCounter = 5;
-    expectFeedback(['idea1'], [], 'final submission');
+    expectFeedback(['idea1'], [KI_SCORE_1], 'final submission');
   });
 }
 

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
@@ -114,11 +114,24 @@ export class DialogGuidanceFeedbackRuleEvaluator {
     return !this.evaluateTerm(termStack.pop(), response);
   }
 
-  private evaluateOrExpression(term1: string, term2: string, response: CRaterResponse): boolean {
-    return this.evaluateTerm(term1, response) || this.evaluateTerm(term2, response);
+  private evaluateTerm(term: string, response: CRaterResponse): boolean {
+    if (this.isHasKIScoreTerm(term)) {
+      return this.evaluateHasKIScoreTerm(term, response);
+    } else {
+      return this.evaluateIdeaTerm(term, response);
+    }
   }
 
-  private evaluateTerm(term: string, response: CRaterResponse): boolean {
+  private isHasKIScoreTerm(term: string): boolean {
+    return /hasKIScore\([1-5]\)/.test(term);
+  }
+
+  private evaluateHasKIScoreTerm(term: string, response: CRaterResponse): boolean {
+    const expectedKIScore = parseInt(term.match(/hasKIScore\((.*)\)/)[1]);
+    return response.getKIScore() === expectedKIScore;
+  }
+
+  private evaluateIdeaTerm(term: string, response: CRaterResponse): boolean {
     return term === 'true' || response.getDetectedIdeaNames().includes(term);
   }
 

--- a/src/assets/wise5/services/cRaterService.ts
+++ b/src/assets/wise5/services/cRaterService.ts
@@ -321,7 +321,7 @@ export class CRaterService {
   }
 
   private getScore(response: any): number {
-    return response.responses.scores.raw_trim_round;
+    return parseInt(response.responses.scores.raw_trim_round);
   }
 
   private getScores(response: any): CRaterScore[] {
@@ -331,10 +331,10 @@ export class CRaterService {
       scores.push(
         new CRaterScore(
           key,
-          value.raw_trim_round,
-          value.raw,
-          value.score_range_min,
-          value.score_range_max
+          parseInt(value.raw_trim_round),
+          parseFloat(value.raw),
+          parseInt(value.score_range_min),
+          parseInt(value.score_range_max)
         )
       );
     }


### PR DESCRIPTION
## Changes
- Add hasKIScore(num) token to Dialog Guidance feedback expression rule, where 1 <= num <= 5
- CRaterResponse.getKIScore() now works for single-score items
- Remove unused code

## Test
- Add "hasKIScore(X)" feedback rules for both multiple-score item ("MusicalInstruments_Speed_score-ki_idea-ki_nonscor") and single-score item ("GREENROOF-II") and make sure that they are matched and the corresponding feedback is shown
- Try using operators to combine the token like ```hasKIScore(2) || hasKIScore(3)``` and make sure that it is matched and the corresponding feedback is shown

Closes #737