### PR TITLE
fix(Graph): Categories data point authoring

### DIFF
--- a/src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.html
+++ b/src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.html
@@ -431,7 +431,7 @@
   <div *ngIf="series.data == null || series.data.length == 0">
     This series has no starter data points. Click the "Add Data Point" button to add a starter data point if you'd like.
   </div>
-  <div *ngFor="let dataPoint of series.data; index as dataPointIndex; first as isFirst; last as isLast">
+  <div *ngFor="let dataPoint of series.data; index as dataPointIndex; first as isFirst; last as isLast; trackBy: customTrackBy">
     <span *ngIf="authoringComponentContent.xAxis.type === 'limits' || authoringComponentContent.xAxis.type === '' || authoringComponentContent.xAxis.type == null">
       <mat-form-field class="data-point-input">
         <mat-label i18n>X</mat-label>

--- a/src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.ts
+++ b/src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.ts
@@ -569,4 +569,8 @@ export class GraphAuthoring extends ComponentAuthoring {
       delete series.dashStyle;
     }
   }
+
+  customTrackBy(index: number): number {
+    return index;
+  }
 }


### PR DESCRIPTION
## Changes

## Test

1. Open a project in the Authoring Tool
2. Create a Graph component in a step
3. Set the X Axis type to Categories
4. Go down to the Series and add two Data Points
5. Type a number with two digits like 11 into the first data point input "Category One"
6. 11 should show up in the input. Previously, you would end up with 1 in the first data point input and 11 in the second data point input "Categories Two" because it would switch focus to the second data point input for some reason.
7. Try adding some digits into the second data point input "Categories Two"
8. The digits should show up as expected. Previously, it would only let you enter one digit at a time because the input would lose focus after you entered a digit.

Closes #741 