### PR TITLE
Support Table row selection to filter connected Graphs

### DIFF
--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
@@ -111,7 +111,6 @@ describe('GraphStudentComponent', () => {
   getTheYValueFromDataPoint();
   getTrialNumbers();
   getValuesInColumn();
-  handleDataExplorer();
   handleDeleteKeyPressed();
   handleTableConnectedComponentStudentDataChanged();
   handleTrialIdsToShowChanged();
@@ -391,14 +390,34 @@ function createChartConfig() {
   });
 }
 
+function createTableConnectedComponent(): any {
+  return {
+    skipFirstRow: true,
+    xColumn: 0,
+    yColumn: 1
+  };
+}
+
+function createDataExplorerStudentData(): any {
+  return {
+    isDataExplorerEnabled: true,
+    dataExplorerGraphType: 'scatter',
+    tableData: [
+      [{ text: 'ID' }, { text: 'Age' }, { text: 'Score' }],
+      [{ text: '1' }, { text: '10' }, { text: '100' }],
+      [{ text: '2' }, { text: '20' }, { text: '200' }],
+      [{ text: '3' }, { text: '30' }, { text: '300' }]
+    ],
+    dataExplorerSeries: [{ xColumn: 0, yColumn: 1, name: 'The series name' }],
+    dataExplorerXAxisLabel: 'Hello',
+    dataExplorerYAxisLabel: 'World'
+  };
+}
+
 function handleTableConnectedComponentStudentDataChanged() {
   describe('handleTableConnectedComponentStudentDataChanged', () => {
     it('should handle table connected component student data changed', () => {
-      const connectedComponent = {
-        skipFirstRow: true,
-        xColumn: 0,
-        yColumn: 1
-      };
+      const connectedComponent = createTableConnectedComponent();
       const dataRows: any[] = [sampleData];
       const tableDataRows: any[] = [['Time', 'Position']].concat(dataRows);
       const componentState = {
@@ -408,6 +427,64 @@ function handleTableConnectedComponentStudentDataChanged() {
       };
       component.handleTableConnectedComponentStudentDataChanged(connectedComponent, componentState);
       expect(component.activeTrial.series[0].data).toEqual(dataRows);
+    });
+    it('should handle table connected component student data changed with selected rows', () => {
+      const connectedComponent = createTableConnectedComponent();
+      const dataRows: any[] = [
+        [0, 0],
+        [10, 20],
+        [20, 40],
+        [30, 80]
+      ];
+      const tableDataRows: any[] = [['Time', 'Position']].concat(dataRows);
+      const componentState = {
+        studentData: {
+          tableData: createTable(tableDataRows),
+          selectedRowIndices: [0, 2]
+        }
+      };
+      component.handleTableConnectedComponentStudentDataChanged(connectedComponent, componentState);
+      expect(component.activeTrial.series[0].data).toEqual([
+        [0, 0],
+        [20, 40]
+      ]);
+    });
+    it('should handle connected data explorer student data changed', () => {
+      const connectedComponent = createTableConnectedComponent();
+      const studentData = createDataExplorerStudentData();
+      const componentState = {
+        studentData: studentData
+      };
+      component.activeTrial = {};
+      component.handleTableConnectedComponentStudentDataChanged(connectedComponent, componentState);
+      expect(component.xAxis.title.text).toEqual('Hello');
+      expect(component.yAxis.title.text).toEqual('World');
+      expect(component.activeTrial.series.length).toEqual(1);
+      const series = component.activeTrial.series[0];
+      expect(series.type).toEqual('scatter');
+      expect(series.name).toEqual('The series name');
+      expect(series.color).toEqual('blue');
+      expect(series.data[0][0]).toEqual(1);
+      expect(series.data[1][1]).toEqual(20);
+    });
+    it('should handle connected data explorer student data changed with selected rows', () => {
+      const connectedComponent = createTableConnectedComponent();
+      const studentData = createDataExplorerStudentData();
+      studentData.selectedRowIndices = [0, 2];
+      const componentState = {
+        studentData: studentData
+      };
+      component.activeTrial = {};
+      component.handleTableConnectedComponentStudentDataChanged(connectedComponent, componentState);
+      expect(component.xAxis.title.text).toEqual('Hello');
+      expect(component.yAxis.title.text).toEqual('World');
+      expect(component.activeTrial.series.length).toEqual(1);
+      const series = component.activeTrial.series[0];
+      expect(series.type).toEqual('scatter');
+      expect(series.name).toEqual('The series name');
+      expect(series.color).toEqual('blue');
+      expect(series.data[0][0]).toEqual(1);
+      expect(series.data[1][1]).toEqual(30);
     });
   });
 }
@@ -1537,34 +1614,6 @@ function notSetTheActiveTrialAndSeriesIfTheTrialCanNotBeEdited() {
     expect(component.series).toEqual(trial1.series);
     expect(component.activeTrial).toEqual(trial1);
     expect(component.activeSeries).toEqual(trial1.series[0]);
-  });
-}
-
-function handleDataExplorer() {
-  it('should handle data explorer', () => {
-    const studentData = {
-      dataExplorerGraphType: 'scatter',
-      tableData: [
-        [{ text: 'ID' }, { text: 'Age' }, { text: 'Score' }],
-        [{ text: '1' }, { text: '10' }, { text: '100' }],
-        [{ text: '2' }, { text: '20' }, { text: '200' }],
-        [{ text: '3' }, { text: '30' }, { text: '300' }]
-      ],
-      dataExplorerSeries: [{ xColumn: 0, yColumn: 1, name: 'The series name' }],
-      dataExplorerXAxisLabel: 'Hello',
-      dataExplorerYAxisLabel: 'World'
-    };
-    component.activeTrial = {};
-    component.handleDataExplorer(studentData);
-    expect(component.xAxis.title.text).toEqual('Hello');
-    expect(component.yAxis.title.text).toEqual('World');
-    expect(component.activeTrial.series.length).toEqual(1);
-    const series = component.activeTrial.series[0];
-    expect(series.type).toEqual('scatter');
-    expect(series.name).toEqual('The series name');
-    expect(series.color).toEqual('blue');
-    expect(series.data[0][0]).toEqual(1);
-    expect(series.data[0][1]).toEqual(10);
   });
 }
 

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -272,7 +272,7 @@ export class GraphStudent extends ComponentStudent {
     this.isDirty = true;
   }
 
-  private getVisibleRows(tableData: any, selectedRowIndices: number[]): any {
+  private getVisibleRows(tableData: any, selectedRowIndices: number[]): any[] {
     const visibleRows = [];
     visibleRows.push(tableData[0]);
     tableData.forEach((row, index) => {

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -257,40 +257,33 @@ export class GraphStudent extends ComponentStudent {
   }
 
   handleTableConnectedComponentStudentDataChanged(connectedComponent, componentState) {
-    const studentData = componentState.studentData;
+    const studentData = this.UtilService.makeCopyOfJSONObject(componentState.studentData);
+    const selectedRowIndices = studentData.selectedRowIndices;
+    const tableData = studentData.tableData;
+    if (tableData.length > 0 && selectedRowIndices != null && selectedRowIndices.length > 0) {
+      studentData.tableData = this.getVisibleRows(studentData.tableData, selectedRowIndices);
+    }
     if (studentData.isDataExplorerEnabled) {
       this.handleDataExplorer(studentData);
     } else {
-      const rows = studentData.tableData;
-      const data = this.convertRowDataToSeriesData(rows, connectedComponent);
-      let seriesIndex = connectedComponent.seriesIndex;
-      if (seriesIndex == null) {
-        seriesIndex = 0;
-      }
-      if (this.isStudentDataVersion1()) {
-        let series = this.series[seriesIndex];
-        if (series == null) {
-          series = {};
-          this.series[seriesIndex] = series;
-        }
-        series.data = data;
-      } else {
-        const trial = this.activeTrial;
-        if (trial != null && trial.series != null) {
-          let series = trial.series[seriesIndex];
-          if (series == null) {
-            series = {};
-            this.series[seriesIndex] = series;
-          }
-          series.data = data;
-        }
-      }
+      this.handleConnectedComponentData(studentData, connectedComponent);
     }
     this.drawGraph();
     this.isDirty = true;
   }
 
-  handleDataExplorer(studentData) {
+  private getVisibleRows(tableData: any, selectedRowIndices: number[]): any {
+    const visibleRows = [];
+    visibleRows.push(tableData[0]);
+    tableData.forEach((row, index) => {
+      if (selectedRowIndices.includes(index - 1)) {
+        visibleRows.push(row);
+      }
+    });
+    return visibleRows;
+  }
+
+  private handleDataExplorer(studentData: any): void {
     const dataExplorerSeries = studentData.dataExplorerSeries;
     const graphType = studentData.dataExplorerGraphType;
     this.xAxis.title.text = studentData.dataExplorerXAxisLabel;
@@ -326,6 +319,33 @@ export class GraphStudent extends ComponentStudent {
           );
           this.activeTrial.series.push(regressionSeries);
         }
+      }
+    }
+  }
+
+  private handleConnectedComponentData(studentData: any, connectedComponent: any): void {
+    const rows = studentData.tableData;
+    const data = this.convertRowDataToSeriesData(rows, connectedComponent);
+    let seriesIndex = connectedComponent.seriesIndex;
+    if (seriesIndex == null) {
+      seriesIndex = 0;
+    }
+    if (this.isStudentDataVersion1()) {
+      let series = this.series[seriesIndex];
+      if (series == null) {
+        series = {};
+        this.series[seriesIndex] = series;
+      }
+      series.data = data;
+    } else {
+      const trial = this.activeTrial;
+      if (trial != null && trial.series != null) {
+        let series = trial.series[seriesIndex];
+        if (series == null) {
+          series = {};
+          this.series[seriesIndex] = series;
+        }
+        series.data = data;
       }
     }
   }

--- a/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html
+++ b/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html
@@ -140,14 +140,16 @@
       color="primary"
       class="import-table-button"
       fxLayoutAlign="center center">
-    <div i18n>Import Table</div>
+    <span i18n>Import Table</span>
     <input type="file"
         accept=".csv"
         class="import-table-input"
         (change)="importTableFile($event)"/>
   </button>
   <mat-icon matTooltip="Only .csv (comma separated values) files are allowed"
-      i18n-matTooltip>
+      i18n-matTooltip
+      tabindex="0"
+      aria-role="button">
     help
   </mat-icon>
   <mat-progress-spinner *ngIf="isImportingTable"
@@ -166,6 +168,14 @@
 <br/>
 <edit-component-submit-button [authoringComponentContent]="authoringComponentContent">
 </edit-component-submit-button>
+<div>
+  <mat-checkbox color="primary"
+      [(ngModel)]="authoringComponentContent.enableRowSelection"
+      (ngModelChange)="componentChanged()"
+      i18n>
+    Enable Row Selection
+  </mat-checkbox>
+</div>
 <edit-component-max-submit
     *ngIf="authoringComponentContent.showSubmitButton"
     [(maxSubmitCount)]="authoringComponentContent.maxSubmitCount"

--- a/src/assets/wise5/components/table/table-show-work/table-show-work.component.html
+++ b/src/assets/wise5/components/table/table-show-work/table-show-work.component.html
@@ -1,6 +1,6 @@
 <div class="table-container">
   <tabulator-table [editableCells]="tabulatorData.editableCells"
-      [isDisabled]="true"
+      [disabled]="true"
       [tabColumns]="tabulatorData.columns"
       [tabData]="tabulatorData.data"
       [tabOptions]="tabulatorData.options"></tabulator-table>

--- a/src/assets/wise5/components/table/table-show-work/table-show-work.component.html
+++ b/src/assets/wise5/components/table/table-show-work/table-show-work.component.html
@@ -1,6 +1,8 @@
 <div class="table-container">
   <tabulator-table [editableCells]="tabulatorData.editableCells"
       [disabled]="true"
+      [enableRowSelection]="componentContent.enableRowSelection"
+      [selectedRowIndices]="selectedRowIndices"
       [tabColumns]="tabulatorData.columns"
       [tabData]="tabulatorData.data"
       [tabOptions]="tabulatorData.options"></tabulator-table>

--- a/src/assets/wise5/components/table/table-show-work/table-show-work.component.ts
+++ b/src/assets/wise5/components/table/table-show-work/table-show-work.component.ts
@@ -16,12 +16,16 @@ export class TableShowWorkComponent extends ComponentShowWorkDirective {
   dataExplorerXAxisLabel: string;
   dataExplorerYAxisLabel: string;
   dataExplorerYAxisLabels: string[];
+  selectedRowIndices: number[];
   xColumnIndex: number;
   columnNames: string[] = [];
   noneText: string = $localize`(None)`;
   tabulatorData: TabulatorData;
 
-  constructor(protected ProjectService: ProjectService, private TabulatorDataService: TabulatorDataService) {
+  constructor(
+    protected ProjectService: ProjectService,
+    private TabulatorDataService: TabulatorDataService
+  ) {
     super(ProjectService);
   }
 
@@ -29,6 +33,7 @@ export class TableShowWorkComponent extends ComponentShowWorkDirective {
     super.ngOnInit();
     const studentData = this.componentState.studentData;
     this.tableData = studentData.tableData;
+    this.selectedRowIndices = studentData.selectedRowIndices ? studentData.selectedRowIndices : [];
     if (studentData.isDataExplorerEnabled) {
       this.dataExplorerGraphType = studentData.dataExplorerGraphType;
       this.dataExplorerSeries = studentData.dataExplorerSeries;
@@ -38,7 +43,7 @@ export class TableShowWorkComponent extends ComponentShowWorkDirective {
       this.xColumnIndex = this.calculateXColumnIndex(this.componentState);
       this.columnNames = this.calculateColumnNames(this.componentState);
     }
-    this.setupTable()
+    this.setupTable();
   }
 
   calculateXColumnIndex(componentState: any): number {

--- a/src/assets/wise5/components/table/table-student/table-student.component.html
+++ b/src/assets/wise5/components/table/table-student/table-student.component.html
@@ -33,7 +33,7 @@
 <tabulator-table [id]="tableId"
     [editableCells]="tabulatorData.editableCells"
     [enableRowSelection]="componentContent.enableRowSelection"
-    [selectedRowIndeces]="selectedRowIndeces"
+    [selectedRowIndices]="selectedRowIndices"
     [tabColumns]="tabulatorData.columns"
     [tabData]="tabulatorData.data"
     [tabOptions]="tabulatorData.options"

--- a/src/assets/wise5/components/table/table-student/table-student.component.html
+++ b/src/assets/wise5/components/table/table-student/table-student.component.html
@@ -32,10 +32,13 @@
 </div>
 <tabulator-table [id]="tableId"
     [editableCells]="tabulatorData.editableCells"
+    [enableRowSelection]="componentContent.enableRowSelection"
+    [selectedRowIndeces]="selectedRowIndeces"
     [tabColumns]="tabulatorData.columns"
     [tabData]="tabulatorData.data"
     [tabOptions]="tabulatorData.options"
-    (cellChanged)="tabulatorCellChanged($event)"></tabulator-table>
+    (cellChanged)="tabulatorCellChanged($event)"
+    (rowSelectionChanged)="tabulatorRowSelectionChanged($event)"></tabulator-table>
 <div *ngIf="isDataExplorerEnabled">
   <br/>
   <mat-form-field *ngIf="componentContent.dataExplorerGraphTypes.length > 1" appearance="fill">

--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -41,7 +41,7 @@ export class TableStudent extends ComponentStudent {
   latestConnectedComponentState: any;
   notebookConfig: any;
   numDataExplorerSeries: number;
-  selectedRowIndices: number[];
+  selectedRowIndices: number[] = [];
   tableData: any;
   tableId: string;
   tabulatorData: TabulatorData;
@@ -396,7 +396,7 @@ export class TableStudent extends ComponentStudent {
     const componentState: any = this.NodeService.createNewComponentState();
     const studentData: any = {};
     studentData.tableData = this.getCopyOfTableData(this.tableData);
-    studentData.selectedRowIndices = this.getselectedRowIndices();
+    studentData.selectedRowIndices = this.getSelectedRowIndices();
     studentData.isDataExplorerEnabled = this.isDataExplorerEnabled;
     studentData.dataExplorerGraphType = this.dataExplorerGraphType;
     studentData.dataExplorerXAxisLabel = this.dataExplorerXAxisLabel;
@@ -1188,7 +1188,7 @@ export class TableStudent extends ComponentStudent {
     this.studentDataChanged();
   }
 
-  private getselectedRowIndices(): number[] {
+  private getSelectedRowIndices(): number[] {
     return this.componentContent.enableRowSelection ? this.selectedRowIndices : [];
   }
 }

--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -41,7 +41,7 @@ export class TableStudent extends ComponentStudent {
   latestConnectedComponentState: any;
   notebookConfig: any;
   numDataExplorerSeries: number;
-  selectedRowIndeces: number[];
+  selectedRowIndices: number[];
   tableData: any;
   tableId: string;
   tabulatorData: TabulatorData;
@@ -377,8 +377,8 @@ export class TableStudent extends ComponentStudent {
           this.submitCounter = submitCounter;
         }
 
-        this.selectedRowIndeces = studentData.selectedRowIndeces
-          ? studentData.selectedRowIndeces
+        this.selectedRowIndices = studentData.selectedRowIndices
+          ? studentData.selectedRowIndices
           : [];
 
         this.processLatestStudentWork();
@@ -396,7 +396,7 @@ export class TableStudent extends ComponentStudent {
     const componentState: any = this.NodeService.createNewComponentState();
     const studentData: any = {};
     studentData.tableData = this.getCopyOfTableData(this.tableData);
-    studentData.selectedRowIndeces = this.getselectedRowIndeces();
+    studentData.selectedRowIndices = this.getselectedRowIndices();
     studentData.isDataExplorerEnabled = this.isDataExplorerEnabled;
     studentData.dataExplorerGraphType = this.dataExplorerGraphType;
     studentData.dataExplorerXAxisLabel = this.dataExplorerXAxisLabel;
@@ -1181,14 +1181,14 @@ export class TableStudent extends ComponentStudent {
   }
 
   tabulatorRowSelectionChanged(rows: Tabulator.RowComponent[]): void {
-    this.selectedRowIndeces = [];
+    this.selectedRowIndices = [];
     for (const row of rows) {
-      this.selectedRowIndeces.push(row.getIndex());
+      this.selectedRowIndices.push(row.getIndex());
     }
     this.studentDataChanged();
   }
 
-  private getselectedRowIndeces(): number[] {
-    return this.componentContent.enableRowSelection ? this.selectedRowIndeces : [];
+  private getselectedRowIndices(): number[] {
+    return this.componentContent.enableRowSelection ? this.selectedRowIndices : [];
   }
 }

--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -41,6 +41,7 @@ export class TableStudent extends ComponentStudent {
   latestConnectedComponentState: any;
   notebookConfig: any;
   numDataExplorerSeries: number;
+  selectedRowIndeces: number[];
   tableData: any;
   tableId: string;
   tabulatorData: TabulatorData;
@@ -376,6 +377,10 @@ export class TableStudent extends ComponentStudent {
           this.submitCounter = submitCounter;
         }
 
+        this.selectedRowIndeces = studentData.selectedRowIndeces
+          ? studentData.selectedRowIndeces
+          : [];
+
         this.processLatestStudentWork();
       }
     }
@@ -391,6 +396,7 @@ export class TableStudent extends ComponentStudent {
     const componentState: any = this.NodeService.createNewComponentState();
     const studentData: any = {};
     studentData.tableData = this.getCopyOfTableData(this.tableData);
+    studentData.selectedRowIndeces = this.getselectedRowIndeces();
     studentData.isDataExplorerEnabled = this.isDataExplorerEnabled;
     studentData.dataExplorerGraphType = this.dataExplorerGraphType;
     studentData.dataExplorerXAxisLabel = this.dataExplorerXAxisLabel;
@@ -1172,5 +1178,17 @@ export class TableStudent extends ComponentStudent {
     const rowIndex = cell.getRow().getIndex() + 1;
     this.tableData[rowIndex][columnIndex].text = cell.getValue();
     this.studentDataChanged();
+  }
+
+  tabulatorRowSelectionChanged(rows: Tabulator.RowComponent[]): void {
+    this.selectedRowIndeces = [];
+    for (const row of rows) {
+      this.selectedRowIndeces.push(row.getIndex());
+    }
+    this.studentDataChanged();
+  }
+
+  private getselectedRowIndeces(): number[] {
+    return this.componentContent.enableRowSelection ? this.selectedRowIndeces : [];
   }
 }

--- a/src/assets/wise5/components/table/tableService.ts
+++ b/src/assets/wise5/components/table/tableService.ts
@@ -185,6 +185,7 @@ export class TableService extends ComponentService {
         }
       }
     }
+    return false;
   }
 
   /**

--- a/src/assets/wise5/components/table/tableService.ts
+++ b/src/assets/wise5/components/table/tableService.ts
@@ -147,34 +147,44 @@ export class TableService extends ComponentService {
     if (componentState != null) {
       const studentData = componentState.studentData;
       if (studentData != null) {
-        const studentTableData = studentData.tableData;
-        const componentContentTableData = componentContent.tableData;
-        if (studentTableData != null) {
-          const studentRows = studentTableData;
-          for (let r = 0; r < studentRows.length; r++) {
-            const studentRow = studentRows[r];
-            if (studentRow != null) {
-              for (let c = 0; c < studentRow.length; c++) {
-                const studentCell = this.getTableDataCellValue(r, c, studentTableData);
-                const componentContentCell = this.getTableDataCellValue(
-                  r,
-                  c,
-                  componentContentTableData
-                );
-                if (studentCell !== componentContentCell) {
-                  /*
-                   * the cell values are not the same which means
-                   * the student has changed the table
-                   */
-                  return true;
-                }
-              }
+        return (
+          this.studentDataHasSelectedRows(studentData) ||
+          this.studentDataHasTableData(studentData, componentContent)
+        );
+      }
+    }
+  }
+
+  private studentDataHasSelectedRows(studentData: any): boolean {
+    return studentData.selectedRowIndeces != null;
+  }
+
+  private studentDataHasTableData(studentData: any, componentContent: any): boolean {
+    const studentTableData = studentData.tableData;
+    const componentContentTableData = componentContent.tableData;
+    if (studentTableData != null) {
+      const studentRows = studentTableData;
+      for (let r = 0; r < studentRows.length; r++) {
+        const studentRow = studentRows[r];
+        if (studentRow != null) {
+          for (let c = 0; c < studentRow.length; c++) {
+            const studentCell = this.getTableDataCellValue(r, c, studentTableData);
+            const componentContentCell = this.getTableDataCellValue(
+              r,
+              c,
+              componentContentTableData
+            );
+            if (studentCell !== componentContentCell) {
+              /*
+               * the cell values are not the same which means
+               * the student has changed the table
+               */
+              return true;
             }
           }
         }
       }
     }
-    return false;
   }
 
   /**

--- a/src/assets/wise5/components/table/tableService.ts
+++ b/src/assets/wise5/components/table/tableService.ts
@@ -156,7 +156,7 @@ export class TableService extends ComponentService {
   }
 
   private studentDataHasSelectedRows(studentData: any): boolean {
-    return studentData.selectedRowIndeces != null;
+    return studentData.selectedRowIndices != null;
   }
 
   private studentDataHasTableData(studentData: any, componentContent: any): boolean {

--- a/src/assets/wise5/components/table/tableService.ts
+++ b/src/assets/wise5/components/table/tableService.ts
@@ -161,8 +161,8 @@ export class TableService extends ComponentService {
 
   private studentDataHasTableData(studentData: any, componentContent: any): boolean {
     const studentTableData = studentData.tableData;
-    const componentContentTableData = componentContent.tableData;
     if (studentTableData != null) {
+      const componentContentTableData = componentContent.tableData;
       const studentRows = studentTableData;
       for (let r = 0; r < studentRows.length; r++) {
         const studentRow = studentRows[r];

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.scss
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.scss
@@ -12,9 +12,12 @@
 }
 
 .tabulator-row {
+  border-bottom: 0 none;
+
   .tabulator-cell {
-    min-height: 44px; // temporary hack to fix height for some rows with empty cell values; TODO: investigate and fix
     background-color: #ffffff;
+    min-height: 44px; // temporary hack to fix height for some rows with empty cell values; TODO: investigate and fix
+    border-bottom: 1px solid #dddddd;
 
     &.tabulator-cell-editable {
       &:before {
@@ -43,6 +46,22 @@
         border-width: 2px;
         border-color: #000000;
       }
+    }
+
+    input[type=checkbox] {
+      vertical-align: middle;
+    }
+  }
+
+  &.tabulator-selected {
+    background-color: transparent !important;
+
+    &:hover {
+      background-color: transparent !important;
+    }
+
+    .tabulator-cell {
+      background-color: #eeeeee;
     }
   }
 }

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
@@ -64,25 +64,16 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
 
   ngAfterViewInit(): void {
     this.tabOptions.columns = this.setupColumns(this.tabColumns);
-    if (this.enableRowSelection) {
-      this.tabOptions.columns.unshift({
-        formatter: 'rowSelection',
-        titleFormatter: 'rowSelection',
-        hozAlign: 'center',
-        headerSort: false,
-        frozen: true,
-        cellClick: (e, cell) => {
-          cell.getRow().toggleSelect();
-        }
-      });
-    }
+    this.initializeRowSelection();
     this.tabOptions.data = this.tabData;
     this.table = new Tabulator(this.tableEl, this.tabOptions);
     this.table.on('cellEdited', (cell) => {
       this.cellChanged.emit(cell);
     });
     this.table.on('tableBuilt', () => {
-      this.onTableBuilt();
+      if (this.enableRowSelection) {
+        this.setupRowSelection();
+      }
     });
     this.tableContainer.nativeElement.appendChild(this.tableEl);
     this.viewInit$.next();
@@ -131,6 +122,21 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
     return cell.getValue();
   }
 
+  private initializeRowSelection(): void {
+    if (this.enableRowSelection && !this.disabled) {
+      this.tabOptions.columns.unshift({
+        formatter: 'rowSelection',
+        titleFormatter: 'rowSelection',
+        hozAlign: 'center',
+        headerSort: false,
+        frozen: true,
+        cellClick: (e, cell) => {
+          cell.getRow().toggleSelect();
+        }
+      });
+    }
+  }
+
   private processChanges(changes: SimpleChanges): void {
     if (changes['tabColumns'] && !changes['tabColumns'].isFirstChange()) {
       this.table.setColumns(this.setupColumns(this.tabColumns));
@@ -138,23 +144,14 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
     if (changes['tabData'] && !changes['tabData'].isFirstChange()) {
       this.table.setData(this.tabData);
     }
-    if (changes['selectedRowIndices'] && !changes['selectedRowIndices'].isFirstChange()) {
-      this.processSelectedRowChanges(changes['selectedRowIndices']);
-    }
   }
 
-  private onTableBuilt(): void {
-    if (this.enableRowSelection) {
-      if (this.selectedRowIndices != null && this.selectedRowIndices.length > 0) {
-        this.table.selectRow(this.selectedRowIndices);
-      }
-      this.table.on('rowSelectionChanged', (data, rows) => {
-        this.rowSelectionChanged.emit(rows);
-      });
+  private setupRowSelection(): void {
+    if (this.selectedRowIndices != null && this.selectedRowIndices.length > 0) {
+      this.table.selectRow(this.selectedRowIndices);
     }
-  }
-
-  processSelectedRowChanges(change: SimpleChange): void {
-    const currentChange = change.currentValue;
+    this.table.on('rowSelectionChanged', (data, rows) => {
+      this.rowSelectionChanged.emit(rows);
+    });
   }
 }

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
@@ -35,7 +35,7 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
   @Input() editableCells: any;
   @Input() enableRowSelection: boolean;
   @Input() disabled: boolean;
-  @Input() selectedRowIndeces: number[] = [];
+  @Input() selectedRowIndices: number[] = [];
   @Input() tabColumns: TabulatorColumn[]; // see http://tabulator.info/docs/5.3/columns
   @Input() tabData: any[]; // see http://tabulator.info/docs/5.3/data
   @Input() tabOptions: any; // see http://tabulator.info/docs/5.3/options
@@ -138,15 +138,15 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
     if (changes['tabData'] && !changes['tabData'].isFirstChange()) {
       this.table.setData(this.tabData);
     }
-    if (changes['selectedRowIndeces'] && !changes['selectedRowIndeces'].isFirstChange()) {
-      this.processSelectedRowChanges(changes['selectedRowIndeces']);
+    if (changes['selectedRowIndices'] && !changes['selectedRowIndices'].isFirstChange()) {
+      this.processSelectedRowChanges(changes['selectedRowIndices']);
     }
   }
 
   private onTableBuilt(): void {
     if (this.enableRowSelection) {
-      if (this.selectedRowIndeces != null && this.selectedRowIndeces.length > 0) {
-        this.table.selectRow(this.selectedRowIndeces);
+      if (this.selectedRowIndices != null && this.selectedRowIndices.length > 0) {
+        this.table.selectRow(this.selectedRowIndices);
       }
       this.table.on('rowSelectionChanged', (data, rows) => {
         this.rowSelectionChanged.emit(rows);

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
@@ -6,7 +6,6 @@ import {
   Input,
   OnChanges,
   Output,
-  SimpleChange,
   SimpleChanges,
   ViewChild,
   ViewEncapsulation
@@ -40,11 +39,10 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
   @Input() tabData: any[]; // see http://tabulator.info/docs/5.3/data
   @Input() tabOptions: any; // see http://tabulator.info/docs/5.3/options
   @Output() cellChanged = new EventEmitter<Tabulator.CellComponent>();
-  @Output() rowSelectionChanged = new EventEmitter<Tabulator.CellComponent>();
+  @Output() rowSelectionChanged = new EventEmitter<Tabulator.RowComponent>();
   @ViewChild('table', { static: false }) tableContainer: ElementRef;
 
   table: Tabulator;
-  tableBuilt: boolean = false;
   tableEl = document.createElement('div');
   subscriptions: Subscription = new Subscription();
   viewInit$ = new ReplaySubject();
@@ -147,7 +145,7 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
   }
 
   private setupRowSelection(): void {
-    if (this.selectedRowIndices != null && this.selectedRowIndices.length > 0) {
+    if (this.selectedRowIndices.length > 0) {
       this.table.selectRow(this.selectedRowIndices);
     }
     this.table.on('rowSelectionChanged', (data, rows) => {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13442,39 +13442,39 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>The series you are trying to add a point to is currently hidden. Please show the series by clicking the series name in the legend and try adding the point again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1017</context>
+          <context context-type="linenumber">1037</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2852989551014711458" datatype="html">
         <source>You can not edit this series. Please choose a series that can be edited.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1031</context>
+          <context context-type="linenumber">1051</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7053114367342967943" datatype="html">
         <source>Are you sure you want to reset the series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1309</context>
+          <context context-type="linenumber">1329</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7889560203726829643" datatype="html">
         <source>Are you sure you want to reset the &quot;<x id="PH" equiv-text="seriesName"/>&quot; series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1311</context>
+          <context context-type="linenumber">1331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6999515396807067782" datatype="html">
         <source>Trial</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1866</context>
+          <context context-type="linenumber">1886</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">2701</context>
+          <context context-type="linenumber">2721</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9070768663485888935" datatype="html">
@@ -15369,7 +15369,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">21</context>
+          <context context-type="linenumber">23</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
@@ -15621,7 +15621,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Graph Type</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">11</context>
+          <context context-type="linenumber">13</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
@@ -15632,14 +15632,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Y Data <x id="INTERPOLATION" equiv-text="{{dataExplorerSeries.length &gt; 1 ? (i + 1) : &apos;&apos;}}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">33</context>
+          <context context-type="linenumber">35</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b703c5f9773985dca9e4594ae0c3ecb9f3da4462" datatype="html">
         <source>X Axis Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">51</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
@@ -15650,7 +15650,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Y Axis Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">62</context>
+          <context context-type="linenumber">64</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
@@ -15661,14 +15661,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Y Axis <x id="INTERPOLATION" equiv-text="{{i + 1}}"/> Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">79</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8764032794209664551" datatype="html">
         <source>(None)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.ts</context>
-          <context context-type="linenumber">21</context>
+          <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d56d67fc38809e23fcba86a9acc09bd9e40e8b2a" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15419,6 +15419,13 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">149</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="3d7f8dac570a1d36a691e532f23a1f61297f4858" datatype="html">
+        <source> Enable Row Selection </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html</context>
+          <context context-type="linenumber">175,177</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="3802284852279199102" datatype="html">
         <source>Are you sure you want to overwrite the existing table?</source>
         <context-group purpose="location">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15005,11 +15005,11 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">62</context>
+          <context context-type="linenumber">65</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1702c8b1dfd9b74fe218322fb3509b227cd41b1b" datatype="html">
@@ -15373,7 +15373,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">60</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2c57dd23349e236c076c19356af17d5de965d398" datatype="html">
@@ -15625,7 +15625,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">45</context>
         </context-group>
       </trans-unit>
       <trans-unit id="967a05fa93ce8900222661f7beb6c08924b3a857" datatype="html">
@@ -15643,7 +15643,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">98</context>
+          <context context-type="linenumber">101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="484e9a22dbb7f73c463535f204e1f221b6cbdacb" datatype="html">
@@ -15654,7 +15654,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">110</context>
+          <context context-type="linenumber">113</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f15f150caaef41e4e915900660dae93b053ec897" datatype="html">
@@ -15682,36 +15682,36 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Choose the table data you want to graph:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">54</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a3e2cbd23a21040a6893d669847148041dd03868" datatype="html">
         <source>Y Data <x id="INTERPOLATION" equiv-text="{{ dataExplorerSeries.length &gt; 1 ? seriesIndex + 1 : &quot;&quot;}}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">79</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7c0b21d6d77a0c42b3a86c8922b7766ebfaeb4c1" datatype="html">
         <source>Enter Text Here</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">103</context>
+          <context context-type="linenumber">106</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">115</context>
+          <context context-type="linenumber">118</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">132</context>
+          <context context-type="linenumber">135</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2ba0ed2ffebe37a936032b49e9fdf057a9af7d07" datatype="html">
         <source>Y Axis <x id="INTERPOLATION" equiv-text="{{yAxisIndex + 1}}"/> Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">127</context>
+          <context context-type="linenumber">130</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1358239534403218079" datatype="html">


### PR DESCRIPTION
## Changes
- Adds an option to Table advanced authoring to enable or disable row selection using checkboxes.
- Saves student row selections when enable.
- If Table is connected to a Graph component, Graph will only display data from selected rows.

Closes #740.

## Test
- Make sure that enabling row selection shows checkboxes to select rows in Table component.
- Make sure student row selections are saved.
- Make sure student row selections can be seen (highlighted) in show work and grading view.
- Make sure connected Graph data is filtered to only show selected rows if any rows are selected.
