### PR TITLE
fix(Data Explorer): Fix rendering with empty cells

### DIFF
--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -1708,28 +1708,26 @@ export class GraphStudent extends ComponentStudent {
   }
 
   addPointFromTableIntoData(xCell: any, yCell: any, data: any[]) {
-    let xText = xCell.text;
-    if (xText == null || xText === '') {
-      xText = 'N/A';
-    }
-    let yText = yCell.text;
-    if (yText == null || yText === '') {
-      yText = 'N/A';
-    }
-    const xNumber = Number(xText);
-    const yNumber = Number(yText);
-    const point = [];
-    if (!isNaN(xNumber)) {
-      point.push(xNumber);
+    const xText = xCell.text;
+    const yText = yCell.text;
+    if (xText != null && xText !== '' && yText != null && yText !== '') {
+      const xNumber = Number(xText);
+      const yNumber = Number(yText);
+      const point = [];
+      if (!isNaN(xNumber)) {
+        point.push(xNumber);
+      } else {
+        point.push(xText);
+      }
+      if (!isNaN(yNumber)) {
+        point.push(yNumber);
+      } else {
+        point.push(yText);
+      }
+      data.push(point);
     } else {
-      point.push(xText);
+      data.push([]);
     }
-    if (!isNaN(yNumber)) {
-      point.push(yNumber);
-    } else {
-      point.push(yText);
-    }
-    data.push(point);
   }
 
   setSeriesIds(allSeries) {


### PR DESCRIPTION
## Changes

When a cell does not have a value, we now add an empty array [] to the data point array instead of ['N/A', 'N/A'].

## Test

Make sure Data Explorer still renders if some cells in a column are empty like in the step below

For "X Data" choose "Demographic"
For "Y Data 1" choose "Percent COVID-19 Deaths"

https://wise.berkeley.edu/preview/unit/38172/node214

Closes #747