### PR TITLE
feat(Dialog Guidance): Add IdeaCount tokens to Feedback Rule expression

### DIFF
--- a/src/assets/wise5/components/dialogGuidance/CRaterResponse.ts
+++ b/src/assets/wise5/components/dialogGuidance/CRaterResponse.ts
@@ -8,6 +8,10 @@ export class CRaterResponse {
 
   constructor() {}
 
+  getDetectedIdeaCount(): number {
+    return this.getDetectedIdeaNames().length;
+  }
+
   getDetectedIdeaNames(): string[] {
     const detectedIdeaNames = [];
     this.ideas.forEach((idea: CRaterIdea) => {

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.spec.ts
@@ -81,10 +81,6 @@ describe('DialogGuidanceFeedbackRuleEvaluator', () => {
       feedback: '!idea11 || idea12'
     },
     {
-      expression: 'idea2',
-      feedback: 'You hit idea2'
-    },
-    {
       expression: 'isDefault',
       feedback: 'This is a default feedback'
     }
@@ -134,6 +130,7 @@ describe('DialogGuidanceFeedbackRuleEvaluator', () => {
   matchRule_MultipleIdeasUsingAndOr();
   matchRule_MultipleIdeasUsingNotAndOr();
   matchRule_hasKIScore();
+  matchRule_ideaCount();
   matchNoRule_ReturnDefault();
   matchNoRule_NoDefaultFeedbackAuthored_ReturnApplicationDefault();
   secondToLastSubmit();
@@ -207,6 +204,32 @@ function matchRule_hasKIScore() {
     it('should not match rule if KI score is out of range [1-5]', () => {
       expectFeedback([], [KI_SCORE_0], 'isDefault');
       expectFeedback([], [KI_SCORE_6], 'isDefault');
+    });
+  });
+}
+
+function matchRule_ideaCount() {
+  describe('ideaCount[MoreThan|Equals|LessThan]()', () => {
+    beforeEach(() => {
+      component.componentContent.feedbackRules = [
+        {
+          expression: 'ideaCountMoreThan(3)',
+          feedback: 'ideaCountMoreThan(3)'
+        },
+        {
+          expression: 'ideaCountEquals(3)',
+          feedback: 'ideaCountEquals(3)'
+        },
+        {
+          expression: 'ideaCountLessThan(3)',
+          feedback: 'ideaCountLessThan(3)'
+        }
+      ];
+    });
+    it('should match rules based on number of ideas found', () => {
+      expectFeedback(['idea1', 'idea2', 'idea3', 'idea4'], [KI_SCORE_1], 'ideaCountMoreThan(3)');
+      expectFeedback(['idea1', 'idea2', 'idea3'], [KI_SCORE_1], 'ideaCountEquals(3)');
+      expectFeedback(['idea1', 'idea2'], [KI_SCORE_1], 'ideaCountLessThan(3)');
     });
   });
 }

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
@@ -132,12 +132,13 @@ export class DialogGuidanceFeedbackRuleEvaluator {
     const matches = term.match(/ideaCount(.*)\((.*)\)/);
     const comparer = matches[1];
     const expectedIdeaCount = parseInt(matches[2]);
-    if (comparer === 'MoreThan') {
-      return response.getDetectedIdeaCount() > expectedIdeaCount;
-    } else if (comparer === 'Equals') {
-      return response.getDetectedIdeaCount() === expectedIdeaCount;
-    } else {
-      return response.getDetectedIdeaCount() < expectedIdeaCount;
+    switch (comparer) {
+      case 'MoreThan':
+        return response.getDetectedIdeaCount() > expectedIdeaCount;
+      case 'Equals':
+        return response.getDetectedIdeaCount() === expectedIdeaCount;
+      case 'LessThan':
+        return response.getDetectedIdeaCount() < expectedIdeaCount;
     }
   }
 

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
@@ -117,8 +117,27 @@ export class DialogGuidanceFeedbackRuleEvaluator {
   private evaluateTerm(term: string, response: CRaterResponse): boolean {
     if (this.isHasKIScoreTerm(term)) {
       return this.evaluateHasKIScoreTerm(term, response);
+    } else if (this.isIdeaCountTerm(term)) {
+      return this.evaluateIdeaCountTerm(term, response);
     } else {
       return this.evaluateIdeaTerm(term, response);
+    }
+  }
+
+  private isIdeaCountTerm(term: string): boolean {
+    return /ideaCount(MoreThan|Equals|LessThan)\([\d+]\)/.test(term);
+  }
+
+  private evaluateIdeaCountTerm(term: string, response: CRaterResponse): boolean {
+    const matches = term.match(/ideaCount(.*)\((.*)\)/);
+    const comparer = matches[1];
+    const expectedIdeaCount = parseInt(matches[2]);
+    if (comparer === 'MoreThan') {
+      return response.getDetectedIdeaCount() > expectedIdeaCount;
+    } else if (comparer === 'Equals') {
+      return response.getDetectedIdeaCount() === expectedIdeaCount;
+    } else {
+      return response.getDetectedIdeaCount() < expectedIdeaCount;
     }
   }
 


### PR DESCRIPTION
## Changes
- Add ideaCount(MoreThan|Equals|LessThan)(num) tokens to Dialog Guidance feedback expression rule
   - ideaCountMoreThan(num): student has more than num ideas (exclusive)
   - ideaCountEquals(num): student has exactly num ideas
   - ideaCountLessThan(num): student has less than num ideas (exclusive)
- Clean up test

## Test
- Add "ideaCount(MoreThan|Equals|LessThan)(num)" feedback rules for both multiple-score item ("MusicalInstruments_Speed_score-ki_idea-ki_nonscor") and single-score item ("GREENROOF-II") and make sure that they are matched and the corresponding feedback is shown
   - For example, add these rules for MusicalInstruments_Speed_score-ki_idea-ki_nonscor item and test that they're matched
      - ideaCountLessThan(2) is matched by the response "Bubbles. He's under water."
      - ideaCountEquals(2) is matched by the response "Bubbles. Sound travels faster under water compared to air, so it reaches Bubbles first."
      - ideaCountMoreThan(2) is matched by the response "Bubbles. Sound travels faster under water compared to air, so it reaches Bubbles first. It's more dense in the water, so molecules are closer together."

Closes #739