### PR TITLE
fix(Graph): Data points now show up immediately

### DIFF
--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener } from '@angular/core';
+import { ChangeDetectorRef, Component, HostListener } from '@angular/core';
 import { AnnotationService } from '../../../services/annotationService';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
@@ -78,6 +78,7 @@ export class GraphStudent extends ComponentStudent {
 
   constructor(
     protected AnnotationService: AnnotationService,
+    private changeDetectorRef: ChangeDetectorRef,
     protected ComponentService: ComponentService,
     protected ConfigService: ConfigService,
     protected dialog: MatDialog,
@@ -831,6 +832,7 @@ export class GraphStudent extends ComponentStudent {
         this.setCustomLegend();
       });
     }
+    this.changeDetectorRef.detectChanges();
   }
 
   turnOffXAxisDecimals() {


### PR DESCRIPTION
## Changes

Added a call to detect changes so that Graph data points show up immediately.

## Test

1. Go to the [Thermo challenge step](https://wise.berkeley.edu/preview/unit/35627/node81)
2. Click on a cell in the table like Aluminum/Hot Liquid
3. Click the Play button in the bottom left model
4. Temperature data points should start showing up every second in the bottom right graph. Previously, no data points would show up unless you moved the mouse over the graph.

Closes #752