### PR TITLE
refactor(VLEComponent): Use @HostListener to snip image to notebook

### DIFF
--- a/src/assets/wise5/services/studentAssetService.ts
+++ b/src/assets/wise5/services/studentAssetService.ts
@@ -85,7 +85,7 @@ export class StudentAssetService {
 
   getFileNameFromAsset(asset) {
     if (this.ConfigService.isPreview()) {
-      return asset.file.name;
+      return asset.file;
     } else {
       return asset.fileName;
     }

--- a/src/assets/wise5/vle/vle.component.ts
+++ b/src/assets/wise5/vle/vle.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, HostListener, OnInit, ViewChild } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Subscription } from 'rxjs';
@@ -33,7 +33,6 @@ export class VLEComponent implements OnInit {
   reportEnabled: boolean = false;
   reportFullscreen: boolean = false;
   runEndedAndLocked: boolean;
-  snipImageHandler: any;
   subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -95,23 +94,19 @@ export class VLEComponent implements OnInit {
     this.currentNode = this.studentDataService.getCurrentNode();
     this.setLayoutState();
     this.initializeSubscriptions();
-    this.addSnipImageListener();
   }
 
   ngOnDestroy() {
     this.subscriptions.unsubscribe();
-    window.removeEventListener('snip-image', this.snipImageHandler);
     this.sessionService.broadcastExit();
   }
 
-  private addSnipImageListener(): void {
-    this.snipImageHandler = (event: CustomEvent) => {
-      this.notebookService.addNote(
-        this.studentDataService.getCurrentNodeId(),
-        this.utilService.getImageObjectFromImageElement(event.detail.target)
-      );
-    };
-    window.addEventListener('snip-image', this.snipImageHandler);
+  @HostListener('window:snip-image', ['$event.detail.target'])
+  snipImage(image: Element): void {
+    this.notebookService.addNote(
+      this.studentDataService.getCurrentNodeId(),
+      this.utilService.getImageObjectFromImageElement(image)
+    );
   }
 
   closeNotes(): void {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -16823,21 +16823,21 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>You have been inactive for a long time. Do you want to stay logged in?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">136</context>
+          <context context-type="linenumber">131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="537022937435161177" datatype="html">
         <source>Session Timeout</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">137</context>
+          <context context-type="linenumber">132</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3023661788238273336" datatype="html">
         <source>Error: Data is not being saved! Check your internet connection.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">288</context>
+          <context context-type="linenumber">283</context>
         </context-group>
       </trans-unit>
     </body>


### PR DESCRIPTION
## Changes
- Use @HostListener instead of calling window.addEventListener/removeEventListener
- Fix issue where snip image was not working in preview

## Test
- Snipping image to notebook works in both student and preview. Before, there was an in issue snipping image in preview

Closes #758