### PR TITLE
refactor(VLEComponent): Remove unused server connection handling

### DIFF
--- a/src/assets/wise5/vle/vle.component.html
+++ b/src/assets/wise5/vle/vle.component.html
@@ -7,9 +7,7 @@
   </mat-drawer>
   <mat-drawer-content>
     <top-bar></top-bar>
-    <step-tools *ngIf="layoutState === 'node'"
-        class="control-bg-bg mat-elevation-z1"
-        show-position="numberProject"></step-tools>
+    <step-tools *ngIf="layoutState === 'node'" class="control-bg-bg mat-elevation-z1"></step-tools>
     <div id="content"
         class="vle-content"
         [ngClass]="{'nav-view': layoutState === 'nav', 'node-view': layoutState === 'node'}">

--- a/src/assets/wise5/vle/vle.component.spec.ts
+++ b/src/assets/wise5/vle/vle.component.spec.ts
@@ -6,7 +6,6 @@ import { NotebookService } from '../services/notebookService';
 import { VLEProjectService } from './vleProjectService';
 import { VLEComponent } from './vle.component';
 import { StudentDataService } from '../services/studentDataService';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { TopBarComponent } from '../../../app/student/top-bar/top-bar.component';
@@ -53,7 +52,6 @@ describe('VLEComponent', () => {
         MatToolbarModule,
         MatSelectModule,
         MatSidenavModule,
-        MatSnackBarModule,
         RouterTestingModule,
         StudentTeacherCommonServicesModule
       ],

--- a/src/assets/wise5/vle/vle.component.ts
+++ b/src/assets/wise5/vle/vle.component.ts
@@ -1,6 +1,5 @@
 import { Component, HostListener, OnInit, ViewChild } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { Subscription } from 'rxjs';
 import { ConfigService } from '../services/configService';
 import { InitializeVLEService } from '../services/initializeVLEService';
@@ -20,7 +19,6 @@ import { ActivatedRoute, Router } from '@angular/router';
   styleUrls: ['./vle.component.scss']
 })
 export class VLEComponent implements OnInit {
-  connectionLostShown: boolean = false;
   currentNode: any;
   @ViewChild('drawer') public drawer: any;
   isInitialized: boolean;
@@ -46,7 +44,6 @@ export class VLEComponent implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     private sessionService: SessionService,
-    private snackBar: MatSnackBar,
     private studentDataService: StudentDataService,
     private utilService: UtilService
   ) {}
@@ -118,7 +115,6 @@ export class VLEComponent implements OnInit {
     this.subscribeToCurrentNodeChanged();
     this.subscribeToNotesVisible();
     this.subscribeToReportFullScreen();
-    this.subscribeToServerConnectionStatus();
     this.subscribeToViewCurrentAmbientNotification();
   }
 
@@ -219,18 +215,6 @@ export class VLEComponent implements OnInit {
     );
   }
 
-  private subscribeToServerConnectionStatus(): void {
-    this.subscriptions.add(
-      this.notificationService.serverConnectionStatus$.subscribe((isConnected) => {
-        if (isConnected) {
-          this.handleServerReconnect();
-        } else {
-          this.handleServerDisconnect();
-        }
-      })
-    );
-  }
-
   private subscribeToViewCurrentAmbientNotification(): void {
     this.subscriptions.add(
       this.notificationService.viewCurrentAmbientNotification$.subscribe((args) => {
@@ -275,19 +259,6 @@ export class VLEComponent implements OnInit {
       }
     }
     this.layoutState = layoutState;
-  }
-
-  private handleServerDisconnect() {
-    if (!this.connectionLostShown) {
-      this.snackBar.open(
-        $localize`Error: Data is not being saved! Check your internet connection.`
-      );
-      this.connectionLostShown = true;
-    }
-  }
-
-  private handleServerReconnect() {
-    this.connectionLostShown = false;
   }
 
   /**

--- a/src/assets/wise5/vle/vle.component.ts
+++ b/src/assets/wise5/vle/vle.component.ts
@@ -26,7 +26,6 @@ export class VLEComponent implements OnInit {
   notebookConfig: any;
   notesEnabled: boolean = false;
   notesVisible: boolean = false;
-  numberProject: boolean;
   projectStyle: string;
   reportEnabled: boolean = false;
   reportFullscreen: boolean = false;
@@ -86,7 +85,6 @@ export class VLEComponent implements OnInit {
     });
 
     // TODO: set these variables dynamically from theme settings
-    this.numberProject = true;
     this.notebookConfig = this.notebookService.getNotebookConfig();
     this.currentNode = this.studentDataService.getCurrentNode();
     this.setLayoutState();

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -16872,21 +16872,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>You have been inactive for a long time. Do you want to stay logged in?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">131</context>
+          <context context-type="linenumber">127</context>
         </context-group>
       </trans-unit>
       <trans-unit id="537022937435161177" datatype="html">
         <source>Session Timeout</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">132</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3023661788238273336" datatype="html">
-        <source>Error: Data is not being saved! Check your internet connection.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">283</context>
+          <context context-type="linenumber">128</context>
         </context-group>
       </trans-unit>
     </body>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -16872,14 +16872,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>You have been inactive for a long time. Do you want to stay logged in?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">127</context>
+          <context context-type="linenumber">125</context>
         </context-group>
       </trans-unit>
       <trans-unit id="537022937435161177" datatype="html">
         <source>Session Timeout</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">128</context>
+          <context context-type="linenumber">126</context>
         </context-group>
       </trans-unit>
     </body>


### PR DESCRIPTION
## Changes
- Remove server connection handling from VLEComponent, which used to show a snack message. But after this PR: https://github.com/WISE-Community/WISE-Client/pull/656, when the student is logged out of the server, they will immediately see the login page. This is handled by http-error-interceptor. The code in VLEComponent is no longer used.
- Remove unused numberProjects variable

## Test
- While using VLE as a student, log out of the session in another tab. Then, try saving work by making changes or going to the next step.
   - They should be redirected to the log in page and see an error message, prompting them to log back in and check recent work
   - When they log in, they should be redirected to where they were before in the app 

Closes #761 