### PR TITLE
fix(Data Explorer): Fix x axis N/A tick label

### DIFF
--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -399,7 +399,12 @@ export class GraphStudent extends ComponentStudent {
             studentData.tableData,
             this.value
           );
-          if (textValue !== '' && isNaN(parseFloat(textValue))) {
+          if (
+            textValue !== '' &&
+            textValue !== 'NA' &&
+            textValue !== 'N/A' &&
+            isNaN(parseFloat(textValue))
+          ) {
             return studentData.tableData[this.value + 1][studentData.dataExplorerSeries[0].xColumn]
               .text;
           }

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -400,9 +400,9 @@ export class GraphStudent extends ComponentStudent {
             this.value
           );
           if (
+            typeof textValue === 'string' &&
             textValue !== '' &&
-            textValue !== 'NA' &&
-            textValue !== 'N/A' &&
+            !thisComponent.isNA(textValue) &&
             isNaN(parseFloat(textValue))
           ) {
             return studentData.tableData[this.value + 1][studentData.dataExplorerSeries[0].xColumn]
@@ -412,6 +412,11 @@ export class GraphStudent extends ComponentStudent {
         return this.value;
       }
     };
+  }
+
+  isNA(text: string): boolean {
+    const textUpperCase = text.toUpperCase();
+    return textUpperCase === 'NA' || textUpperCase === 'N/A';
   }
 
   getXColumnTextValue(dataExplorerSeries: any[], tableData: any[][], value: number): string {


### PR DESCRIPTION
1. Go to a Data Explorer step like this https://wise.berkeley.edu/preview/unit/38172/node210
2. For X Data choose "% 12+ fully vaccinated"
3. For Y Data 1 choose "% 12+ fully vaccinated with a first booster dose"
4. There used to be an N/A tick label between 22 and 26 because the 24th row (Modoc County) has N/A in the cells for "% 12+ fully vaccinated" and "% 12+ fully vaccinated with a first booster dose". Now it should properly display the number 24 there instead.
5. Make sure if the x value for a cell is NA or N/A or na or n/a that it does not show up as an x axis tick label.

Closes #769