### PR TITLE
fix(Graph): First value N/A now renders properly

### DIFF
--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
@@ -418,7 +418,7 @@ function handleTableConnectedComponentStudentDataChanged() {
   describe('handleTableConnectedComponentStudentDataChanged', () => {
     it('should handle table connected component student data changed', () => {
       const connectedComponent = createTableConnectedComponent();
-      const dataRows: any[] = [sampleData];
+      const dataRows: any[] = sampleData;
       const tableDataRows: any[] = [['Time', 'Position']].concat(dataRows);
       const componentState = {
         studentData: {

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -1758,7 +1758,7 @@ export class GraphStudent extends ComponentStudent {
       if (!isNaN(yNumber)) {
         point.push(yNumber);
       } else {
-        point.push(yText);
+        point.push(null);
       }
       data.push(point);
     } else {


### PR DESCRIPTION
## Changes

If a y value is a string, instead of adding the string to the data point, we add null.

## Test

1. Go to a Data Explorer step like this https://wise.berkeley.edu/preview/unit/38172/node210
2. In the table, select the first 3 rows (Alameda, Alpine, Amador)
3. For X Data choose "County"
4. For Y Data 1 choose "% 12+ fully vaccinated"
5. The graph should render
6. Go to the table and unselect "Alameda County". This means the first row will now be "Alpine County" and for "% 12+ fully vaccinated" it has the value "N/A". The graph used to throw an error and would not render but now it should work.

Closes #773