### PR TITLE
fix(Notebook): Fix notebook tools to window in VLE

### DIFF
--- a/src/assets/wise5/vle/vle.component.scss
+++ b/src/assets/wise5/vle/vle.component.scss
@@ -4,7 +4,11 @@
   '~style/abstracts/variables';
 
 .mat-drawer-container {
-  height: 100%;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
 }
 
 step-tools {
@@ -38,6 +42,12 @@ step-tools {
   margin-top: $toolbar-height;
 }
 
+notebook-launcher {
+  bottom: 24px;
+  position: fixed;
+  right: 28px;
+}
+
 notebook-notes {
   display: block;
   width: $notebook-sidebar-width;
@@ -49,6 +59,10 @@ notebook-notes {
 
 notebook-report {
   z-index: 10;
+  bottom: 0;
+  position: fixed;
+  right: 96px;
+  transition: right 0.25s;
 }
 
 .ended-and-locked-div {


### PR DESCRIPTION
## Changes
Notebook report, launcher, and notes should now be fixed to the browser window and always visible in the VLE again. (A previous update had attached them to the bottom of the VLE content.)

Closes #735.

## Test
- Check that the notebook tools are always visible when viewing a unit as a student or in preview.
- Make sure the position of the report positioning updates correctly when notes bar is opened and closed, report is expanded to full screen, small view, and collapsed.
- Test with different window sizes (from mobile to desktop widths).
- Make sure editing and saving report and notes content works as before.