### PR TITLE
feat(Site): Make all run list links keyboard accessible

### DIFF
--- a/src/app/student/student-run-list/student-run-list.component.html
+++ b/src/app/student/student-run-list/student-run-list.component.html
@@ -5,14 +5,14 @@
   </div>
   <div class="content-block" *ngIf="runs.length">
     <div class="content-block__header controls dark-theme primary-bg"
-         fxLayout="row"
-         fxLayout.xs="column"
-         fxLayoutGap.sm="16px">
+        fxLayout="row"
+        fxLayout.xs="column"
+        fxLayoutGap.sm="16px">
       <app-search-bar fxFlex="0 0 100%"
-                      fxFlex.gt-sm="0 0 auto"
-                      [placeholderText]="'Search'"
-                      [value]="search"
-                      (update)="searchUpdated($event)"></app-search-bar>
+          fxFlex.gt-sm="0 0 auto"
+          [placeholderText]="'Search'"
+          [value]="search"
+          (update)="searchUpdated($event)"></app-search-bar>
     </div>
     <div id="unitCount" *ngIf="loaded" class="notice">
       <p>
@@ -23,7 +23,11 @@
           <ng-container><span i18n>{{ activeTotal() }} active</span></ng-container>)
         </span>
         <ng-container *ngIf="search">
-          | <a [routerLink]="" (click)="reset()" i18n>Reset</a>
+          | <a [routerLink]=""
+              (click)="reset()"
+              (keyup.enter)="reset()"
+              tabindex="0"
+              i18n>Clear search</a>
         </ng-container>
       </p>
     </div>
@@ -42,8 +46,7 @@
         </app-timeline-item>
       </ng-container>
     </app-timeline>
-    <div class="content-block__actions"
-         *ngIf="filteredRuns.length > 10 && !showAll" >
+    <div class="content-block__actions" *ngIf="filteredRuns.length > 10 && !showAll">
       <a mat-raised-button color="accent" (click)="showAll = true" i18n>Show More</a>
     </div>
   </div>

--- a/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html
+++ b/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html
@@ -1,6 +1,7 @@
 <ng-template #runInfo>
   <div>
     <span class="more-info"
+          tabindex="0"
           [matTooltip]="periodsTooltipText"
           matTooltipPosition="above">
       {{run.periods.length}}
@@ -30,7 +31,7 @@
   </div>
   <div>
     <span i18n>Access Code: {{ run.runCode }}</span> (<a [routerLink]=""
-        (click)="shareCode()" i18n>Share with students</a>)
+        (click)="shareCode()" (keyup.enter)="shareCode()" tabindex="0" i18n>Share with students</a>)
   </div>
   <div *ngIf="run.shared" class="info" i18n>
     Shared by {{run.owner.firstName}} {{run.owner.lastName}}
@@ -85,14 +86,14 @@
               fxFlex.xs="100">
         <ng-container i18n>Starts {{run.startTime | date}}</ng-container>
       </button>
-      <a *ngIf="isRunActive(run) || isRunCompleted(run)"
+      <button *ngIf="isRunActive(run) || isRunCompleted(run)"
          mat-flat-button
          (click)="launchGradeAndManageTool()"
          color="primary"
          fxFlex="0 0 auto"
          fxFlex.xs="100">
         <mat-icon>assignment_turned_in</mat-icon>&nbsp;<ng-container i18n>Teacher Tools</ng-container>
-      </a>
+      </button>
     </div>
   </mat-card-actions>
 </mat-card>

--- a/src/app/teacher/teacher-run-list/teacher-run-list.component.html
+++ b/src/app/teacher/teacher-run-list/teacher-run-list.component.html
@@ -4,28 +4,28 @@
 </div>
 <div class="content-block" *ngIf="runs.length">
   <div class="content-block__header controls dark-theme primary-bg"
-       fxLayout="row"
-       fxLayout.xs="column"
-       fxLayoutGap.sm="16px">
+      fxLayout="row"
+      fxLayout.xs="column"
+      fxLayoutGap.sm="16px">
     <app-search-bar fxFlex="0 0 auto"
-                    fxFlex.xs="0 0 100%"
-                    fxFlex.sm="0 0 calc(50%-8px)"
-                    i18n-placeholderText
-                    placeholderText="Search"
-                    [disable]="!loaded"
-                    [value]="searchValue"
-                    (update)="searchChanged($event)"></app-search-bar>
+        fxFlex.xs="0 0 100%"
+        fxFlex.sm="0 0 calc(50%-8px)"
+        i18n-placeholderText
+        placeholderText="Search"
+        [disable]="!loaded"
+        [value]="searchValue"
+        (update)="searchChanged($event)"></app-search-bar>
     <span fxFlex="1 1 auto" fxHide fxShow.gt-sm></span>
     <app-select-menu fxFlex="0 0 auto"
-                     fxFlex.sm="0 0 calc(50%-8px)"
-                     [options]="filterOptions"
-                     i18n-placeholderText
-                     placeholderText="Filter By Period"
-                     [disable]="!loaded"
-                     [value]="filterValue"
-                     (update)="filterChanged($event)"
-                     [valueProp]="'value'"
-                     [viewValueProp]="'label'">
+        fxFlex.sm="0 0 calc(50%-8px)"
+        [options]="filterOptions"
+        i18n-placeholderText
+        placeholderText="Filter By Period"
+        [disable]="!loaded"
+        [value]="filterValue"
+        (update)="filterChanged($event)"
+        [valueProp]="'value'"
+        [viewValueProp]="'label'">
     </app-select-menu>
   </div>
   <div class="notice">
@@ -37,7 +37,11 @@
         <ng-container><span i18n>{{ activeTotal() }} active</span></ng-container>)
       </span>
       <ng-container *ngIf="searchValue || filterValue">
-        | <a [routerLink]="" (click)="reset()" i18n>Reset</a>
+        | <a [routerLink]=""
+            (click)="reset()"
+            (keyup.enter)="reset()"
+            tabindex="0"
+            i18n>Clear filters</a>
       </ng-container>
     </p>
   </div>
@@ -58,8 +62,7 @@
     </ng-container>
   </app-timeline>
 
-  <div class="content-block__actions"
-       *ngIf="filteredRuns.length > 10 && !showAll" >
-    <a mat-raised-button color="accent" (click)="showAll = true" i18n>Show More</a>
+  <div class="content-block__actions" *ngIf="filteredRuns.length > 10 && !showAll">
+    <button mat-raised-button color="accent" (click)="showAll = true" i18n>Show More</button>
   </div>
 </div>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -4904,14 +4904,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">25</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/student/student-run-list/student-run-list.component.html</context>
-          <context context-type="linenumber">26</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/teacher-run-list/teacher-run-list.component.html</context>
-          <context context-type="linenumber">40</context>
-        </context-group>
-        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/animation/animation-student/animation-student.component.html</context>
           <context context-type="linenumber">42</context>
         </context-group>
@@ -4970,7 +4962,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">55</context>
+          <context context-type="linenumber">56</context>
         </context-group>
       </trans-unit>
       <trans-unit id="59a08e65c39e2cecb841fc7123a77756f52c8db3" datatype="html">
@@ -5669,11 +5661,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/student/student-run-list/student-run-list.component.html</context>
-          <context context-type="linenumber">47</context>
+          <context context-type="linenumber">50</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list/teacher-run-list.component.html</context>
-          <context context-type="linenumber">63</context>
+          <context context-type="linenumber">66</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3376099465386156138" datatype="html">
@@ -6982,7 +6974,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">86</context>
+          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2874cc3a35edcf67e588849afeb796f57163458b" datatype="html">
@@ -7051,6 +7043,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list/teacher-run-list.component.html</context>
           <context context-type="linenumber">37</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="940ac9990f6a15fadf0a162bd4206ce5661592ed" datatype="html">
+        <source>Clear search</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/student/student-run-list/student-run-list.component.html</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="13c602751734f72430891c9781167bf53c612481" datatype="html">
@@ -7386,7 +7385,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
       <trans-unit id="534ba8ba6d05fed93bd074e67fb6d03d2e466b46" datatype="html">
@@ -8037,83 +8036,83 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>periods</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">8</context>
+          <context context-type="linenumber">9</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">10</context>
+          <context context-type="linenumber">11</context>
         </context-group>
       </trans-unit>
       <trans-unit id="97d146f3502e6472ae9aca1b2bdacfb3ae9c40a4" datatype="html">
         <source>period</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">9</context>
+          <context context-type="linenumber">10</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c1e3525227cd71f6849b07d4d0babd32b1e1ea9d" datatype="html">
         <source>students</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">17</context>
+          <context context-type="linenumber">18</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">19</context>
+          <context context-type="linenumber">20</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">26</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="de9dcd15573cb1dcf344993c1eae59f09a2a6ba5" datatype="html">
         <source>student</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">18</context>
+          <context context-type="linenumber">19</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a6437b7108a94d0e2f631cf39c4f2a65469b5357" datatype="html">
         <source>Share with students</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">33</context>
+          <context context-type="linenumber">34</context>
         </context-group>
       </trans-unit>
       <trans-unit id="958238c9a38f867922fab7579f5e7c77194fe6a1" datatype="html">
         <source> Shared by <x id="INTERPOLATION" equiv-text="{{run.owner.firstName}}"/> <x id="INTERPOLATION_1" equiv-text="{{run.owner.lastName}}"/> </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">35,37</context>
+          <context context-type="linenumber">36,38</context>
         </context-group>
       </trans-unit>
       <trans-unit id="490233cd77b10fe95606d32aa5ed4be533645820" datatype="html">
         <source>(Legacy Unit)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c939f7061b636699d1c0dcef58f1b70a9b5cea41" datatype="html">
         <source>Last student login: <x id="INTERPOLATION" equiv-text="{{run.lastRun | date: &apos;short&apos;}}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f31a4ac5cfc26f2d23677bd24f59219dc5f1c491" datatype="html">
         <source>Teacher Tools</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">94</context>
+          <context context-type="linenumber">95</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1133960927497534087" datatype="html">
@@ -8149,6 +8148,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list/teacher-run-list.component.html</context>
           <context context-type="linenumber">34</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1e5e23363e949f7dcbaf034bdb141a561132a10e" datatype="html">
+        <source>Clear filters</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/teacher-run-list/teacher-run-list.component.html</context>
+          <context context-type="linenumber">44</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1775311053456611668" datatype="html">


### PR DESCRIPTION
## Changes
Makes all links in student and teacher run lists (Class Schedule) accessible via keyboard.

Closes #673.

## Test
Make sure each of these links can be accessed and selected with keyboard:
- Reset search/filters
- Class periods hover
- Share with students
- Teacher tools