### PR TITLE
feat(Dialog Guidance): Feedback rule authoring help page

### DIFF
--- a/src/app/teacher/component-authoring.module.ts
+++ b/src/app/teacher/component-authoring.module.ts
@@ -71,6 +71,7 @@ import { EditDialogGuidanceAdvancedComponent } from '../../assets/wise5/componen
 import { EditDialogGuidanceComputerAvatarComponent } from '../../assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component';
 import { PeerGroupingAuthoringModule } from '../../assets/wise5/authoringTool/peer-grouping/peer-grouping-authoring.module';
 import { StudentTeacherCommonModule } from '../student-teacher-common.module';
+import { DialogGuidanceFeedbackRuleHelpComponent } from '../../assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component';
 
 @NgModule({
   declarations: [
@@ -80,6 +81,7 @@ import { StudentTeacherCommonModule } from '../student-teacher-common.module';
     ConceptMapAuthoring,
     DrawAuthoring,
     DialogGuidanceAuthoringComponent,
+    DialogGuidanceFeedbackRuleHelpComponent,
     DiscussionAuthoring,
     EditAnimationAdvancedComponent,
     EditAudioOscillatorAdvancedComponent,

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.module.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.module.ts
@@ -24,10 +24,12 @@ import { EditDialogGuidanceFeedbackRulesComponent } from '../edit-dialog-guidanc
 import { DialogGuidanceAuthoringComponent } from './dialog-guidance-authoring.component';
 import { ComputerAvatarService } from '../../../services/computerAvatarService';
 import { DialogGuidanceService } from '../dialogGuidanceService';
+import { DialogGuidanceFeedbackRuleHelpComponent } from '../dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component';
 
 @NgModule({
   declarations: [
     DialogGuidanceAuthoringComponent,
+    DialogGuidanceFeedbackRuleHelpComponent,
     EditComponentPrompt,
     EditComponentMaxSubmitComponent,
     EditDialogGuidanceFeedbackRulesComponent

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html
@@ -1,0 +1,108 @@
+<h2 class="mat-dialog-title" i18n>About Dialog Guidance Feedback Rules</h2>
+<mat-dialog-content class="dialog-content-scroll">
+  <h3 i18n>Introduction</h3>
+  <div i18n>
+    Rules are evaluated top to bottom, and the first rule that matches is used to provide
+    feedback. Rules are made up of terms and operators.
+  </div>
+  <h3 i18n>Terms</h3>
+  <div>
+    <p i18n>Terms lets you specify what to look for in a student response</p>
+    <table>
+      <tr><th i18n>Term</th><th i18n>Description</th></tr>
+      <tr>
+        <td class="term">1,2,...18,...</td>
+        <td i18n>Evaluates to true if idea 1, 2, 18, etc was found in the student’s response</td>
+      </tr>
+      <tr>
+        <td class="term">hasKIScore(X)</td>
+        <td i18n>
+          Evaluates to true if the student received a KI score of X<br/>
+          Ex: <b>hasKIScore(3)</b> evaluates to true if the student received KI score 3
+        </td>
+      </tr>
+      <tr>
+        <td class="term">ideaCountMoreThan(X)</td>
+        <td i18n>
+          Evaluates to true if more than X ideas were found in the student’s response<br/>
+          Ex: <b>ideaCountMoreThan(2)</b> evaluates to true if the student had more than 2 ideas
+        </td>
+      </tr>
+      <tr>
+        <td class="term">ideaCountLessThan(X)</td>
+        <td i18n>
+          Evaluates to true if less than X ideas were found in the student’s response<br/>
+          Ex: <b>ideaCountLessThan(2)</b> evaluates to true if the student had less than 2 ideas
+        </td>
+      </tr>
+      <tr>
+        <td class="term">ideaCountEquals(X)</td>
+        <td i18n>
+          Evaluates to true if exactly X ideas were found in the student’s response<br/>
+          Ex: <b>ideaCountEquals(2)</b> evaluates to true if the student had exactly 2 ideas
+        </td>
+      </tr>
+      <tr>
+        <td class="term">isSecondToLastSubmit</td>
+        <td i18n>
+          Evaluates to true if this is the student’s second to last response when the max
+          number of submits is specified
+        </td>
+      </tr>
+      <tr>
+        <td class="term">isFinalSubmit</td>
+        <td i18n>
+          Evaluates to true if this is the student’s final response when the max number of
+          submits is specified
+        </td>
+      </tr>
+      <tr>
+        <td class="term">isNonScorable</td>
+        <td i18n>Evaluates to true if the student’s response was not scorable</td>
+      </tr>
+      <tr>
+        <td class="term">isDefault</td>
+        <td i18n>
+          Evaluates to true if no other terms were matched. Add this term as the final rule to
+          specify a default feedback
+        </td>
+      </tr>
+    </table>
+    <h3 i18n>Operators</h3>
+    <div>
+      <p i18n>Operators lets you combine one more terms together to make a rule</p>
+      <table>
+        <tr><th i18n>Operator</th><th i18n>Description</th></tr>
+        <tr>
+          <td class="operator">&&</td>
+          <td i18n>
+            Evaluates to true if terms on both sides of this operator evaluates to true<br/>
+            Ex: <b>1 && 2</b> evaluates to true if both idea 1 and 2 were found <br/>
+            Ex: <b>1 && hasKIScore(2)</b> evaluates to true if idea 1 was found and the student
+            received a KI score of 2
+          </td>
+        </tr>
+        <tr>
+          <td class="operator">||</td>
+          <td i18n>
+            Evaluates to true if a term on either side of this operator evaluates to true<br/>
+            Ex: <b>1 || 2</b> evaluates to true if either idea 1 or 2 was found
+            Ex: <b>1 && 2 || 3</b> evaluates to true if both idea 1 and 2 were found, or idea 3
+            was found
+          </td>
+        </tr>
+        <tr>
+          <td class="operator">!</td>
+          <td i18n>
+            Evaluates to true if a term following this operator evaluates to false<br/>
+            Ex: <b>!1</b> evaluates to true if idea 1 was not found
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
+</mat-dialog-content>
+<mat-dialog-actions fxLayoutAlign="end">
+  <button mat-button mat-dialog-close cdkFocusRegionstart i18n>Close</button>
+</mat-dialog-actions>
+

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html
@@ -86,7 +86,7 @@
           <td class="operator">||</td>
           <td i18n>
             Evaluates to true if a term on either side of this operator evaluates to true<br/>
-            Ex: <b>1 || 2</b> evaluates to true if either idea 1 or 2 was found
+            Ex: <b>1 || 2</b> evaluates to true if either idea 1 or 2 was found<br/>
             Ex: <b>1 && 2 || 3</b> evaluates to true if both idea 1 and 2 were found, or idea 3
             was found
           </td>

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html
@@ -1,106 +1,109 @@
-<h2 class="mat-dialog-title" i18n>About Dialog Guidance Feedback Rules</h2>
+<h2 class="mat-dialog-title" i18n>Feedback Rule Authoring</h2>
 <mat-dialog-content class="dialog-content-scroll">
   <h3 i18n>Introduction</h3>
-  <div i18n>
-    Rules are evaluated top to bottom, and the first rule that matches is used to provide
-    feedback. Rules are made up of terms and operators.
-  </div>
+  <p i18n>
+    Rules are evaluated top to bottom. The first rule <b>Expression</b> that matches the student's
+    response is used to provide feedback.
+  </p>
+  <p i18n>You can add multiple <b>Feedback</b> items per rule. The first time a rule matches, Feedback
+    #1 will be shown to the student.<br />
+    If the rule matches a second time (in a subsequent round), Feedback #2 will be shown, and so on.
+  </p>
+  <p i18n><b>Expressions</b> are made up of terms and operators:</p>
   <h3 i18n>Terms</h3>
-  <div>
-    <p i18n>Terms lets you specify what to look for in a student response</p>
-    <table>
-      <tr><th i18n>Term</th><th i18n>Description</th></tr>
-      <tr>
-        <td class="term">1,2,...18,...</td>
-        <td i18n>Evaluates to true if idea 1, 2, 18, etc was found in the student’s response</td>
-      </tr>
-      <tr>
-        <td class="term">hasKIScore(X)</td>
-        <td i18n>
-          Evaluates to true if the student received a KI score of X<br/>
-          Ex: <b>hasKIScore(3)</b> evaluates to true if the student received KI score 3
+  <p i18n>Terms lets you specify what to look for in a student response.</p>
+  <table class="app-bg-bg">
+    <tr><th i18n>Term</th><th i18n>Description</th></tr>
+    <tr>
+      <td class="term">1,2,...18,...</td>
+      <td i18n>Evaluates to true if idea 1, 2, 18, etc was found in the student’s response.</td>
+    </tr>
+    <tr>
+      <td class="term">hasKIScore(X)</td>
+      <td i18n>
+        Evaluates to true if the student received a KI score of X.<br />
+        Ex: <b>hasKIScore(3)</b> evaluates to true if the student received KI score 3.
+      </td>
+    </tr>
+    <tr>
+      <td class="term">ideaCountMoreThan(X)</td>
+      <td i18n>
+        Evaluates to true if more than X ideas were found in the student’s response.<br />
+        Ex: <b>ideaCountMoreThan(2)</b> evaluates to true if the student had more than 2 ideas.
+      </td>
+    </tr>
+    <tr>
+      <td class="term">ideaCountLessThan(X)</td>
+      <td i18n>
+        Evaluates to true if less than X ideas were found in the student’s response.<br />
+        Ex: <b>ideaCountLessThan(2)</b> evaluates to true if the student had less than 2 ideas.
+      </td>
+    </tr>
+    <tr>
+      <td class="term">ideaCountEquals(X)</td>
+      <td i18n>
+        Evaluates to true if exactly X ideas were found in the student’s response.<br />
+        Ex: <b>ideaCountEquals(2)</b> evaluates to true if the student had exactly 2 ideas.
+      </td>
+    </tr>
+    <tr>
+      <td class="term">isSecondToLastSubmit</td>
+      <td i18n>
+        Evaluates to true if this is the student’s second to last response when the max number of submits is
+        specified.
+      </td>
+    </tr>
+    <tr>
+      <td class="term">isFinalSubmit</td>
+      <td i18n>
+        Evaluates to true if this is the student’s final response when the max number of submits is
+        specified.
+      </td>
+    </tr>
+    <tr>
+      <td class="term">isNonScorable</td>
+      <td i18n>Evaluates to true if the student’s response was not scorable.</td>
+    </tr>
+    <tr>
+      <td class="term">isDefault</td>
+      <td i18n>
+        Evaluates to true if no other terms were matched. Add this term as the final rule to specify a
+        default feedback.
+      </td>
+    </tr>
+  </table>
+  <h3 i18n>Operators</h3>
+  <p i18n>Operators let you combine one more terms together to make a rule.</p>
+  <table class="app-bg-bg">
+    <tr>
+      <th i18n>Operator</th>
+      <th i18n>Description</th>
+    </tr>
+    <tr>
+      <td class="operator">&&</td>
+      <td i18n>
+        Evaluates to true if terms on both sides of this operator evaluate to true.<br />
+        Ex: <b>1 && 2</b> evaluates to true if both idea 1 and 2 were found.<br />
+        Ex: <b>1 && hasKIScore(2)</b> evaluates to true if idea 1 was found and the student received a KI
+        score of 2.
         </td>
-      </tr>
-      <tr>
-        <td class="term">ideaCountMoreThan(X)</td>
-        <td i18n>
-          Evaluates to true if more than X ideas were found in the student’s response<br/>
-          Ex: <b>ideaCountMoreThan(2)</b> evaluates to true if the student had more than 2 ideas
-        </td>
-      </tr>
-      <tr>
-        <td class="term">ideaCountLessThan(X)</td>
-        <td i18n>
-          Evaluates to true if less than X ideas were found in the student’s response<br/>
-          Ex: <b>ideaCountLessThan(2)</b> evaluates to true if the student had less than 2 ideas
-        </td>
-      </tr>
-      <tr>
-        <td class="term">ideaCountEquals(X)</td>
-        <td i18n>
-          Evaluates to true if exactly X ideas were found in the student’s response<br/>
-          Ex: <b>ideaCountEquals(2)</b> evaluates to true if the student had exactly 2 ideas
-        </td>
-      </tr>
-      <tr>
-        <td class="term">isSecondToLastSubmit</td>
-        <td i18n>
-          Evaluates to true if this is the student’s second to last response when the max
-          number of submits is specified
-        </td>
-      </tr>
-      <tr>
-        <td class="term">isFinalSubmit</td>
-        <td i18n>
-          Evaluates to true if this is the student’s final response when the max number of
-          submits is specified
-        </td>
-      </tr>
-      <tr>
-        <td class="term">isNonScorable</td>
-        <td i18n>Evaluates to true if the student’s response was not scorable</td>
-      </tr>
-      <tr>
-        <td class="term">isDefault</td>
-        <td i18n>
-          Evaluates to true if no other terms were matched. Add this term as the final rule to
-          specify a default feedback
-        </td>
-      </tr>
-    </table>
-    <h3 i18n>Operators</h3>
-    <div>
-      <p i18n>Operators lets you combine one more terms together to make a rule</p>
-      <table>
-        <tr><th i18n>Operator</th><th i18n>Description</th></tr>
-        <tr>
-          <td class="operator">&&</td>
-          <td i18n>
-            Evaluates to true if terms on both sides of this operator evaluates to true<br/>
-            Ex: <b>1 && 2</b> evaluates to true if both idea 1 and 2 were found <br/>
-            Ex: <b>1 && hasKIScore(2)</b> evaluates to true if idea 1 was found and the student
-            received a KI score of 2
-          </td>
-        </tr>
-        <tr>
-          <td class="operator">||</td>
-          <td i18n>
-            Evaluates to true if a term on either side of this operator evaluates to true<br/>
-            Ex: <b>1 || 2</b> evaluates to true if either idea 1 or 2 was found<br/>
-            Ex: <b>1 && 2 || 3</b> evaluates to true if both idea 1 and 2 were found, or idea 3
-            was found
-          </td>
-        </tr>
-        <tr>
-          <td class="operator">!</td>
-          <td i18n>
-            Evaluates to true if a term following this operator evaluates to false<br/>
-            Ex: <b>!1</b> evaluates to true if idea 1 was not found
-          </td>
-        </tr>
-      </table>
-    </div>
-  </div>
+    </tr>
+    <tr>
+      <td class="operator">||</td>
+      <td i18n>
+        Evaluates to true if a term on either side of this operator evaluates to true.<br />
+        Ex: <b>1 || 2</b> evaluates to true if either idea 1 or 2 was found.<br />
+        Ex: <b>1 && 2 || 3</b> evaluates to true if both idea 1 and 2 were found or idea 3 was found.
+      </td>
+    </tr>
+    <tr>
+      <td class="operator">!</td>
+      <td i18n>
+        Evaluates to true if a term following this operator evaluates to false.<br />
+        Ex: <b>!1</b> evaluates to true if idea 1 was not found.
+      </td>
+    </tr>
+  </table>
 </mat-dialog-content>
 <mat-dialog-actions fxLayoutAlign="end">
   <button mat-button mat-dialog-close cdkFocusRegionstart i18n>Close</button>

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html
@@ -73,7 +73,7 @@
     </tr>
   </table>
   <h3 i18n>Operators</h3>
-  <p i18n>Operators let you combine one more terms together to make a rule.</p>
+  <p i18n>Operators let you combine one or more terms together to make a rule.</p>
   <table class="app-bg-bg">
     <tr>
       <th i18n>Operator</th>

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.scss
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.scss
@@ -1,0 +1,11 @@
+table, th, td {
+  border: 1px solid;
+}
+
+.term,.operator {
+  font-weight: bold;
+}
+
+h3 {
+  margin: 16px 0 0 0;
+}

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.scss
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.scss
@@ -1,11 +1,20 @@
-table, th, td {
-  border: 1px solid;
+table {
+  border-collapse: collapse;
 }
 
-.term,.operator {
+th, td {
+  border: 1px solid #cccccc;
+  padding: 4px;
+}
+
+.term, .operator {
   font-weight: bold;
 }
 
 h3 {
-  margin: 16px 0 0 0;
+  margin: 16px 0 8px;
+
+  &:first-of-type {
+    margin-top: 0;
+  }
 }

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.ts
@@ -1,0 +1,7 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  styleUrls: ['./dialog-guidance-feedback-rule-help.component.scss'],
+  templateUrl: './dialog-guidance-feedback-rule-help.component.html'
+})
+export class DialogGuidanceFeedbackRuleHelpComponent {}

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.html
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.html
@@ -9,6 +9,8 @@
         (click)="addNewRule('beginning')">
       <mat-icon>add_circle</mat-icon>
     </button>
+    <span fxFlex></span>
+    <button mat-button (click)="showHelp()" i18n>Help</button>
   </h5>
   <ul cdkDropList [cdkDropListData]="feedbackRules" (cdkDropListDropped)="drop($event)" cdkScrollable>
     <ng-container *ngFor="let rule of feedbackRules; let ruleIndex = index; let first = first; let last = last">

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.spec.ts
@@ -4,14 +4,21 @@ import { EditDialogGuidanceFeedbackRulesComponent } from './edit-dialog-guidance
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { UtilService } from '../../../services/utilService';
 import { FeedbackRule } from '../FeedbackRule';
+import { MatDialog } from '@angular/material/dialog';
+import { DialogGuidanceFeedbackRuleHelpComponent } from '../dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component';
 
 class MockTeacherProjectService {
   nodeChanged() {}
 }
 
+class MockMatDialog {
+  open() {}
+}
+
 let component: EditDialogGuidanceFeedbackRulesComponent;
 const feedbackString1: string = 'you hit idea1';
 const feedbackString2: string = 'you hit idea2';
+let dialogOpenSpy: jasmine.Spy;
 let nodeChangedSpy: jasmine.Spy;
 
 describe('EditDialogGuidanceFeedbackRulesComponent', () => {
@@ -22,6 +29,7 @@ describe('EditDialogGuidanceFeedbackRulesComponent', () => {
       imports: [],
       declarations: [EditDialogGuidanceFeedbackRulesComponent],
       providers: [
+        { provide: MatDialog, useClass: MockMatDialog },
         { provide: TeacherProjectService, useClass: MockTeacherProjectService },
         UtilService
       ],
@@ -34,6 +42,7 @@ describe('EditDialogGuidanceFeedbackRulesComponent', () => {
       new FeedbackRule({ id: '1111111111', expression: 'idea1', feedback: [feedbackString1] }),
       new FeedbackRule({ id: '2222222222', expression: 'idea2', feedback: [feedbackString2] })
     ];
+    dialogOpenSpy = spyOn(TestBed.inject(MatDialog), 'open');
     nodeChangedSpy = spyOn(TestBed.inject(TeacherProjectService), 'nodeChanged');
     fixture.detectChanges();
   });
@@ -44,6 +53,7 @@ describe('EditDialogGuidanceFeedbackRulesComponent', () => {
   moveDown();
   addNewFeedbackToRule();
   deleteFeedbackInRule();
+  showHelp();
 });
 
 function addNewRule() {
@@ -143,6 +153,15 @@ function deleteFeedbackInRule() {
       });
       component.deleteFeedbackInRule(feedbackRule, 1);
       expect(feedbackRule.feedback).toEqual(['Hello']);
+    });
+  });
+}
+
+function showHelp() {
+  describe('showHelp()', () => {
+    it('should show DialogGuidanceFeedbackRuleHelpComponent in a dialog', () => {
+      component.showHelp();
+      expect(dialogOpenSpy).toHaveBeenCalledOnceWith(DialogGuidanceFeedbackRuleHelpComponent);
     });
   });
 }

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.ts
@@ -5,6 +5,8 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { UtilService } from '../../../services/utilService';
 import { FeedbackRule } from '../FeedbackRule';
+import { MatDialog } from '@angular/material/dialog';
+import { DialogGuidanceFeedbackRuleHelpComponent } from '../dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component';
 
 @Component({
   selector: 'edit-dialog-guidance-feedback-rules',
@@ -17,12 +19,16 @@ export class EditDialogGuidanceFeedbackRulesComponent implements OnInit {
   subscriptions: Subscription = new Subscription();
   @Input() version: number;
 
-  constructor(private ProjectService: TeacherProjectService, private utilService: UtilService) {}
+  constructor(
+    private dialog: MatDialog,
+    private projectService: TeacherProjectService,
+    private utilService: UtilService
+  ) {}
 
   ngOnInit(): void {
     this.subscriptions.add(
       this.inputChanged.pipe(debounceTime(1000), distinctUntilChanged()).subscribe(() => {
-        this.ProjectService.nodeChanged();
+        this.projectService.nodeChanged();
       })
     );
   }
@@ -45,7 +51,7 @@ export class EditDialogGuidanceFeedbackRulesComponent implements OnInit {
 
   moveRuleItem(previousIndex: number, currentIndex: number): void {
     moveItemInArray(this.feedbackRules, previousIndex, currentIndex);
-    this.ProjectService.nodeChanged();
+    this.projectService.nodeChanged();
   }
 
   addNewRule(position: string): void {
@@ -55,7 +61,7 @@ export class EditDialogGuidanceFeedbackRulesComponent implements OnInit {
     } else {
       this.feedbackRules.push(newFeedbackRule);
     }
-    this.ProjectService.nodeChanged();
+    this.projectService.nodeChanged();
   }
 
   private createNewFeedbackRule(): any {
@@ -68,24 +74,28 @@ export class EditDialogGuidanceFeedbackRulesComponent implements OnInit {
 
   addNewFeedbackToRule(rule: FeedbackRule): void {
     (rule.feedback as string[]).push('');
-    this.ProjectService.nodeChanged();
+    this.projectService.nodeChanged();
   }
 
   deleteFeedbackInRule(rule: FeedbackRule, feedbackIndex: number): void {
     if (confirm($localize`Are you sure you want to delete this feedback?`)) {
       (rule.feedback as string[]).splice(feedbackIndex, 1);
-      this.ProjectService.nodeChanged();
+      this.projectService.nodeChanged();
     }
   }
 
   deleteRule(ruleIndex: number): void {
     if (confirm($localize`Are you sure you want to delete this feedback rule?`)) {
       this.feedbackRules.splice(ruleIndex, 1);
-      this.ProjectService.nodeChanged();
+      this.projectService.nodeChanged();
     }
   }
 
   customTrackBy(index: number): number {
     return index;
+  }
+
+  showHelp(): void {
+    this.dialog.open(DialogGuidanceFeedbackRuleHelpComponent);
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12247,8 +12247,8 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">78,83</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3d77040007fc8a27e9ecbc997c10d29839ff3959" datatype="html">
-        <source> Evaluates to true if a term on either side of this operator evaluates to true<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 || 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if either idea 1 or 2 was found Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2 || 3<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found, or idea 3 was found </source>
+      <trans-unit id="9b6d3cce00caf762fd168120ed200945252cb39b" datatype="html">
+        <source> Evaluates to true if a term on either side of this operator evaluates to true<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 || 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if either idea 1 or 2 was found<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2 || 3<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found, or idea 3 was found </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
           <context context-type="linenumber">87,92</context>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -306,6 +306,10 @@
           <context context-type="linenumber">152</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/dialog-with-close/dialog-with-close.component.html</context>
           <context context-type="linenumber">7</context>
         </context-group>
@@ -1476,6 +1480,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
           <context context-type="linenumber">87</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7491b1ebfc5dd457492a5c481e2d2254216dc1fc" datatype="html">
@@ -4735,6 +4747,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/header/header-account-menu/header-account-menu.component.html</context>
           <context context-type="linenumber">81</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.html</context>
+          <context context-type="linenumber">13</context>
         </context-group>
       </trans-unit>
       <trans-unit id="640eec093c685babaa3265137215e3cc92ad704d" datatype="html">
@@ -12098,6 +12114,153 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">16</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="9e75f4cce91b22668189b7c992289eab9d0cf290" datatype="html">
+        <source>About Dialog Guidance Feedback Rules</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5499b81e5db6d551e39b1731b360d787148bfea2" datatype="html">
+        <source>Introduction</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="0332ce88b09e2457eef8dee49b223c22b72066c6" datatype="html">
+        <source> Rules are evaluated top to bottom, and the first rule that matches is used to provide feedback. Rules are made up of terms and operators. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">4,7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="69580f2c2dbf4edf7096820ba8c393367352d774" datatype="html">
+        <source>Terms</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5014ddee7747a6b640b82197065549072ceccab3" datatype="html">
+        <source>Terms lets you specify what to look for in a student response</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="be1c273fc76e686667bff39d321970c9487f9ee7" datatype="html">
+        <source>Term</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3b3419f206cf782f06a32d1158f272648272b847" datatype="html">
+        <source>Evaluates to true if idea 1, 2, 18, etc was found in the student’s response</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="0e34c7779bdf2c4df453bb545fcdfe358565848b" datatype="html">
+        <source> Evaluates to true if the student received a KI score of X<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>hasKIScore(3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student received KI score 3 </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">19,22</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="a002956c5fe1d2df31c2f9ce57ae41f8738734e5" datatype="html">
+        <source> Evaluates to true if more than X ideas were found in the student’s response<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountMoreThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had more than 2 ideas </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">26,29</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="f00f26f724c9f15b9e43401111bc67a9150b78ef" datatype="html">
+        <source> Evaluates to true if less than X ideas were found in the student’s response<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountLessThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had less than 2 ideas </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">33,36</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1d7522eac1766bebce663f9bbcb4b6a3e6df2197" datatype="html">
+        <source> Evaluates to true if exactly X ideas were found in the student’s response<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountEquals(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had exactly 2 ideas </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">40,43</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="15641367e5a05c67a56e52ca22c5b8b811fd8066" datatype="html">
+        <source> Evaluates to true if this is the student’s second to last response when the max number of submits is specified </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">47,50</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="0cb22cee2544fe215ab51cd44e8a24484bab8872" datatype="html">
+        <source> Evaluates to true if this is the student’s final response when the max number of submits is specified </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">54,57</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="47f9fcf7ce7ae5beacc007aaa10eb48d12b037ce" datatype="html">
+        <source>Evaluates to true if the student’s response was not scorable</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="f449ad0ace8954bb3f44bc0bd49d079a7847ca1a" datatype="html">
+        <source> Evaluates to true if no other terms were matched. Add this term as the final rule to specify a default feedback </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">65,68</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="9d4ed1f582fafcfd1035ea83e58a5e1fe8d6a1a5" datatype="html">
+        <source>Operators</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">71</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4591f33630563bafe4084c5e981ac26f3bc285c2" datatype="html">
+        <source>Operators lets you combine one more terms together to make a rule</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">73</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="c39d43f18d10f925621abc77ad15de80a9cc7516" datatype="html">
+        <source>Operator</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="141f25af35189f05ffe0775ba7018fe458520391" datatype="html">
+        <source> Evaluates to true if terms on both sides of this operator evaluates to true<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; hasKIScore(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if idea 1 was found and the student received a KI score of 2 </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">78,83</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3d77040007fc8a27e9ecbc997c10d29839ff3959" datatype="html">
+        <source> Evaluates to true if a term on either side of this operator evaluates to true<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 || 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if either idea 1 or 2 was found Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2 || 3<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found, or idea 3 was found </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">87,92</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7cde3e80e7bcff6dd5d7683944cf0851bf971dcd" datatype="html">
+        <source> Evaluates to true if a term following this operator evaluates to false<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>!1<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if idea 1 was not found </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">96,99</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="c50661356b4d4941e7eb9b151c65f5f5897d236e" datatype="html">
         <source>Add response...</source>
         <context-group purpose="location">
@@ -12299,25 +12462,25 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Drag to reorder</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.html</context>
-          <context context-type="linenumber">19</context>
+          <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cc697167c19fb984956b08b0e01767da0dce90fa" datatype="html">
         <source>Expression</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.html</context>
-          <context context-type="linenumber">23</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e9b20820eab2b7caad859fd12f5e211cdb4eae88" datatype="html">
         <source>Feedback</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.html</context>
-          <context context-type="linenumber">36</context>
+          <context context-type="linenumber">38</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">68</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
@@ -12332,70 +12495,70 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Feedback #<x id="INTERPOLATION" equiv-text="{{feedbackIndex + 1}}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.html</context>
-          <context context-type="linenumber">37</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3aa2cdd901989a09c8e86d46bd5f7286269dfb04" datatype="html">
         <source>Delete feedback</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">48</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e01a2fbbb7dc8f23d76bc4546e106de85ec707a5" datatype="html">
         <source>Add new feedback</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.html</context>
-          <context context-type="linenumber">55</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a21168341f6e8fcc754c90ac1bab01a5348d5647" datatype="html">
         <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon&gt;"/>add_circle<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.html</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d3ccd931bd0661bdf42d1023fc5a8f26503a4d5f" datatype="html">
         <source>Delete rule</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.html</context>
-          <context context-type="linenumber">79</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f5d502c5d44fd9d78ed4979a7efae43369b09dca" datatype="html">
         <source>Move up</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.html</context>
-          <context context-type="linenumber">88</context>
+          <context context-type="linenumber">90</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7a91e24cda07c3ccff6a84d88c25de674bf288f0" datatype="html">
         <source>Move down</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.html</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">98</context>
         </context-group>
       </trans-unit>
       <trans-unit id="28b0236983b8c9cde819e9f8dc2f3b85fa419168" datatype="html">
         <source>Add a new rule at the end</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.html</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9105812558859476049" datatype="html">
         <source>Are you sure you want to delete this feedback?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.ts</context>
-          <context context-type="linenumber">75</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7484685939884481783" datatype="html">
         <source>Are you sure you want to delete this feedback rule?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.ts</context>
-          <context context-type="linenumber">82</context>
+          <context context-type="linenumber">88</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f1affa088d785794802225dbc56ee2ff3d785f87" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -307,7 +307,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">106</context>
+          <context context-type="linenumber">109</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/dialog-with-close/dialog-with-close.component.html</context>
@@ -1483,11 +1483,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">16</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">75</context>
+          <context context-type="linenumber">80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7491b1ebfc5dd457492a5c481e2d2254216dc1fc" datatype="html">
@@ -12114,8 +12114,8 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">16</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="9e75f4cce91b22668189b7c992289eab9d0cf290" datatype="html">
-        <source>About Dialog Guidance Feedback Rules</source>
+      <trans-unit id="21a9fc818b21be4ca6e733d9cf3defc9b28f3879" datatype="html">
+        <source>Feedback Rule Authoring</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
           <context context-type="linenumber">1</context>
@@ -12128,137 +12128,151 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="0332ce88b09e2457eef8dee49b223c22b72066c6" datatype="html">
-        <source> Rules are evaluated top to bottom, and the first rule that matches is used to provide feedback. Rules are made up of terms and operators. </source>
+      <trans-unit id="2b697376f40eff0851d7401d0e93b7243059e8ef" datatype="html">
+        <source> Rules are evaluated top to bottom. The first rule <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>Expression<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> that matches the student&apos;s response is used to provide feedback. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
           <context context-type="linenumber">4,7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="c9221bf820334c924a79cbd23f21e521a5bc5a90" datatype="html">
+        <source>You can add multiple <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>Feedback<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> items per rule. The first time a rule matches, Feedback #1 will be shown to the student.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> If the rule matches a second time (in a subsequent round), Feedback #2 will be shown, and so on. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">8,11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="f7b73495b143340f88fb636d660bde8a62016d55" datatype="html">
+        <source><x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>Expressions<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> are made up of terms and operators:</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
+          <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
       <trans-unit id="69580f2c2dbf4edf7096820ba8c393367352d774" datatype="html">
         <source>Terms</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">8</context>
+          <context context-type="linenumber">13</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="5014ddee7747a6b640b82197065549072ceccab3" datatype="html">
-        <source>Terms lets you specify what to look for in a student response</source>
+      <trans-unit id="4386e2f920c44a2d81df324615b6daba105a6d92" datatype="html">
+        <source>Terms lets you specify what to look for in a student response.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">10</context>
+          <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
       <trans-unit id="be1c273fc76e686667bff39d321970c9487f9ee7" datatype="html">
         <source>Term</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">16</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3b3419f206cf782f06a32d1158f272648272b847" datatype="html">
-        <source>Evaluates to true if idea 1, 2, 18, etc was found in the student’s response</source>
+      <trans-unit id="75d2b95268e9105792456110196b6d0959f64682" datatype="html">
+        <source>Evaluates to true if idea 1, 2, 18, etc was found in the student’s response.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="0e34c7779bdf2c4df453bb545fcdfe358565848b" datatype="html">
-        <source> Evaluates to true if the student received a KI score of X<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>hasKIScore(3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student received KI score 3 </source>
+      <trans-unit id="b76eb1dfebc7cbec7f95dae60708804c3eb23e15" datatype="html">
+        <source> Evaluates to true if the student received a KI score of X.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>hasKIScore(3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student received KI score 3. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">19,22</context>
+          <context context-type="linenumber">23,26</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="a002956c5fe1d2df31c2f9ce57ae41f8738734e5" datatype="html">
-        <source> Evaluates to true if more than X ideas were found in the student’s response<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountMoreThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had more than 2 ideas </source>
+      <trans-unit id="0d416f044b1ada4a09ca8aeae1f1eda976c755de" datatype="html">
+        <source> Evaluates to true if more than X ideas were found in the student’s response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountMoreThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had more than 2 ideas. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">26,29</context>
+          <context context-type="linenumber">30,33</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="f00f26f724c9f15b9e43401111bc67a9150b78ef" datatype="html">
-        <source> Evaluates to true if less than X ideas were found in the student’s response<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountLessThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had less than 2 ideas </source>
+      <trans-unit id="1e95f0f9a80f8d69c7161cee29dae19260b0413c" datatype="html">
+        <source> Evaluates to true if less than X ideas were found in the student’s response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountLessThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had less than 2 ideas. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">33,36</context>
+          <context context-type="linenumber">37,40</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1d7522eac1766bebce663f9bbcb4b6a3e6df2197" datatype="html">
-        <source> Evaluates to true if exactly X ideas were found in the student’s response<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountEquals(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had exactly 2 ideas </source>
+      <trans-unit id="43741e9a8cbb377bc249abc1b62354e7afdc8fa4" datatype="html">
+        <source> Evaluates to true if exactly X ideas were found in the student’s response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountEquals(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had exactly 2 ideas. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">40,43</context>
+          <context context-type="linenumber">44,47</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="15641367e5a05c67a56e52ca22c5b8b811fd8066" datatype="html">
-        <source> Evaluates to true if this is the student’s second to last response when the max number of submits is specified </source>
+      <trans-unit id="c2486592cf45d20e09baab39819c38505fad8a6b" datatype="html">
+        <source> Evaluates to true if this is the student’s second to last response when the max number of submits is specified. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">47,50</context>
+          <context context-type="linenumber">51,54</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="0cb22cee2544fe215ab51cd44e8a24484bab8872" datatype="html">
-        <source> Evaluates to true if this is the student’s final response when the max number of submits is specified </source>
+      <trans-unit id="2a3efda5e801cb07e2e472eddd138e8f0f3c7443" datatype="html">
+        <source> Evaluates to true if this is the student’s final response when the max number of submits is specified. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">54,57</context>
+          <context context-type="linenumber">58,61</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="47f9fcf7ce7ae5beacc007aaa10eb48d12b037ce" datatype="html">
-        <source>Evaluates to true if the student’s response was not scorable</source>
+      <trans-unit id="b0a572a715e1e342333c536fea0001cf15619361" datatype="html">
+        <source>Evaluates to true if the student’s response was not scorable.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">65</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="f449ad0ace8954bb3f44bc0bd49d079a7847ca1a" datatype="html">
-        <source> Evaluates to true if no other terms were matched. Add this term as the final rule to specify a default feedback </source>
+      <trans-unit id="288b2a5b903bd5a233bc6dde453ce2cca7f59f06" datatype="html">
+        <source> Evaluates to true if no other terms were matched. Add this term as the final rule to specify a default feedback. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">65,68</context>
+          <context context-type="linenumber">69,72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9d4ed1f582fafcfd1035ea83e58a5e1fe8d6a1a5" datatype="html">
         <source>Operators</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">71</context>
+          <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4591f33630563bafe4084c5e981ac26f3bc285c2" datatype="html">
-        <source>Operators lets you combine one more terms together to make a rule</source>
+      <trans-unit id="ab6ce985f2b7efd20fb47919fbcd7b75ff940acb" datatype="html">
+        <source>Operators let you combine one more terms together to make a rule.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">73</context>
+          <context context-type="linenumber">76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c39d43f18d10f925621abc77ad15de80a9cc7516" datatype="html">
         <source>Operator</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">75</context>
+          <context context-type="linenumber">79</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="141f25af35189f05ffe0775ba7018fe458520391" datatype="html">
-        <source> Evaluates to true if terms on both sides of this operator evaluates to true<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; hasKIScore(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if idea 1 was found and the student received a KI score of 2 </source>
+      <trans-unit id="f8fe51bf6c4939808e8ce9047e067b7fa4fd7a54" datatype="html">
+        <source> Evaluates to true if terms on both sides of this operator evaluate to true.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; hasKIScore(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if idea 1 was found and the student received a KI score of 2. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">78,83</context>
+          <context context-type="linenumber">84,89</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="9b6d3cce00caf762fd168120ed200945252cb39b" datatype="html">
-        <source> Evaluates to true if a term on either side of this operator evaluates to true<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 || 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if either idea 1 or 2 was found<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2 || 3<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found, or idea 3 was found </source>
+      <trans-unit id="3442eeed9a3956346f4fe2a2f2efb6158c5c54d9" datatype="html">
+        <source> Evaluates to true if a term on either side of this operator evaluates to true.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 || 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if either idea 1 or 2 was found.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2 || 3<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found or idea 3 was found. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">87,92</context>
+          <context context-type="linenumber">93,97</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7cde3e80e7bcff6dd5d7683944cf0851bf971dcd" datatype="html">
-        <source> Evaluates to true if a term following this operator evaluates to false<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>!1<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if idea 1 was not found </source>
+      <trans-unit id="414f2fd4ea5c948c6ebbf8417e6afe371bea442d" datatype="html">
+        <source> Evaluates to true if a term following this operator evaluates to false.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>!1<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if idea 1 was not found. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
-          <context context-type="linenumber">96,99</context>
+          <context context-type="linenumber">101,104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c50661356b4d4941e7eb9b151c65f5f5897d236e" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12240,8 +12240,8 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="ab6ce985f2b7efd20fb47919fbcd7b75ff940acb" datatype="html">
-        <source>Operators let you combine one more terms together to make a rule.</source>
+      <trans-unit id="b2145d0c97ccffaf79c5770f967a429c84af4123" datatype="html">
+        <source>Operators let you combine one or more terms together to make a rule.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-feedback-rule-help/dialog-guidance-feedback-rule-help.component.html</context>
           <context context-type="linenumber">76</context>


### PR DESCRIPTION
## Notes
- @breity please style as you see fit

## Changes
- Add help button to Dialog Guidance feedback rule authoring section
- Add dialog with help contents when the above help button is clicked
- Rename variable ProjectService -> projectService 

## Test
- Click on the help button. It should show the help page in a dialog
   - You can scroll through the page
   - You can close the dialog via the close button, clicking outside the dialog, and hitting the escape key

Closes #766