### PR TITLE
fix(AT): Display shared units in descending id order

### DIFF
--- a/src/assets/wise5/authoringTool/main/mainAuthoringComponent.ts
+++ b/src/assets/wise5/authoringTool/main/mainAuthoringComponent.ts
@@ -53,7 +53,9 @@ class MainAuthoringController {
 
   $onInit() {
     this.projects = this.ConfigService.getConfigParam('projects');
-    this.sharedProjects = this.ConfigService.getConfigParam('sharedProjects');
+    this.sharedProjects = this.ConfigService.getConfigParam('sharedProjects').sort(
+      (projectA, projectB) => projectB.id - projectA.id
+    );
     this.is_rtl = $('html').attr('dir') == 'rtl';
     this.icons = { prev: 'arrow_back', next: 'arrow_forward' };
     if (this.is_rtl) {


### PR DESCRIPTION
## Test
In the authoring tool's unit listing page
- Shared units appear in descending id order
- If no units are shared, you should see the message "You have no shared units"

Closes #801