### PR TITLE
feat(OpenResponse): Add FeedbackRuleEvaluator expressions

### DIFF
--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceFeedbackRuleEvaluator.ts
@@ -1,5 +1,5 @@
+import { FeedbackRuleComponent } from '../feedbackRule/FeedbackRuleComponent';
 import { CRaterResponse } from './CRaterResponse';
-import { DialogGuidanceStudentComponent } from './dialog-guidance-student/dialog-guidance-student.component';
 import { FeedbackRule } from './FeedbackRule';
 import { HasKIScoreTermEvaluator } from './TermEvaluator/HasKIScoreTermEvaluator';
 import { IdeaCountTermEvaluator } from './TermEvaluator/IdeaCountTermEvaluator';
@@ -9,15 +9,15 @@ import { TermEvaluator } from './TermEvaluator/TermEvaluator';
 export class DialogGuidanceFeedbackRuleEvaluator {
   defaultFeedback = $localize`Thanks for submitting your response.`;
 
-  constructor(private component: DialogGuidanceStudentComponent) {}
+  constructor(private component: FeedbackRuleComponent) {}
 
   getFeedbackRule(response: CRaterResponse): FeedbackRule {
-    for (const feedbackRule of this.component.componentContent.feedbackRules) {
+    for (const feedbackRule of this.component.getFeedbackRules()) {
       if (this.satisfiesRule(response, Object.assign(new FeedbackRule(), feedbackRule))) {
         return feedbackRule;
       }
     }
-    return this.getDefaultRule(this.component.componentContent.feedbackRules);
+    return this.getDefaultRule(this.component.getFeedbackRules());
   }
 
   private satisfiesRule(response: CRaterResponse, feedbackRule: FeedbackRule): boolean {
@@ -140,7 +140,9 @@ export class DialogGuidanceFeedbackRuleEvaluator {
       feedbackRules.find((rule) => FeedbackRule.isDefaultRule(rule)) ||
       Object.assign(new FeedbackRule(), {
         expression: 'isDefault',
-        feedback: this.component.isVersion1() ? this.defaultFeedback : [this.defaultFeedback]
+        feedback: this.component.isMultipleFeedbackTextsForSameRuleAllowed()
+          ? [this.defaultFeedback]
+          : this.defaultFeedback
       })
     );
   }

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
 import { AnnotationService } from '../../../services/annotationService';
-import { ComponentStudent } from '../../component-student.component';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
@@ -23,13 +22,14 @@ import { ComputerAvatar } from '../../../common/ComputerAvatar';
 import { ComputerAvatarService } from '../../../services/computerAvatarService';
 import { StudentStatusService } from '../../../services/studentStatusService';
 import { DialogGuidanceFeedbackService } from '../../../services/dialogGuidanceFeedbackService';
+import { FeedbackRuleComponent } from '../../feedbackRule/FeedbackRuleComponent';
 
 @Component({
   selector: 'dialog-guidance-student',
   templateUrl: './dialog-guidance-student.component.html',
   styleUrls: ['./dialog-guidance-student.component.scss']
 })
-export class DialogGuidanceStudentComponent extends ComponentStudent {
+export class DialogGuidanceStudentComponent extends FeedbackRuleComponent {
   computerAvatar: ComputerAvatar;
   cRaterTimeout: number = 40000;
   feedbackRuleEvaluator: DialogGuidanceFeedbackRuleEvaluator;
@@ -312,5 +312,13 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
   studentResponseChanged(): void {
     this.isSubmitEnabled = this.studentResponse.length > 0;
     this.setIsSubmitDirty(this.isSubmitDirty || this.isSubmitEnabled);
+  }
+
+  getFeedbackRules(): FeedbackRule[] {
+    return this.componentContent.feedbackRules;
+  }
+
+  isMultipleFeedbackTextsForSameRuleAllowed(): boolean {
+    return !this.isVersion1();
   }
 }

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
@@ -23,13 +23,16 @@ import { ComputerAvatarService } from '../../../services/computerAvatarService';
 import { StudentStatusService } from '../../../services/studentStatusService';
 import { DialogGuidanceFeedbackService } from '../../../services/dialogGuidanceFeedbackService';
 import { FeedbackRuleComponent } from '../../feedbackRule/FeedbackRuleComponent';
+import { ComponentStudent } from '../../component-student.component';
 
 @Component({
   selector: 'dialog-guidance-student',
   templateUrl: './dialog-guidance-student.component.html',
   styleUrls: ['./dialog-guidance-student.component.scss']
 })
-export class DialogGuidanceStudentComponent extends FeedbackRuleComponent {
+export class DialogGuidanceStudentComponent
+  extends ComponentStudent
+  implements FeedbackRuleComponent {
   computerAvatar: ComputerAvatar;
   cRaterTimeout: number = 40000;
   feedbackRuleEvaluator: DialogGuidanceFeedbackRuleEvaluator;

--- a/src/assets/wise5/components/feedbackRule/FeedbackRuleComponent.ts
+++ b/src/assets/wise5/components/feedbackRule/FeedbackRuleComponent.ts
@@ -1,7 +1,9 @@
-import { ComponentStudent } from '../component-student.component';
 import { FeedbackRule } from '../dialogGuidance/FeedbackRule';
 
-export abstract class FeedbackRuleComponent extends ComponentStudent {
-  abstract getFeedbackRules(): FeedbackRule[];
-  abstract isMultipleFeedbackTextsForSameRuleAllowed(): boolean;
+export interface FeedbackRuleComponent {
+  getFeedbackRules(): FeedbackRule[];
+  getNumberOfSubmitsLeft(): number;
+  hasMaxSubmitCount(): boolean;
+  hasMaxSubmitCountAndUsedAllSubmits(): boolean;
+  isMultipleFeedbackTextsForSameRuleAllowed(): boolean;
 }

--- a/src/assets/wise5/components/feedbackRule/FeedbackRuleComponent.ts
+++ b/src/assets/wise5/components/feedbackRule/FeedbackRuleComponent.ts
@@ -1,0 +1,7 @@
+import { ComponentStudent } from '../component-student.component';
+import { FeedbackRule } from '../dialogGuidance/FeedbackRule';
+
+export abstract class FeedbackRuleComponent extends ComponentStudent {
+  abstract getFeedbackRules(): FeedbackRule[];
+  abstract isMultipleFeedbackTextsForSameRuleAllowed(): boolean;
+}

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
@@ -467,8 +467,8 @@ export class OpenResponseStudent extends FeedbackRuleComponent {
 
   private hasFeedbackRules(): boolean {
     return (
-      this.componentContent.cRater.feedbackRules != null &&
-      this.componentContent.cRater.feedbackRules.length > 0
+      this.componentContent.cRater.feedbackRules?.enabled &&
+      this.componentContent.cRater.feedbackRules.rules.length > 0
     );
   }
 
@@ -600,7 +600,7 @@ export class OpenResponseStudent extends FeedbackRuleComponent {
   }
 
   getFeedbackRules(): FeedbackRule[] {
-    return this.componentContent.cRater.feedbackRules;
+    return this.componentContent.cRater.feedbackRules.rules;
   }
 
   isMultipleFeedbackTextsForSameRuleAllowed(): boolean {

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
@@ -468,8 +468,8 @@ export class OpenResponseStudent extends ComponentStudent implements FeedbackRul
 
   private hasFeedbackRules(): boolean {
     return (
-      this.componentContent.cRater.feedbackRules?.enabled &&
-      this.componentContent.cRater.feedbackRules.rules.length > 0
+      this.componentContent.cRater.feedback?.enabled &&
+      this.componentContent.cRater.feedback.rules.length > 0
     );
   }
 
@@ -601,7 +601,7 @@ export class OpenResponseStudent extends ComponentStudent implements FeedbackRul
   }
 
   getFeedbackRules(): FeedbackRule[] {
-    return this.componentContent.cRater.feedbackRules.rules;
+    return this.componentContent.cRater.feedback.rules;
   }
 
   isMultipleFeedbackTextsForSameRuleAllowed(): boolean {

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
@@ -12,6 +12,7 @@ import { ProjectService } from '../../../services/projectService';
 import { StudentAssetService } from '../../../services/studentAssetService';
 import { StudentDataService } from '../../../services/studentDataService';
 import { UtilService } from '../../../services/utilService';
+import { ComponentStudent } from '../../component-student.component';
 import { ComponentService } from '../../componentService';
 import { CRaterResponse } from '../../dialogGuidance/CRaterResponse';
 import { DialogGuidanceFeedbackRuleEvaluator } from '../../dialogGuidance/DialogGuidanceFeedbackRuleEvaluator';
@@ -24,7 +25,7 @@ import { OpenResponseService } from '../openResponseService';
   templateUrl: 'open-response-student.component.html',
   styleUrls: ['open-response-student.component.scss']
 })
-export class OpenResponseStudent extends FeedbackRuleComponent {
+export class OpenResponseStudent extends ComponentStudent implements FeedbackRuleComponent {
   audioAttachments: any[] = [];
   cRaterTimeout: number = 40000;
   isPublicSpaceExist: boolean = false;

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -11382,11 +11382,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">157</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">170</context>
+          <context context-type="linenumber">173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4965414112249568013" datatype="html">
@@ -11942,7 +11942,7 @@ Are you ready to receive feedback on this answer?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">157</context>
+          <context context-type="linenumber">160</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8429316238784832901" datatype="html">
@@ -15195,7 +15195,7 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">161</context>
+          <context context-type="linenumber">164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7482125205220618294" datatype="html">
@@ -15204,7 +15204,7 @@ Are you ready to receive feedback on this answer?</source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">173</context>
+          <context context-type="linenumber">176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6316287012266891697" datatype="html">
@@ -15213,21 +15213,21 @@ Are you ready to receive feedback on this answer?</source>
 Are you ready to submit this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">177</context>
+          <context context-type="linenumber">180</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8936495196157450285" datatype="html">
         <source>We are scoring your work...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">291</context>
+          <context context-type="linenumber">294</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2283191014272031538" datatype="html">
         <source>Please Wait</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">292</context>
+          <context context-type="linenumber">295</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8785209093929133444" datatype="html">
@@ -15235,7 +15235,7 @@ Are you ready to submit this answer?</source>
 If this problem continues, let your teacher know and move on to the next activity. Your work will still be saved.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">314</context>
+          <context context-type="linenumber">317</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5623290610025495479" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -11382,11 +11382,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">157</context>
+          <context context-type="linenumber">158</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">173</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4965414112249568013" datatype="html">
@@ -11942,7 +11942,7 @@ Are you ready to receive feedback on this answer?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">160</context>
+          <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8429316238784832901" datatype="html">
@@ -15195,7 +15195,7 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">164</context>
+          <context context-type="linenumber">165</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7482125205220618294" datatype="html">
@@ -15204,7 +15204,7 @@ Are you ready to receive feedback on this answer?</source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">176</context>
+          <context context-type="linenumber">177</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6316287012266891697" datatype="html">
@@ -15213,21 +15213,21 @@ Are you ready to receive feedback on this answer?</source>
 Are you ready to submit this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">180</context>
+          <context context-type="linenumber">181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8936495196157450285" datatype="html">
         <source>We are scoring your work...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">294</context>
+          <context context-type="linenumber">295</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2283191014272031538" datatype="html">
         <source>Please Wait</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">295</context>
+          <context context-type="linenumber">296</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8785209093929133444" datatype="html">
@@ -15235,7 +15235,7 @@ Are you ready to submit this answer?</source>
 If this problem continues, let your teacher know and move on to the next activity. Your work will still be saved.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">317</context>
+          <context context-type="linenumber">318</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5623290610025495479" datatype="html">


### PR DESCRIPTION
Part 1 of work for issue #829 "feat(OpenResponse): Add FeedbackRuleEvaluator". These are planned future PR's for this issue:
- refactoring, organizing folders to share common classes between OR and DG
- adding FeedbackRule authoring to OR

## Changes
- Evaluate FeedbackRules if authored for the OpenResponse content (see "Test Prep" section below). If the component content has cRater.feedbackRules, assume that it will use the FeedbackRuleEvaluator to provide feedback instead of other feedback mechanisms (e.g. MutlipleRoundsFeedback). Also assume that the author can specify one or more feedback texts for a FeedbackRule.
- Refactoring to share classes between DG and OR
   - Created abstract FeedbackRuleComponent that extends ComponentStudent and use this in DialogGuidanceFeedbackRuleEvaluator

## Test Prep
Using component advanced authoring, directly edit the component JSON and add "feedbackRules" block to OpenResponse's "cRater" block. Make sure that the feedback rules contain an id and a feedback array (instead of feedback string)
```
...
"cRater": {
  "feedback": {
    "enabled": true,
    "rules": [
      {
        "id": "lq3duxi3se",
        "expression": "ideaCountMoreThan(2)",
        "feedback": [
          "ideaCountMoreThan 2: first feedback",
          "ideaCountMoreThan 2: second feedback,
        ]
      },
      {
        "id": "default",
        "expression": "isDefault",
        "feedback": [
          "The default feedback"
        ]
      },
      ...
    ]
  }
  ...
}
...
```

## Test
- FeedbackRule evaluation for OR works and the correct feedback is shown to the student. 
   - If the rule has more than one feedback text, it should cycle through them.
- Existing C-Rater items that do not use FeedbackRule should work as before
- DG works as before
