### PR TITLE
feat(OpenResponse): Add FeedbackRule authoring

### DIFF
--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-feedback-rules/edit-dialog-guidance-feedback-rules.component.ts
@@ -17,7 +17,7 @@ export class EditDialogGuidanceFeedbackRulesComponent implements OnInit {
   @Input() feedbackRules: FeedbackRule[] = [];
   inputChanged: Subject<string> = new Subject<string>();
   subscriptions: Subscription = new Subscription();
-  @Input() version: number;
+  @Input() version: number = 2;
 
   constructor(
     private dialog: MatDialog,

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
@@ -90,6 +90,69 @@
     </edit-dialog-guidance-feedback-rules>
   </div>
   <div class="section-container">
+    <div fxLayoutGap="10px" class="section-label">
+      <span i18n>Scoring Rule</span>
+      <button
+          mat-raised-button
+          color="primary"
+          (click)="addScoringRule()"
+          matTooltip="Add Scoring Rule"
+          matTooltipPosition="above"
+          i18n-matTooltip>
+        <mat-icon>add</mat-icon>
+      </button>
+    </div>
+    <div *ngFor="let scoringRule of authoringComponentContent.cRater.scoringRules; index as scoringRuleIndex; first as isFirst; last as isLast"
+        fxLayout="row wrap" fxLayoutAlign="start start" fxLayoutGap="20px" class="section-item">
+      <mat-form-field class="scoring-rule-score">
+        <mat-label i18n>Score</mat-label>
+        <input matInput
+            type="number"
+            min="0"
+            [(ngModel)]="scoringRule.score"
+            (ngModelChange)="componentChanged()"/>
+      </mat-form-field>
+      <mat-form-field class="scoring-rule-feedback-text">
+        <mat-label i18n>Feedback Text</mat-label>
+        <textarea matInput
+            [(ngModel)]="scoringRule.feedbackText"
+            (ngModelChange)="componentChanged()"
+            cdkTextareaAutosize>
+        </textarea>
+      </mat-form-field>
+      <div fxLayoutGap="10px">
+        <button
+            mat-raised-button
+            color="primary"
+            (click)="moveObjectUp(authoringComponentContent.cRater.scoringRules, scoringRuleIndex)"
+            [disabled]="isFirst"
+            matTooltip="Move Scoring Rule Up"
+            matTooltipPosition="above"
+            i18n-matTooltip>
+          <mat-icon>arrow_upward</mat-icon>
+        </button>
+        <button
+            mat-raised-button
+            color="primary"
+            (click)="moveObjectDown(authoringComponentContent.cRater.scoringRules, scoringRuleIndex)"
+            [disabled]="isLast"
+            matTooltip="Move Scoring Rule Down"
+            matTooltipPosition="above"
+            i18n-matTooltip>
+          <mat-icon>arrow_downward</mat-icon>
+        </button>
+        <button
+            mat-raised-button
+            color="primary" (click)="scoringRuleDeleteClicked(scoringRuleIndex)"
+            matTooltip="Delete Scoring Rule"
+            matTooltipPosition="above"
+            i18n-matTooltip>
+          <mat-icon>delete</mat-icon>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div class="section-container">
     <div>
       <mat-checkbox
           color="primary"

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
@@ -89,7 +89,7 @@
         [feedbackRules]="authoringComponentContent.cRater.feedback.rules">
     </edit-dialog-guidance-feedback-rules>
   </div>
-  <div class="section-container">
+  <div class="section-container" *ngIf="!authoringComponentContent.cRater.feedback?.enabled">
     <div fxLayoutGap="10px" class="section-label">
       <span i18n>Scoring Rule</span>
       <button

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
@@ -77,67 +77,17 @@
     Show Feedback
   </mat-checkbox>
   <div class="section-container">
-    <div fxLayoutGap="10px" class="section-label">
-      <span i18n>Scoring Rule</span>
-      <button
-          mat-raised-button
-          color="primary"
-          (click)="addScoringRule()"
-          matTooltip="Add Scoring Rule"
-          matTooltipPosition="above"
-          i18n-matTooltip>
-        <mat-icon>add</mat-icon>
-      </button>
-    </div>
-    <div *ngFor="let scoringRule of authoringComponentContent.cRater.scoringRules; index as scoringRuleIndex; first as isFirst; last as isLast"
-        fxLayout="row wrap" fxLayoutAlign="start start" fxLayoutGap="20px" class="section-item">
-      <mat-form-field class="scoring-rule-score">
-        <mat-label i18n>Score</mat-label>
-        <input matInput
-            type="number"
-            min="0"
-            [(ngModel)]="scoringRule.score"
-            (ngModelChange)="componentChanged()"/>
-      </mat-form-field>
-      <mat-form-field class="scoring-rule-feedback-text">
-        <mat-label i18n>Feedback Text</mat-label>
-        <textarea matInput
-            [(ngModel)]="scoringRule.feedbackText"
-            (ngModelChange)="componentChanged()"
-            cdkTextareaAutosize>
-        </textarea>
-      </mat-form-field>
-      <div fxLayoutGap="10px">
-        <button
-            mat-raised-button
-            color="primary"
-            (click)="moveObjectUp(authoringComponentContent.cRater.scoringRules, scoringRuleIndex)"
-            [disabled]="isFirst"
-            matTooltip="Move Scoring Rule Up"
-            matTooltipPosition="above"
-            i18n-matTooltip>
-          <mat-icon>arrow_upward</mat-icon>
-        </button>
-        <button
-            mat-raised-button
-            color="primary"
-            (click)="moveObjectDown(authoringComponentContent.cRater.scoringRules, scoringRuleIndex)"
-            [disabled]="isLast"
-            matTooltip="Move Scoring Rule Down"
-            matTooltipPosition="above"
-            i18n-matTooltip>
-          <mat-icon>arrow_downward</mat-icon>
-        </button>
-        <button
-            mat-raised-button
-            color="primary" (click)="scoringRuleDeleteClicked(scoringRuleIndex)"
-            matTooltip="Delete Scoring Rule"
-            matTooltipPosition="above"
-            i18n-matTooltip>
-          <mat-icon>delete</mat-icon>
-        </button>
-      </div>
-    </div>
+    <mat-checkbox
+        color="primary"
+        class="checkbox"
+        [ngModel]="authoringComponentContent.cRater.feedback?.enabled"
+        (ngModelChange)="setFeedbackEnabled($event)"
+        i18n>
+      Enable Feedback Rules
+    </mat-checkbox>
+    <edit-dialog-guidance-feedback-rules *ngIf="authoringComponentContent.cRater.feedback?.enabled"
+        [feedbackRules]="authoringComponentContent.cRater.feedback.rules">
+    </edit-dialog-guidance-feedback-rules>
   </div>
   <div class="section-container">
     <div>

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
@@ -27,9 +27,6 @@ import { EditOpenResponseAdvancedComponent } from './edit-open-response-advanced
 
 let component: EditOpenResponseAdvancedComponent;
 let fixture: ComponentFixture<EditOpenResponseAdvancedComponent>;
-const scoringRule1 = createScoringRuleObject(1, 'You got 1 point');
-const scoringRule2 = createScoringRuleObject(2, 'You got 2 points');
-const scoringRule3 = createScoringRuleObject(3, 'You got 3 points');
 
 describe('EditOpenResponseAdvancedComponent', () => {
   beforeEach(async () => {
@@ -84,8 +81,6 @@ describe('EditOpenResponseAdvancedComponent', () => {
   });
 
   enableCRaterClicked();
-  addScoringRule();
-  scoringRuleDeleteClicked();
   addMultipleAttemptScoringRule();
   multipleAttemptScoringRuleDeleteClicked();
   addNotification();
@@ -95,6 +90,7 @@ describe('EditOpenResponseAdvancedComponent', () => {
   useCustomCompletionCriteriaClicked();
   addCompletionCriteria();
   deleteCompletionCriteria();
+  setFeedbackEnabled();
 });
 
 function enableCRaterClicked() {
@@ -104,44 +100,6 @@ function enableCRaterClicked() {
       component.authoringComponentContent.enableCRater = true;
       component.enableCRaterClicked();
       expect(component.authoringComponentContent.cRater).toEqual(component.createCRaterObject());
-    });
-  });
-}
-
-function addScoringRule() {
-  describe('addScoringRule', () => {
-    it('should add scoring rule', () => {
-      component.authoringComponentContent.cRater = component.createCRaterObject();
-      component.addScoringRule();
-      expect(component.authoringComponentContent.cRater.scoringRules.length).toEqual(1);
-      expect(component.authoringComponentContent.cRater.scoringRules[0]).toEqual(
-        component.createScoringRule()
-      );
-    });
-  });
-}
-
-function createScoringRuleObject(score: number, feedbackText: string): any {
-  return {
-    feedbackText: feedbackText,
-    score: score
-  };
-}
-
-function scoringRuleDeleteClicked() {
-  describe('scoringRuleDeleteClicked', () => {
-    it('should handle moving a scoring rule down', () => {
-      component.authoringComponentContent.cRater = component.createCRaterObject();
-      component.authoringComponentContent.cRater.scoringRules = [
-        scoringRule1,
-        scoringRule2,
-        scoringRule3
-      ];
-      spyOn(window, 'confirm').and.returnValue(true);
-      component.scoringRuleDeleteClicked(1);
-      expect(component.authoringComponentContent.cRater.scoringRules.length).toEqual(2);
-      expect(component.authoringComponentContent.cRater.scoringRules[0]).toEqual(scoringRule1);
-      expect(component.authoringComponentContent.cRater.scoringRules[1]).toEqual(scoringRule3);
     });
   });
 }
@@ -359,6 +317,17 @@ function deleteCompletionCriteria() {
       expect(component.authoringComponentContent.completionCriteria.criteria[1]).toEqual(
         completionCriteria3
       );
+    });
+  });
+}
+
+function setFeedbackEnabled() {
+  describe('setFeedbackEnabled()', () => {
+    it('should initialize feedback settings and set enabled field', () => {
+      component.authoringComponentContent.cRater = {};
+      component.setFeedbackEnabled(true);
+      expect(component.authoringComponentContent.cRater.feedback.enabled).toBeTruthy();
+      expect(component.authoringComponentContent.cRater.feedback.rules.length).toEqual(1);
     });
   });
 }

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
@@ -27,6 +27,9 @@ import { EditOpenResponseAdvancedComponent } from './edit-open-response-advanced
 
 let component: EditOpenResponseAdvancedComponent;
 let fixture: ComponentFixture<EditOpenResponseAdvancedComponent>;
+const scoringRule1 = createScoringRuleObject(1, 'You got 1 point');
+const scoringRule2 = createScoringRuleObject(2, 'You got 2 points');
+const scoringRule3 = createScoringRuleObject(3, 'You got 3 points');
 
 describe('EditOpenResponseAdvancedComponent', () => {
   beforeEach(async () => {
@@ -81,6 +84,8 @@ describe('EditOpenResponseAdvancedComponent', () => {
   });
 
   enableCRaterClicked();
+  addScoringRule();
+  scoringRuleDeleteClicked();
   addMultipleAttemptScoringRule();
   multipleAttemptScoringRuleDeleteClicked();
   addNotification();
@@ -100,6 +105,44 @@ function enableCRaterClicked() {
       component.authoringComponentContent.enableCRater = true;
       component.enableCRaterClicked();
       expect(component.authoringComponentContent.cRater).toEqual(component.createCRaterObject());
+    });
+  });
+}
+
+function addScoringRule() {
+  describe('addScoringRule', () => {
+    it('should add scoring rule', () => {
+      component.authoringComponentContent.cRater = component.createCRaterObject();
+      component.addScoringRule();
+      expect(component.authoringComponentContent.cRater.scoringRules.length).toEqual(1);
+      expect(component.authoringComponentContent.cRater.scoringRules[0]).toEqual(
+        component.createScoringRule()
+      );
+    });
+  });
+}
+
+function createScoringRuleObject(score: number, feedbackText: string): any {
+  return {
+    feedbackText: feedbackText,
+    score: score
+  };
+}
+
+function scoringRuleDeleteClicked() {
+  describe('scoringRuleDeleteClicked', () => {
+    it('should handle moving a scoring rule down', () => {
+      component.authoringComponentContent.cRater = component.createCRaterObject();
+      component.authoringComponentContent.cRater.scoringRules = [
+        scoringRule1,
+        scoringRule2,
+        scoringRule3
+      ];
+      spyOn(window, 'confirm').and.returnValue(true);
+      component.scoringRuleDeleteClicked(1);
+      expect(component.authoringComponentContent.cRater.scoringRules.length).toEqual(2);
+      expect(component.authoringComponentContent.cRater.scoringRules[0]).toEqual(scoringRule1);
+      expect(component.authoringComponentContent.cRater.scoringRules[1]).toEqual(scoringRule3);
     });
   });
 }

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
@@ -14,6 +14,13 @@ import { UtilService } from '../../../services/utilService';
 export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComponent {
   allowedConnectedComponentTypes = ['OpenResponse'];
   cRaterItemIdIsValid: boolean = null;
+  initialFeedbackRules = [
+    {
+      id: 'isDefault',
+      expression: 'isDefault',
+      feedback: [$localize`Default feedback`]
+    }
+  ];
   isVerifyingCRaterItemId: boolean = false;
   nodeIds: string[] = [];
   useCustomCompletionCriteria: boolean = false;
@@ -55,40 +62,13 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
       scoreOn: 'submit',
       showScore: true,
       showFeedback: true,
-      scoringRules: [],
+      feedback: {
+        enabled: false,
+        rules: this.initialFeedbackRules
+      },
       enableMultipleAttemptScoringRules: false,
       multipleAttemptScoringRules: []
     };
-  }
-
-  addScoringRule(): void {
-    if (
-      this.authoringComponentContent.cRater != null &&
-      this.authoringComponentContent.cRater.scoringRules != null
-    ) {
-      this.authoringComponentContent.cRater.scoringRules.push(this.createScoringRule());
-      this.componentChanged();
-    }
-  }
-
-  createScoringRule() {
-    return {
-      score: '',
-      feedbackText: ''
-    };
-  }
-
-  scoringRuleDeleteClicked(index: number): void {
-    const scoringRule = this.authoringComponentContent.cRater.scoringRules[index];
-    const score = scoringRule.score;
-    const feedbackText = scoringRule.feedbackText;
-    const answer = confirm(
-      $localize`Are you sure you want to delete this scoring rule?\n\nScore: ${score}\n\nFeedback Text: ${feedbackText}`
-    );
-    if (answer) {
-      this.authoringComponentContent.cRater.scoringRules.splice(index, 1);
-      this.componentChanged();
-    }
   }
 
   verifyCRaterItemId(itemId: string): void {
@@ -263,5 +243,20 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
 
   getNodePositionAndTitleByNodeId(nodeId: string): string {
     return this.TeacherProjectService.getNodePositionAndTitleByNodeId(nodeId);
+  }
+
+  setFeedbackEnabled(feedbackEnabled: boolean): void {
+    this.initializeFeedback();
+    this.authoringComponentContent.cRater.feedback.enabled = feedbackEnabled;
+    this.componentChanged();
+  }
+
+  private initializeFeedback(): void {
+    if (!this.authoringComponentContent.cRater.feedback) {
+      this.authoringComponentContent.cRater.feedback = {
+        enabled: false,
+        rules: this.initialFeedbackRules
+      };
+    }
   }
 }

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
@@ -62,6 +62,7 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
       scoreOn: 'submit',
       showScore: true,
       showFeedback: true,
+      scoringRules: [],
       feedback: {
         enabled: false,
         rules: this.initialFeedbackRules
@@ -69,6 +70,36 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
       enableMultipleAttemptScoringRules: false,
       multipleAttemptScoringRules: []
     };
+  }
+
+  addScoringRule(): void {
+    if (
+      this.authoringComponentContent.cRater != null &&
+      this.authoringComponentContent.cRater.scoringRules != null
+    ) {
+      this.authoringComponentContent.cRater.scoringRules.push(this.createScoringRule());
+      this.componentChanged();
+    }
+  }
+
+  createScoringRule() {
+    return {
+      score: '',
+      feedbackText: ''
+    };
+  }
+
+  scoringRuleDeleteClicked(index: number): void {
+    const scoringRule = this.authoringComponentContent.cRater.scoringRules[index];
+    const score = scoringRule.score;
+    const feedbackText = scoringRule.feedbackText;
+    const answer = confirm(
+      $localize`Are you sure you want to delete this scoring rule?\n\nScore: ${score}\n\nFeedback Text: ${feedbackText}`
+    );
+    if (answer) {
+      this.authoringComponentContent.cRater.scoringRules.splice(index, 1);
+      this.componentChanged();
+    }
   }
 
   verifyCRaterItemId(itemId: string): void {

--- a/src/assets/wise5/components/openResponse/i18n/i18n_ar.json
+++ b/src/assets/wise5/components/openResponse/i18n/i18n_ar.json
@@ -2,7 +2,6 @@
   "openResponse.addFile": "إضافة ملف",
   "openResponse.addMultipleAttemptScoringRule": "إضافة محاولات متعددة قاعدة تسجيل النقاط",
   "openResponse.addNewNotification": "إضافة إشعار جديد",
-  "openResponse.addScoringRule": "إضافة قاعدة تسجيل نقاط.",
   "openResponse.areYouSureYouWantToDeleteThisMultipleAttemptScoringRule": "هل أنت متأكد من رغبتك في حذف قاعدة تسجيل النقاط هذه؟\\n\\nالنقطة السابقة: {{previousScore}}\\n\\nالنقطة الحالية: {{النقطة الحالية}}\\n\\nنص التعقيب: {{feedbackText}}",
   "openResponse.areYouSureYouWantToDeleteThisNotification": "هل أنت متأكد من رغبتك في حذف هذا الإشعار؟\\n\\nالنقطة السابقة: {{previousScore}}\\n\\nالنقطة الحالية: {{currentScore}}",
   "openResponse.areYouSureYouWantToDeleteThisScoringRule": "هل أنت متأكد من رغبتك في حذف قاعدة تسجيل النقاط هذه؟\\n\\nالنقطة: {{النقطة}}\\n\\nنص الملاحظات: {{feedbackText}}",

--- a/src/assets/wise5/components/openResponse/i18n/i18n_el.json
+++ b/src/assets/wise5/components/openResponse/i18n/i18n_el.json
@@ -2,7 +2,6 @@
   "openResponse.addFile": "Προσθήκη Αρχείου",
   "openResponse.addMultipleAttemptScoringRule": "Προσθήκη Κανόνα Βαθμολόγησης Πολλαπλής Προσπάθειας",
   "openResponse.addNewNotification": "Προσθήκη Νέας Γνωστοποίησης",
-  "openResponse.addScoringRule": "Προσθήκη Κανόνα Βαθμολόγησης",
   "openResponse.areYouSureYouWantToDeleteThisMultipleAttemptScoringRule": "Θέλετε σίγουρα να διαγράψετε αυτό τον κανόνα βαθμολόγησης;\n\nΠροηγούμενη Βαθμολογία: {{previousScore}}\n\nΤρέχουσα Βαθμολογία: {{currentScore}}\n\nΚείμενο Ανατροφοδότησης: {{feedbackText}}",
   "openResponse.areYouSureYouWantToDeleteThisNotification": "Θέλετε σίγουρα να διαγράψετε αυτή τη γνωστοποίηση;\n\nΠροηγούμενη Βαθμολογία: {{previousScore}}\n\nΤρέχουσα Βαθμολογία: {{currentScore}}",
   "openResponse.areYouSureYouWantToDeleteThisScoringRule": "Θέλετε σίγουρα να διαγράψετε αυτό τον κανόνα βαθμολόγησης;\n\nΒαθμολογία: {{score}}\n\nΚείμενο Ανατρφοδότησης: {{feedbackText}}",

--- a/src/assets/wise5/components/openResponse/i18n/i18n_en.json
+++ b/src/assets/wise5/components/openResponse/i18n/i18n_en.json
@@ -2,7 +2,6 @@
   "openResponse.addFile": "Add File",
   "openResponse.addMultipleAttemptScoringRule": "Add Multiple Attempt Scoring Rule",
   "openResponse.addNewNotification": "Add New Notification",
-  "openResponse.addScoringRule": "Add Scoring Rule",
   "openResponse.areYouSureYouWantToDeleteThisMultipleAttemptScoringRule": "Are you sure you want to delete this scoring rule?\n\nPrevious Score: {{previousScore}}\n\nCurrent Score: {{currentScore}}\n\nFeedback Text: {{feedbackText}}",
   "openResponse.areYouSureYouWantToDeleteThisNotification": "Are you sure you want to delete this notification?\n\nPrevious Score: {{previousScore}}\n\nCurrent Score: {{currentScore}}",
   "openResponse.areYouSureYouWantToDeleteThisScoringRule": "Are you sure you want to delete this scoring rule?\n\nScore: {{score}}\n\nFeedback Text: {{feedbackText}}",

--- a/src/assets/wise5/components/openResponse/i18n/i18n_zh_CN.json
+++ b/src/assets/wise5/components/openResponse/i18n/i18n_zh_CN.json
@@ -2,7 +2,6 @@
   "openResponse.addFile": "添加文件",
   "openResponse.addMultipleAttemptScoringRule": "添加多次尝试评分规则",
   "openResponse.addNewNotification": "添加新通知",
-  "openResponse.addScoringRule": "添加评分规则",
   "openResponse.areYouSureYouWantToDeleteThisMultipleAttemptScoringRule": "您真的要删除这条评分规则么?\n\n先前得分: {{previousScore}}\n\n当前得分: {{currentScore}}\n\n反馈文本: {{feedbackText}}",
   "openResponse.areYouSureYouWantToDeleteThisNotification": "您真的要删除这条通知么？\n\n先前得分: {{previousScore}}\n\n当前得分: {{currentScore}}",
   "openResponse.areYouSureYouWantToDeleteThisScoringRule": "您真的要删除这条评分规则么？\n\n分数: {{score}}\n\n反馈文本: {{feedbackText}}",

--- a/src/assets/wise5/components/openResponse/i18n/i18n_zh_TW.json
+++ b/src/assets/wise5/components/openResponse/i18n/i18n_zh_TW.json
@@ -2,7 +2,6 @@
   "openResponse.addFile": "新增檔案",
   "openResponse.addMultipleAttemptScoringRule": "新增多次實驗評分規則",
   "openResponse.addNewNotification": "新增新通知",
-  "openResponse.addScoringRule": "新增評分規則",
   "openResponse.areYouSureYouWantToDeleteThisMultipleAttemptScoringRule": "您真的要刪除這條評分規則嗎？先前分數: {{previousScore}}目前分數: {{currentScore}}回饋文字: {{feedbackText}}",
   "openResponse.areYouSureYouWantToDeleteThisNotification": "您真的要刪除這條通知嗎？先前分數: {{previousScore}}目前分數: {{currentScore}}",
   "openResponse.areYouSureYouWantToDeleteThisScoringRule": "您真的要刪除這條評分規則嗎？分數: {{score}}回饋文字: {{feedbackText}}",

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -966,7 +966,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">340</context>
+          <context context-type="linenumber">403</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html</context>
@@ -981,7 +981,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">346</context>
+          <context context-type="linenumber">409</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.html</context>
@@ -1008,7 +1008,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">328</context>
+          <context context-type="linenumber">391</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html</context>
@@ -1552,7 +1552,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">354</context>
+          <context context-type="linenumber">417</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/component-save-submit-buttons/component-save-submit-buttons.component.html</context>
@@ -5820,7 +5820,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">355</context>
+          <context context-type="linenumber">418</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/component-save-submit-buttons/component-save-submit-buttons.component.html</context>
@@ -8536,6 +8536,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading-view/node-grading-view.component.html</context>
           <context context-type="linenumber">138</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
+          <context context-type="linenumber">108</context>
         </context-group>
       </trans-unit>
       <trans-unit id="811195f9acaa8be6f8d39184c94c2e3c63bff00c" datatype="html">
@@ -14864,135 +14868,177 @@ Warning: This will delete all existing choices in this component.</source>
           <context context-type="linenumber">85,87</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1af86cf046af1ad99f6148363089317c4711f840" datatype="html">
+        <source>Scoring Rule</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
+          <context context-type="linenumber">94</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1fd3b06c122aa8a76f671b604246ea4ac4ceb733" datatype="html">
+        <source>Add Scoring Rule</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
+          <context context-type="linenumber">99</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5fc3903f250aaeac1c91ede889c1d759e8524bd7" datatype="html">
+        <source>Feedback Text</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
+          <context context-type="linenumber">116</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="15ff433c6152bcc0653e60e459c440bdc772aec5" datatype="html">
+        <source>Move Scoring Rule Up</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
+          <context context-type="linenumber">129</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="04a96f1c6d8b00a057ad6fca4fb1680cea118142" datatype="html">
+        <source>Move Scoring Rule Down</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
+          <context context-type="linenumber">139</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8db5e82a6d07bf4aadf3c778b57db528379ee102" datatype="html">
+        <source>Delete Scoring Rule</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
+          <context context-type="linenumber">147</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="766b54d3e45afff8eea756ea51c8d39c56e1d78a" datatype="html">
         <source> Enable Multiple Attempt Feedback </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">99,101</context>
+          <context context-type="linenumber">162,164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="11df69265a4e5fc90cf35339dce44d6868d7c882" datatype="html">
         <source>Multiple Attempt Scoring Rules</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">105</context>
+          <context context-type="linenumber">168</context>
         </context-group>
       </trans-unit>
       <trans-unit id="644afde69e25c08c87bb299feda60ddfc286c035" datatype="html">
         <source>Add Multiple Attempt Scoring Rule</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">110</context>
+          <context context-type="linenumber">173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="41dccabf954b252df19946f6926e8d69df2e6223" datatype="html">
         <source>Previous Score</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">119</context>
+          <context context-type="linenumber">182</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">202</context>
+          <context context-type="linenumber">265</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fb1e5a694a54df3978ca47c93c6f85ee44dc41fc" datatype="html">
         <source>Current Score</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">126</context>
+          <context context-type="linenumber">189</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">210</context>
+          <context context-type="linenumber">273</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0e77256e7f17964f23969c5bbf35aa1ec494e5a7" datatype="html">
         <source>Feedback to Student</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">133</context>
+          <context context-type="linenumber">196</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">270</context>
+          <context context-type="linenumber">333</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0153489f24e8fca3ec53f77aaa6ad073918805a6" datatype="html">
         <source>Move Multiple Attempt Scoring Rule Up</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">146</context>
+          <context context-type="linenumber">209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5a6ba3716f10b71afc99f0948e15f124e082699b" datatype="html">
         <source>Move Multiple Attempt Scoring Rule Down</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">156</context>
+          <context context-type="linenumber">219</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bdd28ea81708715738540f3ffd1a6702d5416b74" datatype="html">
         <source>Delet Multiple Attempt Scoring</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">165</context>
+          <context context-type="linenumber">228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6ad814fb4ed4d391b5981e0f66edaca73682f369" datatype="html">
         <source> Enable Notifications </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">181,183</context>
+          <context context-type="linenumber">244,246</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8bcabdf6b16cad0313a86c7e940c5e3ad7f9f8ab" datatype="html">
         <source>Notifications</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">187</context>
+          <context context-type="linenumber">250</context>
         </context-group>
       </trans-unit>
       <trans-unit id="993fa2a51a4be7f00603dc7a85ccd20dd27fd974" datatype="html">
         <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon&gt;"/>add<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">195</context>
+          <context context-type="linenumber">258</context>
         </context-group>
       </trans-unit>
       <trans-unit id="02c1371da872a1989dd16ee5b4bbc60ce619173c" datatype="html">
         <source>Move Notification Up</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">224</context>
+          <context context-type="linenumber">287</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b90a653590a4e37aedb232278befe4d6534498f9" datatype="html">
         <source>Move Notification Down</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">234</context>
+          <context context-type="linenumber">297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="beda496f3a2e498b89cb87603e127419f002d329" datatype="html">
         <source>Delete Notification</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">243</context>
+          <context context-type="linenumber">306</context>
         </context-group>
       </trans-unit>
       <trans-unit id="30d1c1578593a3fec78ecd4fd7402cb832589534" datatype="html">
         <source> Enable Ambient Display Dismiss Mode </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">251,253</context>
+          <context context-type="linenumber">314,316</context>
         </context-group>
       </trans-unit>
       <trans-unit id="63b3b8c5d1dec65dae0464caf7af5a74e1fb69e8" datatype="html">
         <source>Dismiss Code</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">255</context>
+          <context context-type="linenumber">318</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.html</context>
@@ -15003,63 +15049,63 @@ Warning: This will delete all existing choices in this component.</source>
         <source> Notify Student </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">266,268</context>
+          <context context-type="linenumber">329,331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b5fbf162f2273b47d29a8246337ab53593c7758d" datatype="html">
         <source> Notify Teacher </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">284,286</context>
+          <context context-type="linenumber">347,349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d66b9370ca0ed83e6b75ba0224226150c9085679" datatype="html">
         <source>Feedback to Teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">288</context>
+          <context context-type="linenumber">351</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8bf4a48a7842ed465fb5824cc30da7ae61d58a55" datatype="html">
         <source> Use Custom Completion Criteria </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">306,308</context>
+          <context context-type="linenumber">369,371</context>
         </context-group>
       </trans-unit>
       <trans-unit id="245242e60650a95ad1fb2529d437e805277bdf06" datatype="html">
         <source>Custom Completion Criteria</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">311</context>
+          <context context-type="linenumber">374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0a009a3aed71504a0176cb8dab58c5bcaaac934f" datatype="html">
         <source>Add Completion Criteria</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">316</context>
+          <context context-type="linenumber">379</context>
         </context-group>
       </trans-unit>
       <trans-unit id="50402d02643dd3a5a8f0e5c6305d21c36a792bcd" datatype="html">
         <source>Move Completion Criteria Up</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">365</context>
+          <context context-type="linenumber">428</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3f39284f9eaabca99528d60f7ced8b5f13670ff9" datatype="html">
         <source>Move Completion Criteria Down</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">375</context>
+          <context context-type="linenumber">438</context>
         </context-group>
       </trans-unit>
       <trans-unit id="34596e0fbbe0cb6a3b26baaeee2f9d863ce6ac9a" datatype="html">
         <source>Delete Completion Criteria</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">384</context>
+          <context context-type="linenumber">447</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8705933649296793690" datatype="html">
@@ -15067,6 +15113,17 @@ Warning: This will delete all existing choices in this component.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
           <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2839735751687486837" datatype="html">
+        <source>Are you sure you want to delete this scoring rule?
+
+Score: <x id="PH" equiv-text="score"/>
+
+Feedback Text: <x id="PH_1" equiv-text="feedbackText"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
+          <context context-type="linenumber">97</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1461861786609911168" datatype="html">
@@ -15079,28 +15136,28 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/>
 Feedback Text: <x id="PH_2" equiv-text="feedbackText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">114</context>
+          <context context-type="linenumber">145</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846244999760672149" datatype="html">
         <source>you got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">146</context>
+          <context context-type="linenumber">177</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7599226289089492371" datatype="html">
         <source>Please talk to your teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">148</context>
+          <context context-type="linenumber">179</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5580639382077453513" datatype="html">
         <source>got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="867656616658826137" datatype="html">
@@ -15111,21 +15168,21 @@ Previous Score: <x id="PH" equiv-text="previousScore"/>
 Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">164</context>
+          <context context-type="linenumber">195</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3689003016353565518" datatype="html">
         <source>Are you sure you want to delete the custom completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2986030604058491184" datatype="html">
         <source>Are you sure you want to delete this completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">230</context>
+          <context context-type="linenumber">261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="350e893dc35c1ca7a171e2944630e2c8f3f4785a" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -966,7 +966,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">390</context>
+          <context context-type="linenumber">340</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html</context>
@@ -981,7 +981,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">396</context>
+          <context context-type="linenumber">346</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.html</context>
@@ -1008,7 +1008,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">378</context>
+          <context context-type="linenumber">328</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html</context>
@@ -1552,7 +1552,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">404</context>
+          <context context-type="linenumber">354</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/component-save-submit-buttons/component-save-submit-buttons.component.html</context>
@@ -5820,7 +5820,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">405</context>
+          <context context-type="linenumber">355</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/component-save-submit-buttons/component-save-submit-buttons.component.html</context>
@@ -8536,10 +8536,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading-view/node-grading-view.component.html</context>
           <context context-type="linenumber">138</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">95</context>
         </context-group>
       </trans-unit>
       <trans-unit id="811195f9acaa8be6f8d39184c94c2e3c63bff00c" datatype="html">
@@ -14861,177 +14857,142 @@ Warning: This will delete all existing choices in this component.</source>
           <context context-type="linenumber">67,69</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1af86cf046af1ad99f6148363089317c4711f840" datatype="html">
-        <source>Scoring Rule</source>
+      <trans-unit id="494056b50610a243c90e28f9a7e464529b9b2685" datatype="html">
+        <source> Enable Feedback Rules </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">81</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1fd3b06c122aa8a76f671b604246ea4ac4ceb733" datatype="html">
-        <source>Add Scoring Rule</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">86</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="5fc3903f250aaeac1c91ede889c1d759e8524bd7" datatype="html">
-        <source>Feedback Text</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">103</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="15ff433c6152bcc0653e60e459c440bdc772aec5" datatype="html">
-        <source>Move Scoring Rule Up</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">116</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="04a96f1c6d8b00a057ad6fca4fb1680cea118142" datatype="html">
-        <source>Move Scoring Rule Down</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">126</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8db5e82a6d07bf4aadf3c778b57db528379ee102" datatype="html">
-        <source>Delete Scoring Rule</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">134</context>
+          <context context-type="linenumber">85,87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="766b54d3e45afff8eea756ea51c8d39c56e1d78a" datatype="html">
         <source> Enable Multiple Attempt Feedback </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">149,151</context>
+          <context context-type="linenumber">99,101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="11df69265a4e5fc90cf35339dce44d6868d7c882" datatype="html">
         <source>Multiple Attempt Scoring Rules</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">155</context>
+          <context context-type="linenumber">105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="644afde69e25c08c87bb299feda60ddfc286c035" datatype="html">
         <source>Add Multiple Attempt Scoring Rule</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">160</context>
+          <context context-type="linenumber">110</context>
         </context-group>
       </trans-unit>
       <trans-unit id="41dccabf954b252df19946f6926e8d69df2e6223" datatype="html">
         <source>Previous Score</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">169</context>
+          <context context-type="linenumber">119</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">252</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fb1e5a694a54df3978ca47c93c6f85ee44dc41fc" datatype="html">
         <source>Current Score</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">176</context>
+          <context context-type="linenumber">126</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">260</context>
+          <context context-type="linenumber">210</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0e77256e7f17964f23969c5bbf35aa1ec494e5a7" datatype="html">
         <source>Feedback to Student</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">133</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">320</context>
+          <context context-type="linenumber">270</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0153489f24e8fca3ec53f77aaa6ad073918805a6" datatype="html">
         <source>Move Multiple Attempt Scoring Rule Up</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">196</context>
+          <context context-type="linenumber">146</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5a6ba3716f10b71afc99f0948e15f124e082699b" datatype="html">
         <source>Move Multiple Attempt Scoring Rule Down</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">206</context>
+          <context context-type="linenumber">156</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bdd28ea81708715738540f3ffd1a6702d5416b74" datatype="html">
         <source>Delet Multiple Attempt Scoring</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">215</context>
+          <context context-type="linenumber">165</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6ad814fb4ed4d391b5981e0f66edaca73682f369" datatype="html">
         <source> Enable Notifications </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">231,233</context>
+          <context context-type="linenumber">181,183</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8bcabdf6b16cad0313a86c7e940c5e3ad7f9f8ab" datatype="html">
         <source>Notifications</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">237</context>
+          <context context-type="linenumber">187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="993fa2a51a4be7f00603dc7a85ccd20dd27fd974" datatype="html">
         <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon&gt;"/>add<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">245</context>
+          <context context-type="linenumber">195</context>
         </context-group>
       </trans-unit>
       <trans-unit id="02c1371da872a1989dd16ee5b4bbc60ce619173c" datatype="html">
         <source>Move Notification Up</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">274</context>
+          <context context-type="linenumber">224</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b90a653590a4e37aedb232278befe4d6534498f9" datatype="html">
         <source>Move Notification Down</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">284</context>
+          <context context-type="linenumber">234</context>
         </context-group>
       </trans-unit>
       <trans-unit id="beda496f3a2e498b89cb87603e127419f002d329" datatype="html">
         <source>Delete Notification</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">293</context>
+          <context context-type="linenumber">243</context>
         </context-group>
       </trans-unit>
       <trans-unit id="30d1c1578593a3fec78ecd4fd7402cb832589534" datatype="html">
         <source> Enable Ambient Display Dismiss Mode </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">301,303</context>
+          <context context-type="linenumber">251,253</context>
         </context-group>
       </trans-unit>
       <trans-unit id="63b3b8c5d1dec65dae0464caf7af5a74e1fb69e8" datatype="html">
         <source>Dismiss Code</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">305</context>
+          <context context-type="linenumber">255</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.html</context>
@@ -15042,74 +15003,70 @@ Warning: This will delete all existing choices in this component.</source>
         <source> Notify Student </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">316,318</context>
+          <context context-type="linenumber">266,268</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b5fbf162f2273b47d29a8246337ab53593c7758d" datatype="html">
         <source> Notify Teacher </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">334,336</context>
+          <context context-type="linenumber">284,286</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d66b9370ca0ed83e6b75ba0224226150c9085679" datatype="html">
         <source>Feedback to Teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">338</context>
+          <context context-type="linenumber">288</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8bf4a48a7842ed465fb5824cc30da7ae61d58a55" datatype="html">
         <source> Use Custom Completion Criteria </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">356,358</context>
+          <context context-type="linenumber">306,308</context>
         </context-group>
       </trans-unit>
       <trans-unit id="245242e60650a95ad1fb2529d437e805277bdf06" datatype="html">
         <source>Custom Completion Criteria</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">361</context>
+          <context context-type="linenumber">311</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0a009a3aed71504a0176cb8dab58c5bcaaac934f" datatype="html">
         <source>Add Completion Criteria</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">366</context>
+          <context context-type="linenumber">316</context>
         </context-group>
       </trans-unit>
       <trans-unit id="50402d02643dd3a5a8f0e5c6305d21c36a792bcd" datatype="html">
         <source>Move Completion Criteria Up</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">415</context>
+          <context context-type="linenumber">365</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3f39284f9eaabca99528d60f7ced8b5f13670ff9" datatype="html">
         <source>Move Completion Criteria Down</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">425</context>
+          <context context-type="linenumber">375</context>
         </context-group>
       </trans-unit>
       <trans-unit id="34596e0fbbe0cb6a3b26baaeee2f9d863ce6ac9a" datatype="html">
         <source>Delete Completion Criteria</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">434</context>
+          <context context-type="linenumber">384</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2839735751687486837" datatype="html">
-        <source>Are you sure you want to delete this scoring rule?
-
-Score: <x id="PH" equiv-text="score"/>
-
-Feedback Text: <x id="PH_1" equiv-text="feedbackText"/></source>
+      <trans-unit id="8705933649296793690" datatype="html">
+        <source>Default feedback</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">86</context>
+          <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1461861786609911168" datatype="html">
@@ -15122,28 +15079,28 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/>
 Feedback Text: <x id="PH_2" equiv-text="feedbackText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">134</context>
+          <context context-type="linenumber">114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846244999760672149" datatype="html">
         <source>you got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">166</context>
+          <context context-type="linenumber">146</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7599226289089492371" datatype="html">
         <source>Please talk to your teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">168</context>
+          <context context-type="linenumber">148</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5580639382077453513" datatype="html">
         <source>got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">170</context>
+          <context context-type="linenumber">150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="867656616658826137" datatype="html">
@@ -15154,21 +15111,21 @@ Previous Score: <x id="PH" equiv-text="previousScore"/>
 Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">184</context>
+          <context context-type="linenumber">164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3689003016353565518" datatype="html">
         <source>Are you sure you want to delete the custom completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">218</context>
+          <context context-type="linenumber">198</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2986030604058491184" datatype="html">
         <source>Are you sure you want to delete this completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">250</context>
+          <context context-type="linenumber">230</context>
         </context-group>
       </trans-unit>
       <trans-unit id="350e893dc35c1ca7a171e2944630e2c8f3f4785a" datatype="html">


### PR DESCRIPTION
Part 2 of work for issue #829 "feat(OpenResponse): Add FeedbackRuleEvaluator". These are planned future PR's for this issue:
- refactoring, organizing folders to share common classes between OR and DG

## Changes
- Add FeedbackRule authoring to OpenResponse advanced component editing view
- Remove ScoringRule authoring from OpenResponse advanced component editing view
- Remove old translation strings

## Test
In the OpenResponse advanced component editing view:
- Verify that "Enable Feedback Rules" checkbox appears iff CRater is enabled
- Verify that "Scoring Rule" authoring section no longer appears when CRater is enabled
- Check "Enable Feedback Rules" checkbox
   - Verify that "isDefault" feedback is displayed as initial rule
   - Verify that the help button launches the Feedback Rule Authoring help dialog
   - Test that you can add, delete, reorder feedback rules as you can in DialogGuidance
      - Multiple feedback per rule is allowed (you can use the "+" to add more feedback per rule) 
- Un-check "Enable Feedback Rules" checkbox
   - Verify that FeedbackRules is not used 
   - If you enable the checkbox again, the rules that you authored before should appear again

In the OpenResponse student view:
- Test that the Feedback Rules that you authored above work as expected