### PR TITLE
feat(Password): Handle password change error responses

### DIFF
--- a/src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.html
+++ b/src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.html
@@ -9,17 +9,17 @@
         <mat-form-field appearance="fill" fxFlex>
           <mat-label i18n>Password</mat-label>
           <input matInput
-                 id="password"
-                 name="password"
-                 formControlName="password"
+                 id="newPassword"
+                 name="newPassword"
+                 formControlName="newPassword"
                  type="password"
                  autofocus
                  required />
-          <mat-error *ngIf="changePasswordFormGroup.controls['password'].hasError('required')" i18n>Password required</mat-error>
-          <mat-error *ngIf="changePasswordFormGroup.controls['password'].hasError('minlength')">
+          <mat-error *ngIf="changePasswordFormGroup.controls['newPassword'].hasError('required')" i18n>Password required</mat-error>
+          <mat-error *ngIf="changePasswordFormGroup.controls['newPassword'].hasError('minlength')">
             {{ passwordService.minLengthErrorMessage }}
           </mat-error>
-          <mat-error *ngIf="changePasswordFormGroup.controls['password'].hasError('pattern')">
+          <mat-error *ngIf="changePasswordFormGroup.controls['newPassword'].hasError('pattern')">
             {{ passwordService.patternErrorMessage }}
           </mat-error>
         </mat-form-field>
@@ -28,13 +28,14 @@
         <mat-form-field appearance="fill" fxFlex>
           <mat-label i18n>Confirm Password</mat-label>
           <input matInput
-                 id="confirmPassword"
-                 name="confirmPassword"
-                 formControlName="confirmPassword"
+                 id="confirmNewPassword"
+                 name="confirmNewPassword"
+                 formControlName="confirmNewPassword"
                  type="password"
                  autofocus
                  required />
-          <mat-error *ngIf="changePasswordFormGroup.controls['confirmPassword'].hasError('required')" i18n>Confirm Password required</mat-error>
+          <mat-error *ngIf="changePasswordFormGroup.controls['confirmNewPassword'].hasError('required')" i18n>Confirm Password required</mat-error>
+          <mat-error *ngIf="changePasswordFormGroup.controls['confirmNewPassword'].hasError('passwordDoesNotMatch')" i18n>Passwords do not match</mat-error>
         </mat-form-field>
       </p>
       <p>

--- a/src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.spec.ts
+++ b/src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.spec.ts
@@ -59,19 +59,19 @@ describe('ForgotStudentPasswordChangeComponent', () => {
   });
 
   it('should enable the submit button when the password fields are filled in', () => {
-    component.setControlFieldValue('newPassword', PASSWORD);
-    component.setControlFieldValue('confirmNewPassword', PASSWORD);
+    component.changePasswordFormGroup.controls['newPassword'].setValue(PASSWORD);
+    component.changePasswordFormGroup.controls['confirmNewPassword'].setValue(PASSWORD);
     fixture.detectChanges();
     const submitButton = getSubmitButton();
     expect(submitButton.disabled).toBe(false);
   });
 
-  it('should navigate to the complete page', () => {
+  it('should submit and navigate to the complete page', () => {
     const router = TestBed.get(Router);
     const navigateSpy = spyOn(router, 'navigate');
     const username = 'SpongebobS0101';
     component.username = username;
-    component.goToSuccessPage();
+    component.submit();
     const params = {
       username: username
     };

--- a/src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.spec.ts
+++ b/src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.spec.ts
@@ -32,31 +32,6 @@ describe('ForgotStudentPasswordChangeComponent', () => {
   let component: ForgotStudentPasswordChangeComponent;
   let fixture: ComponentFixture<ForgotStudentPasswordChangeComponent>;
 
-  const submitAndReceiveResponse = (studentServiceFunctionName, status, messageCode) => {
-    const studentService = TestBed.get(StudentService);
-    const observableResponse = createObservableResponse(status, messageCode);
-    spyOn(studentService, studentServiceFunctionName).and.returnValue(observableResponse);
-    component.submit();
-    fixture.detectChanges();
-  };
-
-  const createObservableResponse = (status, messageCode) => {
-    const observableResponse = Observable.create((observer) => {
-      const response = {
-        status: status,
-        messageCode: messageCode
-      };
-      observer.next(response);
-      observer.complete();
-    });
-    return observableResponse;
-  };
-
-  const getErrorMessage = () => {
-    const errorMessageDiv = fixture.debugElement.nativeElement.querySelector('.warn');
-    return errorMessageDiv.textContent;
-  };
-
   const getSubmitButton = () => {
     return fixture.debugElement.nativeElement.querySelector('button[type="submit"]');
   };
@@ -84,24 +59,11 @@ describe('ForgotStudentPasswordChangeComponent', () => {
   });
 
   it('should enable the submit button when the password fields are filled in', () => {
-    component.setControlFieldValue('password', PASSWORD);
-    component.setControlFieldValue('confirmPassword', PASSWORD);
+    component.setControlFieldValue('newPassword', PASSWORD);
+    component.setControlFieldValue('confirmNewPassword', PASSWORD);
     fixture.detectChanges();
     const submitButton = getSubmitButton();
     expect(submitButton.disabled).toBe(false);
-  });
-
-  it('should display the password cannot be blank message', () => {
-    submitAndReceiveResponse('changePassword', 'failure', 'passwordIsBlank');
-    expect(getErrorMessage()).toContain('Password cannot be blank');
-  });
-
-  it('should display the passwords do not match message', () => {
-    component.setControlFieldValue('password', 'a');
-    component.setControlFieldValue('confirmPassword', 'b');
-    component.submit();
-    fixture.detectChanges();
-    expect(getErrorMessage()).toContain('Passwords do not match');
   });
 
   it('should navigate to the complete page', () => {

--- a/src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.ts
+++ b/src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { StudentService } from '../../../student/student.service';
 import { finalize } from 'rxjs/operators';
 import { PasswordService } from '../../../services/password.service';
+import { passwordMatchValidator } from '../../../modules/shared/validators/password-match.validator';
 
 @Component({
   selector: 'app-forgot-student-password-change',
@@ -14,14 +15,17 @@ export class ForgotStudentPasswordChangeComponent implements OnInit {
   username: string;
   questionKey: string;
   answer: string;
-  changePasswordFormGroup: FormGroup = this.fb.group({
-    password: new FormControl('', [
-      Validators.required,
-      Validators.minLength(this.passwordService.minLength),
-      Validators.pattern(this.passwordService.pattern)
-    ]),
-    confirmPassword: new FormControl('', [Validators.required])
-  });
+  changePasswordFormGroup: FormGroup = this.fb.group(
+    {
+      newPassword: new FormControl('', [
+        Validators.required,
+        Validators.minLength(this.passwordService.minLength),
+        Validators.pattern(this.passwordService.pattern)
+      ]),
+      confirmNewPassword: new FormControl('', [Validators.required])
+    },
+    { validator: passwordMatchValidator }
+  );
   message: string = '';
   processing: boolean = false;
 
@@ -33,90 +37,83 @@ export class ForgotStudentPasswordChangeComponent implements OnInit {
     private studentService: StudentService
   ) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.username = this.route.snapshot.queryParamMap.get('username');
     this.questionKey = this.route.snapshot.queryParamMap.get('questionKey');
     this.answer = this.route.snapshot.queryParamMap.get('answer');
   }
 
-  submit() {
+  submit(): void {
     this.clearMessage();
-    const password = this.getPassword();
-    const confirmPassword = this.getConfirmPassword();
-    if (this.isPasswordsMatch(password, confirmPassword)) {
-      this.processing = true;
-      this.studentService
-        .changePassword(this.username, this.answer, password, confirmPassword)
-        .pipe(
-          finalize(() => {
-            this.processing = false;
-          })
-        )
-        .subscribe((response) => {
-          if (response.status === 'success') {
-            this.goToSuccessPage();
-          } else {
-            if (response.messageCode === 'passwordIsBlank') {
-              this.setPasswordIsBlankMessage();
-            } else if (response.messageCode === 'passwordsDoNotMatch') {
-              this.setPasswordsDoNotMatchMessage();
-            } else if (response.messageCode === 'invalidPassword') {
-              this.setInvalidPasswordMessage();
-            } else {
-              this.setErrorOccurredMessage();
-            }
-          }
-        });
-    } else {
-      this.setPasswordsDoNotMatchMessage();
+    const password = this.getNewPassword();
+    const confirmPassword = this.getConfirmNewPassword();
+    this.processing = true;
+    this.studentService
+      .changePassword(this.username, this.answer, password, confirmPassword)
+      .pipe(
+        finalize(() => {
+          this.processing = false;
+        })
+      )
+      .subscribe(
+        () => {
+          this.changePasswordSuccess();
+        },
+        (response) => {
+          this.changePasswordError(response.error);
+        }
+      );
+  }
+
+  changePasswordSuccess(): void {
+    this.goToSuccessPage();
+  }
+
+  changePasswordError(error: any): void {
+    const formError: any = {};
+    switch (error.messageCode) {
+      case 'invalidPasswordLength':
+        formError.minlength = true;
+        this.changePasswordFormGroup.get('newPassword').setErrors(formError);
+        break;
+      case 'invalidPasswordPattern':
+        formError.pattern = true;
+        this.changePasswordFormGroup.get('newPassword').setErrors(formError);
+        break;
+      default:
+        this.setErrorOccurredMessage();
     }
   }
 
-  getPassword() {
-    return this.getControlFieldValue('password');
+  getNewPassword(): string {
+    return this.getControlFieldValue('newPassword');
   }
 
-  getConfirmPassword() {
-    return this.getControlFieldValue('confirmPassword');
+  getConfirmNewPassword(): string {
+    return this.getControlFieldValue('confirmNewPassword');
   }
 
-  getControlFieldValue(fieldName) {
+  getControlFieldValue(fieldName: string): string {
     return this.changePasswordFormGroup.get(fieldName).value;
   }
 
-  setControlFieldValue(name: string, value: string) {
+  setControlFieldValue(name: string, value: string): void {
     this.changePasswordFormGroup.controls[name].setValue(value);
   }
 
-  isPasswordsMatch(password, confirmPassword) {
-    return password === confirmPassword;
-  }
-
-  setPasswordIsBlankMessage() {
-    this.setMessage($localize`Password cannot be blank. Please try again.`);
-  }
-
-  setPasswordsDoNotMatchMessage() {
-    this.setMessage($localize`Passwords do not match. Please try again.`);
-  }
-
-  setInvalidPasswordMessage() {
-    this.setMessage($localize`Password is invalid. Please try a different password.`);
-  }
-
-  setErrorOccurredMessage() {
+  setErrorOccurredMessage(): void {
     this.setMessage($localize`An error occurred. Please try again.`);
   }
 
-  setMessage(message) {
+  setMessage(message: string): void {
     this.message = message;
   }
 
-  clearMessage() {
+  clearMessage(): void {
     this.message = '';
   }
 
-  goToSuccessPage() {
+  goToSuccessPage(): void {
     const params = {
       username: this.username
     };

--- a/src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.ts
+++ b/src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.ts
@@ -65,11 +65,11 @@ export class ForgotStudentPasswordChangeComponent implements OnInit {
       );
   }
 
-  changePasswordSuccess(): void {
+  private changePasswordSuccess(): void {
     this.goToSuccessPage();
   }
 
-  changePasswordError(error: any): void {
+  private changePasswordError(error: any): void {
     const formError: any = {};
     switch (error.messageCode) {
       case 'invalidPasswordLength':
@@ -85,35 +85,31 @@ export class ForgotStudentPasswordChangeComponent implements OnInit {
     }
   }
 
-  getNewPassword(): string {
+  private getNewPassword(): string {
     return this.getControlFieldValue('newPassword');
   }
 
-  getConfirmNewPassword(): string {
+  private getConfirmNewPassword(): string {
     return this.getControlFieldValue('confirmNewPassword');
   }
 
-  getControlFieldValue(fieldName: string): string {
+  private getControlFieldValue(fieldName: string): string {
     return this.changePasswordFormGroup.get(fieldName).value;
   }
 
-  setControlFieldValue(name: string, value: string): void {
-    this.changePasswordFormGroup.controls[name].setValue(value);
-  }
-
-  setErrorOccurredMessage(): void {
+  private setErrorOccurredMessage(): void {
     this.setMessage($localize`An error occurred. Please try again.`);
   }
 
-  setMessage(message: string): void {
+  private setMessage(message: string): void {
     this.message = message;
   }
 
-  clearMessage(): void {
+  private clearMessage(): void {
     this.message = '';
   }
 
-  goToSuccessPage(): void {
+  private goToSuccessPage(): void {
     const params = {
       username: this.username
     };

--- a/src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.html
+++ b/src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.html
@@ -9,17 +9,17 @@
         <mat-form-field appearance="fill" fxFlex>
           <mat-label i18n>Password</mat-label>
           <input matInput
-                 id="password"
-                 name="password"
-                 formControlName="password"
+                 id="newPassword"
+                 name="newPassword"
+                 formControlName="newPassword"
                  type="password"
                  autofocus
                  required />
-          <mat-error *ngIf="changePasswordFormGroup.controls['password'].hasError('required')" i18n>Password required</mat-error>
-          <mat-error *ngIf="changePasswordFormGroup.controls['password'].hasError('minlength')">
+          <mat-error *ngIf="changePasswordFormGroup.controls['newPassword'].hasError('required')" i18n>Password required</mat-error>
+          <mat-error *ngIf="changePasswordFormGroup.controls['newPassword'].hasError('minlength')">
             {{ passwordService.minLengthErrorMessage }}
           </mat-error>
-          <mat-error *ngIf="changePasswordFormGroup.controls['password'].hasError('pattern')">
+          <mat-error *ngIf="changePasswordFormGroup.controls['newPassword'].hasError('pattern')">
             {{ passwordService.patternErrorMessage }}
           </mat-error>
         </mat-form-field>
@@ -28,13 +28,14 @@
         <mat-form-field appearance="fill" fxFlex>
           <mat-label i18n>Confirm Password</mat-label>
           <input matInput
-                 id="confirmPassword"
-                 name="confirmPassword"
-                 formControlName="confirmPassword"
+                 id="confirmNewPassword"
+                 name="confirmNewPassword"
+                 formControlName="confirmNewPassword"
                  type="password"
                  autofocus
                  required />
-          <mat-error *ngIf="changePasswordFormGroup.controls['confirmPassword'].hasError('required')" i18n>Confirm Password required</mat-error>
+          <mat-error *ngIf="changePasswordFormGroup.controls['confirmNewPassword'].hasError('required')" i18n>Confirm Password required</mat-error>
+          <mat-error *ngIf="changePasswordFormGroup.controls['confirmNewPassword'].hasError('passwordDoesNotMatch')" i18n>Passwords do not match</mat-error>
         </mat-form-field>
       </p>
       <button mat-flat-button

--- a/src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.spec.ts
+++ b/src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.spec.ts
@@ -74,10 +74,10 @@ describe('ForgotTeacherPasswordChangeComponent', () => {
     expect(getErrorMessage()).toContain('The verification code is invalid');
   });
 
-  it('should go to the complete page', () => {
+  it('should submit and navigate to the complete page', () => {
     const router = TestBed.get(Router);
     const navigateSpy = spyOn(router, 'navigate');
-    component.goToSuccessPage();
+    component.submit();
     const params = {
       username: null
     };
@@ -92,8 +92,9 @@ describe('ForgotTeacherPasswordChangeComponent', () => {
     const navigateSpy = spyOn(router, 'navigate');
     component.username = 'SpongebobSquarepants';
     component.verificationCode = '123456';
-    component.setControlFieldValue('newPassword', 'a');
-    component.setControlFieldValue('confirmNewPassword', 'a');
+    const newPassword = 'Abcd1234';
+    component.changePasswordFormGroup.controls['newPassword'].setValue(newPassword);
+    component.changePasswordFormGroup.controls['confirmNewPassword'].setValue(newPassword);
     component.submit();
     fixture.detectChanges();
     const params = {

--- a/src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.spec.ts
+++ b/src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.spec.ts
@@ -4,7 +4,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TeacherService } from '../../../teacher/teacher.service';
-import { Observable } from 'rxjs/index';
+import { Observable, throwError } from 'rxjs/index';
 import { Router } from '@angular/router';
 import { PasswordService } from '../../../services/password.service';
 
@@ -31,7 +31,7 @@ describe('ForgotTeacherPasswordChangeComponent', () => {
 
   const submitAndReceiveResponse = (teacherServiceFunctionName, status, messageCode) => {
     const teacherService = TestBed.get(TeacherService);
-    const observableResponse = createObservableResponse(status, messageCode);
+    const observableResponse = throwError({ error: { messageCode: messageCode } });
     spyOn(teacherService, teacherServiceFunctionName).and.returnValue(observableResponse);
     component.submit();
     fixture.detectChanges();
@@ -87,16 +87,6 @@ describe('ForgotTeacherPasswordChangeComponent', () => {
     expect(getErrorMessage()).toContain('The verification code is invalid');
   });
 
-  it('should display the password cannot be blank message', () => {
-    submitAndReceiveResponse('changePassword', 'failure', 'passwordIsBlank');
-    expect(getErrorMessage()).toContain('Password cannot be blank');
-  });
-
-  it('should show the passwords do not match message', () => {
-    submitAndReceiveResponse('changePassword', 'failure', 'passwordsDoNotMatch');
-    expect(getErrorMessage()).toContain('Passwords do not match');
-  });
-
   it('should go to the complete page', () => {
     const router = TestBed.get(Router);
     const navigateSpy = spyOn(router, 'navigate');
@@ -115,8 +105,8 @@ describe('ForgotTeacherPasswordChangeComponent', () => {
     const navigateSpy = spyOn(router, 'navigate');
     component.username = 'SpongebobSquarepants';
     component.verificationCode = '123456';
-    component.setControlFieldValue('password', 'a');
-    component.setControlFieldValue('confirmPassword', 'a');
+    component.setControlFieldValue('newPassword', 'a');
+    component.setControlFieldValue('confirmNewPassword', 'a');
     component.submit();
     fixture.detectChanges();
     const params = {

--- a/src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.spec.ts
+++ b/src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.spec.ts
@@ -29,24 +29,11 @@ describe('ForgotTeacherPasswordChangeComponent', () => {
   let component: ForgotTeacherPasswordChangeComponent;
   let fixture: ComponentFixture<ForgotTeacherPasswordChangeComponent>;
 
-  const submitAndReceiveResponse = (teacherServiceFunctionName, status, messageCode) => {
-    const teacherService = TestBed.get(TeacherService);
+  const submitAndReceiveErrorResponse = (messageCode: string) => {
     const observableResponse = throwError({ error: { messageCode: messageCode } });
-    spyOn(teacherService, teacherServiceFunctionName).and.returnValue(observableResponse);
+    spyOn(TestBed.get(TeacherService), 'changePassword').and.returnValue(observableResponse);
     component.submit();
     fixture.detectChanges();
-  };
-
-  const createObservableResponse = (status, messageCode) => {
-    const observableResponse = Observable.create((observer) => {
-      const response = {
-        status: status,
-        messageCode: messageCode
-      };
-      observer.next(response);
-      observer.complete();
-    });
-    return observableResponse;
   };
 
   const getErrorMessage = () => {
@@ -71,19 +58,19 @@ describe('ForgotTeacherPasswordChangeComponent', () => {
   });
 
   it('should show the too many verification code attempts message', () => {
-    submitAndReceiveResponse('changePassword', 'failure', 'tooManyVerificationCodeAttempts');
+    submitAndReceiveErrorResponse('tooManyVerificationCodeAttempts');
     expect(getErrorMessage()).toContain(
       'You have submitted an invalid verification code too many times'
     );
   });
 
   it('should show the verification code expired message', () => {
-    submitAndReceiveResponse('changePassword', 'failure', 'verificationCodeExpired');
+    submitAndReceiveErrorResponse('verificationCodeExpired');
     expect(getErrorMessage()).toContain('The verification code has expired');
   });
 
   it('should show the verification code incorrect message', () => {
-    submitAndReceiveResponse('changePassword', 'failure', 'verificationCodeIncorrect');
+    submitAndReceiveErrorResponse('verificationCodeIncorrect');
     expect(getErrorMessage()).toContain('The verification code is invalid');
   });
 

--- a/src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.ts
+++ b/src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { AbstractControl, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { TeacherService } from '../../../teacher/teacher.service';
 import { finalize } from 'rxjs/operators';
 import { PasswordService } from '../../../services/password.service';
@@ -38,12 +38,12 @@ export class ForgotTeacherPasswordChangeComponent implements OnInit {
     private teacherService: TeacherService
   ) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.username = this.route.snapshot.queryParamMap.get('username');
     this.verificationCode = this.route.snapshot.queryParamMap.get('verificationCode');
   }
 
-  submit() {
+  submit(): void {
     this.clearMessage();
     const newPassword = this.getNewPassword();
     const confirmNewPassword = this.getConfirmNewPassword();
@@ -70,11 +70,11 @@ export class ForgotTeacherPasswordChangeComponent implements OnInit {
     }
   }
 
-  changePasswordSuccess(): void {
+  private changePasswordSuccess(): void {
     this.goToSuccessPage();
   }
 
-  changePasswordError(error: any): void {
+  private changePasswordError(error: any): void {
     const formError: any = {};
     switch (error.messageCode) {
       case 'tooManyVerificationCodeAttempts':
@@ -109,19 +109,19 @@ export class ForgotTeacherPasswordChangeComponent implements OnInit {
     }
   }
 
-  getNewPassword() {
+  private getNewPassword(): string {
     return this.getControlFieldValue('newPassword');
   }
 
-  getConfirmNewPassword() {
+  private getConfirmNewPassword(): string {
     return this.getControlFieldValue('confirmNewPassword');
   }
 
-  getControlField(fieldName) {
+  private getControlField(fieldName: string): AbstractControl {
     return this.changePasswordFormGroup.get(fieldName);
   }
 
-  getControlFieldValue(fieldName) {
+  private getControlFieldValue(fieldName: string): string {
     return this.getControlField(fieldName).value;
   }
 
@@ -129,55 +129,51 @@ export class ForgotTeacherPasswordChangeComponent implements OnInit {
     this.changePasswordFormGroup.controls[name].setValue(value);
   }
 
-  isPasswordsMatch(password, confirmPassword) {
+  private isPasswordsMatch(password: string, confirmPassword: string): boolean {
     return password === confirmPassword;
   }
 
-  setVerificationCodeExpiredMessage() {
+  private setVerificationCodeExpiredMessage(): void {
     const message = $localize`The verification code has expired. Verification codes are valid for 10 minutes. Please go back to the Teacher Forgot Password page to generate a new one.`;
     this.setMessage(message);
   }
 
-  setVerificationCodeIncorrectMessage() {
+  private setVerificationCodeIncorrectMessage(): void {
     const message = $localize`The verification code is invalid. Please try again.`;
     this.setMessage(message);
   }
 
-  setTooManyVerificationCodeAttemptsMessage() {
+  private setTooManyVerificationCodeAttemptsMessage(): void {
     const message = $localize`You have submitted an invalid verification code too many times. For security reasons, we will lock the ability to change your password for 10 minutes. After 10 minutes, please go back to the Teacher Forgot Password page to generate a new verification code.`;
     this.setMessage(message);
   }
 
-  setPasswordIsBlankMessage() {
-    this.setMessage($localize`Password cannot be blank, please enter a password.`);
-  }
-
-  setPasswordsDoNotMatchMessage() {
+  private setPasswordsDoNotMatchMessage(): void {
     this.setMessage($localize`Passwords do not match, please try again.`);
   }
 
-  setErrorOccurredMessage() {
+  private setErrorOccurredMessage(): void {
     this.setMessage($localize`An error occurred. Please try again.`);
   }
 
-  setMessage(message) {
+  private setMessage(message: string): void {
     this.message = message;
   }
 
-  clearMessage() {
+  private clearMessage(): void {
     this.setMessage('');
   }
 
-  disablePasswordInputs() {
+  private disablePasswordInputs(): void {
     this.getControlField('newPassword').disable();
     this.getControlField('confirmNewPassword').disable();
   }
 
-  disableSubmitButton() {
+  private disableSubmitButton(): void {
     this.isSubmitButtonEnabled = false;
   }
 
-  goToSuccessPage() {
+  private goToSuccessPage(): void {
     const params = {
       username: this.username
     };

--- a/src/app/modules/shared/edit-password/edit-password.component.spec.ts
+++ b/src/app/modules/shared/edit-password/edit-password.component.spec.ts
@@ -31,12 +31,12 @@ export class MockUserService {
   changePassword(username, oldPassword, newPassword) {
     if (oldPassword === CORRECT_OLD_PASS) {
       return new Observable((observer) => {
-        observer.next({ status: 'success', messageCode: 'passwordChanged' });
+        observer.next({ messageCode: 'passwordChanged' });
         observer.complete();
       });
     } else {
       return new Observable((observer) => {
-        observer.next({ status: 'error', messageCode: 'incorrectPassword' });
+        observer.error({ error: { messageCode: 'incorrectPassword' } });
         observer.complete();
       });
     }
@@ -76,8 +76,6 @@ describe('EditPasswordComponent', () => {
   passwordMismatch_disableSubmitButtonAndInvalidateForm();
   oldPasswordIncorrect_disableSubmitButtonAndShowError();
   formSubmit_disableSubmitButton();
-  passwordChanged_handleResponse();
-  incorrectPassword_showError();
   notGoogleUser_showUnlinkOption();
   unlinkGoogleButtonClick_showDialog();
   invalidPasswordTooShort_showError();
@@ -124,35 +122,8 @@ function formSubmit_disableSubmitButton() {
   it('should disable submit button when form is successfully submitted', async () => {
     setPasswords(CORRECT_OLD_PASS, NEW_PASSWORD_1, NEW_PASSWORD_1);
     submitForm();
+    const submitButton = getSubmitButton();
     expectSubmitButtonDisabled();
-  });
-}
-
-function passwordChanged_handleResponse() {
-  it(`should handle the change password response when the password was successfully
-      changed`, () => {
-    const resetFormSpy = spyOn(component, 'resetForm');
-    const snackBarSpy = spyOn(component.snackBar, 'open');
-    const response = {
-      status: 'success',
-      messageCode: 'passwordChanged'
-    };
-    component.handleChangePasswordResponse(response);
-    expect(resetFormSpy).toHaveBeenCalled();
-    expect(snackBarSpy).toHaveBeenCalled();
-  });
-}
-
-function incorrectPassword_showError() {
-  it('should handle the change password response when the password was incorrect', () => {
-    const response = {
-      status: 'error',
-      messageCode: 'incorrectPassword'
-    };
-    component.handleChangePasswordResponse(response);
-    expect(component.changePasswordFormGroup.get('oldPassword').getError('incorrectPassword')).toBe(
-      true
-    );
   });
 }
 

--- a/src/app/modules/shared/edit-password/edit-password.component.ts
+++ b/src/app/modules/shared/edit-password/edit-password.component.ts
@@ -43,13 +43,13 @@ export class EditPasswordComponent {
     private userService: UserService
   ) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.userService.getUser().subscribe((user) => {
       this.isGoogleUser = user.isGoogleUser;
     });
   }
 
-  saveChanges() {
+  saveChanges(): void {
     this.isSaving = true;
     const oldPassword: string = this.getControlFieldValue('oldPassword');
     const newPassword: string = this.getControlFieldValue('newPassword');
@@ -70,16 +70,12 @@ export class EditPasswordComponent {
       );
   }
 
-  getControlFieldValue(fieldName) {
+  private getControlFieldValue(fieldName: string): string {
     if (fieldName === 'newPassword' || fieldName === 'confirmNewPassword') {
       return this.newPasswordFormGroup.get(fieldName).value;
     } else {
       return this.changePasswordFormGroup.get(fieldName).value;
     }
-  }
-
-  getUsername() {
-    return this.userService.getUser().getValue().username;
   }
 
   private changePasswordSuccess(): void {
@@ -105,13 +101,13 @@ export class EditPasswordComponent {
     }
   }
 
-  unlinkGoogleAccount() {
+  unlinkGoogleAccount(): void {
     this.dialog.open(UnlinkGoogleAccountConfirmComponent, {
       panelClass: 'dialog-sm'
     });
   }
 
-  resetForm() {
+  private resetForm(): void {
     this.changePasswordForm.resetForm();
   }
 }

--- a/src/app/modules/shared/edit-password/edit-password.component.ts
+++ b/src/app/modules/shared/edit-password/edit-password.component.ts
@@ -60,9 +60,14 @@ export class EditPasswordComponent {
           this.isSaving = false;
         })
       )
-      .subscribe((response) => {
-        this.handleChangePasswordResponse(response);
-      });
+      .subscribe(
+        () => {
+          this.changePasswordSuccess();
+        },
+        (response) => {
+          this.changePasswordError(response.error);
+        }
+      );
   }
 
   getControlFieldValue(fieldName) {
@@ -77,14 +82,26 @@ export class EditPasswordComponent {
     return this.userService.getUser().getValue().username;
   }
 
-  handleChangePasswordResponse(response) {
-    if (response.status === 'success') {
-      this.resetForm();
-      this.snackBar.open($localize`Password changed.`);
-    } else if (response.status === 'error' && response.messageCode === 'incorrectPassword') {
-      const error = { incorrectPassword: true };
-      const oldPasswordControl = this.changePasswordFormGroup.get('oldPassword');
-      oldPasswordControl.setErrors(error);
+  private changePasswordSuccess(): void {
+    this.resetForm();
+    this.snackBar.open($localize`Password changed.`);
+  }
+
+  private changePasswordError(error: any): void {
+    const formError: any = {};
+    switch (error.messageCode) {
+      case 'incorrectPassword':
+        formError.incorrectPassword = true;
+        this.changePasswordFormGroup.get('oldPassword').setErrors(formError);
+        break;
+      case 'invalidPasswordLength':
+        formError.minlength = true;
+        this.newPasswordFormGroup.get('newPassword').setErrors(formError);
+        break;
+      case 'invalidPasswordPattern':
+        formError.pattern = true;
+        this.newPasswordFormGroup.get('newPassword').setErrors(formError);
+        break;
     }
   }
 

--- a/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html
+++ b/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html
@@ -33,7 +33,7 @@
             formControlName="confirmNewPassword"
             required />
         <mat-error *ngIf="newPasswordFormGroup.controls['confirmNewPassword'].hasError('required')" i18n>Confirm Password required</mat-error>
-        <mat-error *ngIf="newPasswordFormGroup.hasError('passwordDoesNotMatch')" i18n>Passwords do not match</mat-error>
+        <mat-error *ngIf="newPasswordFormGroup.controls['confirmNewPassword'].hasError('passwordDoesNotMatch')" i18n>Passwords do not match</mat-error>
       </mat-form-field>
     </p>
   </mat-dialog-content>

--- a/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.spec.ts
+++ b/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.spec.ts
@@ -3,14 +3,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { Subscription } from 'rxjs';
+import { of } from 'rxjs';
 import { PasswordService } from '../../../services/password.service';
 import { UserService } from '../../../services/user.service';
 import { UnlinkGoogleAccountPasswordComponent } from './unlink-google-account-password.component';
 
 class MockUserService {
   unlinkGoogleUser(newPassword: string) {
-    return new Subscription();
+    return of({});
   }
 }
 
@@ -35,10 +35,8 @@ describe('UnlinkGoogleAccountPasswordComponent', () => {
 
 function formSubmit_callUserServiceUnlinkGoogleUserFunction() {
   it('should call UserService.UnlinkGoogleUserFunction when form is submitted', () => {
-    const unlinkFunctionSpy = spyOn(userService, 'unlinkGoogleUser').and.returnValue(
-      new Subscription()
-    );
-    const newPassword = 'aloha';
+    const unlinkFunctionSpy = spyOn(userService, 'unlinkGoogleUser').and.returnValue(of({}));
+    const newPassword = 'Abcd1234';
     component.newPasswordFormGroup.setValue({
       newPassword: newPassword,
       confirmNewPassword: newPassword

--- a/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.ts
+++ b/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.ts
@@ -43,7 +43,7 @@ export class UnlinkGoogleAccountPasswordComponent {
     );
   }
 
-  success(): void {
+  private success(): void {
     this.isSaving = false;
     this.dialog.closeAll();
     this.dialog.open(UnlinkGoogleAccountSuccessComponent, {
@@ -51,7 +51,7 @@ export class UnlinkGoogleAccountPasswordComponent {
     });
   }
 
-  error(error: any): void {
+  private error(error: any): void {
     this.isSaving = false;
     const formError: any = {};
     switch (error.messageCode) {

--- a/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.ts
+++ b/src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.ts
@@ -31,16 +31,38 @@ export class UnlinkGoogleAccountPasswordComponent {
     private userService: UserService
   ) {}
 
-  submit() {
+  submit(): void {
     this.isSaving = true;
-    this.userService
-      .unlinkGoogleUser(this.newPasswordFormGroup.get('newPassword').value)
-      .add(() => {
-        this.isSaving = false;
-        this.dialog.closeAll();
-        this.dialog.open(UnlinkGoogleAccountSuccessComponent, {
-          panelClass: 'dialog-sm'
-        });
-      });
+    this.userService.unlinkGoogleUser(this.newPasswordFormGroup.get('newPassword').value).subscribe(
+      () => {
+        this.success();
+      },
+      (response: any) => {
+        this.error(response.error);
+      }
+    );
+  }
+
+  success(): void {
+    this.isSaving = false;
+    this.dialog.closeAll();
+    this.dialog.open(UnlinkGoogleAccountSuccessComponent, {
+      panelClass: 'dialog-sm'
+    });
+  }
+
+  error(error: any): void {
+    this.isSaving = false;
+    const formError: any = {};
+    switch (error.messageCode) {
+      case 'invalidPasswordLength':
+        formError.minlength = true;
+        this.newPasswordFormGroup.get('newPassword').setErrors(formError);
+        break;
+      case 'invalidPasswordPattern':
+        formError.pattern = true;
+        this.newPasswordFormGroup.get('newPassword').setErrors(formError);
+        break;
+    }
   }
 }

--- a/src/app/register/register-student-form/register-student-form.component.html
+++ b/src/app/register/register-student-form/register-student-form.component.html
@@ -112,12 +112,13 @@
                    formControlName="confirmPassword"
                    required />
             <mat-error *ngIf="passwordsFormGroup.controls['confirmPassword'].hasError('required')" i18n>Confirm Password required</mat-error>
-            <mat-error *ngIf="passwordsFormGroup.hasError('passwordDoesNotMatch')" i18n>Password does not match</mat-error>
+            <mat-error *ngIf="passwordsFormGroup.controls['confirmPassword'].hasError('passwordDoesNotMatch')" i18n>Password does not match</mat-error>
           </mat-form-field>
         </p>
       </div>
       <p i18n>By clicking "Create Account", you agree to our <a href="privacy" target="_blank">Privacy Policy & Terms of Use</a></p>
-      <button mat-flat-button color="primary" type="submit" [disabled]="processing">
+      <button mat-flat-button color="primary" type="submit"
+          [disabled]="!createStudentAccountFormGroup.valid || processing">
         <mat-progress-bar *ngIf="processing" mode="indeterminate"></mat-progress-bar>
         <span i18n>Create Account</span>
       </button>

--- a/src/app/register/register-student-form/register-student-form.component.ts
+++ b/src/app/register/register-student-form/register-student-form.component.ts
@@ -114,22 +114,38 @@ export class RegisterStudentFormComponent extends RegisterUserFormComponent impl
       this.populateStudentUser();
       this.studentService.registerStudentAccount(this.studentUser).subscribe(
         (response: any) => {
-          if (response.status === 'success') {
-            this.router.navigate([
-              'join/student/complete',
-              { username: response.username, isUsingGoogleId: this.isUsingGoogleId() }
-            ]);
-          } else {
-            this.snackBar.open(this.translateCreateAccountErrorMessageCode(response.messageCode));
-          }
-          this.processing = false;
+          this.createAccountSuccess(response);
         },
-        (error: HttpErrorResponse) => {
-          this.snackBar.open(this.translateCreateAccountErrorMessageCode(error.error.messageCode));
-          this.processing = false;
+        (response: HttpErrorResponse) => {
+          this.createAccountError(response.error);
         }
       );
     }
+  }
+
+  createAccountSuccess(response: any): void {
+    this.router.navigate([
+      'join/student/complete',
+      { username: response.username, isUsingGoogleId: this.isUsingGoogleId() }
+    ]);
+    this.processing = false;
+  }
+
+  createAccountError(error: any): void {
+    const formError: any = {};
+    switch (error.messageCode) {
+      case 'invalidPasswordLength':
+        formError.minlength = true;
+        this.passwordsFormGroup.get('password').setErrors(formError);
+        break;
+      case 'invalidPasswordPattern':
+        formError.pattern = true;
+        this.passwordsFormGroup.get('password').setErrors(formError);
+        break;
+      default:
+        this.snackBar.open(this.translateCreateAccountErrorMessageCode(error.messageCode));
+    }
+    this.processing = false;
   }
 
   populateStudentUser() {

--- a/src/app/register/register-student/register-student.component.ts
+++ b/src/app/register/register-student/register-student.component.ts
@@ -21,7 +21,7 @@ export class RegisterStudentComponent implements OnInit {
     private router: Router
   ) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.configService.getConfig().subscribe((config) => {
       if (config != null) {
         this.isGoogleAuthenticationEnabled = config.googleClientId != null;
@@ -29,14 +29,14 @@ export class RegisterStudentComponent implements OnInit {
     });
   }
 
-  public signUp() {
+  public signUp(): void {
     this.router.navigate([
       'join/student/form',
       { firstName: this.firstName, lastName: this.lastName }
     ]);
   }
 
-  public socialSignIn(socialPlatform: string) {
+  public socialSignIn(socialPlatform: string): void {
     let socialPlatformProvider;
     if (socialPlatform == 'google') {
       socialPlatformProvider = GoogleLoginProvider.PROVIDER_ID;

--- a/src/app/register/register-teacher-form/register-teacher-form.component.html
+++ b/src/app/register/register-teacher-form/register-teacher-form.component.html
@@ -141,7 +141,7 @@
                    formControlName="confirmPassword"
                    required />
             <mat-error *ngIf="passwordsFormGroup.controls['confirmPassword'].hasError('required')" i18n>Confirm Password required</mat-error>
-            <mat-error *ngIf="passwordsFormGroup.hasError('passwordDoesNotMatch')" i18n>Password does not match</mat-error>
+            <mat-error *ngIf="passwordsFormGroup.controls['confirmPassword'].hasError('passwordDoesNotMatch')" i18n>Password does not match</mat-error>
           </mat-form-field>
         </p>
       </div>
@@ -152,7 +152,8 @@
         </p>
       </div>
       <p>
-        <button fxFlex mat-flat-button color="primary" type="submit" [disabled]="processing">
+        <button fxFlex mat-flat-button color="primary" type="submit"
+            [disabled]="!createTeacherAccountFormGroup.valid || processing">
           <mat-progress-bar *ngIf="processing" mode="indeterminate"></mat-progress-bar>
           <span i18n>Create Account</span>
         </button>

--- a/src/app/register/register-teacher-form/register-teacher-form.component.ts
+++ b/src/app/register/register-teacher-form/register-teacher-form.component.ts
@@ -97,22 +97,38 @@ export class RegisterTeacherFormComponent extends RegisterUserFormComponent impl
       this.populateTeacherUser();
       this.teacherService.registerTeacherAccount(this.teacherUser).subscribe(
         (response: any) => {
-          if (response.status === 'success') {
-            this.router.navigate([
-              'join/teacher/complete',
-              { username: response.username, isUsingGoogleId: this.isUsingGoogleId() }
-            ]);
-          } else {
-            this.snackBar.open(this.translateCreateAccountErrorMessageCode(response.messageCode));
-          }
-          this.processing = false;
+          this.createAccountSuccess(response);
         },
-        (error: HttpErrorResponse) => {
-          this.snackBar.open(this.translateCreateAccountErrorMessageCode(error.error.messageCode));
-          this.processing = false;
+        (response: HttpErrorResponse) => {
+          this.createAccountError(response.error);
         }
       );
     }
+  }
+
+  createAccountSuccess(response: any): void {
+    this.router.navigate([
+      'join/teacher/complete',
+      { username: response.username, isUsingGoogleId: this.isUsingGoogleId() }
+    ]);
+    this.processing = false;
+  }
+
+  createAccountError(error: any): void {
+    const formError: any = {};
+    switch (error.messageCode) {
+      case 'invalidPasswordLength':
+        formError.minlength = true;
+        this.passwordsFormGroup.get('password').setErrors(formError);
+        break;
+      case 'invalidPasswordPattern':
+        formError.pattern = true;
+        this.passwordsFormGroup.get('password').setErrors(formError);
+        break;
+      default:
+        this.snackBar.open(this.translateCreateAccountErrorMessageCode(error.messageCode));
+    }
+    this.processing = false;
   }
 
   populateTeacherUser() {

--- a/src/app/register/register-teacher-form/register-teacher-form.component.ts
+++ b/src/app/register/register-teacher-form/register-teacher-form.component.ts
@@ -67,7 +67,7 @@ export class RegisterTeacherFormComponent extends RegisterUserFormComponent impl
     super();
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.route.params.subscribe((params) => {
       this.teacherUser.googleUserId = params['gID'];
       if (!this.isUsingGoogleId()) {
@@ -82,15 +82,15 @@ export class RegisterTeacherFormComponent extends RegisterUserFormComponent impl
     });
   }
 
-  isUsingGoogleId() {
+  private isUsingGoogleId(): boolean {
     return this.teacherUser.googleUserId != null;
   }
 
-  setControlFieldValue(name: string, value: string) {
+  private setControlFieldValue(name: string, value: string): void {
     this.createTeacherAccountFormGroup.controls[name].setValue(value);
   }
 
-  createAccount() {
+  createAccount(): void {
     this.isSubmitted = true;
     if (this.createTeacherAccountFormGroup.valid) {
       this.processing = true;
@@ -106,7 +106,7 @@ export class RegisterTeacherFormComponent extends RegisterUserFormComponent impl
     }
   }
 
-  createAccountSuccess(response: any): void {
+  private createAccountSuccess(response: any): void {
     this.router.navigate([
       'join/teacher/complete',
       { username: response.username, isUsingGoogleId: this.isUsingGoogleId() }
@@ -114,7 +114,7 @@ export class RegisterTeacherFormComponent extends RegisterUserFormComponent impl
     this.processing = false;
   }
 
-  createAccountError(error: any): void {
+  private createAccountError(error: any): void {
     const formError: any = {};
     switch (error.messageCode) {
       case 'invalidPasswordLength':
@@ -131,7 +131,7 @@ export class RegisterTeacherFormComponent extends RegisterUserFormComponent impl
     this.processing = false;
   }
 
-  populateTeacherUser() {
+  private populateTeacherUser(): void {
     for (let key of Object.keys(this.createTeacherAccountFormGroup.controls)) {
       this.teacherUser[key] = this.createTeacherAccountFormGroup.get(key).value;
     }
@@ -142,11 +142,11 @@ export class RegisterTeacherFormComponent extends RegisterUserFormComponent impl
     }
   }
 
-  getPassword() {
+  private getPassword(): string {
     return this.passwordsFormGroup.controls['password'].value;
   }
 
-  passwordMatchValidator(passwordsFormGroup: FormGroup) {
+  private passwordMatchValidator(passwordsFormGroup: FormGroup): any {
     const password = passwordsFormGroup.get('password').value;
     const confirmPassword = passwordsFormGroup.get('confirmPassword').value;
     if (password == confirmPassword) {
@@ -158,7 +158,7 @@ export class RegisterTeacherFormComponent extends RegisterUserFormComponent impl
     }
   }
 
-  agreeCheckboxValidator(createTeacherAccountFormGroup: FormGroup) {
+  private agreeCheckboxValidator(createTeacherAccountFormGroup: FormGroup): any {
     const agree = createTeacherAccountFormGroup.get('agree').value;
     if (!agree) {
       const error = { agreeNotChecked: true };

--- a/src/app/services/user.service.spec.ts
+++ b/src/app/services/user.service.spec.ts
@@ -22,7 +22,7 @@ describe('UserService', () => {
 function unlinkGoogleAccount_postToUrl() {
   it('unlinkGoogleAccount() should make POST request to unlink google account', fakeAsync(() => {
     const newPassword = 'my new pass';
-    service.unlinkGoogleUser(newPassword);
+    service.unlinkGoogleUser(newPassword).subscribe();
     const unlinkRequest = http.expectOne({
       url: '/api/google-user/unlink-account',
       method: 'POST'

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -133,9 +133,11 @@ export class UserService {
     body = body.set('newPassword', newPassword);
     return this.http
       .post<any>(this.unlinkGoogleAccountUrl, body, { headers: headers })
-      .subscribe((user) => {
-        this.user$.next(user);
-      });
+      .pipe(
+        tap((user) => {
+          this.user$.next(user);
+        })
+      );
   }
 
   getUserByGoogleId(googleUserId: string) {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.html
@@ -13,6 +13,11 @@
       <input matInput type="password" formControlName="teacherPassword" />
       <mat-error *ngIf="changePasswordForm.controls['teacherPassword'].hasError('required')"
           i18n>Teacher Password required</mat-error>
+      <mat-error
+          *ngIf="changePasswordForm.controls['teacherPassword'].hasError('incorrectPassword')"
+          i18n>
+        Teacher Password is incorrect
+      </mat-error>
     </mat-form-field>
     <mat-form-field appearance="fill">
       <mat-label i18n>New Student Password</mat-label>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.spec.ts
@@ -83,7 +83,7 @@ function changePassword_failure_keepDialogOpen() {
   it('should keep dialog open on failure', () => {
     spyOn(teacherService, 'changeStudentPassword').and.returnValue(
       throwError({
-        messageCode: 'invalidPasswordLength'
+        error: { messageCode: 'invalidPasswordLength' }
       })
     );
     component.changePassword();

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.spec.ts
@@ -63,7 +63,6 @@ function changePassword() {
       dialogSpy = spyOn(dialog, 'closeAll');
     });
     afterEach(() => {
-      expect(snackBarSpy).toHaveBeenCalled();
       expect(component.isChangingPassword).toBeFalsy();
     });
     changePassword_success_closeDialog();
@@ -75,6 +74,7 @@ function changePassword_success_closeDialog() {
   it('should close dialog on success', () => {
     spyOn(teacherService, 'changeStudentPassword').and.returnValue(of(''));
     component.changePassword();
+    expect(snackBarSpy).toHaveBeenCalled();
     expect(dialogSpy).toHaveBeenCalled();
   });
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.spec.ts
@@ -72,7 +72,7 @@ function changePassword() {
 
 function changePassword_success_closeDialog() {
   it('should close dialog on success', () => {
-    spyOn(teacherService, 'changeStudentPassword').and.returnValue(of(''));
+    spyOn(teacherService, 'changeStudentPassword').and.returnValue(of({}));
     component.changePassword();
     expect(snackBarSpy).toHaveBeenCalled();
     expect(dialogSpy).toHaveBeenCalled();
@@ -81,7 +81,11 @@ function changePassword_success_closeDialog() {
 
 function changePassword_failure_keepDialogOpen() {
   it('should keep dialog open on failure', () => {
-    spyOn(teacherService, 'changeStudentPassword').and.returnValue(throwError('error'));
+    spyOn(teacherService, 'changeStudentPassword').and.returnValue(
+      throwError({
+        messageCode: 'invalidPasswordLength'
+      })
+    );
     component.changePassword();
     expect(dialogSpy).not.toHaveBeenCalled();
   });

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.ts
@@ -54,21 +54,41 @@ export class ChangeStudentPasswordDialogComponent implements OnInit {
       this.changePasswordForm.controls['newPassword'].value,
       this.changePasswordForm.controls['teacherPassword'].value
     ).subscribe(
-      (response) => {
-        this.isChangingPassword = false;
-        this.snackBar.open(
-          this.canViewStudentNames
-            ? $localize`Changed password for ${this.user.name} (${this.user.username}).`
-            : $localize`Changed password for Student ${this.user.id}.`
-        );
-        this.dialog.closeAll();
+      () => {
+        this.changePasswordSuccess();
       },
-      (err) => {
-        this.isChangingPassword = false;
-        this.snackBar.open(
-          $localize`Failed to change student password. Check values and try again.`
-        );
+      (response) => {
+        this.changePasswordError(response.error);
       }
     );
+  }
+
+  changePasswordSuccess(): void {
+    this.isChangingPassword = false;
+    this.snackBar.open(
+      this.canViewStudentNames
+        ? $localize`Changed password for ${this.user.name} (${this.user.username}).`
+        : $localize`Changed password for Student ${this.user.id}.`
+    );
+    this.dialog.closeAll();
+  }
+
+  changePasswordError(error: any): void {
+    const formError: any = {};
+    this.isChangingPassword = false;
+    switch (error.messageCode) {
+      case 'incorrectPassword':
+        formError.incorrectPassword = true;
+        this.changePasswordForm.get('teacherPassword').setErrors(formError);
+        break;
+      case 'invalidPasswordLength':
+        formError.minlength = true;
+        this.changePasswordForm.get('newPassword').setErrors(formError);
+        break;
+      case 'invalidPasswordPattern':
+        formError.pattern = true;
+        this.changePasswordForm.get('newPassword').setErrors(formError);
+        break;
+    }
   }
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.ts
@@ -46,7 +46,7 @@ export class ChangeStudentPasswordDialogComponent implements OnInit {
     }
   }
 
-  changePassword() {
+  changePassword(): void {
     this.isChangingPassword = true;
     this.TeacherService.changeStudentPassword(
       this.ConfigService.getRunId(),
@@ -63,7 +63,7 @@ export class ChangeStudentPasswordDialogComponent implements OnInit {
     );
   }
 
-  changePasswordSuccess(): void {
+  private changePasswordSuccess(): void {
     this.isChangingPassword = false;
     this.snackBar.open(
       this.canViewStudentNames
@@ -73,7 +73,7 @@ export class ChangeStudentPasswordDialogComponent implements OnInit {
     this.dialog.closeAll();
   }
 
-  changePasswordError(error: any): void {
+  private changePasswordError(error: any): void {
     const formError: any = {};
     this.isChangingPassword = false;
     switch (error.messageCode) {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -2147,11 +2147,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>An error occurred. Please try again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.ts</context>
-          <context context-type="linenumber">105</context>
+          <context context-type="linenumber">101</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.ts</context>
-          <context context-type="linenumber">160</context>
+          <context context-type="linenumber">156</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/student/account/edit-profile/edit-profile.component.ts</context>
@@ -2700,18 +2700,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">90</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7375295840965754734" datatype="html">
-        <source>Password cannot be blank, please enter a password.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.ts</context>
-          <context context-type="linenumber">152</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="4839293263479159850" datatype="html">
         <source>Passwords do not match, please try again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.ts</context>
-          <context context-type="linenumber">156</context>
+          <context context-type="linenumber">152</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a4d0068934144e3f61b8e981a62e014ab0a90ebe" datatype="html">
@@ -5590,7 +5583,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Password changed.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/shared/edit-password/edit-password.component.ts</context>
-          <context context-type="linenumber">87</context>
+          <context context-type="linenumber">83</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4580988005648117665" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -476,7 +476,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.html</context>
-          <context context-type="linenumber">40</context>
+          <context context-type="linenumber">45</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html</context>
@@ -1312,7 +1312,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.html</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">57</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-security/forgot-student-password-security.component.html</context>
@@ -1328,7 +1328,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.html</context>
-          <context context-type="linenumber">58</context>
+          <context context-type="linenumber">59</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-verify/forgot-teacher-password-verify.component.html</context>
@@ -1512,7 +1512,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.html</context>
-          <context context-type="linenumber">47</context>
+          <context context-type="linenumber">48</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-security/forgot-student-password-security.component.html</context>
@@ -1524,7 +1524,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">46</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-verify/forgot-teacher-password-verify.component.html</context>
@@ -2089,11 +2089,30 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">143</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="0a9dcaac5aadd48fe716eaff77ab9b21a8bef3af" datatype="html">
+        <source>Passwords do not match</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/shared/edit-password/edit-password.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="8017fdbaf670dcefd48842920617824337d762f7" datatype="html">
         <source>Create New Account</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.html</context>
-          <context context-type="linenumber">59</context>
+          <context context-type="linenumber">60</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-security/forgot-student-password-security.component.html</context>
@@ -2109,7 +2128,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.html</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">62</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-verify/forgot-teacher-password-verify.component.html</context>
@@ -2124,36 +2143,15 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8384809960328910876" datatype="html">
-        <source>Password cannot be blank. Please try again.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.ts</context>
-          <context context-type="linenumber">96</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6465250798669251020" datatype="html">
-        <source>Passwords do not match. Please try again.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.ts</context>
-          <context context-type="linenumber">100</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="324815643617845517" datatype="html">
-        <source>Password is invalid. Please try a different password.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.ts</context>
-          <context context-type="linenumber">104</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="7389211279729440739" datatype="html">
         <source>An error occurred. Please try again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.ts</context>
-          <context context-type="linenumber">108</context>
+          <context context-type="linenumber">105</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.ts</context>
-          <context context-type="linenumber">134</context>
+          <context context-type="linenumber">160</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/student/account/edit-profile/edit-profile.component.ts</context>
@@ -2658,7 +2656,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Teacher Forgot Password</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">53</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-verify/forgot-teacher-password-verify.component.html</context>
@@ -2673,7 +2671,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>The verification code has expired. Verification codes are valid for 10 minutes. Please go back to the Teacher Forgot Password page to generate a new one.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.ts</context>
-          <context context-type="linenumber">111</context>
+          <context context-type="linenumber">137</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-verify/forgot-teacher-password-verify.component.ts</context>
@@ -2684,7 +2682,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>The verification code is invalid. Please try again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.ts</context>
-          <context context-type="linenumber">116</context>
+          <context context-type="linenumber">142</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-verify/forgot-teacher-password-verify.component.ts</context>
@@ -2695,7 +2693,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>You have submitted an invalid verification code too many times. For security reasons, we will lock the ability to change your password for 10 minutes. After 10 minutes, please go back to the Teacher Forgot Password page to generate a new verification code.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.ts</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">147</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-verify/forgot-teacher-password-verify.component.ts</context>
@@ -2706,14 +2704,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Password cannot be blank, please enter a password.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.ts</context>
-          <context context-type="linenumber">126</context>
+          <context context-type="linenumber">152</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4839293263479159850" datatype="html">
         <source>Passwords do not match, please try again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.ts</context>
-          <context context-type="linenumber">130</context>
+          <context context-type="linenumber">156</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a4d0068934144e3f61b8e981a62e014ab0a90ebe" datatype="html">
@@ -4569,11 +4567,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-student-form/register-student-form.component.html</context>
-          <context context-type="linenumber">122</context>
+          <context context-type="linenumber">123</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-teacher-form/register-teacher-form.component.html</context>
-          <context context-type="linenumber">157</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6cdb1fea93d77c07950c0c76c6e0ad79ebbef084" datatype="html">
@@ -5503,17 +5501,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="0a9dcaac5aadd48fe716eaff77ab9b21a8bef3af" datatype="html">
-        <source>Passwords do not match</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/shared/edit-password/edit-password.component.html</context>
-          <context context-type="linenumber">48</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/shared/unlink-google-account-password/unlink-google-account-password.component.html</context>
-          <context context-type="linenumber">36</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="8454739bcb4cf4debfd509a35e466a828ea11363" datatype="html">
         <source><x id="TAG_IMG" ctype="image" equiv-text="&lt;img class=&quot;google-icon&quot; src=&quot;assets/img/icons/google-logo.svg&quot; i18n-alt alt=&quot;Google logo&quot; /&gt;"/><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>This account was created using Google and doesn&apos;t use a WISE password.<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></source>
         <context-group purpose="location">
@@ -5603,7 +5590,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Password changed.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/shared/edit-password/edit-password.component.ts</context>
-          <context context-type="linenumber">83</context>
+          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4580988005648117665" datatype="html">
@@ -9815,46 +9802,53 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">15</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="3f1cf7e18e2551173cb12dedf98f3a48423a7717" datatype="html">
+        <source> Teacher Password is incorrect </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.html</context>
+          <context context-type="linenumber">18,20</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="f1ca7e8784d363977ca2745cb7550fb03ce54d30" datatype="html">
         <source>New Student Password</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.html</context>
-          <context context-type="linenumber">18</context>
+          <context context-type="linenumber">23</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9fe2145f77bb355cd1631bdff398b57391e589e2" datatype="html">
         <source>New Student Password required</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.html</context>
-          <context context-type="linenumber">21</context>
+          <context context-type="linenumber">26</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5b2a4ad87bbdf775c098839a64d666c58a87b84c" datatype="html">
         <source>Confirm New Student Password</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">35</context>
         </context-group>
       </trans-unit>
       <trans-unit id="370ba663153e8440ada175ce55e10ea9e20ce240" datatype="html">
         <source>Confirm New Student Password required</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.html</context>
-          <context context-type="linenumber">33</context>
+          <context context-type="linenumber">38</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1ed031ea5b7a272fbbb7e9eaf12229baa62d0c32" datatype="html">
         <source>New student passwords do not match</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.html</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">40</context>
         </context-group>
       </trans-unit>
       <trans-unit id="68e710782ccb5398b3acb8844caf0b199da2c3da" datatype="html">
         <source>Confirm</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">51</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.html</context>
@@ -9865,21 +9859,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Changed password for <x id="PH" equiv-text="this.user.name"/> (<x id="PH_1" equiv-text="this.user.username"/>).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.ts</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">70</context>
         </context-group>
       </trans-unit>
       <trans-unit id="194071757642374963" datatype="html">
         <source>Changed password for Student <x id="PH" equiv-text="this.user.id"/>.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.ts</context>
-          <context context-type="linenumber">62</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6393419270108352075" datatype="html">
-        <source>Failed to change student password. Check values and try again.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-student-password-dialog/change-student-password-dialog.component.ts</context>
-          <context context-type="linenumber">69</context>
+          <context context-type="linenumber">71</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4333d62731dc124644ca59e02aabfaa86e730714" datatype="html">


### PR DESCRIPTION
Test with
- https://github.com/WISE-Community/WISE-API/pull/178

## Changes

Password change requests now properly utilize the success function and error function of subscribe(). They used to always use the success function even for errors.

## Test

Make sure success and error responses are properly handled when specifying passwords.

Here are the places where users can specify passwords
- student create account
- student forgot password
- teacher create account
- teacher forgot password
- teacher change student password in classroom monitor
- user edit password
- user unlink Google account

Closes #833