### PR TITLE
feat(VLE): Add dynamic prompt component

### DIFF
--- a/src/app/student/student.component.module.ts
+++ b/src/app/student/student.component.module.ts
@@ -4,6 +4,8 @@ import { AddToNotebookButton } from '../../assets/wise5/directives/add-to-notebo
 import { ComponentHeader } from '../../assets/wise5/directives/component-header/component-header.component';
 import { ComponentSaveSubmitButtons } from '../../assets/wise5/directives/component-save-submit-buttons/component-save-submit-buttons.component';
 import { ComponentAnnotationsComponent } from '../../assets/wise5/directives/componentAnnotations/component-annotations.component';
+import { DynamicPromptComponent } from '../../assets/wise5/directives/dynamic-prompt/dynamic-prompt.component';
+import { PromptComponent } from '../../assets/wise5/directives/prompt/prompt.component';
 import { PossibleScoreComponent } from '../possible-score/possible-score.component';
 import { StudentTeacherCommonModule } from '../student-teacher-common.module';
 
@@ -13,7 +15,9 @@ import { StudentTeacherCommonModule } from '../student-teacher-common.module';
     ComponentAnnotationsComponent,
     ComponentHeader,
     ComponentSaveSubmitButtons,
-    PossibleScoreComponent
+    DynamicPromptComponent,
+    PossibleScoreComponent,
+    PromptComponent
   ],
   imports: [StudentTeacherCommonModule, ComponentStateInfoModule],
   exports: [
@@ -21,7 +25,9 @@ import { StudentTeacherCommonModule } from '../student-teacher-common.module';
     ComponentAnnotationsComponent,
     ComponentHeader,
     ComponentSaveSubmitButtons,
-    PossibleScoreComponent
+    DynamicPromptComponent,
+    PossibleScoreComponent,
+    PromptComponent
   ]
 })
 export class StudentComponentModule {}

--- a/src/assets/wise5/directives/component-header/component-header.component.html
+++ b/src/assets/wise5/directives/component-header/component-header.component.html
@@ -1,4 +1,6 @@
 <div class="component-header" fxLayout="row wrap" fxLayoutGap="4px">
-  <div *ngIf="componentContent.prompt" [innerHTML]="prompt" class="prompt"></div>
+  <prompt [prompt]="componentContent.prompt"
+      [dynamicPrompt]="componentContent.dynamicPrompt">
+  </prompt>
   <possible-score [maxScore]="componentContent.maxScore"></possible-score>
 </div>

--- a/src/assets/wise5/directives/component-header/component-header.component.spec.ts
+++ b/src/assets/wise5/directives/component-header/component-header.component.spec.ts
@@ -2,6 +2,8 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ComponentHeader } from './component-header.component';
 import { DomSanitizer } from '@angular/platform-browser';
+import { PromptComponent } from '../prompt/prompt.component';
+import { DynamicPromptComponent } from '../dynamic-prompt/dynamic-prompt.component';
 
 let component: ComponentHeader;
 let fixture: ComponentFixture<ComponentHeader>;
@@ -9,7 +11,7 @@ let fixture: ComponentFixture<ComponentHeader>;
 describe('ComponentHeaderComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ComponentHeader],
+      declarations: [ComponentHeader, DynamicPromptComponent, PromptComponent],
       providers: [
         {
           provide: DomSanitizer,

--- a/src/assets/wise5/directives/dynamic-prompt/DynamicPrompt.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/DynamicPrompt.ts
@@ -1,0 +1,18 @@
+export class DynamicPrompt {
+  enabled: boolean;
+  postPrompt?: string;
+  prePrompt?: string;
+  referenceComponent: {
+    componentId: string;
+    nodeId: string;
+  };
+  rules: any[];
+
+  constructor(jsonObject: any = {}) {
+    for (const key of Object.keys(jsonObject)) {
+      if (jsonObject[key] != null) {
+        this[key] = jsonObject[key];
+      }
+    }
+  }
+}

--- a/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.html
+++ b/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.html
@@ -1,0 +1,4 @@
+<div *ngIf="dynamicPrompt.prePrompt !== ''" [innerHTML]="dynamicPrompt.prePrompt" class="prompt">
+</div>
+<div *ngIf="dynamicPrompt.postPrompt !== ''" [innerHTML]="dynamicPrompt.postPrompt" class="prompt">
+</div>

--- a/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.scss
+++ b/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.scss
@@ -1,0 +1,3 @@
+.prompt {
+  font-weight: 500;
+}

--- a/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.spec.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DynamicPromptComponent } from './dynamic-prompt.component';
+import { DynamicPrompt } from './DynamicPrompt';
+
+describe('DynamicPromptComponent', () => {
+  let component: DynamicPromptComponent;
+  let fixture: ComponentFixture<DynamicPromptComponent>;
+  const postPrompt: string = 'This is the prompt after the dynamic prompt.';
+  const prePrompt: string = 'This is the prompt before the dynamic prompt.';
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DynamicPromptComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DynamicPromptComponent);
+    component = fixture.componentInstance;
+    component.dynamicPrompt = new DynamicPrompt({
+      postPrompt: postPrompt,
+      prePrompt: prePrompt
+    });
+    fixture.detectChanges();
+  });
+
+  it('should display the pre prompt', () => {
+    const firstPrompt = fixture.debugElement.nativeElement.querySelectorAll('.prompt')[0];
+    expect(firstPrompt.textContent).toEqual(prePrompt);
+  });
+
+  it('should display the post prompt', () => {
+    const prompts = fixture.debugElement.nativeElement.querySelectorAll('.prompt');
+    const lastPrompt = prompts[prompts.length - 1];
+    expect(lastPrompt.textContent).toEqual(postPrompt);
+  });
+});

--- a/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { DynamicPrompt } from './DynamicPrompt';
+
+@Component({
+  selector: 'dynamic-prompt',
+  templateUrl: './dynamic-prompt.component.html',
+  styleUrls: ['./dynamic-prompt.component.scss']
+})
+export class DynamicPromptComponent implements OnInit {
+  @Input() dynamicPrompt: DynamicPrompt;
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/assets/wise5/directives/prompt/prompt.component.html
+++ b/src/assets/wise5/directives/prompt/prompt.component.html
@@ -1,0 +1,2 @@
+<div *ngIf="!dynamicPrompt?.enabled" [innerHTML]="prompt" class="prompt"></div>
+<dynamic-prompt *ngIf="dynamicPrompt?.enabled" [dynamicPrompt]="dynamicPrompt"></dynamic-prompt>

--- a/src/assets/wise5/directives/prompt/prompt.component.scss
+++ b/src/assets/wise5/directives/prompt/prompt.component.scss
@@ -1,0 +1,3 @@
+.prompt {
+  font-weight: 500;
+}

--- a/src/assets/wise5/directives/prompt/prompt.component.spec.ts
+++ b/src/assets/wise5/directives/prompt/prompt.component.spec.ts
@@ -1,0 +1,43 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DynamicPromptComponent } from '../dynamic-prompt/dynamic-prompt.component';
+import { DynamicPrompt } from '../dynamic-prompt/DynamicPrompt';
+import { PromptComponent } from './prompt.component';
+
+describe('PromptComponent', () => {
+  let component: PromptComponent;
+  let fixture: ComponentFixture<PromptComponent>;
+  const promptText: string = 'This is the prompt.';
+  const postPromptText: string = 'This is the prompt after the dynamic prompt.';
+  const prePromptText: string = 'This is the prompt before the dynamic prompt.';
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PromptComponent, DynamicPromptComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PromptComponent);
+    component = fixture.componentInstance;
+    component.prompt = promptText;
+    component.dynamicPrompt = new DynamicPrompt({
+      enabled: false,
+      postPrompt: postPromptText,
+      prePrompt: prePromptText
+    });
+    fixture.detectChanges();
+  });
+
+  it('should display the regular prompt', () => {
+    const promptElement = fixture.debugElement.nativeElement.querySelector('.prompt');
+    expect(promptElement.textContent).toEqual(promptText);
+  });
+
+  it('should display the dynamic prompt', () => {
+    component.dynamicPrompt.enabled = true;
+    fixture.detectChanges();
+    const prompts = fixture.debugElement.nativeElement.querySelectorAll('.prompt');
+    expect(prompts[0].textContent).toEqual(prePromptText);
+    expect(prompts[prompts.length - 1].textContent).toEqual(postPromptText);
+  });
+});

--- a/src/assets/wise5/directives/prompt/prompt.component.ts
+++ b/src/assets/wise5/directives/prompt/prompt.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { DynamicPrompt } from '../dynamic-prompt/DynamicPrompt';
+
+@Component({
+  selector: 'prompt',
+  templateUrl: './prompt.component.html',
+  styleUrls: ['./prompt.component.scss']
+})
+export class PromptComponent implements OnInit {
+  @Input() prompt: string;
+  @Input() dynamicPrompt: DynamicPrompt;
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}


### PR DESCRIPTION
# Changes

Added Prompt component and DynamicPrompt component.
Note: This does not contain the rules functionality yet.

# Test

- Manually modify the JSON for a component to have a dynamicPrompt field (see below)
- When the Dynamic Prompt is enabled, it should display the prePrompt and postPrompt
- When the Dynamic Prompt is not enabled, it should show the regular prompt
- Make sure old components that do not have the dynamicPrompt field still work like before

This is what the component content looks like.
```
{
    "id": "7mx88u6y60",
    "type": "OpenResponse",
    "prompt": "This is the regular prompt.",
    "dynamicPrompt": {
        "enabled": true,
        "prePrompt": "This is the pre prompt before the dynamic prompt.",
        "postPrompt": "This is the post prompt after the dynamic prompt."
    }
}
```

Work for #840