### PR TITLE
feat(Dynamic Prompt): Add prompt rules

### DIFF
--- a/src/assets/wise5/components/common/cRater/CRaterResponse.ts
+++ b/src/assets/wise5/components/common/cRater/CRaterResponse.ts
@@ -6,7 +6,13 @@ export class CRaterResponse {
   score: number;
   scores: CRaterScore[];
 
-  constructor() {}
+  constructor(jsonObject: any = {}) {
+    for (const key of Object.keys(jsonObject)) {
+      if (jsonObject[key] != null) {
+        this[key] = jsonObject[key];
+      }
+    }
+  }
 
   getDetectedIdeaCount(): number {
     return this.getDetectedIdeaNames().length;

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRule.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRule.ts
@@ -1,7 +1,8 @@
 export class FeedbackRule {
   id?: string;
   expression: string;
-  feedback: string | string[];
+  feedback?: string | string[];
+  prompt?: string;
   static operatorPrecedences = { '!': 2, '&&': 1, '||': 1 };
 
   constructor(jsonObject: any = {}) {

--- a/src/assets/wise5/directives/component-header/component-header.component.html
+++ b/src/assets/wise5/directives/component-header/component-header.component.html
@@ -1,6 +1,4 @@
 <div class="component-header" fxLayout="row wrap" fxLayoutGap="4px">
-  <prompt [prompt]="componentContent.prompt"
-      [dynamicPrompt]="componentContent.dynamicPrompt">
-  </prompt>
+  <prompt [prompt]="componentContent.prompt" [dynamicPrompt]="dynamicPrompt"></prompt>
   <possible-score [maxScore]="componentContent.maxScore"></possible-score>
 </div>

--- a/src/assets/wise5/directives/component-header/component-header.component.ts
+++ b/src/assets/wise5/directives/component-header/component-header.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { DynamicPrompt } from '../dynamic-prompt/DynamicPrompt';
 
 @Component({
   selector: 'component-header',
@@ -10,11 +11,14 @@ export class ComponentHeader {
   @Input()
   componentContent: any;
 
+  dynamicPrompt: DynamicPrompt;
+
   prompt: SafeHtml;
 
   constructor(protected sanitizer: DomSanitizer) {}
 
   ngOnInit() {
     this.prompt = this.sanitizer.bypassSecurityTrustHtml(this.componentContent.prompt);
+    this.dynamicPrompt = new DynamicPrompt(this.componentContent.dynamicPrompt);
   }
 }

--- a/src/assets/wise5/directives/dynamic-prompt/DynamicPrompt.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/DynamicPrompt.ts
@@ -1,3 +1,5 @@
+import { FeedbackRule } from '../../components/common/feedbackRule/FeedbackRule';
+
 export class DynamicPrompt {
   enabled: boolean;
   postPrompt?: string;
@@ -6,7 +8,7 @@ export class DynamicPrompt {
     componentId: string;
     nodeId: string;
   };
-  rules: any[];
+  rules: FeedbackRule[];
 
   constructor(jsonObject: any = {}) {
     for (const key of Object.keys(jsonObject)) {
@@ -14,5 +16,17 @@ export class DynamicPrompt {
         this[key] = jsonObject[key];
       }
     }
+  }
+
+  getReferenceNodeId(): string {
+    return this.referenceComponent.nodeId;
+  }
+
+  getReferenceComponentId(): string {
+    return this.referenceComponent.componentId;
+  }
+
+  getRules(): FeedbackRule[] {
+    return this.rules;
   }
 }

--- a/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.html
+++ b/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.html
@@ -1,4 +1,6 @@
 <div *ngIf="dynamicPrompt.prePrompt !== ''" [innerHTML]="dynamicPrompt.prePrompt" class="prompt">
 </div>
+<div *ngIf="prompt !== ''" [innerHTML]="prompt" class="prompt">
+</div>
 <div *ngIf="dynamicPrompt.postPrompt !== ''" [innerHTML]="dynamicPrompt.postPrompt" class="prompt">
 </div>

--- a/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.spec.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.spec.ts
@@ -1,4 +1,10 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogModule } from '@angular/material/dialog';
+import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
+import { AnnotationService } from '../../services/annotationService';
+import { ProjectService } from '../../services/projectService';
+import { StudentDataService } from '../../services/studentDataService';
 import { DynamicPromptComponent } from './dynamic-prompt.component';
 import { DynamicPrompt } from './DynamicPrompt';
 
@@ -7,10 +13,15 @@ describe('DynamicPromptComponent', () => {
   let fixture: ComponentFixture<DynamicPromptComponent>;
   const postPrompt: string = 'This is the prompt after the dynamic prompt.';
   const prePrompt: string = 'This is the prompt before the dynamic prompt.';
+  const promptScore1: string = 'This is the prompt when you get a score of 1.';
+  const promptScore2: string = 'This is the prompt when you get a score of 2.';
+  const promptDefault: string = 'This is the default prompt when no other rules match.';
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [DynamicPromptComponent]
+      declarations: [DynamicPromptComponent],
+      imports: [HttpClientTestingModule, MatDialogModule, StudentTeacherCommonServicesModule],
+      providers: []
     }).compileComponents();
   });
 
@@ -19,7 +30,36 @@ describe('DynamicPromptComponent', () => {
     component = fixture.componentInstance;
     component.dynamicPrompt = new DynamicPrompt({
       postPrompt: postPrompt,
-      prePrompt: prePrompt
+      prePrompt: prePrompt,
+      referenceComponent: {
+        componentId: 'component1',
+        nodeId: 'node1'
+      },
+      rules: [
+        { id: 'ebtgds3b1r', expression: 'hasKIScore(2)', prompt: promptScore2 },
+        { id: 'z4yu37jcis', expression: 'hasKIScore(1)', prompt: promptScore1 },
+        { id: 'isDefault', expression: 'isDefault', prompt: promptDefault }
+      ]
+    });
+    spyOn(TestBed.inject(ProjectService), 'getComponentByNodeIdAndComponentId').and.returnValue({
+      type: 'OpenResponse'
+    });
+    spyOn(
+      TestBed.inject(StudentDataService),
+      'getLatestComponentStateByNodeIdAndComponentId'
+    ).and.returnValue({
+      studentData: {
+        submitCounter: 1
+      }
+    });
+    spyOn(TestBed.inject(AnnotationService), 'getLatestScoreAnnotation').and.returnValue({
+      data: {
+        ideas: [
+          { name: '2', detected: false },
+          { name: '3', detected: false }
+        ],
+        scores: [{ id: 'ki', score: 1 }]
+      }
     });
     fixture.detectChanges();
   });
@@ -33,5 +73,11 @@ describe('DynamicPromptComponent', () => {
     const prompts = fixture.debugElement.nativeElement.querySelectorAll('.prompt');
     const lastPrompt = prompts[prompts.length - 1];
     expect(lastPrompt.textContent).toEqual(postPrompt);
+  });
+
+  it('should display the dynamic prompt', () => {
+    const prompts = fixture.debugElement.nativeElement.querySelectorAll('.prompt');
+    const dynamicPrompt = prompts[prompts.length - 2];
+    expect(dynamicPrompt.textContent).toEqual(promptScore1);
   });
 });

--- a/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.ts
@@ -40,11 +40,15 @@ export class DynamicPromptComponent implements OnInit {
   private evaluateOpenResponseComponent(referenceComponent: any): void {
     const nodeId = this.dynamicPrompt.getReferenceNodeId();
     const componentId = referenceComponent.id;
-    const latestComponentState = this.getLatestComponentState(nodeId, componentId);
-    const latestAutoScoreAnnotation = this.getLatestAutoScore(
+    const latestComponentState = this.studentDataService.getLatestComponentStateByNodeIdAndComponentId(
+      nodeId,
+      componentId
+    );
+    const latestAutoScoreAnnotation = this.annotationService.getLatestScoreAnnotation(
       nodeId,
       componentId,
-      this.configService.getWorkgroupId()
+      this.configService.getWorkgroupId(),
+      'autoScore'
     );
     if (latestComponentState != null && latestAutoScoreAnnotation != null) {
       const cRaterResponse = new CRaterResponse({
@@ -57,24 +61,8 @@ export class DynamicPromptComponent implements OnInit {
         this.getSubmitCounter(latestComponentState)
       );
       const feedbackRule: FeedbackRule = feedbackRuleEvaluator.getFeedbackRule(cRaterResponse);
-      this.setPrompt(feedbackRule.prompt);
+      this.prompt = feedbackRule.prompt;
     }
-  }
-
-  private getLatestComponentState(nodeId: string, componentId: string): any {
-    return this.studentDataService.getLatestComponentStateByNodeIdAndComponentId(
-      nodeId,
-      componentId
-    );
-  }
-
-  private getLatestAutoScore(nodeId: string, componentId: string, workgroupId: number): any {
-    return this.annotationService.getLatestScoreAnnotation(
-      nodeId,
-      componentId,
-      workgroupId,
-      'autoScore'
-    );
   }
 
   private getFeedbackRuleEvaluator(
@@ -89,9 +77,5 @@ export class DynamicPromptComponent implements OnInit {
 
   private getSubmitCounter(componentState: any): number {
     return componentState.studentData.submitCounter;
-  }
-
-  private setPrompt(prompt: string): void {
-    this.prompt = prompt;
   }
 }

--- a/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.ts
@@ -1,4 +1,12 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { CRaterResponse } from '../../components/common/cRater/CRaterResponse';
+import { FeedbackRule } from '../../components/common/feedbackRule/FeedbackRule';
+import { FeedbackRuleEvaluator } from '../../components/common/feedbackRule/FeedbackRuleEvaluator';
+import { FeedbackRuleComponent } from '../../components/feedbackRule/FeedbackRuleComponent';
+import { AnnotationService } from '../../services/annotationService';
+import { ConfigService } from '../../services/configService';
+import { ProjectService } from '../../services/projectService';
+import { StudentDataService } from '../../services/studentDataService';
 import { DynamicPrompt } from './DynamicPrompt';
 
 @Component({
@@ -8,8 +16,82 @@ import { DynamicPrompt } from './DynamicPrompt';
 })
 export class DynamicPromptComponent implements OnInit {
   @Input() dynamicPrompt: DynamicPrompt;
+  prompt: string;
+  constructor(
+    private annotationService: AnnotationService,
+    private configService: ConfigService,
+    private projectService: ProjectService,
+    private studentDataService: StudentDataService
+  ) {}
 
-  constructor() {}
+  ngOnInit(): void {
+    const referenceComponent = this.getReferenceComponent(this.dynamicPrompt);
+    if (referenceComponent.type === 'OpenResponse') {
+      this.evaluateOpenResponseComponent(referenceComponent);
+    }
+  }
 
-  ngOnInit(): void {}
+  private getReferenceComponent(dynamicPrompt: DynamicPrompt): any {
+    const nodeId = dynamicPrompt.getReferenceNodeId();
+    const componentId = dynamicPrompt.getReferenceComponentId();
+    return this.projectService.getComponentByNodeIdAndComponentId(nodeId, componentId);
+  }
+
+  private evaluateOpenResponseComponent(referenceComponent: any): void {
+    const nodeId = this.dynamicPrompt.getReferenceNodeId();
+    const componentId = referenceComponent.id;
+    const latestComponentState = this.getLatestComponentState(nodeId, componentId);
+    const latestAutoScoreAnnotation = this.getLatestAutoScore(
+      nodeId,
+      componentId,
+      this.configService.getWorkgroupId()
+    );
+    if (latestComponentState != null && latestAutoScoreAnnotation != null) {
+      const cRaterResponse = new CRaterResponse({
+        ideas: latestAutoScoreAnnotation.data.ideas,
+        scores: latestAutoScoreAnnotation.data.scores
+      });
+      const feedbackRuleEvaluator = this.getFeedbackRuleEvaluator(
+        this.dynamicPrompt.getRules(),
+        referenceComponent.maxSubmitCount,
+        this.getSubmitCounter(latestComponentState)
+      );
+      const feedbackRule: FeedbackRule = feedbackRuleEvaluator.getFeedbackRule(cRaterResponse);
+      this.setPrompt(feedbackRule.prompt);
+    }
+  }
+
+  private getLatestComponentState(nodeId: string, componentId: string): any {
+    return this.studentDataService.getLatestComponentStateByNodeIdAndComponentId(
+      nodeId,
+      componentId
+    );
+  }
+
+  private getLatestAutoScore(nodeId: string, componentId: string, workgroupId: number): any {
+    return this.annotationService.getLatestScoreAnnotation(
+      nodeId,
+      componentId,
+      workgroupId,
+      'autoScore'
+    );
+  }
+
+  private getFeedbackRuleEvaluator(
+    rules: FeedbackRule[],
+    maxSubmitCount: number,
+    submitCount: number
+  ): any {
+    return new FeedbackRuleEvaluator(
+      new FeedbackRuleComponent(rules, maxSubmitCount, false, submitCount)
+    );
+  }
+
+  private getSubmitCounter(componentState: any): number {
+    return componentState.studentData.submitCounter;
+  }
+
+  private setPrompt(prompt: string): void {
+    this.prompt = prompt;
+  }
 }

--- a/src/assets/wise5/directives/prompt/prompt.component.spec.ts
+++ b/src/assets/wise5/directives/prompt/prompt.component.spec.ts
@@ -1,4 +1,8 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogModule } from '@angular/material/dialog';
+import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
+import { ProjectService } from '../../services/projectService';
 import { DynamicPromptComponent } from '../dynamic-prompt/dynamic-prompt.component';
 import { DynamicPrompt } from '../dynamic-prompt/DynamicPrompt';
 import { PromptComponent } from './prompt.component';
@@ -6,13 +10,14 @@ import { PromptComponent } from './prompt.component';
 describe('PromptComponent', () => {
   let component: PromptComponent;
   let fixture: ComponentFixture<PromptComponent>;
-  const promptText: string = 'This is the prompt.';
+  const promptText: string = 'This is the regular prompt.';
   const postPromptText: string = 'This is the prompt after the dynamic prompt.';
   const prePromptText: string = 'This is the prompt before the dynamic prompt.';
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [PromptComponent, DynamicPromptComponent]
+      declarations: [PromptComponent, DynamicPromptComponent],
+      imports: [HttpClientTestingModule, MatDialogModule, StudentTeacherCommonServicesModule]
     }).compileComponents();
   });
 
@@ -23,7 +28,14 @@ describe('PromptComponent', () => {
     component.dynamicPrompt = new DynamicPrompt({
       enabled: false,
       postPrompt: postPromptText,
-      prePrompt: prePromptText
+      prePrompt: prePromptText,
+      referenceComponent: {
+        componentId: 'component1',
+        nodeId: 'node1'
+      }
+    });
+    spyOn(TestBed.inject(ProjectService), 'getComponentByNodeIdAndComponentId').and.returnValue({
+      type: 'OpenResponse'
     });
     fixture.detectChanges();
   });
@@ -33,11 +45,10 @@ describe('PromptComponent', () => {
     expect(promptElement.textContent).toEqual(promptText);
   });
 
-  it('should display the dynamic prompt', () => {
+  it('should not display the regular prompt2', () => {
     component.dynamicPrompt.enabled = true;
     fixture.detectChanges();
-    const prompts = fixture.debugElement.nativeElement.querySelectorAll('.prompt');
-    expect(prompts[0].textContent).toEqual(prePromptText);
-    expect(prompts[prompts.length - 1].textContent).toEqual(postPromptText);
+    const prompt = fixture.debugElement.nativeElement.querySelector('.prompt');
+    expect(prompt.textContent).not.toEqual(promptText);
   });
 });

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15291,7 +15291,7 @@ Score: <x id="PH" equiv-text="score"/>
 Feedback Text: <x id="PH_1" equiv-text="feedbackText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">106</context>
+          <context context-type="linenumber">97</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1461861786609911168" datatype="html">
@@ -15304,28 +15304,28 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/>
 Feedback Text: <x id="PH_2" equiv-text="feedbackText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">145</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846244999760672149" datatype="html">
         <source>you got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">186</context>
+          <context context-type="linenumber">177</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7599226289089492371" datatype="html">
         <source>Please talk to your teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">188</context>
+          <context context-type="linenumber">179</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5580639382077453513" datatype="html">
         <source>got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="867656616658826137" datatype="html">
@@ -15336,21 +15336,21 @@ Previous Score: <x id="PH" equiv-text="previousScore"/>
 Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">204</context>
+          <context context-type="linenumber">195</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3689003016353565518" datatype="html">
         <source>Are you sure you want to delete the custom completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">238</context>
+          <context context-type="linenumber">229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2986030604058491184" datatype="html">
         <source>Are you sure you want to delete this completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">270</context>
+          <context context-type="linenumber">261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="350e893dc35c1ca7a171e2944630e2c8f3f4785a" datatype="html">


### PR DESCRIPTION
## Changes

Added functionality to evaluate which dynamic prompt to display.

## Test

- Add a dynamic prompt to a component content (see below example)
- Have the dynamic prompt reference component point to an OpenResponse CRater component (you'll need to change the nodeId and componentId in the example below)
- As a student, submit an answer on the Open Response step and then go to the step with the dynamic prompt and make sure it displays the correct dynamic prompt

```
{
    "id": "gkvyzuils1",
    "type": "PeerChat",
    "prompt": "",
    "showSaveButton": false,
    "showSubmitButton": false,
    "peerGroupingTag": "847zgyqp1p",
    "questionBank": [],
    "dynamicPrompt": {
        "enabled": true,
        "prePrompt": "This is the pre prompt",
        "postPrompt": "This is the post prompt",
        "referenceComponent": {
            "nodeId": "node49",
            "componentId": "2aabvbcukq"
        },
        "rules": [
            {
                "id": "votbik4ncz",
                "expression": "hasKIScore(5)",
                "prompt": "Prompt when you got 5"
            },
            {
                "id": "hwp6sxf8vr",
                "expression": "hasKIScore(4)",
                "prompt": "Prompt when you got 4"
            },
            {
                "id": "swxzc0j7q0",
                "expression": "hasKIScore(3)",
                "prompt": "Prompt when you got 3"
            },
            {
                "id": "ebtgds3b1r",
                "expression": "hasKIScore(2)",
                "prompt": "Prompt when you got 2"
            },
            {
                "id": "z4yu37jcis",
                "expression": "hasKIScore(1)",
                "prompt": "Prompt when you got 1"
            },
            {
                "id": "isDefault",
                "expression": "isDefault",
                "prompt": "Default prompt"
            }
        ]
    }
}
```

#840