### PR TITLE
feat(Peer Grouping): Add Different Ideas authoring

### DIFF
--- a/src/app/domain/referenceComponent.ts
+++ b/src/app/domain/referenceComponent.ts
@@ -1,0 +1,9 @@
+export class ReferenceComponent {
+  componentId: string;
+  nodeId: string;
+
+  constructor(nodeId: string, componentId: string) {
+    this.nodeId = nodeId;
+    this.componentId = componentId;
+  }
+}

--- a/src/app/teacher/component-authoring.module.ts
+++ b/src/app/teacher/component-authoring.module.ts
@@ -74,6 +74,7 @@ import { StudentTeacherCommonModule } from '../student-teacher-common.module';
 import { FeedbackRuleHelpComponent } from '../../assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component';
 import { EditDynamicPromptComponent } from '../authoring-tool/edit-dynamic-prompt/edit-dynamic-prompt.component';
 import { EditDynamicPromptRulesComponent } from '../authoring-tool/edit-dynamic-prompt-rules/edit-dynamic-prompt-rules.component';
+import { EditPeerGroupingDialogComponent } from '../../assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component';
 
 @NgModule({
   declarations: [
@@ -132,6 +133,7 @@ import { EditDynamicPromptRulesComponent } from '../authoring-tool/edit-dynamic-
     EditOpenResponseAdvancedComponent,
     EditOutsideUrlAdvancedComponent,
     EditPeerChatAdvancedComponentComponent,
+    EditPeerGroupingDialogComponent,
     EditSummaryAdvancedComponent,
     EditTableAdvancedComponent,
     EditTableConnectedComponentsComponent,

--- a/src/assets/wise5/authoringTool/peer-grouping/PeerGroupingLogic.ts
+++ b/src/assets/wise5/authoringTool/peer-grouping/PeerGroupingLogic.ts
@@ -3,7 +3,12 @@ export interface PeerGroupingLogic {
   value: string;
 }
 
+export const DIFFERENT_IDEAS_NAME = $localize`Different Ideas`;
+export const DIFFERENT_IDEAS_REGEX = /differentIdeas\("(\w+)",\s*"(\w+)"\)/g;
+export const DIFFERENT_IDEAS_VALUE = 'differentIdeas';
+
 export const availableLogic: PeerGroupingLogic[] = [
   { name: $localize`Random`, value: 'random' },
-  { name: $localize`Manual`, value: 'manual' }
+  { name: $localize`Manual`, value: 'manual' },
+  { name: DIFFERENT_IDEAS_NAME, value: DIFFERENT_IDEAS_VALUE }
 ];

--- a/src/assets/wise5/authoringTool/peer-grouping/PeerGroupingLogic.ts
+++ b/src/assets/wise5/authoringTool/peer-grouping/PeerGroupingLogic.ts
@@ -7,7 +7,7 @@ export const DIFFERENT_IDEAS_NAME = $localize`Different Ideas`;
 export const DIFFERENT_IDEAS_REGEX = /differentIdeas\("(\w+)",\s*"(\w+)"\)/g;
 export const DIFFERENT_IDEAS_VALUE = 'differentIdeas';
 
-export const availableLogic: PeerGroupingLogic[] = [
+export const AVAILABLE_LOGIC: PeerGroupingLogic[] = [
   { name: $localize`Random`, value: 'random' },
   { name: $localize`Manual`, value: 'manual' },
   { name: DIFFERENT_IDEAS_NAME, value: DIFFERENT_IDEAS_VALUE }

--- a/src/assets/wise5/authoringTool/peer-grouping/author-peer-grouping-dialog/author-peer-grouping-dialog.component.ts
+++ b/src/assets/wise5/authoringTool/peer-grouping/author-peer-grouping-dialog/author-peer-grouping-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Directive, OnInit } from '@angular/core';
 import { MatDialogRef } from '@angular/material/dialog';
 import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
-import { availableLogic, PeerGroupingLogic } from '../PeerGroupingLogic';
+import { AVAILABLE_LOGIC, PeerGroupingLogic } from '../PeerGroupingLogic';
 
 @Directive()
 export abstract class AuthorPeerGroupingDialogComponent implements OnInit {
@@ -9,7 +9,7 @@ export abstract class AuthorPeerGroupingDialogComponent implements OnInit {
   peerGrouping: PeerGrouping;
 
   constructor(protected dialogRef: MatDialogRef<AuthorPeerGroupingDialogComponent>) {
-    this.availableLogic = availableLogic;
+    this.availableLogic = AVAILABLE_LOGIC;
   }
 
   ngOnInit(): void {}

--- a/src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.html
+++ b/src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.html
@@ -4,15 +4,25 @@
     <mat-label i18n>Grouping Name</mat-label>
     <input matInput [(ngModel)]="peerGrouping.name" />
   </mat-form-field>
-  <div>
+  <div fxLayoutGap="20px">
     <mat-form-field>
       <mat-label i18n>Logic</mat-label>
-      <mat-select [(ngModel)]="peerGrouping.logic">
+      <mat-select [(ngModel)]="logicType">
         <mat-option *ngFor="let logic of availableLogic" [value]="logic.value">
           {{ logic.name }}
         </mat-option>
       </mat-select>
     </mat-form-field>
+    <ng-container *ngIf="logicType === 'differentIdeas'">
+      <edit-connected-component-node-select
+          [connectedComponent]="referenceComponent"
+          (connectedComponentChange)="referenceComponentNodeIdChanged($event)">
+      </edit-connected-component-node-select>
+      <edit-connected-component-component-select
+          [connectedComponent]="referenceComponent"
+          [allowedConnectedComponentTypes]="allowedReferenceComponentTypes">
+      </edit-connected-component-component-select>
+    </ng-container>
   </div>
   <div>
     <mat-form-field>

--- a/src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.spec.ts
+++ b/src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.spec.ts
@@ -6,6 +6,7 @@ import { PeerGroupingTestingModule } from '../peer-grouping-testing.module';
 import { EditPeerGroupingDialogComponent } from './edit-peer-grouping-dialog.component';
 import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { DIFFERENT_IDEAS_VALUE } from '../PeerGroupingLogic';
 
 let component: EditPeerGroupingDialogComponent;
 let dialogCloseSpy: jasmine.Spy;
@@ -52,6 +53,33 @@ function savePeerGrouping() {
     expect(updatePeerGroupingSpy).toHaveBeenCalledWith(settings);
     expect(dialogCloseSpy).toHaveBeenCalled();
   });
+
+  it('should save peer grouping with random logic', () => {
+    savePeerGroupingWithLogic('random', 'random');
+  });
+
+  it('should save peer grouping with manual logic', () => {
+    savePeerGroupingWithLogic('manual', 'manual');
+  });
+
+  it('should save peer grouping with different ideas logic', () => {
+    savePeerGroupingWithLogic(DIFFERENT_IDEAS_VALUE, 'differentIdeas("node1", "component1")');
+  });
+}
+
+function savePeerGroupingWithLogic(logicType: string, expectedLogic: string) {
+  const peerGrouping = new PeerGrouping();
+  component.peerGrouping = peerGrouping;
+  component.logicType = logicType;
+  component.referenceComponent = {
+    nodeId: 'node1',
+    componentId: 'component1'
+  };
+  spyOn(TestBed.inject(PeerGroupingAuthoringService), 'updatePeerGrouping').and.returnValue(
+    of(peerGrouping)
+  );
+  component.save();
+  expect(component.peerGrouping.logic).toEqual(expectedLogic);
 }
 
 function deletePeerGrouping() {

--- a/src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.ts
+++ b/src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.ts
@@ -2,8 +2,10 @@ import { Component, Inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
 import { PeerGroupingAuthoringService } from '../../../services/peerGroupingAuthoringService';
+import { ProjectService } from '../../../services/projectService';
 import { UtilService } from '../../../services/utilService';
 import { AuthorPeerGroupingDialogComponent } from '../author-peer-grouping-dialog/author-peer-grouping-dialog.component';
+import { DIFFERENT_IDEAS_REGEX, DIFFERENT_IDEAS_VALUE } from '../PeerGroupingLogic';
 
 @Component({
   selector: 'edit-peer-grouping-dialog',
@@ -11,12 +13,16 @@ import { AuthorPeerGroupingDialogComponent } from '../author-peer-grouping-dialo
   styleUrls: ['./edit-peer-grouping-dialog.component.scss']
 })
 export class EditPeerGroupingDialogComponent extends AuthorPeerGroupingDialogComponent {
+  allowedReferenceComponentTypes: string[] = ['OpenResponse'];
+  logicType: string;
+  referenceComponent: any = {};
   stepsUsedIn: string[] = [];
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public peerGrouping: PeerGrouping,
     protected dialogRef: MatDialogRef<EditPeerGroupingDialogComponent>,
     private peerGroupingAuthoringService: PeerGroupingAuthoringService,
+    private projectService: ProjectService,
     private utilService: UtilService
   ) {
     super(dialogRef);
@@ -25,12 +31,61 @@ export class EditPeerGroupingDialogComponent extends AuthorPeerGroupingDialogCom
   ngOnInit(): void {
     this.peerGrouping = this.utilService.makeCopyOfJSONObject(this.peerGrouping);
     this.stepsUsedIn = this.peerGroupingAuthoringService.getStepsUsedIn(this.peerGrouping.tag);
+    this.logicType = this.getLogicType(this.peerGrouping.logic);
+    if (this.logicType === DIFFERENT_IDEAS_VALUE) {
+      this.referenceComponent = this.getDifferentIdeasReferenceComponent(this.peerGrouping.logic);
+    }
+  }
+
+  private getLogicType(logic: string): string {
+    if (new RegExp(DIFFERENT_IDEAS_REGEX).exec(logic) != null) {
+      return DIFFERENT_IDEAS_VALUE;
+    } else {
+      return logic;
+    }
+  }
+
+  private getDifferentIdeasReferenceComponent(logic: string): any {
+    const result = new RegExp(DIFFERENT_IDEAS_REGEX).exec(logic);
+    return {
+      nodeId: result[1],
+      componentId: result[2]
+    };
+  }
+
+  referenceComponentNodeIdChanged(event: any): void {
+    let numAllowedComponents = 0;
+    let allowedComponent = null;
+    for (const component of this.projectService.getComponentsByNodeId(event.nodeId)) {
+      if (this.allowedReferenceComponentTypes.includes(component.type)) {
+        numAllowedComponents += 1;
+        allowedComponent = component;
+      }
+    }
+    if (numAllowedComponents === 1) {
+      this.referenceComponent.componentId = allowedComponent.id;
+    } else {
+      this.referenceComponent.componentId = null;
+    }
   }
 
   save(): void {
+    this.injectPeerGroupingLogic(this.peerGrouping);
     this.peerGroupingAuthoringService.updatePeerGrouping(this.peerGrouping).subscribe(() => {
       this.dialogRef.close();
     });
+  }
+
+  private injectPeerGroupingLogic(peerGrouping: PeerGrouping): void {
+    if (this.logicType === DIFFERENT_IDEAS_VALUE) {
+      peerGrouping.logic = this.generateDifferentIdeasLogic();
+    } else {
+      peerGrouping.logic = this.logicType;
+    }
+  }
+
+  private generateDifferentIdeasLogic(): string {
+    return `${DIFFERENT_IDEAS_VALUE}("${this.referenceComponent.nodeId}", "${this.referenceComponent.componentId}")`;
   }
 
   delete(): void {

--- a/src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.ts
+++ b/src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.ts
@@ -6,6 +6,7 @@ import { ProjectService } from '../../../services/projectService';
 import { UtilService } from '../../../services/utilService';
 import { AuthorPeerGroupingDialogComponent } from '../author-peer-grouping-dialog/author-peer-grouping-dialog.component';
 import { DIFFERENT_IDEAS_REGEX, DIFFERENT_IDEAS_VALUE } from '../PeerGroupingLogic';
+import { ReferenceComponent } from '../../../../../app/domain/referenceComponent';
 
 @Component({
   selector: 'edit-peer-grouping-dialog',
@@ -15,7 +16,7 @@ import { DIFFERENT_IDEAS_REGEX, DIFFERENT_IDEAS_VALUE } from '../PeerGroupingLog
 export class EditPeerGroupingDialogComponent extends AuthorPeerGroupingDialogComponent {
   allowedReferenceComponentTypes: string[] = ['OpenResponse'];
   logicType: string;
-  referenceComponent: any = {};
+  referenceComponent: ReferenceComponent;
   stepsUsedIn: string[] = [];
 
   constructor(
@@ -38,19 +39,12 @@ export class EditPeerGroupingDialogComponent extends AuthorPeerGroupingDialogCom
   }
 
   private getLogicType(logic: string): string {
-    if (new RegExp(DIFFERENT_IDEAS_REGEX).exec(logic) != null) {
-      return DIFFERENT_IDEAS_VALUE;
-    } else {
-      return logic;
-    }
+    return new RegExp(DIFFERENT_IDEAS_REGEX).exec(logic) != null ? DIFFERENT_IDEAS_VALUE : logic;
   }
 
-  private getDifferentIdeasReferenceComponent(logic: string): any {
+  private getDifferentIdeasReferenceComponent(logic: string): ReferenceComponent {
     const result = new RegExp(DIFFERENT_IDEAS_REGEX).exec(logic);
-    return {
-      nodeId: result[1],
-      componentId: result[2]
-    };
+    return new ReferenceComponent(result[1], result[2]);
   }
 
   referenceComponentNodeIdChanged(event: any): void {
@@ -70,22 +64,17 @@ export class EditPeerGroupingDialogComponent extends AuthorPeerGroupingDialogCom
   }
 
   save(): void {
-    this.injectPeerGroupingLogic(this.peerGrouping);
+    this.updatePeerGroupingLogic();
     this.peerGroupingAuthoringService.updatePeerGrouping(this.peerGrouping).subscribe(() => {
       this.dialogRef.close();
     });
   }
 
-  private injectPeerGroupingLogic(peerGrouping: PeerGrouping): void {
-    if (this.logicType === DIFFERENT_IDEAS_VALUE) {
-      peerGrouping.logic = this.generateDifferentIdeasLogic();
-    } else {
-      peerGrouping.logic = this.logicType;
-    }
-  }
-
-  private generateDifferentIdeasLogic(): string {
-    return `${DIFFERENT_IDEAS_VALUE}("${this.referenceComponent.nodeId}", "${this.referenceComponent.componentId}")`;
+  private updatePeerGroupingLogic(): void {
+    this.peerGrouping.logic =
+      this.logicType === DIFFERENT_IDEAS_VALUE
+        ? `${DIFFERENT_IDEAS_VALUE}("${this.referenceComponent.nodeId}", "${this.referenceComponent.componentId}")`
+        : this.logicType;
   }
 
   delete(): void {

--- a/src/assets/wise5/authoringTool/peer-grouping/peer-grouping-authoring.module.ts
+++ b/src/assets/wise5/authoringTool/peer-grouping/peer-grouping-authoring.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { SelectPeerGroupingOptionComponent } from './select-peer-grouping-option/select-peer-grouping-option.component';
 import { SelectPeerGroupingDialogComponent } from './select-peer-grouping-dialog/select-peer-grouping-dialog.component';
-import { EditPeerGroupingDialogComponent } from './edit-peer-grouping-dialog/edit-peer-grouping-dialog.component';
 import { CreateNewPeerGroupingDialogComponent } from './create-new-peer-grouping-dialog/create-new-peer-grouping-dialog.component';
 import { SelectPeerGroupingAuthoringComponent } from './select-peer-grouping-authoring/select-peer-grouping-authoring.component';
 import { PeerGroupingAuthoringService } from '../../services/peerGroupingAuthoringService';
@@ -11,7 +10,6 @@ import { StudentTeacherCommonModule } from '../../../../app/student-teacher-comm
   imports: [StudentTeacherCommonModule],
   declarations: [
     CreateNewPeerGroupingDialogComponent,
-    EditPeerGroupingDialogComponent,
     SelectPeerGroupingAuthoringComponent,
     SelectPeerGroupingOptionComponent,
     SelectPeerGroupingDialogComponent

--- a/src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-option/select-peer-grouping-option.component.spec.ts
+++ b/src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-option/select-peer-grouping-option.component.spec.ts
@@ -4,6 +4,7 @@ import { SelectPeerGroupingOptionComponent } from './select-peer-grouping-option
 import { getDialogOpenSpy } from '../peer-grouping-testing-helper';
 import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { DIFFERENT_IDEAS_NAME } from '../PeerGroupingLogic';
 
 let component: SelectPeerGroupingOptionComponent;
 let deleteEventSpy: jasmine.Spy;
@@ -30,6 +31,7 @@ describe('SelectPeerGroupingOptionComponent', () => {
 
   selectPeerGrouping();
   editPeerGrouping();
+  setPeerGroupingLogicName();
 });
 
 function selectPeerGrouping() {
@@ -54,4 +56,22 @@ function editPeerGrouping() {
     expect(dialogOpenSpy).toHaveBeenCalled();
     expect(deleteEventSpy).toHaveBeenCalledWith(peerGrouping1);
   });
+}
+
+function setPeerGroupingLogicName() {
+  it('should set peer grouping logic name when logic is random', () => {
+    setAndExpectPeerGroupingLogic('random', 'Random');
+  });
+  it('should set peer grouping logic name when logic is manual', () => {
+    setAndExpectPeerGroupingLogic('manual', 'Manual');
+  });
+  it('should set peer grouping logic name when logic is different ideas', () => {
+    setAndExpectPeerGroupingLogic('differentIdeas("node1", "componen1")', DIFFERENT_IDEAS_NAME);
+  });
+}
+
+function setAndExpectPeerGroupingLogic(logic: string, expectedLogicName: string) {
+  component.peerGrouping.logic = logic;
+  component.setPeerGroupingLogicName();
+  expect(component.peerGroupingLogicName).toEqual(expectedLogicName);
 }

--- a/src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-option/select-peer-grouping-option.component.ts
+++ b/src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-option/select-peer-grouping-option.component.ts
@@ -3,7 +3,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
 import { PeerGroupingAuthoringService } from '../../../services/peerGroupingAuthoringService';
 import { EditPeerGroupingDialogComponent } from '../edit-peer-grouping-dialog/edit-peer-grouping-dialog.component';
-import { availableLogic, DIFFERENT_IDEAS_NAME, DIFFERENT_IDEAS_REGEX } from '../PeerGroupingLogic';
+import { AVAILABLE_LOGIC, DIFFERENT_IDEAS_NAME, DIFFERENT_IDEAS_REGEX } from '../PeerGroupingLogic';
 
 @Component({
   selector: 'select-peer-grouping-option',
@@ -38,8 +38,8 @@ export class SelectPeerGroupingOptionComponent implements OnInit {
     if (new RegExp(DIFFERENT_IDEAS_REGEX).exec(this.peerGrouping.logic) != null) {
       this.peerGroupingLogicName = DIFFERENT_IDEAS_NAME;
     } else {
-      this.peerGroupingLogicName = availableLogic.find(
-        (logic) => this.peerGrouping.logic === logic.value
+      this.peerGroupingLogicName = AVAILABLE_LOGIC.find(
+        (logic) => logic.value === this.peerGrouping.logic
       ).name;
     }
   }

--- a/src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-option/select-peer-grouping-option.component.ts
+++ b/src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-option/select-peer-grouping-option.component.ts
@@ -3,7 +3,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
 import { PeerGroupingAuthoringService } from '../../../services/peerGroupingAuthoringService';
 import { EditPeerGroupingDialogComponent } from '../edit-peer-grouping-dialog/edit-peer-grouping-dialog.component';
-import { availableLogic } from '../PeerGroupingLogic';
+import { availableLogic, DIFFERENT_IDEAS_NAME, DIFFERENT_IDEAS_REGEX } from '../PeerGroupingLogic';
 
 @Component({
   selector: 'select-peer-grouping-option',
@@ -35,9 +35,13 @@ export class SelectPeerGroupingOptionComponent implements OnInit {
   }
 
   setPeerGroupingLogicName(): void {
-    this.peerGroupingLogicName = availableLogic.find(
-      (logic) => logic.value === this.peerGrouping.logic
-    ).name;
+    if (new RegExp(DIFFERENT_IDEAS_REGEX).exec(this.peerGrouping.logic) != null) {
+      this.peerGroupingLogicName = DIFFERENT_IDEAS_NAME;
+    } else {
+      this.peerGroupingLogicName = availableLogic.find(
+        (logic) => this.peerGrouping.logic === logic.value
+      ).name;
+    }
   }
 
   select(): void {
@@ -48,7 +52,7 @@ export class SelectPeerGroupingOptionComponent implements OnInit {
     this.dialog
       .open(EditPeerGroupingDialogComponent, {
         data: this.peerGrouping,
-        panelClass: 'dialog-sm'
+        panelClass: 'dialog-md'
       })
       .afterClosed()
       .subscribe((isDelete: boolean) => {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -468,7 +468,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">56</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/add-team-dialog/add-team-dialog.component.html</context>
@@ -8826,7 +8826,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/PeerGroupingLogic.ts</context>
-          <context context-type="linenumber">7</context>
+          <context context-type="linenumber">11</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-logic-options.ts</context>
@@ -9615,11 +9615,18 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="4199930238964775542" datatype="html">
+        <source>Different Ideas</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/PeerGroupingLogic.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="2233560223291461480" datatype="html">
         <source>Manual</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/PeerGroupingLogic.ts</context>
-          <context context-type="linenumber">8</context>
+          <context context-type="linenumber">12</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-logic-options.ts</context>
@@ -9663,7 +9670,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.html</context>
-          <context context-type="linenumber">19</context>
+          <context context-type="linenumber">29</context>
         </context-group>
       </trans-unit>
       <trans-unit id="70a67e04629f6d412db0a12d51820b480788d795" datatype="html">
@@ -9695,35 +9702,35 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Used in </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.html</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5a8f0930e6a9f0a3350c4a43858d01e75f752762" datatype="html">
         <source>Not used in any steps.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.html</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">42</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d9797b7f7d130802253f3bdd06f7da9f474816af" datatype="html">
         <source> Delete </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.html</context>
-          <context context-type="linenumber">41,43</context>
+          <context context-type="linenumber">51,53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="047f50bc5b5d17b5bec0196355953e1a5c590ddb" datatype="html">
         <source>Update</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.html</context>
-          <context context-type="linenumber">47</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4659585107312140486" datatype="html">
         <source>Are you sure you want to delete this Peer Grouping?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.ts</context>
-          <context context-type="linenumber">37</context>
+          <context context-type="linenumber">92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="aba67b55d7f550e72a7134adf3dee25d2be00f9b" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9730,7 +9730,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete this Peer Grouping?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.ts</context>
-          <context context-type="linenumber">92</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="aba67b55d7f550e72a7134adf3dee25d2be00f9b" datatype="html">


### PR DESCRIPTION
## Changes

- Added ability to author Peer Grouping with Different Ideas logic
- Moved EditPeerGroupingDialogComponent from PeerGroupingAuthoringModule to ComponentAuthoringModule otherwise the EditPeerGroupingDialogComponent couldn't use \<edit-connected-component-node-select\> and \<edit-connected-component-component-select\>

## Test

- Edit a Peer Grouping to use Different Ideas logic and set the Step and Component
- Make sure the Different Ideas logic and Step and Component are repopulated if you refresh the page
- Edit a Peer Grouping to use Random or Manual and make sure it still saves correctly like before
- Make sure the correct logic values are saved in the database

#840