### PR TITLE
feat(Peer Chat): Show Dynamic Prompt in Grading

### DIFF
--- a/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.html
@@ -1,5 +1,6 @@
 <ng-container *ngIf="isPeerChatWorkgroupsAvailable">
   <div fxLayout="column" fxLayout.gt-md="row" fxLayoutAlign.gt-md="start start" fxLayoutGap="16px">
+    <div *ngIf="dynamicPrompt != null" [innerHTML]="dynamicPrompt.prompt"></div>
     <div *ngIf="componentContent.questionBank.length > 0"
         fxFlex
         fxFlex.gt-md="40"

--- a/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.html
@@ -1,6 +1,7 @@
 <ng-container *ngIf="isPeerChatWorkgroupsAvailable">
+  <div *ngIf="dynamicPrompt != null" [innerHTML]="dynamicPrompt.prompt" class="dynamic-prompt">
+  </div>
   <div fxLayout="column" fxLayout.gt-md="row" fxLayoutAlign.gt-md="start start" fxLayoutGap="16px">
-    <div *ngIf="dynamicPrompt != null" [innerHTML]="dynamicPrompt.prompt"></div>
     <div *ngIf="componentContent.questionBank.length > 0"
         fxFlex
         fxFlex.gt-md="40"

--- a/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.scss
+++ b/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.scss
@@ -1,0 +1,4 @@
+.dynamic-prompt {
+  margin-bottom: 10px;
+  font-weight: 500;
+}

--- a/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.ts
@@ -18,8 +18,6 @@ import { PeerGroup } from '../PeerGroup';
   styleUrls: ['./peer-chat-grading.component.scss']
 })
 export class PeerChatGradingComponent extends PeerChatShowWorkComponent {
-  peerGroup: PeerGroup;
-
   constructor(
     protected configService: ConfigService,
     protected nodeService: NodeService,
@@ -32,15 +30,6 @@ export class PeerChatGradingComponent extends PeerChatShowWorkComponent {
     protected teacherWorkService: TeacherWorkService
   ) {
     super(configService, nodeService, peerChatService, peerGroupService, projectService);
-  }
-
-  ngOnInit(): void {
-    super.ngOnInit();
-    this.peerGroupService
-      .retrievePeerGroup(this.componentContent.peerGroupingTag, this.workgroupId)
-      .subscribe((peerGroup) => {
-        this.peerGroup = peerGroup;
-      });
   }
 
   submitTeacherResponse(response: string): void {

--- a/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.ts
@@ -9,16 +9,19 @@ import { PeerGroupService } from '../../../services/peerGroupService';
 import { PeerGroup } from '../PeerGroup';
 import { PeerGroupMember } from '../PeerGroupMember';
 import { NodeService } from '../../../services/nodeService';
+import { FeedbackRule } from '../../common/feedbackRule/FeedbackRule';
 
 @Component({
   selector: 'peer-chat-show-work',
   templateUrl: 'peer-chat-show-work.component.html'
 })
 export class PeerChatShowWorkComponent extends ComponentShowWorkDirective {
+  dynamicPrompt: FeedbackRule;
   isPeerChatWorkgroupsAvailable: boolean = false;
   peerChatMessages: PeerChatMessage[] = [];
   peerChatWorkgroupIds: Set<number> = new Set<number>();
   peerChatWorkgroupInfos: any = {};
+  peerGroup: PeerGroup;
   requestTimeout: number = 10000;
 
   @Input() workgroupId: number;
@@ -48,6 +51,7 @@ export class PeerChatShowWorkComponent extends ComponentShowWorkDirective {
   }
 
   private requestChatWorkgroupsSuccess(peerGroup: PeerGroup): void {
+    this.peerGroup = peerGroup;
     this.addWorkgroupIdsFromPeerGroup(this.peerChatWorkgroupIds, peerGroup);
     this.addTeacherWorkgroupIds(this.peerChatWorkgroupIds);
     this.retrievePeerChatComponentStates();
@@ -79,6 +83,17 @@ export class PeerChatShowWorkComponent extends ComponentShowWorkDirective {
   private setPeerChatMessages(componentStates: any[]): void {
     this.peerChatMessages = [];
     this.peerChatService.setPeerChatMessages(this.peerChatMessages, componentStates);
+    this.dynamicPrompt = this.getDynamicPrompt(componentStates);
+  }
+
+  private getDynamicPrompt(componentStates: any[]): FeedbackRule {
+    for (let c = componentStates.length - 1; c >= 0; c--) {
+      const dynamicPrompt = componentStates[c].studentData.dynamicPrompt;
+      if (dynamicPrompt != null) {
+        return dynamicPrompt;
+      }
+    }
+    return null;
   }
 
   private addWorkgroupIdsFromPeerChatMessages(

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15740,7 +15740,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source> This Peer Chat activity is not yet available. Please check back later or wait for a notification to return. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.html</context>
-          <context context-type="linenumber">21,23</context>
+          <context context-type="linenumber">23,25</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.html</context>


### PR DESCRIPTION
## Changes

- Display the Dynamic Prompt in the Peer Chat grading if the latest component state has a Dynamic Prompt in the student data
- Removed PeerChatGradingComponent.ngOnInit() because it was making a duplicate call to retrieve the PeerGroup. The parent component (PeerChatShowWorkComponent) already retrieves the PeerGroup in its ngOnInit().

## Test

- Make sure the Dynamic Prompt shows up in the Peer Chat grading
- Make sure the Peer Chat messages show up in the Peer Chat grading like before

#840