### PR TITLE
feat(Authoring): Allow add feedback rules in between existing rules

### DIFF
--- a/src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.html
+++ b/src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.html
@@ -5,8 +5,8 @@
         color="primary"
         matTooltip="Add a new rule"
         i18n-matTooltip
-        matTooltipPosition="above"
-        (click)="addNewRule('beginning')">
+        matTooltipPosition="after"
+        (click)="addNewRule(-1)">
       <mat-icon>add_circle</mat-icon>
     </button>
     <span fxFlex></span>
@@ -14,8 +14,8 @@
   </h5>
   <ul cdkDropList [cdkDropListData]="feedbackRules" (cdkDropListDropped)="drop($event)" cdkScrollable>
     <ng-container *ngFor="let rule of feedbackRules; let ruleIndex = index; let first = first; let last = last">
-      <li cdkDrag>
-        <mat-card class="rule" fxLayout="row wrap" fxLayoutGap="8px">
+      <li class="rule" cdkDrag>
+        <mat-card class="rule-content" fxLayout="row wrap" fxLayoutGap="8px">
           <div class="text-secondary" fxLayout="column" fxLayoutAlign="start center" fxLayoutGap="22px">
             <span class="mat-subheading-2">{{ruleIndex + 1}}</span>
             <mat-icon cdkDragHandle title="Drag to reorder" i18n-title>drag_indicator</mat-icon>
@@ -102,16 +102,17 @@
             </button>
           </div>
         </mat-card>
-      </li>
-    </ng-container>
-  </ul>
-  <button *ngIf="feedbackRules.length > 0"
-      mat-icon-button
-      color="primary"
-      matTooltip="Add a new rule at the end"
-      i18n-matTooltip
-      matTooltipPosition="above"
-      (click)="addNewRule('end')">
-    <mat-icon>add_circle</mat-icon>
-  </button>
+        <div class="add-rule">
+          <button mat-icon-button
+              color="primary"
+              matTooltip="Add a new rule"
+              i18n-matTooltip
+              matTooltipPosition="above"
+              (click)="addNewRule(ruleIndex + 1)">
+            <mat-icon>add_circle</mat-icon>
+          </button>
+        </div>
+        </li>
+        </ng-container>
+        </ul>
 </div>

--- a/src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.html
+++ b/src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.html
@@ -6,7 +6,7 @@
         matTooltip="Add a new rule"
         i18n-matTooltip
         matTooltipPosition="after"
-        (click)="addNewRule(-1)">
+        (click)="addNewRule(0)">
       <mat-icon>add_circle</mat-icon>
     </button>
     <span fxFlex></span>

--- a/src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.scss
+++ b/src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.scss
@@ -10,7 +10,8 @@ h5 {
 }
 
 ul {
-  padding: 0;
+  margin: 16px 0 0 0;
+  padding: 0 0 16px;
   max-height: 60vh;
   overflow-y: auto;
 }
@@ -20,6 +21,10 @@ li {
 }
 
 .rule {
+  position: relative;
+}
+
+.rule-content {
   width: 100%;
   padding: 8px;
   margin-bottom: 8px;
@@ -47,4 +52,12 @@ li {
 
 .feedback-input {
   width: 100%;
+}
+
+.add-rule {
+  position: absolute;
+  bottom: -24px;
+  width: 100%;
+  text-align: center;
+  z-index: 1;
 }

--- a/src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.spec.ts
@@ -59,7 +59,7 @@ describe('EditFeedbackRulesComponent', () => {
 function addNewRule() {
   describe('addNewRule()', () => {
     it('should add rule at the beginning', () => {
-      component.addNewRule(-1);
+      component.addNewRule(0);
       expectFeedbackExpressions(['', 'idea1', 'idea2']);
       expect(nodeChangedSpy).toHaveBeenCalled();
     });

--- a/src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.spec.ts
@@ -59,13 +59,19 @@ describe('EditFeedbackRulesComponent', () => {
 function addNewRule() {
   describe('addNewRule()', () => {
     it('should add rule at the beginning', () => {
-      component.addNewRule('beginning');
+      component.addNewRule(-1);
       expectFeedbackExpressions(['', 'idea1', 'idea2']);
       expect(nodeChangedSpy).toHaveBeenCalled();
     });
 
+    it('should add rule in the middle', () => {
+      component.addNewRule(1);
+      expectFeedbackExpressions(['idea1', '', 'idea2']);
+      expect(nodeChangedSpy).toHaveBeenCalled();
+    });
+
     it('should add rule at the end', () => {
-      component.addNewRule('end');
+      component.addNewRule(2);
       expectFeedbackExpressions(['idea1', 'idea2', '']);
       expect(nodeChangedSpy).toHaveBeenCalled();
     });
@@ -73,7 +79,7 @@ function addNewRule() {
     it('should create new rule with feedback version 1', () => {
       component.version = 1;
       component.feedbackRules = [];
-      component.addNewRule('beginning');
+      component.addNewRule(-1);
       expect(component.feedbackRules.length).toEqual(1);
       const feedbackRule = component.feedbackRules[0];
       expect(feedbackRule.expression).toEqual('');
@@ -84,7 +90,7 @@ function addNewRule() {
     it('should create new rule with feedback version 2', () => {
       component.version = 2;
       component.feedbackRules = [];
-      component.addNewRule('beginning');
+      component.addNewRule(-1);
       expect(component.feedbackRules.length).toEqual(1);
       const feedbackRule = component.feedbackRules[0];
       expect(typeof feedbackRule.id).toEqual('string');

--- a/src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.ts
+++ b/src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.ts
@@ -54,12 +54,12 @@ export class EditFeedbackRulesComponent implements OnInit {
     this.projectService.nodeChanged();
   }
 
-  addNewRule(position: string): void {
+  addNewRule(position: number): void {
     const newFeedbackRule = this.createNewFeedbackRule();
-    if (position === 'beginning') {
+    if (position < 0) {
       this.feedbackRules.unshift(newFeedbackRule);
     } else {
-      this.feedbackRules.push(newFeedbackRule);
+      this.feedbackRules.splice(position, 0, newFeedbackRule);
     }
     this.projectService.nodeChanged();
   }

--- a/src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.ts
+++ b/src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.ts
@@ -56,11 +56,7 @@ export class EditFeedbackRulesComponent implements OnInit {
 
   addNewRule(position: number): void {
     const newFeedbackRule = this.createNewFeedbackRule();
-    if (position < 0) {
-      this.feedbackRules.unshift(newFeedbackRule);
-    } else {
-      this.feedbackRules.splice(position, 0, newFeedbackRule);
-    }
+    this.feedbackRules.splice(position, 0, newFeedbackRule);
     this.projectService.nodeChanged();
   }
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -11957,14 +11957,14 @@ Are you ready to receive feedback on this answer?</source>
         <source>Are you sure you want to delete this feedback?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.ts</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7484685939884481783" datatype="html">
         <source>Are you sure you want to delete this feedback rule?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.ts</context>
-          <context context-type="linenumber">88</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="21a9fc818b21be4ca6e733d9cf3defc9b28f3879" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -11866,6 +11866,10 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.html</context>
           <context context-type="linenumber">6</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.html</context>
+          <context context-type="linenumber">108</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="6fcbf761098624382d8edcae063b3f0207059601" datatype="html">
         <source>Drag to reorder</source>
@@ -11947,13 +11951,6 @@ Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.html</context>
           <context context-type="linenumber">98</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="28b0236983b8c9cde819e9f8dc2f3b85fa419168" datatype="html">
-        <source>Add a new rule at the end</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.html</context>
-          <context context-type="linenumber">111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9105812558859476049" datatype="html">
@@ -15291,7 +15288,7 @@ Score: <x id="PH" equiv-text="score"/>
 Feedback Text: <x id="PH_1" equiv-text="feedbackText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">106</context>
+          <context context-type="linenumber">97</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1461861786609911168" datatype="html">
@@ -15304,28 +15301,28 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/>
 Feedback Text: <x id="PH_2" equiv-text="feedbackText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">145</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846244999760672149" datatype="html">
         <source>you got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">186</context>
+          <context context-type="linenumber">177</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7599226289089492371" datatype="html">
         <source>Please talk to your teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">188</context>
+          <context context-type="linenumber">179</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5580639382077453513" datatype="html">
         <source>got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="867656616658826137" datatype="html">
@@ -15336,21 +15333,21 @@ Previous Score: <x id="PH" equiv-text="previousScore"/>
 Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">204</context>
+          <context context-type="linenumber">195</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3689003016353565518" datatype="html">
         <source>Are you sure you want to delete the custom completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">238</context>
+          <context context-type="linenumber">229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2986030604058491184" datatype="html">
         <source>Are you sure you want to delete this completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">270</context>
+          <context context-type="linenumber">261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="350e893dc35c1ca7a171e2944630e2c8f3f4785a" datatype="html">


### PR DESCRIPTION
## Changes
Authors can now add feedback rules in between each existing rule in the authoring interface. An "Add a rule" button is displayed at the bottom of each existing rule (in between the current rule and the next one).

Closes #851.

## Test
- Make sure adding a new feedback rule at the beginning still works.
- Make sure that you can add new rules at any position in the list, including at the end.
- Make sure other rule authoring operations still work properly.