### PR TITLE
refactor(ProjectService): Rename getComponentByNodeIdAndComponentId()

### DIFF
--- a/src/app/authoring-tool/edit-advanced-component/edit-advanced-component.component.ts
+++ b/src/app/authoring-tool/edit-advanced-component/edit-advanced-component.component.ts
@@ -6,10 +6,8 @@ import { TeacherProjectService } from '../../../assets/wise5/services/teacherPro
 @Directive()
 export abstract class EditAdvancedComponentComponent {
   authoringComponentContent: any;
-  @Input()
-  componentId: string;
-  @Input()
-  nodeId: string;
+  @Input() componentId: string;
+  @Input() nodeId: string;
 
   constructor(
     protected NodeService: NodeService,
@@ -18,7 +16,7 @@ export abstract class EditAdvancedComponentComponent {
   ) {}
 
   ngOnInit() {
-    this.authoringComponentContent = this.TeacherProjectService.getComponentByNodeIdAndComponentId(
+    this.authoringComponentContent = this.TeacherProjectService.getComponent(
       this.nodeId,
       this.componentId
     );

--- a/src/app/authoring-tool/edit-advanced-component/editAdvancedComponentAngularJSController.ts
+++ b/src/app/authoring-tool/edit-advanced-component/editAdvancedComponentAngularJSController.ts
@@ -16,7 +16,7 @@ export class EditAdvancedComponentAngularJSController {
   ) {}
 
   $onInit(): void {
-    this.authoringComponentContent = this.ProjectService.getComponentByNodeIdAndComponentId(
+    this.authoringComponentContent = this.ProjectService.getComponent(
       this.nodeId,
       this.componentId
     );

--- a/src/app/authoring-tool/edit-component-json/edit-component-json.component.ts
+++ b/src/app/authoring-tool/edit-component-json/edit-component-json.component.ts
@@ -50,7 +50,7 @@ export class EditComponentJsonComponent {
   }
 
   setComponentContentJsonString() {
-    const authoringComponentContent = this.ProjectService.getComponentByNodeIdAndComponentId(
+    const authoringComponentContent = this.ProjectService.getComponent(
       this.nodeId,
       this.componentId
     );

--- a/src/app/authoring-tool/edit-connected-components-with-background/edit-connected-components-with-background.component.spec.ts
+++ b/src/app/authoring-tool/edit-connected-components-with-background/edit-connected-components-with-background.component.spec.ts
@@ -43,23 +43,20 @@ function createConnectedComponentObject(nodeId: string, componentId: string, typ
 function afterComponentIdChanged() {
   describe('afterComponentIdChanged', () => {
     let connectedComponent: any;
-    let getComponentByNodeIdAndComponentIdSpy: any;
+    let getComponentSpy: any;
     beforeEach(() => {
       component.componentTypesThatCanImportWorkAsBackground = ['Draw'];
-      getComponentByNodeIdAndComponentIdSpy = spyOn(
-        TestBed.inject(ProjectService),
-        'getComponentByNodeIdAndComponentId'
-      );
+      getComponentSpy = spyOn(TestBed.inject(ProjectService), 'getComponent');
       connectedComponent = createConnectedComponentObject(nodeId1, componentId1, importWorkType);
     });
     it('should set import work as background', () => {
-      setSpyReturnComponentType(getComponentByNodeIdAndComponentIdSpy, 'Draw');
+      setSpyReturnComponentType(getComponentSpy, 'Draw');
       expect(connectedComponent.importWorkAsBackground).toBeUndefined();
       component.afterComponentIdChanged(connectedComponent);
       expect(connectedComponent.importWorkAsBackground).toEqual(true);
     });
     it('should not set import work as background', () => {
-      setSpyReturnComponentType(getComponentByNodeIdAndComponentIdSpy, 'Graph');
+      setSpyReturnComponentType(getComponentSpy, 'Graph');
       expect(connectedComponent.importWorkAsBackground).toBeUndefined();
       component.afterComponentIdChanged(connectedComponent);
       expect(connectedComponent.importWorkAsBackground).toBeUndefined();
@@ -67,8 +64,8 @@ function afterComponentIdChanged() {
   });
 }
 
-function setSpyReturnComponentType(getComponentByNodeIdAndComponentIdSpy: any, type: string): void {
-  getComponentByNodeIdAndComponentIdSpy.and.returnValue({
+function setSpyReturnComponentType(getComponentSpy: any, type: string): void {
+  getComponentSpy.and.returnValue({
     nodeId: nodeId1,
     componentId: componentId1,
     type: type

--- a/src/app/authoring-tool/edit-connected-components/edit-connected-components.component.ts
+++ b/src/app/authoring-tool/edit-connected-components/edit-connected-components.component.ts
@@ -7,24 +7,12 @@ import { ProjectService } from '../../../assets/wise5/services/projectService';
   styleUrls: ['./edit-connected-components.component.scss']
 })
 export class EditConnectedComponentsComponent implements OnInit {
-  @Input()
-  componentContent: any;
-
-  @Input()
-  componentId: string;
-
-  @Input()
-  nodeId: string;
-
-  @Input()
-  allowedConnectedComponentTypes: string[] = [];
-
-  @Input()
-  connectedComponents: any[] = [];
-
-  @Output()
-  connectedComponentsChanged: EventEmitter<any> = new EventEmitter();
-
+  @Input() componentContent: any;
+  @Input() componentId: string;
+  @Input() nodeId: string;
+  @Input() allowedConnectedComponentTypes: string[] = [];
+  @Input() connectedComponents: any[] = [];
+  @Output() connectedComponentsChanged: EventEmitter<any> = new EventEmitter();
   nodeIds: string[];
 
   constructor(protected ProjectService: ProjectService) {}
@@ -126,7 +114,7 @@ export class EditConnectedComponentsComponent implements OnInit {
   }
 
   getConnectedComponentType(connectedComponent: any): string {
-    const component: any = this.ProjectService.getComponentByNodeIdAndComponentId(
+    const component: any = this.ProjectService.getComponent(
       connectedComponent.nodeId,
       connectedComponent.componentId
     );

--- a/src/app/services/annotationService.spec.ts
+++ b/src/app/services/annotationService.spec.ts
@@ -74,10 +74,7 @@ function getTotalScore_omitInActiveNodes() {
 
 function getTotalScore_omitExcludFromTotalScoreNodes() {
   it('should omit scores for nodes marked as excludeFromTotalScore', () => {
-    projectService.getComponentByNodeIdAndComponentId(
-      'node3',
-      '0sef5ya2wj'
-    ).excludeFromTotalScore = true;
+    projectService.getComponent('node3', '0sef5ya2wj').excludeFromTotalScore = true;
     expect(service.getTotalScore(annotations)).toEqual(1);
   });
 }

--- a/src/app/services/copyComponentService.spec.ts
+++ b/src/app/services/copyComponentService.spec.ts
@@ -5,7 +5,7 @@ import { TeacherProjectService } from '../../assets/wise5/services/teacherProjec
 import { UtilService } from '../../assets/wise5/services/utilService';
 
 class MockProjectService {
-  getComponentByNodeIdAndComponentId() {}
+  getComponent() {}
   getUnusedComponentId() {}
 }
 class MockUtilService {
@@ -37,10 +37,7 @@ describe('CopyComponentService', () => {
 function copyComponents() {
   describe('copyComponents', () => {
     it('should return a copy of the specified components with new ids', () => {
-      spyOn(projectService, 'getComponentByNodeIdAndComponentId').and.returnValues(
-        { id: 'c1' },
-        { id: 'c2' }
-      );
+      spyOn(projectService, 'getComponent').and.returnValues({ id: 'c1' }, { id: 'c2' });
       spyOn(projectService, 'getUnusedComponentId').and.returnValues('c3', 'c4');
       const copies = service.copyComponents('node1', ['c1', 'c2']);
       expect(copies.length).toEqual(2);

--- a/src/app/services/projectService.spec.ts
+++ b/src/app/services/projectService.spec.ts
@@ -44,7 +44,7 @@ describe('ProjectService', () => {
   shouldReturnTheStartNodeOfTheProject();
   shouldReturnTheNodeByNodeId();
   shouldReturnTheNodeTitleByNodeId();
-  shouldGetTheComponentByNodeIdAndComponentId();
+  shouldGetTheComponent();
   shouldGetTheComponentPositionByNodeIdAndComonentId();
   shouldGetTheComponentsByNodeId();
   shouldCheckOrderBetweenStepGroupAndStepGroup();
@@ -214,29 +214,26 @@ function shouldReturnTheNodeTitleByNodeId() {
   });
 }
 
-function shouldGetTheComponentByNodeIdAndComponentId() {
+function shouldGetTheComponent() {
   it('should get the component by node id and component id', () => {
     service.setProject(scootersProjectJSON);
-    const nullNodeIdResult = service.getComponentByNodeIdAndComponentId(null, '57lxhwfp5r');
+    const nullNodeIdResult = service.getComponent(null, '57lxhwfp5r');
     expect(nullNodeIdResult).toBeNull();
 
-    const nullComponentIdResult = service.getComponentByNodeIdAndComponentId('node13', null);
+    const nullComponentIdResult = service.getComponent('node13', null);
     expect(nullComponentIdResult).toBeNull();
 
-    const nodeIdDNEResult = service.getComponentByNodeIdAndComponentId('badNodeId', '57lxhwfp5r');
+    const nodeIdDNEResult = service.getComponent('badNodeId', '57lxhwfp5r');
     expect(nodeIdDNEResult).toBeNull();
 
-    const componentIdDNEResult = service.getComponentByNodeIdAndComponentId(
-      'node13',
-      'badComponentId'
-    );
+    const componentIdDNEResult = service.getComponent('node13', 'badComponentId');
     expect(componentIdDNEResult).toBeNull();
 
-    const componentExists = service.getComponentByNodeIdAndComponentId('node13', '57lxhwfp5r');
+    const componentExists = service.getComponent('node13', '57lxhwfp5r');
     expect(componentExists).not.toBe(null);
     expect(componentExists.type).toEqual('HTML');
 
-    const componentExists2 = service.getComponentByNodeIdAndComponentId('node9', 'mnzx68ix8h');
+    const componentExists2 = service.getComponent('node9', 'mnzx68ix8h');
     expect(componentExists2).not.toBe(null);
     expect(componentExists2.type).toEqual('embedded');
     expect(componentExists2.url).toEqual('NewtonScooters-potential-kinetic.html');
@@ -483,7 +480,7 @@ function getMaxScoreForNode_noExcludedComponents_returnSumOfComponentMaxScores()
 function getMaxScoreForNode_excludeComponentFromTotalScore_returnExcludedScore() {
   it('should return sum of component max scores that are not excluded', () => {
     service.setProject(demoProjectJSON);
-    service.getComponentByNodeIdAndComponentId('node10', '2upmb3om1q').excludeFromTotalScore = true;
+    service.getComponent('node10', '2upmb3om1q').excludeFromTotalScore = true;
     expect(service.getMaxScoreForNode('node10')).toEqual(6);
   });
 }
@@ -497,7 +494,7 @@ function getMaxScoreForComponent() {
 function getMaxScoreForComponent_excludeFromTotalScore_returnNull() {
   it('should return null if component is excluded from total score', () => {
     service.setProject(demoProjectJSON);
-    service.getComponentByNodeIdAndComponentId('node2', '7edwu1p29b').excludeFromTotalScore = true;
+    service.getComponent('node2', '7edwu1p29b').excludeFromTotalScore = true;
     expect(service.getMaxScoreForComponent('node2', '7edwu1p29b')).toBeNull();
   });
 }

--- a/src/app/services/studentDataService.spec.ts
+++ b/src/app/services/studentDataService.spec.ts
@@ -1221,7 +1221,7 @@ function shouldCheckIsCompleted() {
     const nodeEvents = [];
     spyOn(service, 'getEventsByNodeId').and.returnValue(nodeEvents);
     const component = { id: 'component1', type: 'OpenResponse' };
-    spyOn(projectService, 'getComponentByNodeIdAndComponentId').and.returnValue(component);
+    spyOn(projectService, 'getComponent').and.returnValue(component);
     const node = { id: 'node1' };
     spyOn(projectService, 'getNodeById').and.returnValue(node);
     expect(service.isCompleted('node1', 'component1')).toEqual(false);
@@ -1234,7 +1234,7 @@ function shouldCheckIsCompleted() {
     const nodeEvents = [];
     spyOn(service, 'getEventsByNodeId').and.returnValue(nodeEvents);
     const component = { id: 'component1', type: 'OpenResponse' };
-    spyOn(projectService, 'getComponentByNodeIdAndComponentId').and.returnValue(component);
+    spyOn(projectService, 'getComponent').and.returnValue(component);
     const node = { id: 'node1' };
     spyOn(projectService, 'getNodeById').and.returnValue(node);
     expect(service.isCompleted('node1', 'component1')).toEqual(true);

--- a/src/app/services/teacherProjectService.spec.ts
+++ b/src/app/services/teacherProjectService.spec.ts
@@ -166,9 +166,9 @@ function testDeleteComponent() {
   describe('deleteComponent', () => {
     it('should delete the component from the node', () => {
       service.setProject(demoProjectJSON);
-      expect(service.getComponentByNodeIdAndComponentId('node1', 'zh4h1urdys')).not.toBeNull();
+      expect(service.getComponent('node1', 'zh4h1urdys')).not.toBeNull();
       service.deleteComponent('node1', 'zh4h1urdys');
-      expect(service.getComponentByNodeIdAndComponentId('node1', 'zh4h1urdys')).toBeNull();
+      expect(service.getComponent('node1', 'zh4h1urdys')).toBeNull();
     });
   });
 }

--- a/src/assets/wise5/authoringTool/components/component-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/components/component-authoring.component.ts
@@ -8,12 +8,8 @@ import { TeacherProjectService } from '../../services/teacherProjectService';
 
 @Directive()
 export abstract class ComponentAuthoring {
-  @Input()
-  nodeId: string;
-
-  @Input()
-  componentId: string;
-
+  @Input() nodeId: string;
+  @Input() componentId: string;
   inputChange: Subject<string> = new Subject<string>();
   promptChange: Subject<string> = new Subject<string>();
   allowedConnectedComponentTypes: string[];
@@ -36,7 +32,7 @@ export abstract class ComponentAuthoring {
   ) {}
 
   ngOnInit() {
-    this.authoringComponentContent = this.ProjectService.getComponentByNodeIdAndComponentId(
+    this.authoringComponentContent = this.ProjectService.getComponent(
       this.nodeId,
       this.componentId
     );
@@ -145,8 +141,8 @@ export abstract class ComponentAuthoring {
     return this.ProjectService.getComponentsByNodeId(nodeId);
   }
 
-  getComponentByNodeIdAndComponentId(nodeId: string, componentId: string) {
-    return this.ProjectService.getComponentByNodeIdAndComponentId(nodeId, componentId);
+  getComponent(nodeId: string, componentId: string): any {
+    return this.ProjectService.getComponent(nodeId, componentId);
   }
 
   reloadPreview() {

--- a/src/assets/wise5/authoringTool/components/preview-component-dialog/preview-component-dialog.component.ts
+++ b/src/assets/wise5/authoringTool/components/preview-component-dialog/preview-component-dialog.component.ts
@@ -6,11 +6,8 @@ import { ProjectService } from '../../../services/projectService';
   styleUrls: ['preview-component-dialog.component.scss']
 })
 export class PreviewComponentDialogComponent implements OnInit {
-  @Input()
-  componentId: string;
-
-  @Input()
-  nodeId: string;
+  @Input() componentId: string;
+  @Input() nodeId: string;
 
   canSaveStarterState: boolean = false;
 
@@ -21,10 +18,7 @@ export class PreviewComponentDialogComponent implements OnInit {
   constructor(private projectService: ProjectService) {}
 
   ngOnInit(): void {
-    const component = this.projectService.getComponentByNodeIdAndComponentId(
-      this.nodeId,
-      this.componentId
-    );
+    const component = this.projectService.getComponent(this.nodeId, this.componentId);
     this.canSaveStarterState = this.componentTypesWithStarterStates.includes(component.type);
   }
 

--- a/src/assets/wise5/authoringTool/components/preview-component/preview-component.component.ts
+++ b/src/assets/wise5/authoringTool/components/preview-component/preview-component.component.ts
@@ -16,7 +16,7 @@ export class PreviewComponentComponent implements OnInit {
 
   ngOnInit() {
     this.componentContent = this.projectService.injectAssetPaths(
-      this.projectService.getComponentByNodeIdAndComponentId(this.nodeId, this.componentId)
+      this.projectService.getComponent(this.nodeId, this.componentId)
     );
   }
 

--- a/src/assets/wise5/authoringTool/node/advanced/branch/node-advanced-branch-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/advanced/branch/node-advanced-branch-authoring.component.ts
@@ -427,7 +427,7 @@ export class NodeAdvancedBranchAuthoringComponent implements OnInit {
   }
 
   createBranchUpdateChoiceChosenIds() {
-    const component = this.ProjectService.getComponentByNodeIdAndComponentId(
+    const component = this.ProjectService.getComponent(
       this.createBranchNodeId,
       this.createBranchComponentId
     );

--- a/src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts
@@ -389,7 +389,7 @@ export class NodeAdvancedConstraintAuthoringComponent implements OnInit {
 
   getChoiceTypeByNodeIdAndComponentId(nodeId: string, componentId: string): string {
     let choiceType = null;
-    let component = this.ProjectService.getComponentByNodeIdAndComponentId(nodeId, componentId);
+    let component = this.ProjectService.getComponent(nodeId, componentId);
     if (component != null && component.choiceType != null) {
       choiceType = component.choiceType;
     }

--- a/src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts
@@ -218,7 +218,7 @@ export class NodeAdvancedPathAuthoringComponent implements OnInit {
 
   getChoiceTypeByNodeIdAndComponentId(nodeId, componentId) {
     let choiceType = null;
-    let component = this.ProjectService.getComponentByNodeIdAndComponentId(nodeId, componentId);
+    let component = this.ProjectService.getComponent(nodeId, componentId);
     if (component != null && component.choiceType != null) {
       choiceType = component.choiceType;
     }

--- a/src/assets/wise5/authoringTool/node/nodeAuthoringComponent.ts
+++ b/src/assets/wise5/authoringTool/node/nodeAuthoringComponent.ts
@@ -576,10 +576,7 @@ class NodeAuthoringController {
   getComponentObjectsForEventData(componentIds) {
     const componentObjects = [];
     for (const componentId of componentIds) {
-      const component = this.ProjectService.getComponentByNodeIdAndComponentId(
-        this.nodeId,
-        componentId
-      );
+      const component = this.ProjectService.getComponent(this.nodeId, componentId);
       if (component != null) {
         componentObjects.push({
           componentId: component.id,

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-workgroup-item/milestone-workgroup-item.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-workgroup-item/milestone-workgroup-item.component.ts
@@ -65,10 +65,7 @@ export class MilestoneWorkgroupItemComponent implements OnInit {
     const lastLocation = this.locations[this.locations.length - 1];
     this.lastNodeId = lastLocation.nodeId;
     this.lastComponentId = lastLocation.componentId;
-    this.lastComponent = this.projectService.getComponentByNodeIdAndComponentId(
-      this.lastNodeId,
-      this.lastComponentId
-    );
+    this.lastComponent = this.projectService.getComponent(this.lastNodeId, this.lastComponentId);
     this.setLastComponentMaxScore();
   }
 
@@ -76,10 +73,7 @@ export class MilestoneWorkgroupItemComponent implements OnInit {
     const firstLocation = this.locations[0];
     this.firstComponentId = firstLocation.componentId;
     this.firstNodeId = firstLocation.nodeId;
-    this.firstComponent = this.projectService.getComponentByNodeIdAndComponentId(
-      this.firstNodeId,
-      this.firstComponentId
-    );
+    this.firstComponent = this.projectService.getComponent(this.firstNodeId, this.firstComponentId);
     this.setFirstComponentMaxScore();
   }
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.ts
@@ -31,10 +31,7 @@ export class WorkgroupComponentGradingComponent {
 
   ngOnInit() {
     this.teacherWorkgroupId = this.ConfigService.getWorkgroupId();
-    this.component = this.ProjectService.getComponentByNodeIdAndComponentId(
-      this.nodeId,
-      this.componentId
-    );
+    this.component = this.ProjectService.getComponent(this.nodeId, this.componentId);
     this.componentStates = this.TeacherDataService.getComponentStatesByWorkgroupIdAndComponentId(
       this.workgroupId,
       this.componentId

--- a/src/assets/wise5/classroomMonitor/dataExport/dataExportController.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/dataExportController.ts
@@ -424,7 +424,7 @@ class DataExportController {
         componentState.componentId
       ) + 1;
     row[columnNameToNumber['Component Part Number']] = componentPartNumber;
-    var component = this.ProjectService.getComponentByNodeIdAndComponentId(
+    var component = this.ProjectService.getComponent(
       componentState.nodeId,
       componentState.componentId
     );
@@ -1214,10 +1214,7 @@ class DataExportController {
     const nodeId = data.nodeId;
     const componentId = data.componentId;
     if (nodeId != null && componentId != null) {
-      const component = this.ProjectService.getComponentByNodeIdAndComponentId(
-        data.nodeId,
-        data.componentId
-      );
+      const component = this.ProjectService.getComponent(data.nodeId, data.componentId);
       this.setComponentType(row, columnNameToNumber, component);
       this.setComponentPrompt(row, columnNameToNumber, component);
     }
@@ -1390,7 +1387,7 @@ class DataExportController {
     row[columnNameToNumber['Note Item ID']] = notebookItem.localNotebookItemId;
     row[columnNameToNumber['Node ID']] = notebookItem.nodeId;
     row[columnNameToNumber['Component ID']] = notebookItem.componentId;
-    const component = this.ProjectService.getComponentByNodeIdAndComponentId(
+    const component = this.ProjectService.getComponent(
       notebookItem.nodeId,
       notebookItem.componentId
     );
@@ -1501,7 +1498,7 @@ class DataExportController {
     row[columnNameToNumber['ID']] = notification.id;
     row[columnNameToNumber['Node ID']] = notification.nodeId;
     row[columnNameToNumber['Component ID']] = notification.componentId;
-    const component = this.ProjectService.getComponentByNodeIdAndComponentId(
+    const component = this.ProjectService.getComponent(
       notification.nodeId,
       notification.componentId
     );

--- a/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.html
+++ b/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.html
@@ -413,7 +413,7 @@
           </mat-option>
         </mat-select>
       </mat-form-field>
-      <div *ngIf="getComponentByNodeIdAndComponentId(object.dataSource.nodeId, object.dataSource.componentId).type === 'Graph'"
+      <div *ngIf="getComponent(object.dataSource.nodeId, object.dataSource.componentId).type === 'Graph'"
            fxLayout="row wrap">
         <mat-form-field class="index-input">
           <mat-label i18n>Trial Index</mat-label>

--- a/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.spec.ts
+++ b/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.spec.ts
@@ -47,10 +47,9 @@ describe('AnimationAuthoring', () => {
     fixture = TestBed.createComponent(AnimationAuthoring);
     component = fixture.componentInstance;
     const componentContent = createComponentContent();
-    spyOn(
-      TestBed.inject(TeacherProjectService),
-      'getComponentByNodeIdAndComponentId'
-    ).and.returnValue(JSON.parse(JSON.stringify(componentContent)));
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue(
+      JSON.parse(JSON.stringify(componentContent))
+    );
     spyOn(component, 'componentChanged');
     component.componentContent = JSON.parse(JSON.stringify(componentContent));
     fixture.detectChanges();

--- a/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.ts
+++ b/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.ts
@@ -214,7 +214,7 @@ export class AnimationAuthoring extends ComponentAuthoring {
   dataSourceComponentChanged(authoredObject: any): void {
     const nodeId = authoredObject.dataSource.nodeId;
     const componentId = authoredObject.dataSource.componentId;
-    const component = this.getComponentByNodeIdAndComponentId(nodeId, componentId);
+    const component = this.getComponent(nodeId, componentId);
     authoredObject.dataSource = {
       nodeId: nodeId,
       componentId: componentId
@@ -289,9 +289,9 @@ export class AnimationAuthoring extends ComponentAuthoring {
     });
   }
 
-  getComponentByNodeIdAndComponentId(nodeId: string, componentId: string): any {
+  getComponent(nodeId: string, componentId: string): any {
     if (nodeId != null && componentId != null) {
-      const component = super.getComponentByNodeIdAndComponentId(nodeId, componentId);
+      const component = super.getComponent(nodeId, componentId);
       if (component != null) {
         return component;
       }

--- a/src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.spec.ts
+++ b/src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.spec.ts
@@ -15,7 +15,7 @@ import { AudioOscillatorAuthoring } from './audio-oscillator-authoring.component
 
 let component: AudioOscillatorAuthoring;
 let fixture: ComponentFixture<AudioOscillatorAuthoring>;
-let getComponentByNodeIdAndComponentIdSpy;
+let getComponentSpy;
 
 describe('AudioOscillatorAuthoring', () => {
   beforeEach(() => {
@@ -38,11 +38,8 @@ describe('AudioOscillatorAuthoring', () => {
     component = fixture.componentInstance;
     const componentContent = createComponentContent();
     component.componentContent = componentContent;
-    getComponentByNodeIdAndComponentIdSpy = spyOn(
-      TestBed.inject(TeacherProjectService),
-      'getComponentByNodeIdAndComponentId'
-    );
-    getComponentByNodeIdAndComponentIdSpy.and.returnValue(componentContent);
+    getComponentSpy = spyOn(TestBed.inject(TeacherProjectService), 'getComponent');
+    getComponentSpy.and.returnValue(componentContent);
     fixture.detectChanges();
   });
 

--- a/src/assets/wise5/components/audioOscillator/audio-oscillator-show-work/audio-oscillator-show-work.component.spec.ts
+++ b/src/assets/wise5/components/audioOscillator/audio-oscillator-show-work/audio-oscillator-show-work.component.spec.ts
@@ -16,7 +16,7 @@ describe('AudioOscillatorShowWorkComponent', () => {
       declarations: [AudioOscillatorShowWorkComponent]
     });
     fixture = TestBed.createComponent(AudioOscillatorShowWorkComponent);
-    spyOn(TestBed.inject(ProjectService), 'getComponentByNodeIdAndComponentId').and.returnValue({});
+    spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({});
     component = fixture.componentInstance;
     const audioOscillatorStudentData = {
       amplitudesPlayed: null,

--- a/src/assets/wise5/components/component-show-work.directive.ts
+++ b/src/assets/wise5/components/component-show-work.directive.ts
@@ -14,10 +14,7 @@ export abstract class ComponentShowWorkDirective {
   constructor(protected nodeService: NodeService, protected projectService: ProjectService) {}
 
   ngOnInit() {
-    this.componentContent = this.projectService.getComponentByNodeIdAndComponentId(
-      this.nodeId,
-      this.componentId
-    );
+    this.componentContent = this.projectService.getComponent(this.nodeId, this.componentId);
   }
 
   ngAfterViewInit(): void {

--- a/src/assets/wise5/components/component/component.component.ts
+++ b/src/assets/wise5/components/component/component.component.ts
@@ -45,10 +45,7 @@ export class ComponentComponent {
   }
 
   setComponentContent(): void {
-    let componentContent = this.projectService.getComponentByNodeIdAndComponentId(
-      this.nodeId,
-      this.componentId
-    );
+    let componentContent = this.projectService.getComponent(this.nodeId, this.componentId);
     componentContent = this.projectService.injectAssetPaths(componentContent);
     componentContent = this.configService.replaceStudentNames(componentContent);
     if (

--- a/src/assets/wise5/components/conceptMap/concept-map-authoring/concept-map-authoring.component.spec.ts
+++ b/src/assets/wise5/components/conceptMap/concept-map-authoring/concept-map-authoring.component.spec.ts
@@ -88,10 +88,9 @@ describe('ConceptMapAuthoringComponent', () => {
     });
     fixture = TestBed.createComponent(ConceptMapAuthoring);
     component = fixture.componentInstance;
-    spyOn(
-      TestBed.inject(TeacherProjectService),
-      'getComponentByNodeIdAndComponentId'
-    ).and.returnValue(JSON.parse(JSON.stringify(componentContent)));
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue(
+      JSON.parse(JSON.stringify(componentContent))
+    );
     component.componentContent = JSON.parse(JSON.stringify(componentContent));
     fixture.detectChanges();
   });

--- a/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.spec.ts
+++ b/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.spec.ts
@@ -62,10 +62,7 @@ describe('EditConceptMapAdvancedComponent', () => {
   });
 
   beforeEach(() => {
-    spyOn(
-      TestBed.inject(TeacherProjectService),
-      'getComponentByNodeIdAndComponentId'
-    ).and.returnValue({
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue({
       rules: []
     });
     spyOn(TestBed.inject(NotebookService), 'isNotebookEnabled').and.returnValue(true);

--- a/src/assets/wise5/components/conceptMap/edit-concept-map-connected-components/edit-concept-map-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/conceptMap/edit-concept-map-connected-components/edit-concept-map-connected-components.component.spec.ts
@@ -56,7 +56,7 @@ function createLink(id: string, label: string, color: string = 'blue'): any {
 function askIfWantToCopyNodesAndLinks() {
   describe('askIfWantToCopyNodesAndLinks', () => {
     beforeEach(() => {
-      spyOn(TestBed.inject(ProjectService), 'getComponentByNodeIdAndComponentId').and.returnValue({
+      spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({
         id: componentId1,
         nodes: [createNode('node1', 'Tree', 'tree.png')],
         links: [createLink('link1', 'Energy', 'green')]

--- a/src/assets/wise5/components/conceptMap/edit-concept-map-connected-components/edit-concept-map-connected-components.component.ts
+++ b/src/assets/wise5/components/conceptMap/edit-concept-map-connected-components/edit-concept-map-connected-components.component.ts
@@ -38,10 +38,7 @@ export class EditConceptMapConnectedComponentsComponent extends EditConnectedCom
           $localize`Warning: This will delete all existing nodes and links in this component.`
       )
     ) {
-      const connectedComponentContent = this.ProjectService.getComponentByNodeIdAndComponentId(
-        nodeId,
-        componentId
-      );
+      const connectedComponentContent = this.ProjectService.getComponent(nodeId, componentId);
       this.componentContent.nodes = connectedComponentContent.nodes;
       this.componentContent.links = connectedComponentContent.links;
       this.connectedComponentChanged();

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.spec.ts
@@ -31,10 +31,9 @@ describe('DialogGuidanceAuthoringComponent', () => {
     });
     fixture = TestBed.createComponent(DialogGuidanceAuthoringComponent);
     component = fixture.componentInstance;
-    spyOn(
-      TestBed.inject(TeacherProjectService),
-      'getComponentByNodeIdAndComponentId'
-    ).and.returnValue(JSON.parse(JSON.stringify(componentContent)));
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue(
+      JSON.parse(JSON.stringify(componentContent))
+    );
     component.componentContent = JSON.parse(JSON.stringify(componentContent));
     fixture.detectChanges();
   });

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.spec.ts
@@ -53,10 +53,9 @@ describe('EditDialogGuidanceComputerAvatarComponent', () => {
       new ComputerAvatar('girl', 'Girl', 'girl.png')
     ];
     spyOn(TestBed.inject(ComputerAvatarService), 'getAvatars').and.returnValue(allComputerAvatars);
-    spyOn(
-      TestBed.inject(TeacherProjectService),
-      'getComponentByNodeIdAndComponentId'
-    ).and.returnValue(JSON.parse(JSON.stringify(componentContent)));
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue(
+      JSON.parse(JSON.stringify(componentContent))
+    );
     component.computerAvatarSettings = {
       ids: [],
       label: 'Thought Buddy',

--- a/src/assets/wise5/components/draw/draw-authoring/draw-authoring.component.spec.ts
+++ b/src/assets/wise5/components/draw/draw-authoring/draw-authoring.component.spec.ts
@@ -51,10 +51,9 @@ describe('DrawAuthoringComponent', () => {
     });
     fixture = TestBed.createComponent(DrawAuthoring);
     component = fixture.componentInstance;
-    spyOn(
-      TestBed.inject(TeacherProjectService),
-      'getComponentByNodeIdAndComponentId'
-    ).and.returnValue(JSON.parse(JSON.stringify(componentContent)));
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue(
+      JSON.parse(JSON.stringify(componentContent))
+    );
     component.componentContent = JSON.parse(JSON.stringify(componentContent));
     fixture.detectChanges();
   });

--- a/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.spec.ts
+++ b/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.spec.ts
@@ -22,10 +22,9 @@ describe('EmbeddedAuthoringComponent', () => {
     fixture = TestBed.createComponent(EmbeddedAuthoring);
     component = fixture.componentInstance;
     const componentContent = createComponentContent();
-    spyOn(
-      TestBed.inject(TeacherProjectService),
-      'getComponentByNodeIdAndComponentId'
-    ).and.returnValue(JSON.parse(JSON.stringify(componentContent)));
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue(
+      JSON.parse(JSON.stringify(componentContent))
+    );
     component.componentContent = JSON.parse(JSON.stringify(componentContent));
     fixture.detectChanges();
   });

--- a/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.spec.ts
+++ b/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.spec.ts
@@ -63,10 +63,7 @@ describe('EditGraphAdvancedComponent', () => {
   });
 
   beforeEach(() => {
-    spyOn(
-      TestBed.inject(TeacherProjectService),
-      'getComponentByNodeIdAndComponentId'
-    ).and.returnValue({
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue({
       xAxis: {},
       yAxis: {}
     });

--- a/src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.spec.ts
+++ b/src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.spec.ts
@@ -47,10 +47,9 @@ describe('GraphAuthoringComponent', () => {
     fixture = TestBed.createComponent(GraphAuthoring);
     component = fixture.componentInstance;
     const componentContent = createComponentContent();
-    spyOn(
-      TestBed.inject(TeacherProjectService),
-      'getComponentByNodeIdAndComponentId'
-    ).and.returnValue(JSON.parse(JSON.stringify(componentContent)));
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue(
+      JSON.parse(JSON.stringify(componentContent))
+    );
     spyOn(component, 'componentChanged').and.callFake(() => {});
     component.componentContent = JSON.parse(JSON.stringify(componentContent));
     fixture.detectChanges();

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -2608,7 +2608,7 @@ export class GraphStudent extends ComponentStudent {
           connectedComponent.showClassmateWorkSource
         )
       );
-      let component = this.ProjectService.getComponentByNodeIdAndComponentId(nodeId, componentId);
+      let component = this.ProjectService.getComponent(nodeId, componentId);
       component = this.ProjectService.injectAssetPaths(component);
       connectedComponentBackgroundImage = component.backgroundImage;
     }
@@ -2651,7 +2651,7 @@ export class GraphStudent extends ComponentStudent {
           connectedComponentBackgroundImage = latestComponentState.studentData.backgroundImage;
         }
         if (connectedComponent.importGraphSettings) {
-          const component = this.ProjectService.getComponentByNodeIdAndComponentId(
+          const component = this.ProjectService.getComponent(
             connectedComponent.nodeId,
             connectedComponent.componentId
           );

--- a/src/assets/wise5/components/match/edit-match-connected-components/edit-match-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/match/edit-match-connected-components/edit-match-connected-components.component.spec.ts
@@ -61,9 +61,7 @@ function askIfWantToCopyChoicesAndBuckets() {
         choices: [createChoice('choice1', 'A Choice')],
         buckets: [createBucket('bucket1', 'A Bucket')]
       };
-      spyOn(TestBed.inject(ProjectService), 'getComponentByNodeIdAndComponentId').and.returnValue(
-        componentContent
-      );
+      spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue(componentContent);
       connectedComponent = createConnectedComponentObject(nodeId1, componentId1, 'importWork');
     });
     it('should copy choices and buckets from the connected component', () => {

--- a/src/assets/wise5/components/match/edit-match-connected-components/edit-match-connected-components.component.ts
+++ b/src/assets/wise5/components/match/edit-match-connected-components/edit-match-connected-components.component.ts
@@ -29,7 +29,7 @@ export class EditMatchConnectedComponentsComponent extends EditConnectedComponen
       )
     ) {
       const connectedComponentContent = this.UtilService.makeCopyOfJSONObject(
-        this.ProjectService.getComponentByNodeIdAndComponentId(nodeId, componentId)
+        this.ProjectService.getComponent(nodeId, componentId)
       );
       this.componentContent.choices = connectedComponentContent.choices;
       this.componentContent.buckets = connectedComponentContent.buckets;

--- a/src/assets/wise5/components/match/match-student/match-student.component.spec.ts
+++ b/src/assets/wise5/components/match/match-student/match-student.component.spec.ts
@@ -96,7 +96,7 @@ describe('MatchStudentComponent', () => {
       ]
     };
     component.componentContent = componentContent;
-    spyOn(TestBed.inject(ProjectService), 'getComponentByNodeIdAndComponentId').and.returnValue(
+    spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue(
       JSON.parse(JSON.stringify(componentContent))
     );
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});

--- a/src/assets/wise5/components/match/match-student/match-student.component.ts
+++ b/src/assets/wise5/components/match/match-student/match-student.component.ts
@@ -578,7 +578,7 @@ export class MatchStudent extends ComponentStudent {
     componentState.isSubmit = this.isSubmit;
     const studentData: any = {
       buckets: this.cleanBuckets(
-        this.ProjectService.getComponentByNodeIdAndComponentId(this.nodeId, this.componentId),
+        this.ProjectService.getComponent(this.nodeId, this.componentId),
         this.getDeepCopyOfBuckets()
       ),
       submitCounter: this.submitCounter

--- a/src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.spec.ts
@@ -54,9 +54,7 @@ function askIfWantToCopyChoices() {
         ],
         choiceType: 'radio'
       };
-      spyOn(TestBed.inject(ProjectService), 'getComponentByNodeIdAndComponentId').and.returnValue(
-        componentContent
-      );
+      spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue(componentContent);
       connectedComponent = createConnectedComponentObject(nodeId1, componentId1, 'importWork');
     });
     it('should copy choices from connected component', () => {

--- a/src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.ts
+++ b/src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.ts
@@ -34,7 +34,7 @@ export class EditMultipleChoiceConnectedComponentsComponent extends EditConnecte
   }
 
   copyChoiceTypeFromComponent(nodeId: string, componentId: string): void {
-    const component = this.ProjectService.getComponentByNodeIdAndComponentId(nodeId, componentId);
+    const component = this.ProjectService.getComponent(nodeId, componentId);
     this.componentContent.choiceType = component.choiceType;
   }
 
@@ -43,7 +43,7 @@ export class EditMultipleChoiceConnectedComponentsComponent extends EditConnecte
   }
 
   getCopyOfChoicesFromComponent(nodeId: string, componentId: string): void {
-    const component = this.ProjectService.getComponentByNodeIdAndComponentId(nodeId, componentId);
+    const component = this.ProjectService.getComponent(nodeId, componentId);
     return this.UtilService.makeCopyOfJSONObject(component.choices);
   }
 }

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.ts
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.ts
@@ -392,7 +392,7 @@ export class MultipleChoiceStudent extends ComponentStudent {
 
   getStudentChosenRadioChoice(): any[] {
     const studentChoiceObjects = [];
-    const originalComponentContent = this.ProjectService.getComponentByNodeIdAndComponentId(
+    const originalComponentContent = this.ProjectService.getComponent(
       this.nodeId,
       this.componentId
     );
@@ -409,7 +409,7 @@ export class MultipleChoiceStudent extends ComponentStudent {
 
   getStudentChosenCheckboxChoice(): any[] {
     const studentChoiceObjects = [];
-    const originalComponentContent = this.ProjectService.getComponentByNodeIdAndComponentId(
+    const originalComponentContent = this.ProjectService.getComponent(
       this.nodeId,
       this.componentId
     );

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
@@ -66,10 +66,7 @@ describe('EditOpenResponseAdvancedComponent', () => {
   });
 
   beforeEach(() => {
-    spyOn(
-      TestBed.inject(TeacherProjectService),
-      'getComponentByNodeIdAndComponentId'
-    ).and.returnValue({});
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue({});
     spyOn(TestBed.inject(NotebookService), 'isNotebookEnabled').and.returnValue(true);
     spyOn(TestBed.inject(TeacherProjectService), 'getFlattenedProjectAsNodeIds').and.returnValue([
       'node1',

--- a/src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.spec.ts
@@ -76,13 +76,12 @@ describe('PeerChatAuthoringComponent', () => {
       'node2',
       'node3'
     ]);
-    spyOn(TestBed.inject(ProjectService), 'getComponentByNodeIdAndComponentId').and.returnValue(
+    spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue(
       JSON.parse(JSON.stringify(componentContent))
     );
-    spyOn(
-      TestBed.inject(TeacherProjectService),
-      'getComponentByNodeIdAndComponentId'
-    ).and.returnValue(JSON.parse(JSON.stringify(componentContent)));
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue(
+      JSON.parse(JSON.stringify(componentContent))
+    );
     spyOn(component, 'componentChanged').and.callFake(() => {});
     component.componentContent = JSON.parse(JSON.stringify(componentContent));
     fixture.detectChanges();

--- a/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.spec.ts
@@ -52,7 +52,7 @@ describe('PeerChatGradingComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PeerChatGradingComponent);
-    spyOn(TestBed.inject(ProjectService), 'getComponentByNodeIdAndComponentId').and.returnValue({});
+    spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({});
     spyOn(TestBed.inject(ConfigService), 'getRunId').and.returnValue(1);
     spyOn(TestBed.inject(ConfigService), 'getWorkgroupId').and.returnValue(100);
     spyOn(TestBed.inject(ConfigService), 'getTeacherWorkgroupIds').and.returnValue([

--- a/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.spec.ts
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.spec.ts
@@ -42,10 +42,7 @@ describe('ShowGroupWorkAuthoringComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ShowGroupWorkAuthoringComponent);
-    spyOn(
-      TestBed.inject(TeacherProjectService),
-      'getComponentByNodeIdAndComponentId'
-    ).and.returnValue({});
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue({});
     spyOn(TestBed.inject(TeacherProjectService), 'getFlattenedProjectAsNodeIds').and.returnValue([
       nodeId1
     ]);

--- a/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.ts
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.ts
@@ -95,7 +95,7 @@ export class ShowGroupWorkStudentComponent extends ComponentStudent {
 
   private setShowWorkComponentContent(): void {
     this.showWorkComponentContent = this.projectService.injectAssetPaths(
-      this.projectService.getComponentByNodeIdAndComponentId(
+      this.projectService.getComponent(
         this.componentContent.showWorkNodeId,
         this.componentContent.showWorkComponentId
       )

--- a/src/assets/wise5/components/showMyWork/show-my-work-authoring/show-my-work-authoring.component.spec.ts
+++ b/src/assets/wise5/components/showMyWork/show-my-work-authoring/show-my-work-authoring.component.spec.ts
@@ -51,10 +51,7 @@ describe('ShowMyWorkAuthoringComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ShowMyWorkAuthoringComponent);
-    spyOn(
-      TestBed.inject(TeacherProjectService),
-      'getComponentByNodeIdAndComponentId'
-    ).and.returnValue({});
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue({});
     spyOn(TestBed.inject(TeacherProjectService), 'getFlattenedProjectAsNodeIds').and.returnValue([
       nodeId1
     ]);

--- a/src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.ts
+++ b/src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.ts
@@ -49,7 +49,7 @@ export class ShowMyWorkStudentComponent extends ComponentStudent {
 
   ngOnInit(): void {
     super.ngOnInit();
-    this.showWorkComponentContent = this.projectService.getComponentByNodeIdAndComponentId(
+    this.showWorkComponentContent = this.projectService.getComponent(
       this.componentContent.showWorkNodeId,
       this.componentContent.showWorkComponentId
     );

--- a/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.spec.ts
+++ b/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.spec.ts
@@ -23,7 +23,7 @@ export class MockConfigService {}
 
 let component: SummaryAuthoring;
 let fixture: ComponentFixture<SummaryAuthoring>;
-let getComponentByNodeIdAndComponentIdSpy;
+let getComponentSpy;
 
 describe('SummaryAuthoringComponent', () => {
   beforeEach(() => {
@@ -55,11 +55,8 @@ describe('SummaryAuthoringComponent', () => {
     component = fixture.componentInstance;
     const componentContent = createComponentContent();
     component.componentContent = JSON.parse(JSON.stringify(componentContent));
-    getComponentByNodeIdAndComponentIdSpy = spyOn(
-      TestBed.inject(TeacherProjectService),
-      'getComponentByNodeIdAndComponentId'
-    );
-    getComponentByNodeIdAndComponentIdSpy.and.returnValue(componentContent);
+    getComponentSpy = spyOn(TestBed.inject(TeacherProjectService), 'getComponent');
+    getComponentSpy.and.returnValue(componentContent);
     spyOn(component, 'componentChanged');
     fixture.detectChanges();
   });
@@ -158,7 +155,7 @@ function checkIfStudentDataTypeIsAvailableForAComponentWhenTrue() {
       prompt: 'This is hxh43zj46j',
       type: 'OpenResponse'
     };
-    getComponentByNodeIdAndComponentIdSpy.and.returnValue(componentContent);
+    getComponentSpy.and.returnValue(componentContent);
     const isAvailable = component.isStudentDataTypeAvailableForComponent(
       'node1',
       'hxh43zj46j',
@@ -175,7 +172,7 @@ function checkIfStudentDataTypeIsAvailableForAComponentWhenFalse() {
       prompt: 'This is hxh43zj46j',
       type: 'OpenResponse'
     };
-    getComponentByNodeIdAndComponentIdSpy.and.returnValue(componentContent);
+    getComponentSpy.and.returnValue(componentContent);
     const isAvailable = component.isStudentDataTypeAvailableForComponent(
       'node1',
       'hxh43zj46j',

--- a/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.ts
+++ b/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.ts
@@ -125,7 +125,7 @@ export class SummaryAuthoring extends ComponentAuthoring {
     componentId: string,
     studentDataType: string
   ): boolean {
-    const component = this.ProjectService.getComponentByNodeIdAndComponentId(nodeId, componentId);
+    const component = this.ProjectService.getComponent(nodeId, componentId);
     if (component != null) {
       if (studentDataType === 'scores') {
         return this.SummaryService.isScoresSummaryAvailableForComponentType(component.type);
@@ -140,7 +140,7 @@ export class SummaryAuthoring extends ComponentAuthoring {
     const nodeId = this.authoringComponentContent.summaryNodeId;
     const componentId = this.authoringComponentContent.summaryComponentId;
     if (nodeId != null && componentId != null) {
-      const component = this.ProjectService.getComponentByNodeIdAndComponentId(nodeId, componentId);
+      const component = this.ProjectService.getComponent(nodeId, componentId);
       if (component != null) {
         const componentService = this.componentServiceLookupService.getService(component.type);
         return componentService.componentHasCorrectAnswer(component);
@@ -153,7 +153,7 @@ export class SummaryAuthoring extends ComponentAuthoring {
     const nodeId = this.authoringComponentContent.summaryNodeId;
     const componentId = this.authoringComponentContent.summaryComponentId;
     if (nodeId != null && componentId != null) {
-      const component = this.ProjectService.getComponentByNodeIdAndComponentId(nodeId, componentId);
+      const component = this.ProjectService.getComponent(nodeId, componentId);
       if (component != null) {
         return component.choiceType === 'checkbox';
       }

--- a/src/assets/wise5/components/summary/summary-student/summary-student.component.spec.ts
+++ b/src/assets/wise5/components/summary/summary-student/summary-student.component.spec.ts
@@ -100,7 +100,7 @@ function getOtherPrompt() {
   describe('getOtherPrompt', () => {
     it('should get other prompt', () => {
       const prompt = 'Choose your favorite ice cream flavor.';
-      spyOn(TestBed.inject(ProjectService), 'getComponentByNodeIdAndComponentId').and.returnValue({
+      spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({
         prompt: prompt
       });
       expect(component.getOtherPrompt('node2', 'component2')).toEqual(prompt);

--- a/src/assets/wise5/components/summary/summary-student/summary-student.component.ts
+++ b/src/assets/wise5/components/summary/summary-student/summary-student.component.ts
@@ -88,10 +88,7 @@ export class SummaryStudent extends ComponentStudent {
   }
 
   getOtherPrompt(nodeId, componentId) {
-    const otherComponent = this.ProjectService.getComponentByNodeIdAndComponentId(
-      nodeId,
-      componentId
-    );
+    const otherComponent = this.ProjectService.getComponent(nodeId, componentId);
     if (otherComponent != null) {
       return otherComponent.prompt;
     }

--- a/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.spec.ts
+++ b/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.spec.ts
@@ -65,10 +65,7 @@ describe('EditTableAdvancedComponent', () => {
   });
 
   beforeEach(() => {
-    spyOn(
-      TestBed.inject(TeacherProjectService),
-      'getComponentByNodeIdAndComponentId'
-    ).and.returnValue(createComponent());
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue(createComponent());
     spyOn(TestBed.inject(NotebookService), 'isNotebookEnabled').and.returnValue(true);
     spyOn(TestBed.inject(TeacherProjectService), 'getFlattenedProjectAsNodeIds').and.returnValue([
       'node1',

--- a/src/assets/wise5/components/table/table-show-work/table-show-work.component.spec.ts
+++ b/src/assets/wise5/components/table/table-show-work/table-show-work.component.spec.ts
@@ -19,9 +19,7 @@ describe('TableShowWorkComponent', () => {
     const componentContent = {
       isDataExplorerEnabled: false
     };
-    spyOn(TestBed.inject(ProjectService), 'getComponentByNodeIdAndComponentId').and.returnValue(
-      componentContent
-    );
+    spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue(componentContent);
     component = fixture.componentInstance;
     component.componentContent = {};
     component.componentState = { studentData: { tableData: [] } };

--- a/src/assets/wise5/directives/generate-image-dialog/generate-image-dialog.component.spec.ts
+++ b/src/assets/wise5/directives/generate-image-dialog/generate-image-dialog.component.spec.ts
@@ -36,7 +36,7 @@ describe('GenerateImageDialogComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(GenerateImageDialogComponent);
-    spyOn(TestBed.inject(ProjectService), 'getComponentByNodeIdAndComponentId').and.returnValue({});
+    spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({});
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/assets/wise5/directives/student-summary-display/student-summary-display.component.spec.ts
+++ b/src/assets/wise5/directives/student-summary-display/student-summary-display.component.spec.ts
@@ -205,9 +205,7 @@ function initializeOtherComponent() {
         id: 'component2',
         type: otherComponentType
       };
-      spyOn(TestBed.inject(ProjectService), 'getComponentByNodeIdAndComponentId').and.returnValue(
-        otherComponent
-      );
+      spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue(otherComponent);
       component.initializeOtherComponent();
       expect(component.otherComponent).toEqual(otherComponent);
       expect(component.otherComponentType).toEqual(otherComponentType);

--- a/src/assets/wise5/directives/summary-display/summary-display.component.ts
+++ b/src/assets/wise5/directives/summary-display/summary-display.component.ts
@@ -93,10 +93,7 @@ export abstract class SummaryDisplay {
   }
 
   initializeOtherComponent() {
-    this.otherComponent = this.projectService.getComponentByNodeIdAndComponentId(
-      this.nodeId,
-      this.componentId
-    );
+    this.otherComponent = this.projectService.getComponent(this.nodeId, this.componentId);
     if (this.otherComponent != null) {
       this.otherComponentType = this.otherComponent.type;
     }

--- a/src/assets/wise5/services/copyComponentService.ts
+++ b/src/assets/wise5/services/copyComponentService.ts
@@ -21,7 +21,7 @@ export class CopyComponentService {
   }
 
   private copyComponent(nodeId: string, componentId: string, componentIdsToSkip: string[]): any {
-    const component = this.ProjectService.getComponentByNodeIdAndComponentId(nodeId, componentId);
+    const component = this.ProjectService.getComponent(nodeId, componentId);
     const newComponent = this.UtilService.makeCopyOfJSONObject(component);
     newComponent.id = this.ProjectService.getUnusedComponentId(componentIdsToSkip);
     return newComponent;

--- a/src/assets/wise5/services/notificationService.ts
+++ b/src/assets/wise5/services/notificationService.ts
@@ -58,7 +58,7 @@ export class NotificationService {
   ): Notification {
     const nodePosition = this.ProjectService.getNodePositionById(nodeId);
     const nodePositionAndTitle = this.ProjectService.getNodePositionAndTitleByNodeId(nodeId);
-    const component = this.ProjectService.getComponentByNodeIdAndComponentId(nodeId, componentId);
+    const component = this.ProjectService.getComponent(nodeId, componentId);
     let componentType = null;
     if (component != null) {
       componentType = component.type;

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -1351,7 +1351,7 @@ export class ProjectService {
    * @param componentId the component id
    * @returns the component or null if the nodeId or componentId are null or does not exist
    */
-  getComponentByNodeIdAndComponentId(nodeId, componentId) {
+  getComponent(nodeId: string, componentId: string): any {
     const components = this.getComponentsByNodeId(nodeId);
     for (const component of components) {
       if (component.id === componentId) {
@@ -1430,8 +1430,8 @@ export class ProjectService {
     return maxScore;
   }
 
-  getMaxScoreForComponent(nodeId: string, componentId: string) {
-    const component = this.getComponentByNodeIdAndComponentId(nodeId, componentId);
+  getMaxScoreForComponent(nodeId: string, componentId: string): number {
+    const component = this.getComponent(nodeId, componentId);
     if (component != null && !component.excludeFromTotalScore) {
       return component.maxScore;
     }
@@ -1603,8 +1603,8 @@ export class ProjectService {
    * @param componentId The component id.
    * @return The choices from the component.
    */
-  getChoicesByNodeIdAndComponentId(nodeId, componentId) {
-    const component = this.getComponentByNodeIdAndComponentId(nodeId, componentId);
+  getChoicesByNodeIdAndComponentId(nodeId, componentId): any {
+    const component = this.getComponent(nodeId, componentId);
     return component.choices;
   }
 
@@ -1657,8 +1657,7 @@ export class ProjectService {
 
   shouldIncludeInTotalScore(nodeId: string, componentId: string): boolean {
     return (
-      this.isNodeActive(nodeId) &&
-      !this.getComponentByNodeIdAndComponentId(nodeId, componentId).excludeFromTotalScore
+      this.isNodeActive(nodeId) && !this.getComponent(nodeId, componentId).excludeFromTotalScore
     );
   }
 
@@ -1713,7 +1712,7 @@ export class ProjectService {
   }
 
   getComponentType(nodeId: string, componentId: string): string {
-    const component = this.getComponentByNodeIdAndComponentId(nodeId, componentId);
+    const component = this.getComponent(nodeId, componentId);
     return component.type;
   }
 
@@ -2278,7 +2277,7 @@ export class ProjectService {
   }
 
   componentExists(nodeId: string, componentId: string): boolean {
-    return this.getComponentByNodeIdAndComponentId(nodeId, componentId) != null;
+    return this.getComponent(nodeId, componentId) != null;
   }
 
   broadcastProjectChanged() {

--- a/src/assets/wise5/services/studentDataService.ts
+++ b/src/assets/wise5/services/studentDataService.ts
@@ -1247,7 +1247,7 @@ export class StudentDataService extends DataService {
   }
 
   private isComponentCompleted(nodeId: string, componentId: string): boolean {
-    const component = this.ProjectService.getComponentByNodeIdAndComponentId(nodeId, componentId);
+    const component = this.ProjectService.getComponent(nodeId, componentId);
     if (component != null) {
       const node = this.ProjectService.getNodeById(nodeId);
       const componentType = component.type;

--- a/src/assets/wise5/services/teacherDataService.ts
+++ b/src/assets/wise5/services/teacherDataService.ts
@@ -180,7 +180,7 @@ export class TeacherDataService extends DataService {
   getConnectedComponentsWithRequiredStudentData(components): any {
     const connectedComponents = [];
     for (const component of components) {
-      const componentContent = this.ProjectService.getComponentByNodeIdAndComponentId(
+      const componentContent = this.ProjectService.getComponent(
         component.nodeId,
         component.componentId
       );

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -2080,7 +2080,7 @@ export class TeacherProjectService extends ProjectService {
   }
 
   setMaxScoreForComponent(nodeId: string, componentId: string, maxScore: number): void {
-    const component = this.getComponentByNodeIdAndComponentId(nodeId, componentId);
+    const component = this.getComponent(nodeId, componentId);
     if (component != null) {
       component.maxScore = maxScore;
     }

--- a/src/assets/wise5/vle/studentAsset/student-assets/student-assets.component.spec.ts
+++ b/src/assets/wise5/vle/studentAsset/student-assets/student-assets.component.spec.ts
@@ -39,7 +39,7 @@ describe('StudentAssetsComponent', () => {
 
   it('should upload student assets', fakeAsync(() => {
     const uploadAssetSpy = spyOnUploadAsset();
-    const getComponentSpy = spyOnGetComponentByNodeIdAndComponentId('Draw');
+    const getComponentSpy = spyOnGetComponent('Draw');
     const files = [assetFile1, assetFile2];
     component.uploadStudentAssets(files);
     tick();
@@ -48,7 +48,7 @@ describe('StudentAssetsComponent', () => {
   }));
 
   it('should attach student asset', () => {
-    const getComponentSpy = spyOnGetComponentByNodeIdAndComponentId('Draw');
+    const getComponentSpy = spyOnGetComponent('Draw');
     const broadcastAttachStudentAssetSpy = spyOnBroadcastAttachStudentAsset();
     component.attachStudentAsset(assetFile1);
     expect(getComponentSpy).toHaveBeenCalled();
@@ -56,7 +56,7 @@ describe('StudentAssetsComponent', () => {
   });
 
   it('should not attach student asset', () => {
-    const getComponentSpy = spyOnGetComponentByNodeIdAndComponentId('MultipleChoice');
+    const getComponentSpy = spyOnGetComponent('MultipleChoice');
     const broadcastAttachStudentAssetSpy = spyOnBroadcastAttachStudentAsset();
     component.attachStudentAsset(assetFile1);
     expect(getComponentSpy).toHaveBeenCalled();
@@ -69,11 +69,8 @@ describe('StudentAssetsComponent', () => {
     );
   }
 
-  function spyOnGetComponentByNodeIdAndComponentId(componentType: string) {
-    return spyOn(
-      TestBed.inject(ProjectService),
-      'getComponentByNodeIdAndComponentId'
-    ).and.returnValue({
+  function spyOnGetComponent(componentType: string) {
+    return spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({
       type: componentType
     });
   }

--- a/src/assets/wise5/vle/studentAsset/student-assets/student-assets.component.ts
+++ b/src/assets/wise5/vle/studentAsset/student-assets/student-assets.component.ts
@@ -56,10 +56,7 @@ export class StudentAssetsComponent implements OnInit {
   }
 
   attachStudentAsset(studentAsset: any): void {
-    const component = this.projectService.getComponentByNodeIdAndComponentId(
-      this.nodeId,
-      this.componentId
-    );
+    const component = this.projectService.getComponent(this.nodeId, this.componentId);
     if (this.componentsThatCanAcceptAssets.includes(component.type)) {
       this.studentAssetService.broadcastAttachStudentAsset(
         this.nodeId,

--- a/src/assets/wise5/vle/vleProjectService.ts
+++ b/src/assets/wise5/vle/vleProjectService.ts
@@ -24,7 +24,7 @@ export class VLEProjectService extends ProjectService {
   }
 
   private getConnectedComponentsByNodeIdAndComponentId(nodeId: string, componentId: string): any[] {
-    const component = this.getComponentByNodeIdAndComponentId(nodeId, componentId);
+    const component = this.getComponent(nodeId, componentId);
     if (component != null && component.connectedComponents != null) {
       return component.connectedComponents;
     }
@@ -54,10 +54,7 @@ export class VLEProjectService extends ProjectService {
    * @returns {boolean} whether we need to display the annotation to the student
    */
   displayAnnotation(annotation) {
-    const component = this.getComponentByNodeIdAndComponentId(
-      annotation.nodeId,
-      annotation.componentId
-    );
+    const component = this.getComponent(annotation.nodeId, annotation.componentId);
     const componentService = this.componentServiceLookupService.getService(component.type);
     return componentService.displayAnnotation(component, annotation);
   }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1063,7 +1063,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete this connected component?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-connected-components/edit-connected-components.component.ts</context>
-          <context context-type="linenumber">110</context>
+          <context context-type="linenumber">98</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e8c21747e8604f974b3ed6ecf6089306b7cc0aae" datatype="html">
@@ -10251,7 +10251,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Not Assigned</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-workgroup-item/milestone-workgroup-item.component.ts</context>
-          <context context-type="linenumber">143</context>
+          <context context-type="linenumber">137</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts</context>
@@ -10266,7 +10266,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Completed</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-workgroup-item/milestone-workgroup-item.component.ts</context>
-          <context context-type="linenumber">147</context>
+          <context context-type="linenumber">141</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts</context>
@@ -10281,7 +10281,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Partially Completed</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-workgroup-item/milestone-workgroup-item.component.ts</context>
-          <context context-type="linenumber">151</context>
+          <context context-type="linenumber">145</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts</context>
@@ -10296,14 +10296,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Not Completed</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-workgroup-item/milestone-workgroup-item.component.ts</context>
-          <context context-type="linenumber">156</context>
+          <context context-type="linenumber">150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2981239280931729191" datatype="html">
         <source>No Work</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-workgroup-item/milestone-workgroup-item.component.ts</context>
-          <context context-type="linenumber">158</context>
+          <context context-type="linenumber">152</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts</context>
@@ -14761,11 +14761,11 @@ Warning: This will delete all existing choices and buckets in this component.</s
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summary-display/summary-display.component.ts</context>
-          <context context-type="linenumber">579</context>
+          <context context-type="linenumber">576</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summary-display/summary-display.component.ts</context>
-          <context context-type="linenumber">689</context>
+          <context context-type="linenumber">686</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2496818939481806999" datatype="html">
@@ -14776,11 +14776,11 @@ Warning: This will delete all existing choices and buckets in this component.</s
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summary-display/summary-display.component.ts</context>
-          <context context-type="linenumber">579</context>
+          <context context-type="linenumber">576</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summary-display/summary-display.component.ts</context>
-          <context context-type="linenumber">693</context>
+          <context context-type="linenumber">690</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6619869754055745168" datatype="html">
@@ -15291,7 +15291,7 @@ Score: <x id="PH" equiv-text="score"/>
 Feedback Text: <x id="PH_1" equiv-text="feedbackText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">106</context>
+          <context context-type="linenumber">97</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1461861786609911168" datatype="html">
@@ -15304,28 +15304,28 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/>
 Feedback Text: <x id="PH_2" equiv-text="feedbackText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">145</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846244999760672149" datatype="html">
         <source>you got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">186</context>
+          <context context-type="linenumber">177</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7599226289089492371" datatype="html">
         <source>Please talk to your teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">188</context>
+          <context context-type="linenumber">179</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5580639382077453513" datatype="html">
         <source>got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="867656616658826137" datatype="html">
@@ -15336,21 +15336,21 @@ Previous Score: <x id="PH" equiv-text="previousScore"/>
 Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">204</context>
+          <context context-type="linenumber">195</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3689003016353565518" datatype="html">
         <source>Are you sure you want to delete the custom completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">238</context>
+          <context context-type="linenumber">229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2986030604058491184" datatype="html">
         <source>Are you sure you want to delete this completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">270</context>
+          <context context-type="linenumber">261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="350e893dc35c1ca7a171e2944630e2c8f3f4785a" datatype="html">
@@ -15966,28 +15966,28 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>You must submit work on &quot;<x id="PH" equiv-text="this.otherStepTitle"/>&quot; to view the summary.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-student/summary-student.component.ts</context>
-          <context context-type="linenumber">141</context>
+          <context context-type="linenumber">138</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3834814461916183420" datatype="html">
         <source>You must complete &quot;<x id="PH" equiv-text="this.otherStepTitle"/>&quot; to view the summary.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-student/summary-student.component.ts</context>
-          <context context-type="linenumber">143</context>
+          <context context-type="linenumber">140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1745852243024604075" datatype="html">
         <source>You must submit work on &quot;<x id="PH" equiv-text="this.otherStepTitle"/>&quot; to view the class summary.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-student/summary-student.component.ts</context>
-          <context context-type="linenumber">149</context>
+          <context context-type="linenumber">146</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8412691431688558361" datatype="html">
         <source>You must complete &quot;<x id="PH" equiv-text="this.otherStepTitle"/>&quot; to view the class summary.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-student/summary-student.component.ts</context>
-          <context context-type="linenumber">151</context>
+          <context context-type="linenumber">148</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4739818603756173797" datatype="html">
@@ -16501,63 +16501,63 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>The student will see a graph of their individual data here.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summary-display/summary-display.component.ts</context>
-          <context context-type="linenumber">157</context>
+          <context context-type="linenumber">154</context>
         </context-group>
       </trans-unit>
       <trans-unit id="629070935308008546" datatype="html">
         <source>Your Response</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summary-display/summary-display.component.ts</context>
-          <context context-type="linenumber">713</context>
+          <context context-type="linenumber">710</context>
         </context-group>
       </trans-unit>
       <trans-unit id="610707389788117365" datatype="html">
         <source>Your Score</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summary-display/summary-display.component.ts</context>
-          <context context-type="linenumber">715</context>
+          <context context-type="linenumber">712</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1159047178964534522" datatype="html">
         <source>Period Responses</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summary-display/summary-display.component.ts</context>
-          <context context-type="linenumber">722</context>
+          <context context-type="linenumber">719</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6903542619561738551" datatype="html">
         <source>Period Scores</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summary-display/summary-display.component.ts</context>
-          <context context-type="linenumber">727</context>
+          <context context-type="linenumber">724</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2142002953999044695" datatype="html">
         <source>Class Responses</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summary-display/summary-display.component.ts</context>
-          <context context-type="linenumber">736</context>
+          <context context-type="linenumber">733</context>
         </context-group>
       </trans-unit>
       <trans-unit id="489297649750722424" datatype="html">
         <source>Class Scores</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summary-display/summary-display.component.ts</context>
-          <context context-type="linenumber">741</context>
+          <context context-type="linenumber">738</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4270887249744454870" datatype="html">
         <source><x id="PH" equiv-text="this.percentResponded"/>% Responded (<x id="PH_1" equiv-text="this.numResponses"/>/<x id="PH_2" equiv-text="this.totalWorkgroups"/>)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summary-display/summary-display.component.ts</context>
-          <context context-type="linenumber">752</context>
+          <context context-type="linenumber">749</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8177873832400820695" datatype="html">
         <source>Count</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summary-display/summary-display.component.ts</context>
-          <context context-type="linenumber">869</context>
+          <context context-type="linenumber">866</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d53b401d14b43833857138029db823612e52f518" datatype="html">


### PR DESCRIPTION
## Changes
- Rename ProjectService.getComponentByNodeIdAndComponentId() to getComponent()
- Move ```@Input()``` to same line as variable declarations
- Add missing function param types and return types
- No new feature was added

## Test
- VLE, CM, and AT work as before

Closes #854