### PR TITLE
feat(Dynamic Prompt): Make real request for student data

### DIFF
--- a/src/app/domain/peerGroupStudentData.ts
+++ b/src/app/domain/peerGroupStudentData.ts
@@ -1,0 +1,5 @@
+export class PeerGroupStudentData {
+  annotation: any;
+  studentWork: any;
+  workgroup: any;
+}

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html
@@ -4,6 +4,7 @@
 </div>
 <ng-container *ngIf="isPeerChatWorkgroupsAvailable">
   <component-header [componentContent]="componentContent"
+      [nodeId]="nodeId"
       (dynamicPromptChanged)="onDynamicPromptChanged($event)">
   </component-header>
   <div fxLayout="column"

--- a/src/assets/wise5/directives/component-header/component-header.component.html
+++ b/src/assets/wise5/directives/component-header/component-header.component.html
@@ -1,5 +1,8 @@
 <div class="component-header" fxLayout="row wrap" fxLayoutGap="4px">
-  <prompt [prompt]="componentContent.prompt" [dynamicPrompt]="dynamicPrompt"
+  <prompt [prompt]="componentContent.prompt"
+      [nodeId]="nodeId"
+      [componentId]="componentContent.id"
+      [dynamicPrompt]="dynamicPrompt"
       (dynamicPromptChanged)="onDynamicPromptChanged($event)">
   </prompt>
   <possible-score [maxScore]="componentContent.maxScore"></possible-score>

--- a/src/assets/wise5/directives/component-header/component-header.component.ts
+++ b/src/assets/wise5/directives/component-header/component-header.component.ts
@@ -12,6 +12,7 @@ export class ComponentHeader {
   @Input() componentContent: any;
   dynamicPrompt: DynamicPrompt;
   @Output() dynamicPromptChanged: EventEmitter<FeedbackRule> = new EventEmitter<FeedbackRule>();
+  @Input() nodeId: string;
   prompt: SafeHtml;
 
   constructor(protected sanitizer: DomSanitizer) {}

--- a/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.spec.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.spec.ts
@@ -74,7 +74,7 @@ function peerGroupingTagDisabled(): void {
 }
 
 function peerGroupingTagEnabled(): void {
-  let retrieveDynamicPromptStudentDataSpy: jasmine.Spy;
+  let retrieveStudentDataSpy: jasmine.Spy;
   describe('peerGroupingTagEnabled', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(DynamicPromptComponent);
@@ -84,24 +84,20 @@ function peerGroupingTagEnabled(): void {
       spyOn(TestBed.inject(PeerGroupService), 'retrievePeerGroup').and.returnValue(
         of(createPeerGroup())
       );
-      retrieveDynamicPromptStudentDataSpy = spyOn(
+      retrieveStudentDataSpy = spyOn(
         TestBed.inject(PeerGroupService),
         'retrieveDynamicPromptStudentData'
       );
     });
 
     it('should display the dynamic prompt when idea 2 and 3 are detected', () => {
-      retrieveDynamicPromptStudentDataSpy.and.returnValue(
-        of([createPeerGroupStudentData(['2', '3'], 2, 1)])
-      );
+      retrieveStudentDataSpy.and.returnValue(of([createPeerGroupStudentData(['2', '3'], 2, 1)]));
       fixture.detectChanges();
       expectDynamicPromptToEqual(promptIdea2And3);
     });
 
     it('should display the dynamic prompt when idea 2 or 3 are detected', () => {
-      retrieveDynamicPromptStudentDataSpy.and.returnValue(
-        of([createPeerGroupStudentData(['2'], 2, 1)])
-      );
+      retrieveStudentDataSpy.and.returnValue(of([createPeerGroupStudentData(['2'], 2, 1)]));
       fixture.detectChanges();
       expectDynamicPromptToEqual(promptIdea2Or3);
     });

--- a/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.spec.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { of } from 'rxjs';
+import { PeerGroupStudentData } from '../../../../app/domain/peerGroupStudentData';
 import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
 import { AnnotationService } from '../../services/annotationService';
 import { PeerGroupService } from '../../services/peerGroupService';
@@ -12,8 +13,6 @@ import { DynamicPrompt } from './DynamicPrompt';
 
 let component: DynamicPromptComponent;
 let fixture: ComponentFixture<DynamicPromptComponent>;
-let getLatestAnnotationSpy: jasmine.Spy;
-let getLatestWorkSpy: jasmine.Spy;
 const postPrompt: string = 'This is the prompt after the dynamic prompt.';
 const prePrompt: string = 'This is the prompt before the dynamic prompt.';
 const promptDefault: string = 'This is the default prompt when no other rules match.';
@@ -35,11 +34,6 @@ describe('DynamicPromptComponent', () => {
     spyOn(TestBed.inject(ProjectService), 'getComponentByNodeIdAndComponentId').and.returnValue({
       type: 'OpenResponse'
     });
-    getLatestWorkSpy = spyOn(
-      TestBed.inject(StudentDataService),
-      'getLatestComponentStateByNodeIdAndComponentId'
-    );
-    getLatestAnnotationSpy = spyOn(TestBed.inject(AnnotationService), 'getLatestScoreAnnotation');
   });
 
   peerGroupingTagDisabled();
@@ -52,8 +46,13 @@ function peerGroupingTagDisabled(): void {
       fixture = TestBed.createComponent(DynamicPromptComponent);
       component = fixture.componentInstance;
       component.dynamicPrompt = createDynamicPrompt();
-      getLatestWorkSpy.and.returnValue(createComponentState(1));
-      getLatestAnnotationSpy.and.returnValue(createAnnotation([], 1));
+      spyOn(
+        TestBed.inject(StudentDataService),
+        'getLatestComponentStateByNodeIdAndComponentId'
+      ).and.returnValue(createComponentState(1));
+      spyOn(TestBed.inject(AnnotationService), 'getLatestScoreAnnotation').and.returnValue(
+        createAnnotation([], 1)
+      );
       fixture.detectChanges();
     });
 
@@ -89,29 +88,35 @@ function peerGroupingTagEnabled(): void {
         TestBed.inject(PeerGroupService),
         'retrieveDynamicPromptStudentData'
       );
-      getLatestWorkSpy.and.returnValue(createComponentState(1));
     });
 
     it('should display the dynamic prompt when idea 2 and 3 are detected', () => {
       retrieveDynamicPromptStudentDataSpy.and.returnValue(
-        of([createStudentData(['2', '3'], 2, 1)])
+        of([createPeerGroupStudentData(['2', '3'], 2, 1)])
       );
       fixture.detectChanges();
       expectDynamicPromptToEqual(promptIdea2And3);
     });
 
     it('should display the dynamic prompt when idea 2 or 3 are detected', () => {
-      retrieveDynamicPromptStudentDataSpy.and.returnValue(of([createStudentData(['2'], 2, 1)]));
+      retrieveDynamicPromptStudentDataSpy.and.returnValue(
+        of([createPeerGroupStudentData(['2'], 2, 1)])
+      );
       fixture.detectChanges();
       expectDynamicPromptToEqual(promptIdea2Or3);
     });
   });
 }
 
-function createStudentData(ideas: string[], score: number, submitCounter: number): any {
+function createPeerGroupStudentData(
+  ideas: string[],
+  score: number,
+  submitCounter: number
+): PeerGroupStudentData {
   return {
     annotation: createAnnotation(ideas, score),
-    studentWork: createComponentState(submitCounter)
+    studentWork: createComponentState(submitCounter),
+    workgroup: {}
   };
 }
 

--- a/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Observable } from 'rxjs';
 import { concatMap, map } from 'rxjs/operators';
+import { PeerGroupStudentData } from '../../../../app/domain/peerGroupStudentData';
 import { CRaterResponse } from '../../components/common/cRater/CRaterResponse';
 import { FeedbackRule } from '../../components/common/feedbackRule/FeedbackRule';
 import { FeedbackRuleEvaluator } from '../../components/common/feedbackRule/FeedbackRuleEvaluator';
@@ -59,8 +60,8 @@ export class DynamicPromptComponent implements OnInit {
       this.dynamicPrompt.getPeerGroupingTag(),
       this.nodeId,
       this.componentId
-    ).subscribe((peerGroupData: any[]) => {
-      const cRaterResponses = peerGroupData.map((peerMemberData: any) => {
+    ).subscribe((peerGroupStudentData: PeerGroupStudentData[]) => {
+      const cRaterResponses = peerGroupStudentData.map((peerMemberData: any) => {
         return new CRaterResponse({
           ideas: peerMemberData.annotation.data.ideas,
           scores: peerMemberData.annotation.data.scores,
@@ -87,8 +88,8 @@ export class DynamicPromptComponent implements OnInit {
         return this.peerGroupService
           .retrieveDynamicPromptStudentData(peerGroup.id, nodeId, componentId)
           .pipe(
-            map((studentData) => {
-              return studentData;
+            map((peerGroupStudentData: PeerGroupStudentData[]) => {
+              return peerGroupStudentData;
             })
           );
       })
@@ -124,7 +125,10 @@ export class DynamicPromptComponent implements OnInit {
     }
   }
 
-  private getFeedbackRuleEvaluator(rules: FeedbackRule[], maxSubmitCount: number): any {
+  private getFeedbackRuleEvaluator(
+    rules: FeedbackRule[],
+    maxSubmitCount: number
+  ): FeedbackRuleEvaluator {
     return new FeedbackRuleEvaluator(new FeedbackRuleComponent(rules, maxSubmitCount, false));
   }
 

--- a/src/assets/wise5/directives/prompt/prompt.component.html
+++ b/src/assets/wise5/directives/prompt/prompt.component.html
@@ -1,4 +1,7 @@
 <div *ngIf="!dynamicPrompt?.enabled" [innerHTML]="prompt" class="prompt"></div>
-<dynamic-prompt *ngIf="dynamicPrompt?.enabled" [dynamicPrompt]="dynamicPrompt"
+<dynamic-prompt *ngIf="dynamicPrompt?.enabled"
+    [nodeId]="nodeId"
+    [componentId]="componentId"
+    [dynamicPrompt]="dynamicPrompt"
     (dynamicPromptChanged)="onDynamicPromptChanged($event)">
 </dynamic-prompt>

--- a/src/assets/wise5/directives/prompt/prompt.component.ts
+++ b/src/assets/wise5/directives/prompt/prompt.component.ts
@@ -8,9 +8,11 @@ import { DynamicPrompt } from '../dynamic-prompt/DynamicPrompt';
   styleUrls: ['./prompt.component.scss']
 })
 export class PromptComponent implements OnInit {
-  @Input() prompt: string;
+  @Input() componentId: string;
   @Input() dynamicPrompt: DynamicPrompt;
   @Output() dynamicPromptChanged: EventEmitter<FeedbackRule> = new EventEmitter<FeedbackRule>();
+  @Input() nodeId: string;
+  @Input() prompt: string;
 
   constructor() {}
 

--- a/src/assets/wise5/services/peerGroupService.ts
+++ b/src/assets/wise5/services/peerGroupService.ts
@@ -69,4 +69,14 @@ export class PeerGroupService {
   removeWorkgroupFromGroup(workgroupId: number, groupId: number): Observable<any> {
     return this.http.delete(`/api/peer-group/membership/${groupId}/${workgroupId}`);
   }
+
+  retrieveDynamicPromptStudentData(
+    peerGroupId: number,
+    nodeId: string,
+    componentId: string
+  ): Observable<any> {
+    return this.http.get(
+      `/api/peer-group/${peerGroupId}/${nodeId}/${componentId}/student-data/dynamic-prompt`
+    );
+  }
 }

--- a/src/assets/wise5/services/peerGroupService.ts
+++ b/src/assets/wise5/services/peerGroupService.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { PeerGroupStudentData } from '../../../app/domain/peerGroupStudentData';
 import { Node } from '../common/Node';
 import { PeerGroup } from '../components/peerChat/PeerGroup';
 import { ConfigService } from './configService';
@@ -74,8 +75,8 @@ export class PeerGroupService {
     peerGroupId: number,
     nodeId: string,
     componentId: string
-  ): Observable<any> {
-    return this.http.get(
+  ): Observable<PeerGroupStudentData[]> {
+    return this.http.get<PeerGroupStudentData[]>(
       `/api/peer-group/${peerGroupId}/${nodeId}/${componentId}/student-data/dynamic-prompt`
     );
   }


### PR DESCRIPTION
- Test with https://github.com/WISE-Community/WISE-API/pull/182

## Changes

- Dynamic Prompt now makes a real request to the backend for student data
- We now pass the nodeId to the component-header so that it can be passed down to the prompt and dynamic-prompt

## Test

- Make sure the peer group student data is retrieved from the backend and used to evaluate which prompt to show

#840