### PR TITLE
fix(Classroom Monitor): Fix Grade By Step button

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorController.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorController.ts
@@ -104,9 +104,8 @@ class ClassroomMonitorController {
         icon: 'view_list',
         type: 'primary',
         action: () => {
-          let currentView = this.$state.current.name;
-          if (currentView === 'root.cm.unit') {
-            // if we're currently grading a step, close the node when a nodeProgress menu button is clicked
+          if (this.TeacherDataService.getCurrentNode() !== this.ProjectService.rootNode) {
+            // we are not showing the root project view so go to the parent of the current node
             this.NodeService.closeNode();
           }
         },

--- a/src/assets/wise5/common/side-menu/side-menu.component.ts
+++ b/src/assets/wise5/common/side-menu/side-menu.component.ts
@@ -15,5 +15,11 @@ export class SideMenuComponent implements OnInit {
 
   goToView(view: any): void {
     this.state.go(view.route);
+    if (view.action != null) {
+      // make sure the action is called after this.state.go(view.route) is done changing the route
+      setTimeout(() => {
+        view.action();
+      });
+    }
   }
 }


### PR DESCRIPTION
## Changes

Fixed Grade By Step button to go back to the project view.

## Test

1. Open the Classroom Monitor
2. Go to the Grade By Step view by clicking the button in the left side nav menu
3. Click on a step
4. Click the Grade By Step button in the left side nav menu again. You should be brought back to the project view and see all the activities. Previously nothing would happen.

Closes #864