### PR TITLE
fix(Authoring Tool): Fix side menu buttons

### DIFF
--- a/src/assets/wise5/authoringTool/authoringToolComponent.ts
+++ b/src/assets/wise5/authoringTool/authoringToolComponent.ts
@@ -282,10 +282,16 @@ class AuthoringToolController {
 
     this.subscriptions.add(
       this.TeacherDataService.currentNodeChanged$.subscribe(({ currentNode }) => {
-        if (currentNode) {
-          this.$state.go('root.at.project.node', { nodeId: currentNode.id });
-        } else {
-          this.$state.go('root.at.project', { projectId: this.projectId });
+        const currentStateName = this.$state.$current.name;
+        if (
+          currentStateName === 'root.at.project' ||
+          currentStateName.startsWith('root.at.project.node')
+        ) {
+          if (currentNode) {
+            this.$state.go('root.at.project.node', { nodeId: currentNode.id });
+          } else {
+            this.$state.go('root.at.project', { projectId: this.projectId });
+          }
         }
       })
     );


### PR DESCRIPTION
## Changes

Fixed Authoring Tool side menu buttons only bringing you to the project view instead of the view you actually wanted.

## Test

1. Open a unit in the Authoring Tool
2. Click on a step to go into it
3. Click on one of the icons in the side menu
    - Unit Info
    - File Manager
    - Notebook Settings
    - Milestones
    - Unit List
5. You should now be brought to the correct view. Previously, you would be brought back to the project view instead of the view you actually wanted.

Closes #868