### PR TITLE
fix(Authoring Tool): Fix copy component

### DIFF
--- a/src/assets/wise5/authoringTool/node/nodeAuthoring.html
+++ b/src/assets/wise5/authoringTool/node/nodeAuthoring.html
@@ -137,7 +137,7 @@
    $ctrl.components.length === 0 && !$ctrl.insertComponentMode && !$ctrl.isGroupNode'>
    <em>{{ ::'stepHasNoComponents' | translate }}</em>
 </div>
-<div ng-repeat='(componentIndex, component) in $ctrl.components'
+<div ng-repeat='component in $ctrl.components track by $index'
     class='component'
     style='padding: 0; margin: 0 16px;'
     ng-if='$ctrl.showComponents'>
@@ -146,7 +146,7 @@
       <md-checkbox ng-model='$ctrl.componentsToChecked[component.id]'
           ng-disabled='$ctrl.insertComponentMode'
           class='md-primary'>
-        <span style='font-weight:bold; margin-right:10px'>{{(componentIndex + 1)}}. {{::$ctrl.getComponentTypeLabel(component.type)}}</span>
+        <span style='font-weight:bold; margin-right:10px'>{{($index + 1)}}. {{::$ctrl.getComponentTypeLabel(component.type)}}</span>
       </md-checkbox>
     </div>
     <div ng-if='!$ctrl.insertComponentMode && $ctrl.showComponentAuthoringViews'>


### PR DESCRIPTION
## Changes

Fixed Authoring Tool copy component not showing the new component.

## Test

1. Open a unit in the Authoring Tool
2. Open a step that has a component
3. Click the checkbox for a component
4. Click the "Copy" button near the top
5. Choose anywhere to insert the new component. The new component should show up in the step. Previously you would need to refresh the page to see the new component.

Closes #870