### PR TITLE
refactor(ProjectService): ComponentContent interface and Component class

### DIFF
--- a/src/app/services/copyComponentService.spec.ts
+++ b/src/app/services/copyComponentService.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { ComponentContent } from '../../assets/wise5/common/ComponentContent';
 import { CopyComponentService } from '../../assets/wise5/services/copyComponentService';
 import { TeacherProjectService } from '../../assets/wise5/services/teacherProjectService';
 import { UtilService } from '../../assets/wise5/services/utilService';
@@ -37,7 +38,10 @@ describe('CopyComponentService', () => {
 function copyComponents() {
   describe('copyComponents', () => {
     it('should return a copy of the specified components with new ids', () => {
-      spyOn(projectService, 'getComponent').and.returnValues({ id: 'c1' }, { id: 'c2' });
+      spyOn(projectService, 'getComponent').and.returnValues(
+        { id: 'c1' } as ComponentContent,
+        { id: 'c2' } as ComponentContent
+      );
       spyOn(projectService, 'getUnusedComponentId').and.returnValues('c3', 'c4');
       const copies = service.copyComponents('node1', ['c1', 'c2']);
       expect(copies.length).toEqual(2);

--- a/src/app/services/projectService.spec.ts
+++ b/src/app/services/projectService.spec.ts
@@ -8,6 +8,7 @@ import scootersProjectJSON_import from './sampleData/curriculum/SelfPropelledVeh
 import twoStepsProjectJSON_import from './sampleData/curriculum/TwoSteps.project.json';
 import { PeerGrouping } from '../domain/peerGrouping';
 import { StudentTeacherCommonServicesModule } from '../student-teacher-common-services.module';
+import { EmbeddedContent } from '../../assets/wise5/components/embedded/EmbeddedContent';
 
 const projectIdDefault = 1;
 const projectBaseURL = 'http://localhost:8080/curriculum/12345/';
@@ -232,7 +233,7 @@ function shouldGetTheComponent() {
     expect(componentExists).not.toBe(null);
     expect(componentExists.type).toEqual('HTML');
 
-    const componentExists2 = service.getComponent('node9', 'mnzx68ix8h');
+    const componentExists2 = service.getComponent('node9', 'mnzx68ix8h') as EmbeddedContent;
     expect(componentExists2).not.toBe(null);
     expect(componentExists2.type).toEqual('embedded');
     expect(componentExists2.url).toEqual('NewtonScooters-potential-kinetic.html');
@@ -240,6 +241,7 @@ function shouldGetTheComponent() {
 }
 
 function shouldGetTheComponentsByNodeId() {
+  ``;
   it('should get the components by node id', () => {
     service.setProject(scootersProjectJSON);
     const nullNodeIdResult = service.getComponents(null);

--- a/src/app/services/projectService.spec.ts
+++ b/src/app/services/projectService.spec.ts
@@ -241,7 +241,6 @@ function shouldGetTheComponent() {
 }
 
 function shouldGetTheComponentsByNodeId() {
-  ``;
   it('should get the components by node id', () => {
     service.setProject(scootersProjectJSON);
     const nullNodeIdResult = service.getComponents(null);

--- a/src/app/services/studentDataService.spec.ts
+++ b/src/app/services/studentDataService.spec.ts
@@ -8,6 +8,7 @@ import { UtilService } from '../../assets/wise5/services/utilService';
 import { TagService } from '../../assets/wise5/services/tagService';
 import { MatDialogModule } from '@angular/material/dialog';
 import { StudentTeacherCommonServicesModule } from '../student-teacher-common-services.module';
+import { ComponentContent } from '../../assets/wise5/common/ComponentContent';
 
 let $injector, $rootScope;
 let http: HttpTestingController;
@@ -1220,7 +1221,7 @@ function shouldCheckIsCompleted() {
     spyOn(service, 'getEventsByNodeIdAndComponentId').and.returnValue(componentEvents);
     const nodeEvents = [];
     spyOn(service, 'getEventsByNodeId').and.returnValue(nodeEvents);
-    const component = { id: 'component1', type: 'OpenResponse' };
+    const component = { id: 'component1', type: 'OpenResponse' } as ComponentContent;
     spyOn(projectService, 'getComponent').and.returnValue(component);
     const node = { id: 'node1' };
     spyOn(projectService, 'getNodeById').and.returnValue(node);
@@ -1233,7 +1234,7 @@ function shouldCheckIsCompleted() {
     spyOn(service, 'getEventsByNodeIdAndComponentId').and.returnValue(componentEvents);
     const nodeEvents = [];
     spyOn(service, 'getEventsByNodeId').and.returnValue(nodeEvents);
-    const component = { id: 'component1', type: 'OpenResponse' };
+    const component = { id: 'component1', type: 'OpenResponse' } as ComponentContent;
     spyOn(projectService, 'getComponent').and.returnValue(component);
     const node = { id: 'node1' };
     spyOn(projectService, 'getNodeById').and.returnValue(node);
@@ -1246,7 +1247,7 @@ function shouldCheckIsCompleted() {
     const components = [
       { id: 'component1', type: 'OpenResponse' },
       { id: 'component2', type: 'OpenResponse' }
-    ];
+    ] as ComponentContent[];
     spyOn(projectService, 'getComponents').and.returnValue(components);
     spyOn(service, 'getComponentStatesByNodeIdAndComponentId').and.callFake(
       (nodeId, componentId) => {
@@ -1270,7 +1271,7 @@ function shouldCheckIsCompleted() {
     const components = [
       { id: 'component1', type: 'OpenResponse' },
       { id: 'component2', type: 'OpenResponse' }
-    ];
+    ] as ComponentContent[];
     spyOn(projectService, 'getComponents').and.returnValue(components);
     spyOn(service, 'getComponentStatesByNodeIdAndComponentId').and.callFake(
       (nodeId, componentId) => {

--- a/src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { MultipleChoiceContent } from '../../../../components/multipleChoice/MultipleChoiceContent';
 import { TeacherDataService } from '../../../../services/teacherDataService';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
 import { UtilService } from '../../../../services/utilService';
@@ -389,7 +390,7 @@ export class NodeAdvancedConstraintAuthoringComponent implements OnInit {
 
   getChoiceTypeByNodeIdAndComponentId(nodeId: string, componentId: string): string {
     let choiceType = null;
-    let component = this.ProjectService.getComponent(nodeId, componentId);
+    let component = this.ProjectService.getComponent(nodeId, componentId) as MultipleChoiceContent;
     if (component != null && component.choiceType != null) {
       choiceType = component.choiceType;
     }

--- a/src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { MultipleChoiceContent } from '../../../../components/multipleChoice/MultipleChoiceContent';
 import { TeacherDataService } from '../../../../services/teacherDataService';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
 
@@ -218,7 +219,7 @@ export class NodeAdvancedPathAuthoringComponent implements OnInit {
 
   getChoiceTypeByNodeIdAndComponentId(nodeId, componentId) {
     let choiceType = null;
-    let component = this.ProjectService.getComponent(nodeId, componentId);
+    let component = this.ProjectService.getComponent(nodeId, componentId) as MultipleChoiceContent;
     if (component != null && component.choiceType != null) {
       choiceType = component.choiceType;
     }

--- a/src/assets/wise5/common/Component.ts
+++ b/src/assets/wise5/common/Component.ts
@@ -1,0 +1,13 @@
+import { ComponentContent } from './ComponentContent';
+
+export class Component {
+  content: ComponentContent;
+  id: string;
+  nodeId: string;
+
+  constructor(content: ComponentContent, nodeId: string) {
+    this.content = content;
+    this.id = content.id;
+    this.nodeId = nodeId;
+  }
+}

--- a/src/assets/wise5/common/ComponentContent.ts
+++ b/src/assets/wise5/common/ComponentContent.ts
@@ -1,0 +1,12 @@
+import { DynamicPrompt } from '../directives/dynamic-prompt/DynamicPrompt';
+
+export interface ComponentContent {
+  id: string;
+  connectedComponents?: any[];
+  dynamicPrompt?: DynamicPrompt;
+  excludeFromTotalScore?: boolean;
+  maxScore?: number;
+  prompt?: string;
+  rubric?: string;
+  type: string;
+}

--- a/src/assets/wise5/components/animation/animation-student/animation-student.component.html
+++ b/src/assets/wise5/components/animation/animation-student/animation-student.component.html
@@ -1,5 +1,5 @@
 <div>
-  <component-header [componentContent]="componentContent"></component-header>
+  <component-header [component]="component"></component-header>
   <div fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="20px">
     <button
         mat-raised-button

--- a/src/assets/wise5/components/audioOscillator/audio-oscillator-show-work/audio-oscillator-show-work.component.spec.ts
+++ b/src/assets/wise5/components/audioOscillator/audio-oscillator-show-work/audio-oscillator-show-work.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { ComponentContent } from '../../../common/ComponentContent';
 import { ProjectService } from '../../../services/projectService';
 import { AudioOscillatorStudentData } from '../AudioOscillatorStudentData';
 import { AudioOscillatorShowWorkComponent } from './audio-oscillator-show-work.component';
@@ -16,7 +17,7 @@ describe('AudioOscillatorShowWorkComponent', () => {
       declarations: [AudioOscillatorShowWorkComponent]
     });
     fixture = TestBed.createComponent(AudioOscillatorShowWorkComponent);
-    spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({});
+    spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({} as ComponentContent);
     component = fixture.componentInstance;
     const audioOscillatorStudentData = {
       amplitudesPlayed: null,

--- a/src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.html
+++ b/src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.html
@@ -1,4 +1,4 @@
-<component-header [componentContent]="componentContent"></component-header>
+<component-header [component]="component"></component-header>
 <div fxLayout="row wrap" fxLayoutAlign="start center" class="interaction-div">
   <mat-form-field *ngIf="oscillatorTypes.length > 1" class="oscillator-type">
     <mat-label i18n>Oscillator Type</mat-label>

--- a/src/assets/wise5/components/component-student.component.ts
+++ b/src/assets/wise5/components/component-student.component.ts
@@ -2,6 +2,7 @@ import { Directive, EventEmitter, Input, Output } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { SafeHtml } from '@angular/platform-browser';
 import { Subscription } from 'rxjs';
+import { Component } from '../common/Component';
 import { GenerateImageDialogComponent } from '../directives/generate-image-dialog/generate-image-dialog.component';
 import { AnnotationService } from '../services/annotationService';
 import { ConfigService } from '../services/configService';
@@ -28,6 +29,7 @@ export abstract class ComponentStudent {
   @Output() starterStateChangedEvent = new EventEmitter<any>();
 
   attachments: any[] = [];
+  component: Component;
   componentId: string;
   componentType: string;
   prompt: SafeHtml;
@@ -64,6 +66,7 @@ export abstract class ComponentStudent {
   ) {}
 
   ngOnInit(): void {
+    this.component = new Component(this.componentContent, this.nodeId);
     this.componentId = this.componentContent.id;
     this.componentType = this.componentContent.type;
     this.isSaveButtonVisible = this.componentContent.showSaveButton;

--- a/src/assets/wise5/components/component/component.component.ts
+++ b/src/assets/wise5/components/component/component.component.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '../../services/configService';
 import { NotebookService } from '../../services/notebookService';
 import { ProjectService } from '../../services/projectService';
 import { StudentDataService } from '../../services/studentDataService';
+import { ComponentContent } from '../../common/ComponentContent';
 
 @Component({
   selector: 'component',
@@ -16,7 +17,7 @@ export class ComponentComponent {
   @Input() workgroupId: number;
   @Output() saveComponentStateEvent: EventEmitter<any> = new EventEmitter<any>();
 
-  componentContent: any;
+  componentContent: ComponentContent;
   pulseRubricIcon: boolean = true;
   rubric: string;
   showRubric: boolean;

--- a/src/assets/wise5/components/conceptMap/ConceptMapContent.ts
+++ b/src/assets/wise5/components/conceptMap/ConceptMapContent.ts
@@ -1,0 +1,7 @@
+import { ComponentContent } from '../../common/ComponentContent';
+
+export interface ConceptMapContent extends ComponentContent {
+  links: any[];
+  nodes: any[];
+  rules?: any[];
+}

--- a/src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.html
+++ b/src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.html
@@ -1,5 +1,5 @@
 <div class="main-div">
-  <component-header [componentContent]="componentContent"></component-header>
+  <component-header [component]="component"></component-header>
   <div class="main-concept-map-div">
     <div class="top-buttons" fxLayout="row">
       <button

--- a/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.spec.ts
+++ b/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.spec.ts
@@ -22,6 +22,7 @@ import { EditConnectedComponentsComponent } from '../../../../../app/authoring-t
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { NotebookService } from '../../../services/notebookService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { ConceptMapContent } from '../ConceptMapContent';
 import { EditConceptMapAdvancedComponent } from './edit-concept-map-advanced.component';
 
 let component: EditConceptMapAdvancedComponent;
@@ -64,7 +65,7 @@ describe('EditConceptMapAdvancedComponent', () => {
   beforeEach(() => {
     spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue({
       rules: []
-    });
+    } as ConceptMapContent);
     spyOn(TestBed.inject(NotebookService), 'isNotebookEnabled').and.returnValue(true);
     fixture = TestBed.createComponent(EditConceptMapAdvancedComponent);
     component = fixture.componentInstance;

--- a/src/assets/wise5/components/conceptMap/edit-concept-map-connected-components/edit-concept-map-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/conceptMap/edit-concept-map-connected-components/edit-concept-map-connected-components.component.spec.ts
@@ -4,6 +4,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { ProjectService } from '../../../services/projectService';
+import { ConceptMapContent } from '../ConceptMapContent';
 import { EditConceptMapConnectedComponentsComponent } from './edit-concept-map-connected-components.component';
 
 let component: EditConceptMapConnectedComponentsComponent;
@@ -60,7 +61,7 @@ function askIfWantToCopyNodesAndLinks() {
         id: componentId1,
         nodes: [createNode('node1', 'Tree', 'tree.png')],
         links: [createLink('link1', 'Energy', 'green')]
-      });
+      } as ConceptMapContent);
     });
     it('should copy nodes and links', () => {
       expectNumberOfNodesAndLinks(component.componentContent, 0, 0);

--- a/src/assets/wise5/components/conceptMap/edit-concept-map-connected-components/edit-concept-map-connected-components.component.ts
+++ b/src/assets/wise5/components/conceptMap/edit-concept-map-connected-components/edit-concept-map-connected-components.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { ProjectService } from '../../../services/projectService';
 import { EditConnectedComponentsWithBackgroundComponent } from '../../../../../app/authoring-tool/edit-connected-components-with-background/edit-connected-components-with-background.component';
+import { ConceptMapContent } from '../ConceptMapContent';
 
 @Component({
   selector: 'app-edit-concept-map-connected-components',
@@ -38,9 +39,12 @@ export class EditConceptMapConnectedComponentsComponent extends EditConnectedCom
           $localize`Warning: This will delete all existing nodes and links in this component.`
       )
     ) {
-      const connectedComponentContent = this.ProjectService.getComponent(nodeId, componentId);
-      this.componentContent.nodes = connectedComponentContent.nodes;
-      this.componentContent.links = connectedComponentContent.links;
+      const connectedComponent = this.ProjectService.getComponent(
+        nodeId,
+        componentId
+      ) as ConceptMapContent;
+      this.componentContent.nodes = connectedComponent.nodes;
+      this.componentContent.links = connectedComponent.links;
       this.connectedComponentChanged();
     }
   }

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.html
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.html
@@ -4,7 +4,7 @@
     (chooseAvatarEvent)="selectComputerAvatar($event)">
 </computer-avatar-selector>
 <mat-card *ngIf="!isShowComputerAvatarSelector" class="mat-elevation-z2">
-  <component-header [componentContent]="componentContent"></component-header>
+  <component-header [component]="component"></component-header>
   <dialog-responses
       [responses]="responses"
       [isWaitingForComputerResponse]="isWaitingForComputerResponse"

--- a/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.html
+++ b/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.html
@@ -1,4 +1,4 @@
-<component-header [componentContent]="componentContent"></component-header>
+<component-header [component]="component"></component-header>
 <div class="discussion-content">
   <component-annotations
       *ngIf="mode === 'student'"
@@ -41,7 +41,7 @@
                 alt="Image"
                 i18n-alt
                 class="discussion-post__attachment discussion-new__attachment__content" />
-            <button 
+            <button
                 mat-button
                 class="component__attachment__delete"
                 (click)="removeAttachment(attachment)"

--- a/src/assets/wise5/components/draw/draw-student/draw-student.component.html
+++ b/src/assets/wise5/components/draw/draw-student/draw-student.component.html
@@ -1,4 +1,4 @@
-<component-header [componentContent]="componentContent"></component-header>
+<component-header [component]="component"></component-header>
 <div class="component__actions buttons-div"
     fxLayout="row wrap">
   <button

--- a/src/assets/wise5/components/embedded/EmbeddedContent.ts
+++ b/src/assets/wise5/components/embedded/EmbeddedContent.ts
@@ -1,0 +1,5 @@
+import { ComponentContent } from '../../common/ComponentContent';
+
+export interface EmbeddedContent extends ComponentContent {
+  url: string;
+}

--- a/src/assets/wise5/components/graph/GraphContent.ts
+++ b/src/assets/wise5/components/graph/GraphContent.ts
@@ -1,0 +1,7 @@
+import { ComponentContent } from '../../common/ComponentContent';
+
+export interface GraphContent extends ComponentContent {
+  backgroundImage?: string;
+  xAxis: any;
+  yAxis: any;
+}

--- a/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.spec.ts
+++ b/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.spec.ts
@@ -23,6 +23,7 @@ import { EditConnectedComponentsComponent } from '../../../../../app/authoring-t
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { NotebookService } from '../../../services/notebookService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { GraphContent } from '../GraphContent';
 import { EditGraphAdvancedComponent } from './edit-graph-advanced.component';
 
 let component: EditGraphAdvancedComponent;
@@ -66,7 +67,7 @@ describe('EditGraphAdvancedComponent', () => {
     spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue({
       xAxis: {},
       yAxis: {}
-    });
+    } as GraphContent);
     spyOn(TestBed.inject(NotebookService), 'isNotebookEnabled').and.returnValue(true);
     fixture = TestBed.createComponent(EditGraphAdvancedComponent);
     component = fixture.componentInstance;

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.html
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.html
@@ -1,4 +1,4 @@
-<component-header [componentContent]="componentContent"></component-header>
+<component-header [component]="component"></component-header>
 <input type="file"
      accept=".csv"
      *ngIf="componentContent.enableFileUpload"

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -15,6 +15,7 @@ import HC_exporting from 'highcharts/modules/exporting';
 import * as covariance from 'compute-covariance';
 import canvg from 'canvg';
 import { MatDialog } from '@angular/material/dialog';
+import { GraphContent } from '../GraphContent';
 
 const Draggable = require('highcharts/modules/draggable-points.js');
 Draggable(Highcharts);
@@ -2608,7 +2609,7 @@ export class GraphStudent extends ComponentStudent {
           connectedComponent.showClassmateWorkSource
         )
       );
-      let component = this.ProjectService.getComponent(nodeId, componentId);
+      let component = this.ProjectService.getComponent(nodeId, componentId) as GraphContent;
       component = this.ProjectService.injectAssetPaths(component);
       connectedComponentBackgroundImage = component.backgroundImage;
     }

--- a/src/assets/wise5/components/label/label-student/label-student.component.html
+++ b/src/assets/wise5/components/label/label-student/label-student.component.html
@@ -1,4 +1,4 @@
-<component-header [componentContent]="componentContent"></component-header>
+<component-header [component]="component"></component-header>
 <div class="input-wrapper" fxLayout="row wrap" fxLayoutAlign="start center">
   <button
       *ngIf="isAddNewLabelButtonVisible"

--- a/src/assets/wise5/components/match/MatchContent.ts
+++ b/src/assets/wise5/components/match/MatchContent.ts
@@ -1,0 +1,6 @@
+import { ComponentContent } from '../../common/ComponentContent';
+
+export interface MatchContent extends ComponentContent {
+  buckets: any[];
+  choices: any[];
+}

--- a/src/assets/wise5/components/match/edit-match-connected-components/edit-match-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/match/edit-match-connected-components/edit-match-connected-components.component.spec.ts
@@ -6,6 +6,7 @@ import { ProjectService } from '../../../services/projectService';
 import { EditMatchConnectedComponentsComponent } from './edit-match-connected-components.component';
 import { createConnectedComponentObject } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component.spec';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { MatchContent } from '../MatchContent';
 
 let component: EditMatchConnectedComponentsComponent;
 let fixture: ComponentFixture<EditMatchConnectedComponentsComponent>;
@@ -60,7 +61,7 @@ function askIfWantToCopyChoicesAndBuckets() {
         id: componentId1,
         choices: [createChoice('choice1', 'A Choice')],
         buckets: [createBucket('bucket1', 'A Bucket')]
-      };
+      } as MatchContent;
       spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue(componentContent);
       connectedComponent = createConnectedComponentObject(nodeId1, componentId1, 'importWork');
     });

--- a/src/assets/wise5/components/match/match-student/match-student.component.html
+++ b/src/assets/wise5/components/match/match-student/match-student.component.html
@@ -1,4 +1,4 @@
-<component-header [componentContent]="componentContent"></component-header>
+<component-header [component]="component"></component-header>
 <div class="match" fxLayout="row wrap" cdkDropListGroup>
   <div fxFlex="100" fxFlex.gt-xs="{{isHorizontal ? 50: 100}}" fxFlexOrder="{{isChoicesAfter ? 2 : 1}}">
     <div class="bucket selected-bg-bg"

--- a/src/assets/wise5/components/multipleChoice/MultipleChoiceContent.ts
+++ b/src/assets/wise5/components/multipleChoice/MultipleChoiceContent.ts
@@ -1,0 +1,6 @@
+import { ComponentContent } from '../../common/ComponentContent';
+
+export interface MultipleChoiceContent extends ComponentContent {
+  choices: any[];
+  choiceType: 'checkbox' | 'radio';
+}

--- a/src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.spec.ts
@@ -6,7 +6,6 @@ import { ProjectService } from '../../../services/projectService';
 import { EditMultipleChoiceConnectedComponentsComponent } from './edit-multiple-choice-connected-components.component';
 import { createConnectedComponentObject } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component.spec';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
-import { ComponentContent } from '../../../common/ComponentContent';
 import { MultipleChoiceContent } from '../MultipleChoiceContent';
 
 let component: EditMultipleChoiceConnectedComponentsComponent;

--- a/src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.spec.ts
+++ b/src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.spec.ts
@@ -6,6 +6,8 @@ import { ProjectService } from '../../../services/projectService';
 import { EditMultipleChoiceConnectedComponentsComponent } from './edit-multiple-choice-connected-components.component';
 import { createConnectedComponentObject } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component.spec';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { ComponentContent } from '../../../common/ComponentContent';
+import { MultipleChoiceContent } from '../MultipleChoiceContent';
 
 let component: EditMultipleChoiceConnectedComponentsComponent;
 let fixture: ComponentFixture<EditMultipleChoiceConnectedComponentsComponent>;
@@ -53,7 +55,7 @@ function askIfWantToCopyChoices() {
           createChoiceObject('choice2', 'Patrick')
         ],
         choiceType: 'radio'
-      };
+      } as MultipleChoiceContent;
       spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue(componentContent);
       connectedComponent = createConnectedComponentObject(nodeId1, componentId1, 'importWork');
     });

--- a/src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.ts
+++ b/src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { EditConnectedComponentsComponent } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component';
 import { ProjectService } from '../../../services/projectService';
 import { UtilService } from '../../../services/utilService';
+import { MultipleChoiceContent } from '../MultipleChoiceContent';
 
 @Component({
   selector: 'edit-multiple-choice-connected-components',
@@ -35,7 +36,7 @@ export class EditMultipleChoiceConnectedComponentsComponent extends EditConnecte
 
   copyChoiceTypeFromComponent(nodeId: string, componentId: string): void {
     const component = this.ProjectService.getComponent(nodeId, componentId);
-    this.componentContent.choiceType = component.choiceType;
+    this.componentContent.choiceType = (component as MultipleChoiceContent).choiceType;
   }
 
   copyChoicesFromComponent(nodeId: string, componentId: string): void {
@@ -44,6 +45,6 @@ export class EditMultipleChoiceConnectedComponentsComponent extends EditConnecte
 
   getCopyOfChoicesFromComponent(nodeId: string, componentId: string): void {
     const component = this.ProjectService.getComponent(nodeId, componentId);
-    return this.UtilService.makeCopyOfJSONObject(component.choices);
+    return this.UtilService.makeCopyOfJSONObject((component as MultipleChoiceContent).choices);
   }
 }

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.html
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.html
@@ -1,5 +1,5 @@
 <div [ngSwitch]="choiceType">
-  <component-header [componentContent]="componentContent"></component-header>
+  <component-header [component]="component"></component-header>
   <mat-radio-group *ngSwitchCase="'radio'"
       [(ngModel)]="studentChoices"
       (ngModelChange)="studentDataChanged()">

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
@@ -21,6 +21,7 @@ import { EditComponentWidthComponent } from '../../../../../app/authoring-tool/e
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { EditConnectedComponentsComponent } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { ComponentContent } from '../../../common/ComponentContent';
 import { NotebookService } from '../../../services/notebookService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { EditOpenResponseAdvancedComponent } from './edit-open-response-advanced.component';
@@ -66,7 +67,9 @@ describe('EditOpenResponseAdvancedComponent', () => {
   });
 
   beforeEach(() => {
-    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue({});
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue(
+      {} as ComponentContent
+    );
     spyOn(TestBed.inject(NotebookService), 'isNotebookEnabled').and.returnValue(true);
     spyOn(TestBed.inject(TeacherProjectService), 'getFlattenedProjectAsNodeIds').and.returnValue([
       'node1',

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.html
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.html
@@ -1,4 +1,4 @@
-<component-header [componentContent]="componentContent"></component-header>
+<component-header [component]="component"></component-header>
 <div fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="20px">
   <button
       mat-button

--- a/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.spec.ts
@@ -16,6 +16,7 @@ import { PeerChatGradingComponent } from './peer-chat-grading.component';
 import { of } from 'rxjs';
 import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { ComponentContent } from '../../../common/ComponentContent';
 
 let component: PeerChatGradingComponent;
 let fixture: ComponentFixture<PeerChatGradingComponent>;
@@ -52,7 +53,7 @@ describe('PeerChatGradingComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PeerChatGradingComponent);
-    spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({});
+    spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({} as ComponentContent);
     spyOn(TestBed.inject(ConfigService), 'getRunId').and.returnValue(1);
     spyOn(TestBed.inject(ConfigService), 'getWorkgroupId').and.returnValue(100);
     spyOn(TestBed.inject(ConfigService), 'getTeacherWorkgroupIds').and.returnValue([

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html
@@ -3,8 +3,7 @@
   <!-- TODO: Show different message when student has not completed required previous component(s) -->
 </div>
 <ng-container *ngIf="isPeerChatWorkgroupsAvailable">
-  <component-header [componentContent]="componentContent"
-      [nodeId]="nodeId"
+  <component-header [component]="component"
       (dynamicPromptChanged)="onDynamicPromptChanged($event)">
   </component-header>
   <div fxLayout="column"

--- a/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.spec.ts
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.spec.ts
@@ -14,6 +14,7 @@ import { ShowGroupWorkAuthoringComponent } from './show-group-work-authoring.com
 import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-component-prompt/edit-component-prompt.component';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { ComponentContent } from '../../../common/ComponentContent';
 
 describe('ShowGroupWorkAuthoringComponent', () => {
   let component: ShowGroupWorkAuthoringComponent;
@@ -42,7 +43,9 @@ describe('ShowGroupWorkAuthoringComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ShowGroupWorkAuthoringComponent);
-    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue({});
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue(
+      {} as ComponentContent
+    );
     spyOn(TestBed.inject(TeacherProjectService), 'getFlattenedProjectAsNodeIds').and.returnValue([
       nodeId1
     ]);

--- a/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.html
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.html
@@ -1,4 +1,4 @@
-<component-header [componentContent]="componentContent"></component-header>
+<component-header [component]="component"></component-header>
 <div *ngIf="isPeerGroupRetrieved">
   <div *ngIf="peerGroup == null" class="notice mat-body-2" i18n>
     You have not been paired with a classmate yet. Please check back later.

--- a/src/assets/wise5/components/showMyWork/show-my-work-authoring/show-my-work-authoring.component.spec.ts
+++ b/src/assets/wise5/components/showMyWork/show-my-work-authoring/show-my-work-authoring.component.spec.ts
@@ -11,6 +11,7 @@ import { UpgradeModule } from '@angular/upgrade/static';
 import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-component-prompt/edit-component-prompt.component';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { ComponentContent } from '../../../common/ComponentContent';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { ShowMyWorkAuthoringComponent } from './show-my-work-authoring.component';
 
@@ -51,7 +52,9 @@ describe('ShowMyWorkAuthoringComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ShowMyWorkAuthoringComponent);
-    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue({});
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue(
+      {} as ComponentContent
+    );
     spyOn(TestBed.inject(TeacherProjectService), 'getFlattenedProjectAsNodeIds').and.returnValue([
       nodeId1
     ]);

--- a/src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.html
+++ b/src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.html
@@ -1,4 +1,4 @@
-<component-header [componentContent]="componentContent"></component-header>
+<component-header [component]="component"></component-header>
 <mat-card class="mat-elevation-z0 notice-bg-bg">
   <mat-card-content class="app-bg-bg">
     <span class="text-secondary" *ngIf="studentWork == null" i18n>(No response)</span>

--- a/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.ts
+++ b/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.ts
@@ -7,6 +7,7 @@ import { ComponentServiceLookupService } from '../../../services/componentServic
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { MultipleChoiceContent } from '../../multipleChoice/MultipleChoiceContent';
 import { SummaryService } from '../summaryService';
 
 @Component({
@@ -155,7 +156,7 @@ export class SummaryAuthoring extends ComponentAuthoring {
     if (nodeId != null && componentId != null) {
       const component = this.ProjectService.getComponent(nodeId, componentId);
       if (component != null) {
-        return component.choiceType === 'checkbox';
+        return (component as MultipleChoiceContent).choiceType === 'checkbox';
       }
     }
     return false;

--- a/src/assets/wise5/components/summary/summary-student/summary-student.component.spec.ts
+++ b/src/assets/wise5/components/summary/summary-student/summary-student.component.spec.ts
@@ -10,6 +10,7 @@ import { ConfigService } from '../../../services/configService';
 import { ProjectService } from '../../../services/projectService';
 import { StudentDataService } from '../../../services/studentDataService';
 import { SummaryStudent } from './summary-student.component';
+import { ComponentContent } from '../../../common/ComponentContent';
 
 let component: SummaryStudent;
 const componentId = 'component1';
@@ -102,7 +103,7 @@ function getOtherPrompt() {
       const prompt = 'Choose your favorite ice cream flavor.';
       spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({
         prompt: prompt
-      });
+      } as ComponentContent);
       expect(component.getOtherPrompt('node2', 'component2')).toEqual(prompt);
     });
   });

--- a/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.spec.ts
+++ b/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.spec.ts
@@ -21,6 +21,7 @@ import { EditComponentWidthComponent } from '../../../../../app/authoring-tool/e
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { EditConnectedComponentsComponent } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { ComponentContent } from '../../../common/ComponentContent';
 import { NotebookService } from '../../../services/notebookService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { EditTableConnectedComponentsComponent } from '../edit-table-connected-components/edit-table-connected-components.component';
@@ -98,6 +99,8 @@ describe('EditTableAdvancedComponent', () => {
 function createComponent() {
   return {
     id: '9dbz79h8ge',
+    nodeId: 'node1',
+    rubric: 'rubric text',
     type: 'Table',
     prompt: '',
     showSaveButton: false,
@@ -154,7 +157,7 @@ function createComponent() {
     numDataExplorerSeries: 1,
     isDataExplorerAxisLabelsEditable: false,
     isDataExplorerScatterPlotRegressionLineEnabled: true
-  };
+  } as ComponentContent;
 }
 
 function shouldToggleDataExplorer() {

--- a/src/assets/wise5/components/table/table-show-work/table-show-work.component.spec.ts
+++ b/src/assets/wise5/components/table/table-show-work/table-show-work.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { ComponentContent } from '../../../common/ComponentContent';
 import { ProjectService } from '../../../services/projectService';
 import { TabulatorDataService } from '../tabulatorDataService';
 import { TableShowWorkComponent } from './table-show-work.component';
@@ -17,8 +18,13 @@ describe('TableShowWorkComponent', () => {
     });
     fixture = TestBed.createComponent(TableShowWorkComponent);
     const componentContent = {
-      isDataExplorerEnabled: false
-    };
+      id: 'component1',
+      isDataExplorerEnabled: false,
+      nodeId: 'node1',
+      prompt: 'prompt',
+      rubric: 'rubric',
+      type: 'table'
+    } as ComponentContent;
     spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue(componentContent);
     component = fixture.componentInstance;
     component.componentContent = {};

--- a/src/assets/wise5/components/table/table-student/table-student.component.html
+++ b/src/assets/wise5/components/table/table-student/table-student.component.html
@@ -1,4 +1,4 @@
-<component-header [componentContent]="componentContent"></component-header>
+<component-header [component]="component"></component-header>
 <div class="tools" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="16px">
   <button
       mat-button

--- a/src/assets/wise5/directives/component-header/component-header.component.html
+++ b/src/assets/wise5/directives/component-header/component-header.component.html
@@ -1,9 +1,9 @@
 <div class="component-header" fxLayout="row wrap" fxLayoutGap="4px">
-  <prompt [prompt]="componentContent.prompt"
-      [nodeId]="nodeId"
-      [componentId]="componentContent.id"
+  <prompt [prompt]="component.content.prompt"
+      [nodeId]="component.nodeId"
+      [componentId]="component.id"
       [dynamicPrompt]="dynamicPrompt"
       (dynamicPromptChanged)="onDynamicPromptChanged($event)">
   </prompt>
-  <possible-score [maxScore]="componentContent.maxScore"></possible-score>
+  <possible-score [maxScore]="component.content.maxScore"></possible-score>
 </div>

--- a/src/assets/wise5/directives/component-header/component-header.component.spec.ts
+++ b/src/assets/wise5/directives/component-header/component-header.component.spec.ts
@@ -4,6 +4,8 @@ import { ComponentHeader } from './component-header.component';
 import { DomSanitizer } from '@angular/platform-browser';
 import { PromptComponent } from '../prompt/prompt.component';
 import { DynamicPromptComponent } from '../dynamic-prompt/dynamic-prompt.component';
+import { ComponentContent } from '../../common/ComponentContent';
+import { Component } from '../../common/Component';
 
 let component: ComponentHeader;
 let fixture: ComponentFixture<ComponentHeader>;
@@ -27,7 +29,12 @@ describe('ComponentHeaderComponent', () => {
   it('should show prompt', () => {
     fixture = TestBed.createComponent(ComponentHeader);
     component = fixture.componentInstance;
-    component.componentContent = { prompt: '<h3>Prompt goes here</h3>' };
+    component.component = new Component(
+      {
+        prompt: '<h3>Prompt goes here</h3>'
+      } as ComponentContent,
+      'node1'
+    );
     fixture.detectChanges();
     const compiled = fixture.debugElement.nativeElement;
     expect(compiled.querySelector('.prompt').textContent).toBe('Prompt goes here');

--- a/src/assets/wise5/directives/component-header/component-header.component.ts
+++ b/src/assets/wise5/directives/component-header/component-header.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { Component as WISEComponent } from '../../common/Component';
 import { FeedbackRule } from '../../components/common/feedbackRule/FeedbackRule';
 import { DynamicPrompt } from '../dynamic-prompt/DynamicPrompt';
 
@@ -9,17 +10,16 @@ import { DynamicPrompt } from '../dynamic-prompt/DynamicPrompt';
   templateUrl: 'component-header.component.html'
 })
 export class ComponentHeader {
-  @Input() componentContent: any;
+  @Input() component: WISEComponent;
   dynamicPrompt: DynamicPrompt;
   @Output() dynamicPromptChanged: EventEmitter<FeedbackRule> = new EventEmitter<FeedbackRule>();
-  @Input() nodeId: string;
   prompt: SafeHtml;
 
   constructor(protected sanitizer: DomSanitizer) {}
 
   ngOnInit() {
-    this.prompt = this.sanitizer.bypassSecurityTrustHtml(this.componentContent.prompt);
-    this.dynamicPrompt = new DynamicPrompt(this.componentContent.dynamicPrompt);
+    this.prompt = this.sanitizer.bypassSecurityTrustHtml(this.component.content.prompt);
+    this.dynamicPrompt = new DynamicPrompt(this.component.content.dynamicPrompt);
   }
 
   onDynamicPromptChanged(feedbackRule: FeedbackRule): void {

--- a/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.spec.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.spec.ts
@@ -4,6 +4,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { of } from 'rxjs';
 import { PeerGroupStudentData } from '../../../../app/domain/peerGroupStudentData';
 import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
+import { ComponentContent } from '../../common/ComponentContent';
 import { AnnotationService } from '../../services/annotationService';
 import { PeerGroupService } from '../../services/peerGroupService';
 import { ProjectService } from '../../services/projectService';
@@ -33,7 +34,7 @@ describe('DynamicPromptComponent', () => {
   beforeEach(() => {
     spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({
       type: 'OpenResponse'
-    });
+    } as ComponentContent);
     fixture = TestBed.createComponent(DynamicPromptComponent);
     component = fixture.componentInstance;
     component.dynamicPrompt = createDynamicPrompt();

--- a/src/assets/wise5/directives/generate-image-dialog/generate-image-dialog.component.spec.ts
+++ b/src/assets/wise5/directives/generate-image-dialog/generate-image-dialog.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
+import { ComponentContent } from '../../common/ComponentContent';
 import { ConceptMapService } from '../../components/conceptMap/conceptMapService';
 import { DrawService } from '../../components/draw/drawService';
 import { EmbeddedService } from '../../components/embedded/embeddedService';
@@ -36,7 +37,7 @@ describe('GenerateImageDialogComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(GenerateImageDialogComponent);
-    spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({});
+    spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({} as ComponentContent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/assets/wise5/directives/prompt/prompt.component.spec.ts
+++ b/src/assets/wise5/directives/prompt/prompt.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
+import { ComponentContent } from '../../common/ComponentContent';
 import { ProjectService } from '../../services/projectService';
 import { DynamicPromptComponent } from '../dynamic-prompt/dynamic-prompt.component';
 import { DynamicPrompt } from '../dynamic-prompt/DynamicPrompt';
@@ -36,7 +37,7 @@ describe('PromptComponent', () => {
     });
     spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({
       type: 'OpenResponse'
-    });
+    } as ComponentContent);
     fixture.detectChanges();
   });
 

--- a/src/assets/wise5/directives/student-summary-display/student-summary-display.component.spec.ts
+++ b/src/assets/wise5/directives/student-summary-display/student-summary-display.component.spec.ts
@@ -3,6 +3,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
+import { ComponentContent } from '../../common/ComponentContent';
 import { ConfigService } from '../../services/configService';
 import { ProjectService } from '../../services/projectService';
 import { StudentSummaryDisplay } from './student-summary-display.component';
@@ -204,7 +205,7 @@ function initializeOtherComponent() {
       const otherComponent = {
         id: 'component2',
         type: otherComponentType
-      };
+      } as ComponentContent;
       spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue(otherComponent);
       component.initializeOtherComponent();
       expect(component.otherComponent).toEqual(otherComponent);

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -11,6 +11,8 @@ import { ComponentServiceLookupService } from './componentServiceLookupService';
 import { Branch } from '../../../app/domain/branch';
 import { BranchService } from './branchService';
 import { PathService } from './pathService';
+import { ComponentContent } from '../common/ComponentContent';
+import { MultipleChoiceContent } from '../components/multipleChoice/MultipleChoiceContent';
 
 @Injectable()
 export class ProjectService {
@@ -1352,7 +1354,7 @@ export class ProjectService {
    * @param componentId the component id
    * @returns the component or null if the nodeId or componentId are null or does not exist
    */
-  getComponent(nodeId: string, componentId: string): any {
+  getComponent(nodeId: string, componentId: string): ComponentContent {
     const components = this.getComponents(nodeId);
     for (const component of components) {
       if (component.id === componentId) {
@@ -1369,13 +1371,11 @@ export class ProjectService {
    * doesn't exist in the project.
    * if the node exists but doesn't have any components, returns an empty array.
    */
-  getComponents(nodeId: string): any[] {
-    if (nodeId != null) {
-      const node = this.getNodeById(nodeId);
-      if (node != null) {
-        if (node.components != null) {
-          return node.components;
-        }
+  getComponents(nodeId: string): ComponentContent[] {
+    const node = this.getNodeById(nodeId);
+    if (node != null) {
+      if (node.components != null) {
+        return node.components;
       }
     }
     return [];
@@ -1541,7 +1541,7 @@ export class ProjectService {
    * @return The choices from the component.
    */
   getChoices(nodeId: string, componentId: string): any[] {
-    const component = this.getComponent(nodeId, componentId);
+    const component = this.getComponent(nodeId, componentId) as MultipleChoiceContent;
     return component.choices;
   }
 

--- a/src/assets/wise5/vle/studentAsset/student-assets/student-assets.component.spec.ts
+++ b/src/assets/wise5/vle/studentAsset/student-assets/student-assets.component.spec.ts
@@ -4,6 +4,7 @@ import { StudentAssetsComponent } from './student-assets.component';
 import { ProjectService } from '../../../services/projectService';
 import { StudentAssetService } from '../../../services/studentAssetService';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { ComponentContent } from '../../../common/ComponentContent';
 
 describe('StudentAssetsComponent', () => {
   let component: StudentAssetsComponent;
@@ -72,7 +73,7 @@ describe('StudentAssetsComponent', () => {
   function spyOnGetComponent(componentType: string) {
     return spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({
       type: componentType
-    });
+    } as ComponentContent);
   }
 
   function spyOnBroadcastAttachStudentAsset() {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -8785,7 +8785,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">17</context>
+          <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7123653594948067002" datatype="html">
@@ -8796,7 +8796,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">82</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
@@ -8811,7 +8811,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">113</context>
+          <context context-type="linenumber">114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1102665189929883417" datatype="html">
@@ -8822,7 +8822,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">16</context>
+          <context context-type="linenumber">17</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/PeerGroupingLogic.ts</context>
@@ -8841,11 +8841,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">21</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">50</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6214965175603898773" datatype="html">
@@ -9020,190 +9020,190 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Please Choose an Action</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8564983557318479146" datatype="html">
         <source>Make all nodes after this not visitable</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7251598407563761816" datatype="html">
         <source>Make all nodes after this not visible</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">36</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6911980762729094571" datatype="html">
         <source>Make all other nodes not visitable</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">40</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9001525595437976518" datatype="html">
         <source>Make all other nodes not visible</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">43</context>
+          <context context-type="linenumber">44</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8764818364930909549" datatype="html">
         <source>Make this node not visitable</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">47</context>
+          <context context-type="linenumber">48</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6344618803354581997" datatype="html">
         <source>Make this node not visible</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">52</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1616102757855967475" datatype="html">
         <source>All</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3184700926171002527" datatype="html">
         <source>Any</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4250686915350181595" datatype="html">
         <source>Please Choose a Removal Criteria</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">68</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6460463610153137840" datatype="html">
         <source>Is Completed</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">71</context>
+          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8980375993935541237" datatype="html">
         <source>Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">75</context>
+          <context context-type="linenumber">76</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">85</context>
+          <context context-type="linenumber">86</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">117</context>
+          <context context-type="linenumber">118</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">135</context>
+          <context context-type="linenumber">136</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">149</context>
+          <context context-type="linenumber">150</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">167</context>
+          <context context-type="linenumber">168</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">177</context>
+          <context context-type="linenumber">178</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">187</context>
+          <context context-type="linenumber">188</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">198</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">215</context>
+          <context context-type="linenumber">216</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">229</context>
+          <context context-type="linenumber">230</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5847302460276630595" datatype="html">
         <source>Component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">89</context>
+          <context context-type="linenumber">90</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">122</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">139</context>
+          <context context-type="linenumber">140</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">153</context>
+          <context context-type="linenumber">154</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">202</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">233</context>
+          <context context-type="linenumber">234</context>
         </context-group>
       </trans-unit>
       <trans-unit id="185559960832537937" datatype="html">
         <source>Score(s)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">93</context>
+          <context context-type="linenumber">94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="16986194959433746" datatype="html">
         <source>Branch Path Taken</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">99</context>
+          <context context-type="linenumber">100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6380325907263903883" datatype="html">
         <source>From Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">103</context>
+          <context context-type="linenumber">104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="455666817590621118" datatype="html">
         <source>To Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">107</context>
+          <context context-type="linenumber">108</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6910078656226990536" datatype="html">
         <source>Choices</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">125</context>
+          <context context-type="linenumber">126</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">43</context>
+          <context context-type="linenumber">44</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.ts</context>
@@ -9218,119 +9218,119 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Is Correct</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">131</context>
+          <context context-type="linenumber">132</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4268291134905709874" datatype="html">
         <source>Used X Submits</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">145</context>
+          <context context-type="linenumber">146</context>
         </context-group>
       </trans-unit>
       <trans-unit id="767433972334291022" datatype="html">
         <source>Required Submit Count</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">157</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2997822456018079719" datatype="html">
         <source>Is Visible</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">163</context>
+          <context context-type="linenumber">164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2226381985639556979" datatype="html">
         <source>Is Visitable</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">173</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3284330787067886212" datatype="html">
         <source>Is Visited</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">184</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3120562623622017132" datatype="html">
         <source>Wrote X Number of Words</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">193</context>
+          <context context-type="linenumber">194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3793469420585389570" datatype="html">
         <source>Required Number of Words</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">205</context>
+          <context context-type="linenumber">206</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2346474241177154844" datatype="html">
         <source>Add X Number of Notes On This Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">211</context>
+          <context context-type="linenumber">212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2215706295447985195" datatype="html">
         <source>Required Number of Notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">219</context>
+          <context context-type="linenumber">220</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3753898460381641212" datatype="html">
         <source>Fill X Number of Rows</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">225</context>
+          <context context-type="linenumber">226</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8868642264052368211" datatype="html">
         <source>Required Number of Filled Rows (Not Including Header Row)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">238</context>
+          <context context-type="linenumber">239</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3373179210544883044" datatype="html">
         <source>Table Has Header Row</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">243</context>
+          <context context-type="linenumber">244</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3682483624336387760" datatype="html">
         <source>Require All Cells In a Row To Be Filled</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">248</context>
+          <context context-type="linenumber">249</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6549053190457916462" datatype="html">
         <source>Teacher Removes Constraint</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">254</context>
+          <context context-type="linenumber">255</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7765979807116943270" datatype="html">
         <source>Are you sure you want to delete this constraint?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">320</context>
+          <context context-type="linenumber">321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8870343237719695349" datatype="html">
         <source>Are you sure you want to delete this removal criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">377</context>
+          <context context-type="linenumber">378</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bfab7f41cfc32a926c55987d6a9c3349ae417131" datatype="html">
@@ -9485,50 +9485,39 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>True</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">13</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3800326155195149498" datatype="html">
         <source>False</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">13</context>
+          <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4746248193865274387" datatype="html">
         <source>First Available</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">18</context>
+          <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5749828523955698758" datatype="html">
         <source>Last Available</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">19</context>
+          <context context-type="linenumber">20</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2240347155507306942" datatype="html">
         <source>Get a specific score on a component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">29</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="282405884193383477" datatype="html">
         <source>Node ID</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">31</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">41</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6666903681821403514" datatype="html">
-        <source>Component ID</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
           <context context-type="linenumber">32</context>
@@ -9538,74 +9527,85 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">42</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="6666903681821403514" datatype="html">
+        <source>Component ID</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="5224889179213510862" datatype="html">
         <source>Scores(s)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">33</context>
+          <context context-type="linenumber">34</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5667984727098835392" datatype="html">
         <source>Score ID (Optional)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">34</context>
+          <context context-type="linenumber">35</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4259244002485463451" datatype="html">
         <source>Choose a specific choice on a component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">40</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4749094791509859108" datatype="html">
         <source>Have Tag Assigned To Workgroup</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">48</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2816870790889466850" datatype="html">
         <source>Enter Node</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">53</context>
+          <context context-type="linenumber">54</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7469455958890383589" datatype="html">
         <source>Exit Node</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">54</context>
+          <context context-type="linenumber">55</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2016805497661021642" datatype="html">
         <source>Score Changed</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">55</context>
+          <context context-type="linenumber">56</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6660309701458926514" datatype="html">
         <source>Student Data Changed</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="931706124544241162" datatype="html">
         <source>Are you sure you want to delete this requirement?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">136</context>
+          <context context-type="linenumber">137</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9161423248419359552" datatype="html">
         <source>Are you sure you want to delete this path to &quot;<x id="PH" equiv-text="stepTitle"/>&quot;?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">204</context>
+          <context context-type="linenumber">205</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e5f24fc7a2bf50bd61d109dd9cad3fbff6ec7add" datatype="html">
@@ -12773,14 +12773,14 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Do you want to copy the nodes and links from the connected component?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/edit-concept-map-connected-components/edit-concept-map-connected-components.component.ts</context>
-          <context context-type="linenumber">36</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2323863937149753524" datatype="html">
         <source>Warning: This will delete all existing nodes and links in this component.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/edit-concept-map-connected-components/edit-concept-map-connected-components.component.ts</context>
-          <context context-type="linenumber">38</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="27e0b1e650bef276e8c29dd8d547e3fc8c4f833f" datatype="html">
@@ -14240,46 +14240,46 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Are you sure you want to overwrite the current line data?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">234</context>
+          <context context-type="linenumber">235</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6882380861047606832" datatype="html">
         <source>The series you are trying to add a point to is currently hidden. Please show the series by clicking the series name in the legend and try adding the point again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1053</context>
+          <context context-type="linenumber">1054</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2852989551014711458" datatype="html">
         <source>You can not edit this series. Please choose a series that can be edited.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1067</context>
+          <context context-type="linenumber">1068</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7053114367342967943" datatype="html">
         <source>Are you sure you want to reset the series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1345</context>
+          <context context-type="linenumber">1346</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7889560203726829643" datatype="html">
         <source>Are you sure you want to reset the &quot;<x id="PH" equiv-text="seriesName"/>&quot; series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1347</context>
+          <context context-type="linenumber">1348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6999515396807067782" datatype="html">
         <source>Trial</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1900</context>
+          <context context-type="linenumber">1901</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">2735</context>
+          <context context-type="linenumber">2736</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9070768663485888935" datatype="html">
@@ -14906,7 +14906,7 @@ Warning: This will delete all existing choices and buckets in this component.</s
 Warning: This will delete all existing choices in this component.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.ts</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">29</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5ed696b8da9ac51f371a34f2a89a753b9e18e3c0" datatype="html">
@@ -16058,7 +16058,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Are you sure you want to delete this custom label color?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.ts</context>
-          <context context-type="linenumber">174</context>
+          <context context-type="linenumber">175</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3556872137858469937" datatype="html">


### PR DESCRIPTION
## Changes
- Define ComponentContent interface and child interfaces (e.g. MatchContent, GraphContent, etc)
   - ProjectService.getComponent() now returns ComponentContent 
   - ProjectService.getComponents() now returns ComponentContent[]
- Define Component class that has ComponentContent and nodeId fields
   - Instantiate Component in StudentComponent and pass this into ComponentHeader, replacing ```any``` and ```nodeId```
- Change code and templates to work with the new classes

## Test
- VLE, AT, CM work as before, in particular: 
   - Prompt and dynamic prompt

Closes #872