### PR TITLE
feat(Data Explorer): Sync table row sorting with connected graphs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "sockjs-client": "^1.6.0",
         "svg.draggable.js": "2.2.0",
         "svg.js": "2.7.1",
-        "tabulator-tables": "^5.2.7",
+        "tabulator-tables": "^5.4.2",
         "tinymce": "^5.10.3",
         "tslib": "^2.3.1",
         "webfontloader": "^1.6.28",
@@ -24883,9 +24883,9 @@
       }
     },
     "node_modules/tabulator-tables": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-5.3.1.tgz",
-      "integrity": "sha512-NVZqClCftIfw1+XawNjBFytiZmUJ6nbcEB4NEahVbcXvQ6W9bOZizX/ZGTjtL30fYA0Oe97iZylCcSeTIGWDOg=="
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-5.4.2.tgz",
+      "integrity": "sha512-HDrm9kk5KjkGkUrLSenIbWuhJggfMrQqo9h6ZfaPq8jgPh/DITiboCG3v2xk7xEXd/GecGGeTzqMP5LfzgqcRA=="
     },
     "node_modules/tapable": {
       "version": "1.1.3",
@@ -46145,9 +46145,9 @@
       }
     },
     "tabulator-tables": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-5.3.1.tgz",
-      "integrity": "sha512-NVZqClCftIfw1+XawNjBFytiZmUJ6nbcEB4NEahVbcXvQ6W9bOZizX/ZGTjtL30fYA0Oe97iZylCcSeTIGWDOg=="
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-5.4.2.tgz",
+      "integrity": "sha512-HDrm9kk5KjkGkUrLSenIbWuhJggfMrQqo9h6ZfaPq8jgPh/DITiboCG3v2xk7xEXd/GecGGeTzqMP5LfzgqcRA=="
     },
     "tapable": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "sockjs-client": "^1.6.0",
     "svg.draggable.js": "2.2.0",
     "svg.js": "2.7.1",
-    "tabulator-tables": "^5.2.7",
+    "tabulator-tables": "^5.4.2",
     "tinymce": "^5.10.3",
     "tslib": "^2.3.1",
     "webfontloader": "^1.6.28",

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
@@ -449,6 +449,51 @@ function handleTableConnectedComponentStudentDataChanged() {
         [20, 40]
       ]);
     });
+    it('should handle table connected component student data changed with sorted rows', () => {
+      const connectedComponent = createTableConnectedComponent();
+      const dataRows: any[] = [
+        [0, 0],
+        [10, 20],
+        [20, 40],
+        [30, 80]
+      ];
+      const tableDataRows: any[] = [['Time', 'Position']].concat(dataRows);
+      const componentState = {
+        studentData: {
+          tableData: createTable(tableDataRows),
+          sortOrder: [2, 1, 0, 3]
+        }
+      };
+      component.handleTableConnectedComponentStudentDataChanged(connectedComponent, componentState);
+      expect(component.activeTrial.series[0].data).toEqual([
+        [20, 40],
+        [10, 20],
+        [0, 0],
+        [30, 80]
+      ]);
+    });
+    it('should handle table connected component student data changed with selected and sorted rows', () => {
+      const connectedComponent = createTableConnectedComponent();
+      const dataRows: any[] = [
+        [0, 0],
+        [10, 20],
+        [20, 40],
+        [30, 80]
+      ];
+      const tableDataRows: any[] = [['Time', 'Position']].concat(dataRows);
+      const componentState = {
+        studentData: {
+          tableData: createTable(tableDataRows),
+          selectedRowIndices: [0, 2],
+          sortOrder: [2, 1, 0, 3]
+        }
+      };
+      component.handleTableConnectedComponentStudentDataChanged(connectedComponent, componentState);
+      expect(component.activeTrial.series[0].data).toEqual([
+        [20, 40],
+        [0, 0]
+      ]);
+    });
     it('should handle connected data explorer student data changed', () => {
       const connectedComponent = createTableConnectedComponent();
       const studentData = createDataExplorerStudentData();

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -260,7 +260,7 @@ export class GraphStudent extends ComponentStudent {
   }
 
   handleTableConnectedComponentStudentDataChanged(connectedComponent, componentState) {
-    const studentData = this.UtilService.makeCopyOfJSONObject(componentState.studentData);
+    const studentData = componentState.studentData;
     if (studentData.tableData.length > 0) {
       studentData.tableData = this.getFilteredAndSortedTableData(
         studentData.tableData,

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -261,10 +261,12 @@ export class GraphStudent extends ComponentStudent {
 
   handleTableConnectedComponentStudentDataChanged(connectedComponent, componentState) {
     const studentData = this.UtilService.makeCopyOfJSONObject(componentState.studentData);
-    const selectedRowIndices = studentData.selectedRowIndices;
-    const tableData = studentData.tableData;
-    if (tableData.length > 0 && selectedRowIndices != null && selectedRowIndices.length > 0) {
-      studentData.tableData = this.getVisibleRows(studentData.tableData, selectedRowIndices);
+    if (studentData.tableData.length > 0) {
+      studentData.tableData = this.getFilteredAndSortedTableData(
+        studentData.tableData,
+        studentData.sortOrder,
+        studentData.selectedRowIndices
+      );
     }
     if (studentData.isDataExplorerEnabled) {
       this.handleDataExplorer(studentData);
@@ -275,14 +277,46 @@ export class GraphStudent extends ComponentStudent {
     this.isDirty = true;
   }
 
-  private getVisibleRows(tableData: any, selectedRowIndices: number[]): any[] {
-    const visibleRows = [];
-    visibleRows.push(tableData[0]);
-    tableData.forEach((row, index) => {
-      if (selectedRowIndices.includes(index - 1)) {
-        visibleRows.push(row);
+  private getFilteredAndSortedTableData(
+    tableData: any[],
+    sortOrder: number[] = [],
+    selectedRowIndices: number[] = []
+  ): any[] {
+    if (sortOrder && sortOrder.length > 0) {
+      return this.getSortedTableData(tableData, sortOrder, selectedRowIndices);
+    } else {
+      return this.getFilteredTableData(tableData, selectedRowIndices);
+    }
+  }
+
+  private getSortedTableData(
+    tableData: any[],
+    sortOrder: number[],
+    selectedRowIndices: number[]
+  ): any[] {
+    const sortedTableData = [tableData[0]];
+    sortOrder.forEach((rowNumber, index) => {
+      if (this.isRowSelected(rowNumber, selectedRowIndices)) {
+        sortedTableData.push(tableData[rowNumber + 1]);
       }
     });
+    return sortedTableData;
+  }
+
+  private isRowSelected(rowNumber: number, selectedRowIndices: number[]): boolean {
+    return selectedRowIndices.length > 0 ? selectedRowIndices.includes(rowNumber) : true;
+  }
+
+  private getFilteredTableData(tableData: any[], selectedRowIndices: number[]): any[] {
+    let visibleRows = tableData;
+    if (selectedRowIndices && selectedRowIndices.length > 0) {
+      visibleRows = [tableData[0]];
+      tableData.forEach((row, index) => {
+        if (this.isRowSelected(index - 1, selectedRowIndices)) {
+          visibleRows.push(row);
+        }
+      });
+    }
     return visibleRows;
   }
 

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -262,7 +262,7 @@ export class GraphStudent extends ComponentStudent {
   handleTableConnectedComponentStudentDataChanged(connectedComponent, componentState) {
     const studentData = this.UtilService.makeCopyOfJSONObject(componentState.studentData);
     if (studentData.tableData.length > 0) {
-      studentData.tableData = this.getFilteredAndSortedTableData(
+      studentData.tableData = this.processTableData(
         studentData.tableData,
         studentData.sortOrder,
         studentData.selectedRowIndices
@@ -277,19 +277,19 @@ export class GraphStudent extends ComponentStudent {
     this.isDirty = true;
   }
 
-  private getFilteredAndSortedTableData(
+  private processTableData(
     tableData: any[],
     sortOrder: number[] = [],
     selectedRowIndices: number[] = []
   ): any[] {
     if (sortOrder && sortOrder.length > 0) {
-      return this.getSortedTableData(tableData, sortOrder, selectedRowIndices);
+      return this.getSortedAndFilteredTableData(tableData, sortOrder, selectedRowIndices);
     } else {
       return this.getFilteredTableData(tableData, selectedRowIndices);
     }
   }
 
-  private getSortedTableData(
+  private getSortedAndFilteredTableData(
     tableData: any[],
     sortOrder: number[],
     selectedRowIndices: number[]

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -260,7 +260,7 @@ export class GraphStudent extends ComponentStudent {
   }
 
   handleTableConnectedComponentStudentDataChanged(connectedComponent, componentState) {
-    const studentData = componentState.studentData;
+    const studentData = this.UtilService.makeCopyOfJSONObject(componentState.studentData);
     if (studentData.tableData.length > 0) {
       studentData.tableData = this.getFilteredAndSortedTableData(
         studentData.tableData,

--- a/src/assets/wise5/components/table/table-show-work/table-show-work.component.html
+++ b/src/assets/wise5/components/table/table-show-work/table-show-work.component.html
@@ -6,6 +6,7 @@
       [tabColumns]="tabulatorData.columns"
       [tabData]="tabulatorData.data"
       [tabOptions]="tabulatorData.options"
+      [tabSorters]="tabulatorSorters"
       (ready)="tabulatorRendered()"></tabulator-table>
 </div>
 <ng-container *ngIf="componentContent.isDataExplorerEnabled">

--- a/src/assets/wise5/components/table/table-show-work/table-show-work.component.ts
+++ b/src/assets/wise5/components/table/table-show-work/table-show-work.component.ts
@@ -22,6 +22,7 @@ export class TableShowWorkComponent extends ComponentShowWorkDirective {
   columnNames: string[] = [];
   noneText: string = $localize`(None)`;
   tabulatorData: TabulatorData;
+  tabulatorSorters: any[];
 
   constructor(
     protected nodeService: NodeService,
@@ -36,6 +37,7 @@ export class TableShowWorkComponent extends ComponentShowWorkDirective {
     const studentData = this.componentState.studentData;
     this.tableData = studentData.tableData;
     this.selectedRowIndices = studentData.selectedRowIndices ? studentData.selectedRowIndices : [];
+    this.tabulatorSorters = studentData.tabulatorSorters ? studentData.tabulatorSorters : [];
     if (studentData.isDataExplorerEnabled) {
       this.dataExplorerGraphType = studentData.dataExplorerGraphType;
       this.dataExplorerSeries = studentData.dataExplorerSeries;

--- a/src/assets/wise5/components/table/table-student/table-student.component.html
+++ b/src/assets/wise5/components/table/table-student/table-student.component.html
@@ -37,8 +37,10 @@
     [tabColumns]="tabulatorData.columns"
     [tabData]="tabulatorData.data"
     [tabOptions]="tabulatorData.options"
+    [tabSorters]="tabulatorSorters"
     (cellChanged)="tabulatorCellChanged($event)"
     (rowSelectionChanged)="tabulatorRowSelectionChanged($event)"
+    (rowSortChanged)="tabulatorRowSortChanged($event)"
     (ready)="tabulatorRendered()"></tabulator-table>
 <div *ngIf="isDataExplorerEnabled">
   <br/>

--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -42,9 +42,11 @@ export class TableStudent extends ComponentStudent {
   notebookConfig: any;
   numDataExplorerSeries: number;
   selectedRowIndices: number[] = [];
+  sortOrder: number[] = [];
   tableData: any;
   tableId: string;
   tabulatorData: TabulatorData;
+  tabulatorSorters: any[] = [];
 
   constructor(
     protected AnnotationService: AnnotationService,
@@ -377,6 +379,10 @@ export class TableStudent extends ComponentStudent {
           ? studentData.selectedRowIndices
           : [];
 
+        this.sortOrder = studentData.sortOrder ? studentData.sortOrder : [];
+
+        this.tabulatorSorters = studentData.tabulatorSorters ? studentData.tabulatorSorters : [];
+
         this.processLatestStudentWork();
       }
     }
@@ -393,6 +399,8 @@ export class TableStudent extends ComponentStudent {
     const studentData: any = {};
     studentData.tableData = this.getCopyOfTableData(this.tableData);
     studentData.selectedRowIndices = this.getSelectedRowIndices();
+    studentData.sortOrder = this.sortOrder;
+    studentData.tabulatorSorters = this.tabulatorSorters;
     studentData.isDataExplorerEnabled = this.isDataExplorerEnabled;
     studentData.dataExplorerGraphType = this.dataExplorerGraphType;
     studentData.dataExplorerXAxisLabel = this.dataExplorerXAxisLabel;
@@ -1193,5 +1201,11 @@ export class TableStudent extends ComponentStudent {
 
   private getSelectedRowIndices(): number[] {
     return this.componentContent.enableRowSelection ? this.selectedRowIndices : [];
+  }
+
+  tabulatorRowSortChanged(sortData: any): void {
+    this.sortOrder = sortData.sortOrder;
+    this.tabulatorSorters = sortData.tabSorters;
+    this.studentDataChanged();
   }
 }

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.scss
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.scss
@@ -18,6 +18,10 @@
     background-color: #ffffff;
     min-height: 44px; // temporary hack to fix height for some rows with empty cell values; TODO: investigate and fix
     border-bottom: 1px solid #dddddd;
+    
+    &.tabulator-frozen {
+      background-color: #ffffff;
+    }
 
     &.tabulator-cell-editable {
       &:before {

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.spec.ts
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.spec.ts
@@ -1,8 +1,9 @@
-import { SimpleChange } from '@angular/core';
+import { NO_ERRORS_SCHEMA, SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TabulatorTableComponent } from './tabulator-table.component';
 import { Tabulator } from 'tabulator-tables';
 import { TabulatorColumn } from '../TabulatorData';
+import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 
 let component: TabulatorTableComponent;
 let fixture: ComponentFixture<TabulatorTableComponent>;
@@ -23,13 +24,18 @@ const tabData = [
   { 0: '12', 1: '', 2: '' }
 ];
 const tabOptions = {
-  layout: "fitDataTable",
-  maxHeight: "500px",
-  reactiveData: true,
-}
+  layout: 'fitDataTable',
+  maxHeight: '500px',
+  reactiveData: true
+};
 
 describe('TabulatorTableComponent', () => {
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [StudentTeacherCommonServicesModule],
+      declarations: [TabulatorTableComponent],
+      schemas: [NO_ERRORS_SCHEMA]
+    });
     fixture = TestBed.createComponent(TabulatorTableComponent);
     component = fixture.componentInstance;
     component.tabColumns = tabColumns;

--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
@@ -22,6 +22,7 @@ import {
   SelectRowModule,
   SortModule
 } from 'tabulator-tables';
+import { UtilService } from '../../../services/utilService';
 import { TabulatorColumn } from '../TabulatorData';
 
 @Component({
@@ -50,7 +51,7 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
   subscriptions: Subscription = new Subscription();
   viewInit$ = new ReplaySubject();
 
-  constructor() {
+  constructor(protected UtilService: UtilService) {
     Tabulator.registerModule([
       EditModule,
       FormatModule,
@@ -67,7 +68,7 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
     this.tabOptions.columns = this.setupColumns(this.tabColumns);
     this.initializeRowSelection();
     this.tabOptions.data = this.tabData;
-    this.tabOptions.initialSort = this.tabSorters;
+    this.tabOptions.initialSort = this.UtilService.makeCopyOfJSONObject(this.tabSorters);
     this.table = new Tabulator(this.tableEl, this.tabOptions);
     this.table.on('cellEdited', (cell) => {
       this.cellChanged.emit(cell);

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -14298,39 +14298,39 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>The series you are trying to add a point to is currently hidden. Please show the series by clicking the series name in the legend and try adding the point again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1054</context>
+          <context context-type="linenumber">1088</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2852989551014711458" datatype="html">
         <source>You can not edit this series. Please choose a series that can be edited.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1068</context>
+          <context context-type="linenumber">1102</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7053114367342967943" datatype="html">
         <source>Are you sure you want to reset the series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1346</context>
+          <context context-type="linenumber">1380</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7889560203726829643" datatype="html">
         <source>Are you sure you want to reset the &quot;<x id="PH" equiv-text="seriesName"/>&quot; series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1348</context>
+          <context context-type="linenumber">1382</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6999515396807067782" datatype="html">
         <source>Trial</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1901</context>
+          <context context-type="linenumber">1935</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">2736</context>
+          <context context-type="linenumber">2770</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9070768663485888935" datatype="html">
@@ -15875,11 +15875,11 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">68</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">85</context>
+          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1702c8b1dfd9b74fe218322fb3509b227cd41b1b" datatype="html">
@@ -16243,7 +16243,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">63</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2c57dd23349e236c076c19356af17d5de965d398" datatype="html">
@@ -16502,7 +16502,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">48</context>
         </context-group>
       </trans-unit>
       <trans-unit id="967a05fa93ce8900222661f7beb6c08924b3a857" datatype="html">
@@ -16520,7 +16520,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">102</context>
+          <context context-type="linenumber">104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="484e9a22dbb7f73c463535f204e1f221b6cbdacb" datatype="html">
@@ -16531,7 +16531,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">114</context>
+          <context context-type="linenumber">116</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f15f150caaef41e4e915900660dae93b053ec897" datatype="html">
@@ -16559,36 +16559,36 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Choose the table data you want to graph:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">58</context>
+          <context context-type="linenumber">60</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a3e2cbd23a21040a6893d669847148041dd03868" datatype="html">
         <source>Y Data <x id="INTERPOLATION" equiv-text="{{ dataExplorerSeries.length &gt; 1 ? seriesIndex + 1 : &quot;&quot;}}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7c0b21d6d77a0c42b3a86c8922b7766ebfaeb4c1" datatype="html">
         <source>Enter Text Here</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">107</context>
+          <context context-type="linenumber">109</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">119</context>
+          <context context-type="linenumber">121</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">136</context>
+          <context context-type="linenumber">138</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2ba0ed2ffebe37a936032b49e9fdf057a9af7d07" datatype="html">
         <source>Y Axis <x id="INTERPOLATION" equiv-text="{{yAxisIndex + 1}}"/> Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
-          <context context-type="linenumber">131</context>
+          <context context-type="linenumber">133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1358239534403218079" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -16239,7 +16239,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">25</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
@@ -16498,7 +16498,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Graph Type</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">14</context>
+          <context context-type="linenumber">15</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
@@ -16509,14 +16509,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Y Data <x id="INTERPOLATION" equiv-text="{{dataExplorerSeries.length &gt; 1 ? (i + 1) : &apos;&apos;}}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">36</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b703c5f9773985dca9e4594ae0c3ecb9f3da4462" datatype="html">
         <source>X Axis Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">53</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
@@ -16527,7 +16527,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Y Axis Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">65</context>
+          <context context-type="linenumber">66</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-student/table-student.component.html</context>
@@ -16538,7 +16538,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Y Axis <x id="INTERPOLATION" equiv-text="{{i + 1}}"/> Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/table-show-work/table-show-work.component.html</context>
-          <context context-type="linenumber">82</context>
+          <context context-type="linenumber">83</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8764032794209664551" datatype="html">


### PR DESCRIPTION
## Changes
When students sort a Table component by row, connected graphs now update to reflect the sort order. The sort order is now also saved in the Table's studentData and restored when reloading the component.

The Tabulator library was also updated to the latest version.

Closes #876.

## Test
- Run `npm install` to update dependencies.
- Test with a step that includes a Data Explorer activity (Table component + connected graph component).
- Verify that sorting the table data (by clicking on row headers) updates the connected graph with the same order for the data points.
- Enable row selection on the Table component and test that selecting rows in the table still filters the graph data and that filtering works when sorting the table in different ways.
- Verify that sorting and visible rows are saved with the Table studentData and repopulated when revisiting the step.
- Verify that grading view for Table and Graph components reflect that saved sorting and selected rows.

@geoffreykwan There is also a bug in the connected graph. When the table is sorted, the x-axis labels are properly named in the graph initially. But when you leave the step and come back, they don't show the cell values and are replaced with indices (0, 1, 2, etc.). This also happens in the show work/grading view. (See screenshot below.) Could you take a look to see if you can fix? Thanks!

![Screen Shot 2022-10-27 at 12 59 34 PM](https://user-images.githubusercontent.com/297450/198386549-f2864dce-7313-40c5-a94b-cc9c4c92560f.png)
![Screen Shot 2022-10-27 at 12 58 07 PM](https://user-images.githubusercontent.com/297450/198386268-2d6528a8-fbe8-43be-961f-1a167e3edd75.png)
