### PR TITLE
refactor(UtilService): Move generateKey() to its own class

### DIFF
--- a/src/app/authoring-tool/edit-dynamic-prompt-rules/edit-dynamic-prompt-rules.component.ts
+++ b/src/app/authoring-tool/edit-dynamic-prompt-rules/edit-dynamic-prompt-rules.component.ts
@@ -2,8 +2,8 @@ import { Component } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { EditFeedbackRulesComponent } from '../../../assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component';
 import { FeedbackRule } from '../../../assets/wise5/components/common/feedbackRule/FeedbackRule';
+import { RandomKeyService } from '../../../assets/wise5/services/randomKeyService';
 import { TeacherProjectService } from '../../../assets/wise5/services/teacherProjectService';
-import { UtilService } from '../../../assets/wise5/services/utilService';
 
 @Component({
   selector: 'edit-dynamic-prompt-rules',
@@ -11,12 +11,8 @@ import { UtilService } from '../../../assets/wise5/services/utilService';
   styleUrls: ['./edit-dynamic-prompt-rules.component.scss']
 })
 export class EditDynamicPromptRulesComponent extends EditFeedbackRulesComponent {
-  constructor(
-    protected dialog: MatDialog,
-    protected projectService: TeacherProjectService,
-    protected utilService: UtilService
-  ) {
-    super(dialog, projectService, utilService);
+  constructor(protected dialog: MatDialog, protected projectService: TeacherProjectService) {
+    super(dialog, projectService);
   }
 
   ngOnInit(): void {
@@ -24,7 +20,7 @@ export class EditDynamicPromptRulesComponent extends EditFeedbackRulesComponent 
   }
 
   protected createNewFeedbackRule(): Partial<FeedbackRule> {
-    return { id: this.utilService.generateKey(10), expression: '', prompt: '' };
+    return { id: RandomKeyService.generate(), expression: '', prompt: '' };
   }
 
   deleteRule(ruleIndex: number): void {

--- a/src/app/services/randomKeyService.spec.ts
+++ b/src/app/services/randomKeyService.spec.ts
@@ -1,0 +1,31 @@
+import { RandomKeyService } from '../../assets/wise5/services/randomKeyService';
+
+describe('RandomKeyService', () => {
+  generate();
+});
+
+function generate() {
+  describe('generate()', () => {
+    it('should return random keys of length 10 by default', () => {
+      const key1 = RandomKeyService.generate();
+      const key2 = RandomKeyService.generate();
+      expect(key1.length).toEqual(10);
+      expect(key2.length).toEqual(10);
+      expect(key1).not.toEqual(key2);
+    });
+
+    it('should return random keys of specified length', () => {
+      expect(RandomKeyService.generate(5).length).toEqual(5);
+      expect(RandomKeyService.generate(23).length).toEqual(23);
+    });
+
+    it('should produce 100 unique random strings', () => {
+      const keysSoFar = [];
+      for (let i = 0; i < 100; i++) {
+        const key = RandomKeyService.generate();
+        expect(keysSoFar.includes(key)).toEqual(false);
+        keysSoFar.push(key);
+      }
+    });
+  });
+}

--- a/src/app/services/utilService.spec.ts
+++ b/src/app/services/utilService.spec.ts
@@ -11,7 +11,6 @@ describe('UtilService', () => {
     service = TestBed.get(UtilService);
   });
 
-  generateKeyTests();
   convertStringToNumberTests();
   makeCopyOfJSONObjectTests();
   arrayHasNonNullElementTests();
@@ -22,32 +21,6 @@ describe('UtilService', () => {
   removeHTMLTags();
   replaceImgTagWithFileName();
 });
-
-function generateKeyTests() {
-  describe('generateKey()', () => {
-    it('should return random keys of length 10 by default', () => {
-      const generatedKey1 = service.generateKey();
-      const generatedKey2 = service.generateKey();
-      expect(generatedKey1.length).toEqual(10);
-      expect(generatedKey2.length).toEqual(10);
-      expect(generatedKey1).not.toEqual(generatedKey2);
-    });
-
-    it('should return random keys of specified length', () => {
-      expect(service.generateKey(5).length).toEqual(5);
-      expect(service.generateKey(23).length).toEqual(23);
-    });
-
-    it('should produce 100 unique random strings', () => {
-      const generatedKeysSoFar = [];
-      for (let i = 0; i < 100; i++) {
-        const generatedKey = service.generateKey();
-        expect(generatedKeysSoFar.includes(generatedKey)).toEqual(false);
-        generatedKeysSoFar.push(generatedKey);
-      }
-    });
-  });
-}
 
 function convertStringToNumberTests() {
   describe('convertStringToNumber()', () => {

--- a/src/assets/wise5/authoringTool/milestones/milestonesAuthoringComponent.ts
+++ b/src/assets/wise5/authoringTool/milestones/milestonesAuthoringComponent.ts
@@ -1,7 +1,7 @@
 'use strict';
 
+import { RandomKeyService } from '../../services/randomKeyService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
-import { UtilService } from '../../services/utilService';
 
 class MilestonesAuthoringController {
   $translate: any;
@@ -26,13 +26,9 @@ class MilestonesAuthoringController {
   customScoreKey: string;
   customScoreValues: string;
 
-  static $inject = ['$filter', 'ProjectService', 'UtilService'];
+  static $inject = ['$filter', 'ProjectService'];
 
-  constructor(
-    private $filter: any,
-    private ProjectService: TeacherProjectService,
-    private UtilService: UtilService
-  ) {
+  constructor(private $filter: any, private ProjectService: TeacherProjectService) {
     this.$translate = this.$filter('translate');
   }
 
@@ -197,7 +193,7 @@ class MilestonesAuthoringController {
   }
 
   generateMilestoneSatisfyCriteriaId() {
-    return this.milestoneSatisfyCriteriaIdPrefix + this.UtilService.generateKey(10);
+    return this.milestoneSatisfyCriteriaIdPrefix + RandomKeyService.generate();
   }
 
   isUniqueMilestoneSatisfyCriteriaId(id) {
@@ -287,7 +283,7 @@ class MilestonesAuthoringController {
   generateUniqueId(prefix: string, existingIds: any[]): string {
     let id: string;
     do {
-      id = prefix + this.UtilService.generateKey(10);
+      id = prefix + RandomKeyService.generate();
     } while (existingIds[id] != null);
     return id;
   }

--- a/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.ts
+++ b/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.ts
@@ -7,8 +7,8 @@ import { ProjectAssetService } from '../../../../../app/services/projectAssetSer
 import { ComponentAuthoring } from '../../../authoringTool/components/component-authoring.component';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
+import { RandomKeyService } from '../../../services/randomKeyService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
-import { UtilService } from '../../../services/utilService';
 
 @Component({
   selector: 'animation-authoring',
@@ -25,8 +25,7 @@ export class AnimationAuthoring extends ComponentAuthoring {
     protected ConfigService: ConfigService,
     protected NodeService: NodeService,
     protected ProjectAssetService: ProjectAssetService,
-    protected ProjectService: TeacherProjectService,
-    protected UtilService: UtilService
+    protected ProjectService: TeacherProjectService
   ) {
     super(ConfigService, NodeService, ProjectAssetService, ProjectService);
     this.stepNodesDetails = this.ProjectService.getStepNodesDetailsInOrder();
@@ -42,7 +41,7 @@ export class AnimationAuthoring extends ComponentAuthoring {
       this.authoringComponentContent.objects = [];
     }
     const newObject = {
-      id: this.UtilService.generateKey(10),
+      id: RandomKeyService.generate(),
       type: 'image'
     };
     this.authoringComponentContent.objects.push(newObject);

--- a/src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.ts
+++ b/src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.ts
@@ -3,10 +3,10 @@ import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { Subject, Subscription } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
-import { UtilService } from '../../../../services/utilService';
 import { FeedbackRule } from '../FeedbackRule';
 import { MatDialog } from '@angular/material/dialog';
 import { FeedbackRuleHelpComponent } from '../feedback-rule-help/feedback-rule-help.component';
+import { RandomKeyService } from '../../../../services/randomKeyService';
 
 @Component({
   selector: 'edit-feedback-rules',
@@ -19,11 +19,7 @@ export class EditFeedbackRulesComponent implements OnInit {
   subscriptions: Subscription = new Subscription();
   @Input() version: number = 2;
 
-  constructor(
-    protected dialog: MatDialog,
-    protected projectService: TeacherProjectService,
-    protected utilService: UtilService
-  ) {}
+  constructor(protected dialog: MatDialog, protected projectService: TeacherProjectService) {}
 
   ngOnInit(): void {
     this.subscriptions.add(
@@ -64,7 +60,7 @@ export class EditFeedbackRulesComponent implements OnInit {
     if (this.version === 1) {
       return { expression: '', feedback: '' };
     } else {
-      return { id: this.utilService.generateKey(10), expression: '', feedback: [''] };
+      return { id: RandomKeyService.generate(), expression: '', feedback: [''] };
     }
   }
 

--- a/src/assets/wise5/components/componentService.ts
+++ b/src/assets/wise5/components/componentService.ts
@@ -2,7 +2,7 @@
 
 import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
-import { UtilService } from '../services/utilService';
+import { RandomKeyService } from '../services/randomKeyService';
 import { ComponentStateRequest } from './ComponentStateRequest';
 import { ComponentStateWrapper } from './ComponentStateWrapper';
 
@@ -15,7 +15,7 @@ export class ComponentService {
   private notifyConnectedComponentSource = new Subject<any>();
   public notifyConnectedComponentSource$ = this.notifyConnectedComponentSource.asObservable();
 
-  constructor(protected UtilService: UtilService) {}
+  constructor() {}
 
   getDomIdEnding(nodeId: string, componentId: string, componentState: any): string {
     if (componentState == null) {
@@ -67,7 +67,7 @@ export class ComponentService {
    */
   createComponent() {
     return {
-      id: this.UtilService.generateKey(),
+      id: RandomKeyService.generate(),
       type: '',
       prompt: '',
       showSaveButton: false,

--- a/src/assets/wise5/components/conceptMap/conceptMapService.ts
+++ b/src/assets/wise5/components/conceptMap/conceptMapService.ts
@@ -16,7 +16,7 @@ export class ConceptMapService extends ComponentService {
     private StudentAssetService: StudentAssetService,
     protected UtilService: UtilService
   ) {
-    super(UtilService);
+    super();
   }
 
   getComponentTypeLabel(): string {

--- a/src/assets/wise5/components/dialogGuidance/dialogGuidanceService.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialogGuidanceService.ts
@@ -1,15 +1,11 @@
 import { Injectable } from '@angular/core';
 import { ComputerAvatarService } from '../../services/computerAvatarService';
-import { UtilService } from '../../services/utilService';
 import { ComponentService } from '../componentService';
 
 @Injectable()
 export class DialogGuidanceService extends ComponentService {
-  constructor(
-    protected computerAvatarService: ComputerAvatarService,
-    protected utilService: UtilService
-  ) {
-    super(utilService);
+  constructor(protected computerAvatarService: ComputerAvatarService) {
+    super();
   }
 
   getComponentTypeLabel(): string {

--- a/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.ts
+++ b/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
 import { NotificationService } from '../../../services/notificationService';
+import { RandomKeyService } from '../../../services/randomKeyService';
 import { StudentAssetService } from '../../../services/studentAssetService';
 import { StudentDataService } from '../../../services/studentDataService';
 import { UtilService } from '../../../services/utilService';
@@ -374,7 +375,7 @@ export class DiscussionStudent extends ComponentStudent {
       (this.ConfigService.isPreview() && !this.componentStateIdReplyingTo) ||
       this.mode === 'authoring'
     ) {
-      componentState.id = this.UtilService.generateKey();
+      componentState.id = RandomKeyService.generate();
     }
     if (this.isSubmit) {
       componentState.studentData.isSubmit = this.isSubmit;

--- a/src/assets/wise5/components/discussion/discussionService.ts
+++ b/src/assets/wise5/components/discussion/discussionService.ts
@@ -13,7 +13,7 @@ export class DiscussionService extends ComponentService {
     protected ConfigService: ConfigService,
     protected UtilService: UtilService
   ) {
-    super(UtilService);
+    super();
   }
 
   getComponentTypeLabel(): string {

--- a/src/assets/wise5/components/draw/drawService.ts
+++ b/src/assets/wise5/components/draw/drawService.ts
@@ -35,7 +35,7 @@ export class DrawService extends ComponentService {
     private StudentAssetService: StudentAssetService,
     protected UtilService: UtilService
   ) {
-    super(UtilService);
+    super();
   }
 
   getComponentTypeLabel(): string {

--- a/src/assets/wise5/components/embedded/embeddedService.ts
+++ b/src/assets/wise5/components/embedded/embeddedService.ts
@@ -19,7 +19,7 @@ export class EmbeddedService extends ComponentService {
     protected StudentAssetService: StudentAssetService,
     protected UtilService: UtilService
   ) {
-    super(UtilService);
+    super();
   }
 
   getEmbeddedApplicationIframeId(componentId: string): string {

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -16,6 +16,7 @@ import * as covariance from 'compute-covariance';
 import canvg from 'canvg';
 import { MatDialog } from '@angular/material/dialog';
 import { GraphContent } from '../GraphContent';
+import { RandomKeyService } from '../../../services/randomKeyService';
 
 const Draggable = require('highcharts/modules/draggable-points.js');
 Draggable(Highcharts);
@@ -1643,7 +1644,7 @@ export class GraphStudent extends ComponentStudent {
     if (this.isStudentDataVersion1(studentData.version)) {
       const series = studentData.series;
       const newTrial = {
-        id: this.UtilService.generateKey(10),
+        id: RandomKeyService.generate(),
         name: nodePositionAndTitle,
         show: true,
         series: series
@@ -1901,7 +1902,7 @@ export class GraphStudent extends ComponentStudent {
       name: $localize`Trial` + ' ' + (maxTrialNumber + 1),
       series: series,
       show: true,
-      id: this.UtilService.generateKey(10)
+      id: RandomKeyService.generate()
     };
     this.trials.push(trial);
     this.activeTrial = trial;
@@ -2732,7 +2733,7 @@ export class GraphStudent extends ComponentStudent {
 
   addTrialFromThisComponentIfNecessary(mergedTrials, trialCount, activeTrialIndex) {
     if (this.componentContent.series.length > 0) {
-      const trial = this.createNewTrial(this.UtilService.generateKey(10));
+      const trial = this.createNewTrial(RandomKeyService.generate());
       trial.name = $localize`Trial` + ' ' + trialCount;
       trial.series = this.UtilService.makeCopyOfJSONObject(this.componentContent.series);
       mergedTrials.push(trial);

--- a/src/assets/wise5/components/graph/graphService.ts
+++ b/src/assets/wise5/components/graph/graphService.ts
@@ -18,7 +18,7 @@ export class GraphService extends ComponentService {
     private StudentAssetService: StudentAssetService,
     protected UtilService: UtilService
   ) {
-    super(UtilService);
+    super();
   }
 
   getComponentTypeLabel(): string {

--- a/src/assets/wise5/components/label/labelService.ts
+++ b/src/assets/wise5/components/label/labelService.ts
@@ -18,7 +18,7 @@ export class LabelService extends ComponentService {
     private StudentAssetService: StudentAssetService,
     protected UtilService: UtilService
   ) {
-    super(UtilService);
+    super();
   }
 
   getComponentTypeLabel(): string {

--- a/src/assets/wise5/components/match/match-authoring/match-authoring.component.ts
+++ b/src/assets/wise5/components/match/match-authoring/match-authoring.component.ts
@@ -5,8 +5,8 @@ import { ProjectAssetService } from '../../../../../app/services/projectAssetSer
 import { ComponentAuthoring } from '../../../authoringTool/components/component-authoring.component';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
+import { RandomKeyService } from '../../../services/randomKeyService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
-import { UtilService } from '../../../services/utilService';
 import { MatchService } from '../matchService';
 
 @Component({
@@ -23,8 +23,7 @@ export class MatchAuthoring extends ComponentAuthoring {
     private MatchService: MatchService,
     protected NodeService: NodeService,
     protected ProjectAssetService: ProjectAssetService,
-    protected ProjectService: TeacherProjectService,
-    protected UtilService: UtilService
+    protected ProjectService: TeacherProjectService
   ) {
     super(ConfigService, NodeService, ProjectAssetService, ProjectService);
     this.subscriptions.add(
@@ -43,7 +42,7 @@ export class MatchAuthoring extends ComponentAuthoring {
 
   addChoice(): void {
     const newChoice = {
-      id: this.UtilService.generateKey(10),
+      id: RandomKeyService.generate(),
       value: '',
       type: 'choice'
     };
@@ -54,7 +53,7 @@ export class MatchAuthoring extends ComponentAuthoring {
 
   addBucket(): void {
     const newBucket = {
-      id: this.UtilService.generateKey(10),
+      id: RandomKeyService.generate(),
       value: '',
       type: 'bucket'
     };

--- a/src/assets/wise5/components/match/match-student/match-student.component.ts
+++ b/src/assets/wise5/components/match/match-student/match-student.component.ts
@@ -19,6 +19,7 @@ import {
   moveItemInArray,
   transferArrayItem
 } from '@angular/cdk/drag-drop';
+import { RandomKeyService } from '../../../services/randomKeyService';
 
 @Component({
   selector: 'match-student',
@@ -733,7 +734,7 @@ export class MatchStudent extends ComponentStudent {
       .subscribe((result) => {
         if (result) {
           const newChoice = {
-            id: this.UtilService.generateKey(10),
+            id: RandomKeyService.generate(),
             value: result,
             type: 'choice',
             studentCreated: true

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.ts
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.ts
@@ -5,8 +5,8 @@ import { ProjectAssetService } from '../../../../../app/services/projectAssetSer
 import { ComponentAuthoring } from '../../../authoringTool/components/component-authoring.component';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
+import { RandomKeyService } from '../../../services/randomKeyService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
-import { UtilService } from '../../../services/utilService';
 
 @Component({
   selector: 'multiple-choice-authoring',
@@ -22,8 +22,7 @@ export class MultipleChoiceAuthoring extends ComponentAuthoring {
     protected ConfigService: ConfigService,
     protected NodeService: NodeService,
     protected ProjectAssetService: ProjectAssetService,
-    protected ProjectService: TeacherProjectService,
-    protected UtilService: UtilService
+    protected ProjectService: TeacherProjectService
   ) {
     super(ConfigService, NodeService, ProjectAssetService, ProjectService);
     this.subscriptions.add(
@@ -58,7 +57,7 @@ export class MultipleChoiceAuthoring extends ComponentAuthoring {
 
   addChoice(): void {
     const newChoice = {
-      id: this.UtilService.generateKey(10),
+      id: RandomKeyService.generate(),
       text: '',
       feedback: '',
       isCorrect: false

--- a/src/assets/wise5/components/openResponse/openResponseService.ts
+++ b/src/assets/wise5/components/openResponse/openResponseService.ts
@@ -2,16 +2,12 @@
 
 import { Injectable } from '@angular/core';
 import { ComponentService } from '../componentService';
-import { UtilService } from '../../services/utilService';
 import { OpenResponseCompletionCriteriaService } from './openResponseCompletionCriteriaService';
 
 @Injectable()
 export class OpenResponseService extends ComponentService {
-  constructor(
-    private completionCriteriaService: OpenResponseCompletionCriteriaService,
-    protected UtilService: UtilService
-  ) {
-    super(UtilService);
+  constructor(private completionCriteriaService: OpenResponseCompletionCriteriaService) {
+    super();
   }
 
   getComponentTypeLabel(): string {

--- a/src/assets/wise5/components/outsideURL/outsideURLService.ts
+++ b/src/assets/wise5/components/outsideURL/outsideURLService.ts
@@ -3,12 +3,11 @@
 import { ComponentService } from '../componentService';
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { UtilService } from '../../services/utilService';
 
 @Injectable()
 export class OutsideURLService extends ComponentService {
-  constructor(private http: HttpClient, protected UtilService: UtilService) {
-    super(UtilService);
+  constructor(private http: HttpClient) {
+    super();
   }
 
   getComponentTypeLabel(): string {

--- a/src/assets/wise5/components/peerChat/peerChatService.ts
+++ b/src/assets/wise5/components/peerChat/peerChatService.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ConfigService } from '../../services/configService';

--- a/src/assets/wise5/components/peerChat/peerChatService.ts
+++ b/src/assets/wise5/components/peerChat/peerChatService.ts
@@ -2,18 +2,13 @@ import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ConfigService } from '../../services/configService';
-import { UtilService } from '../../services/utilService';
 import { ComponentService } from '../componentService';
 import { PeerChatMessage } from './PeerChatMessage';
 
 @Injectable()
 export class PeerChatService extends ComponentService {
-  constructor(
-    private configService: ConfigService,
-    private http: HttpClient,
-    protected UtilService: UtilService
-  ) {
-    super(UtilService);
+  constructor(private configService: ConfigService, private http: HttpClient) {
+    super();
   }
 
   getComponentTypeLabel() {

--- a/src/assets/wise5/components/summary/summaryService.ts
+++ b/src/assets/wise5/components/summary/summaryService.ts
@@ -1,7 +1,6 @@
 'use strict';
 
 import { ComponentService } from '../componentService';
-import { UtilService } from '../../services/utilService';
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
@@ -11,8 +10,8 @@ export class SummaryService extends ComponentService {
   componentsWithScoresSummary: string[];
   componentsWithResponsesSummary: string[];
 
-  constructor(private http: HttpClient, protected UtilService: UtilService) {
-    super(UtilService);
+  constructor(private http: HttpClient) {
+    super();
     this.componentsWithScoresSummary = [
       'Animation',
       'AudioOscillator',

--- a/src/assets/wise5/components/table/tableService.ts
+++ b/src/assets/wise5/components/table/tableService.ts
@@ -12,7 +12,7 @@ export class TableService extends ComponentService {
     private StudentAssetService: StudentAssetService,
     protected UtilService: UtilService
   ) {
-    super(UtilService);
+    super();
   }
 
   getComponentTypeLabel(): string {

--- a/src/assets/wise5/services/achievementService.ts
+++ b/src/assets/wise5/services/achievementService.ts
@@ -6,7 +6,6 @@ import { ProjectService } from './projectService';
 import { StudentDataService } from './studentDataService';
 import { Injectable } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
-import { RandomKeyService } from './randomKeyService';
 
 @Injectable()
 export class AchievementService {

--- a/src/assets/wise5/services/achievementService.ts
+++ b/src/assets/wise5/services/achievementService.ts
@@ -5,8 +5,8 @@ import { ConfigService } from './configService';
 import { ProjectService } from './projectService';
 import { StudentDataService } from './studentDataService';
 import { Injectable } from '@angular/core';
-import { UtilService } from './utilService';
 import { Observable, Subject } from 'rxjs';
+import { RandomKeyService } from './randomKeyService';
 
 @Injectable()
 export class AchievementService {
@@ -21,8 +21,7 @@ export class AchievementService {
     private http: HttpClient,
     private ConfigService: ConfigService,
     private ProjectService: ProjectService,
-    private StudentDataService: StudentDataService,
-    private UtilService: UtilService
+    private StudentDataService: StudentDataService
   ) {}
 
   debugOutput(str) {
@@ -450,29 +449,6 @@ export class AchievementService {
       achievementIdToAchievements[projectAchievement.id] = studentAchievements;
     }
     return achievementIdToAchievements;
-  }
-
-  /**
-   * Get an achievement id that isn't being used
-   * @return an achievement id that isn't being used
-   */
-  getAvailableAchievementId() {
-    let id = null;
-    const achievements = this.ProjectService.getAchievementItems();
-    while (id == null) {
-      id = this.UtilService.generateKey(10);
-      for (const achievement of achievements) {
-        if (achievement.id === id) {
-          /*
-           * the id is already being used so we need to find
-           * a different one
-           */
-          id = null;
-          break;
-        }
-      }
-    }
-    return id;
   }
 
   broadcastAchievementCompleted(args: any) {

--- a/src/assets/wise5/services/annotationService.ts
+++ b/src/assets/wise5/services/annotationService.ts
@@ -6,6 +6,7 @@ import { ConfigService } from './configService';
 import { UtilService } from './utilService';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable, Subject } from 'rxjs';
+import { RandomKeyService } from './randomKeyService';
 
 @Injectable()
 export class AnnotationService {
@@ -154,7 +155,7 @@ export class AnnotationService {
    * @returns a promise
    */
   saveAnnotation(annotation) {
-    annotation.requestToken = this.UtilService.generateKey(); // use this to keep track of unsaved annotations.
+    annotation.requestToken = RandomKeyService.generate(); // use this to keep track of unsaved annotations.
     this.addOrUpdateAnnotation(annotation);
     const annotations = [annotation];
     if (this.ConfigService.isPreview()) {

--- a/src/assets/wise5/services/notificationService.ts
+++ b/src/assets/wise5/services/notificationService.ts
@@ -2,12 +2,12 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { ConfigService } from './configService';
 import { ProjectService } from './projectService';
-import { UtilService } from './utilService';
 import { Notification } from '../../../app/domain/notification';
 import { Observable, Subject } from 'rxjs';
 import { AnnotationService } from './annotationService';
 import { DismissAmbientNotificationDialogComponent } from '../vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component';
 import { MatDialog } from '@angular/material/dialog';
+import { RandomKeyService } from './randomKeyService';
 
 @Injectable()
 export class NotificationService {
@@ -28,8 +28,7 @@ export class NotificationService {
     protected dialog: MatDialog,
     protected http: HttpClient,
     protected ConfigService: ConfigService,
-    protected ProjectService: ProjectService,
-    protected UtilService: UtilService
+    protected ProjectService: ProjectService
   ) {}
 
   /**
@@ -183,7 +182,7 @@ export class NotificationService {
       const fromWorkgroupId = this.ConfigService.getWorkgroupId();
       const runId = this.ConfigService.getRunId();
       const periodId = this.ConfigService.getPeriodId();
-      const notificationGroupId = runId + '_' + this.UtilService.generateKey(10); // links student and teacher notifications together
+      const notificationGroupId = runId + '_' + RandomKeyService.generate(); // links student and teacher notifications together
       const notificationData: any = {};
       if (notificationForScore.isAmbient) {
         notificationData.isAmbient = true;

--- a/src/assets/wise5/services/peerGroupingAuthoringService.ts
+++ b/src/assets/wise5/services/peerGroupingAuthoringService.ts
@@ -4,16 +4,15 @@ import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { PeerGrouping } from '../../../app/domain/peerGrouping';
 import { ConfigService } from './configService';
+import { RandomKeyService } from './randomKeyService';
 import { TeacherProjectService } from './teacherProjectService';
-import { UtilService } from './utilService';
 
 @Injectable()
 export class PeerGroupingAuthoringService {
   constructor(
     private configService: ConfigService,
     private http: HttpClient,
-    private projectService: TeacherProjectService,
-    private utilService: UtilService
+    private projectService: TeacherProjectService
   ) {}
 
   getPeerGroupings(): PeerGrouping[] {
@@ -100,10 +99,10 @@ export class PeerGroupingAuthoringService {
   }
 
   getUniqueTag(): string {
-    let newTag = this.utilService.generateKey();
+    let newTag = RandomKeyService.generate();
     const allPeerGroupingTags = this.getAllPeerGroupingTags(this.getPeerGroupings());
     while (allPeerGroupingTags.includes(newTag)) {
-      newTag = this.utilService.generateKey();
+      newTag = RandomKeyService.generate();
     }
     return newTag;
   }

--- a/src/assets/wise5/services/randomKeyService.ts
+++ b/src/assets/wise5/services/randomKeyService.ts
@@ -1,0 +1,49 @@
+export class RandomKeyService {
+  static CHARS = [
+    'a',
+    'b',
+    'c',
+    'd',
+    'e',
+    'f',
+    'g',
+    'h',
+    'i',
+    'j',
+    'k',
+    'l',
+    'm',
+    'n',
+    'o',
+    'p',
+    'q',
+    'r',
+    's',
+    't',
+    'u',
+    'v',
+    'w',
+    'x',
+    'y',
+    'z',
+    '0',
+    '1',
+    '2',
+    '3',
+    '4',
+    '5',
+    '6',
+    '7',
+    '8',
+    '9'
+  ];
+
+  static generate(length = 10): string {
+    let key = '';
+    const numChars = RandomKeyService.CHARS.length;
+    for (let i = 0; i < length; i++) {
+      key += RandomKeyService.CHARS[Math.floor(Math.random() * (numChars - 1))];
+    }
+    return key;
+  }
+}

--- a/src/assets/wise5/services/studentDataService.ts
+++ b/src/assets/wise5/services/studentDataService.ts
@@ -11,6 +11,7 @@ import { Observable, Subject } from 'rxjs';
 import { DataService } from '../../../app/services/data.service';
 import { ComponentServiceLookupService } from './componentServiceLookupService';
 import { NotebookService } from './notebookService';
+import { RandomKeyService } from './randomKeyService';
 
 @Injectable()
 export class StudentDataService extends DataService {
@@ -857,7 +858,7 @@ export class StudentDataService extends DataService {
   prepareComponentStatesForSave(componentStates) {
     const studentWorkList = [];
     for (const componentState of componentStates) {
-      componentState.requestToken = this.UtilService.generateKey();
+      componentState.requestToken = RandomKeyService.generate();
       this.addComponentState(componentState);
       studentWorkList.push(componentState);
     }
@@ -866,14 +867,14 @@ export class StudentDataService extends DataService {
 
   prepareEventsForSave(events) {
     for (const event of events) {
-      event.requestToken = this.UtilService.generateKey();
+      event.requestToken = RandomKeyService.generate();
       this.addEvent(event);
     }
   }
 
   prepareAnnotationsForSave(annotations) {
     for (const annotation of annotations) {
-      annotation.requestToken = this.UtilService.generateKey();
+      annotation.requestToken = RandomKeyService.generate();
       if (annotation.id == null) {
         this.addAnnotation(annotation);
       }

--- a/src/assets/wise5/services/studentNotificationService.ts
+++ b/src/assets/wise5/services/studentNotificationService.ts
@@ -8,7 +8,6 @@ import { Notification } from '../../../app/domain/notification';
 import { NotificationService } from './notificationService';
 import { ProjectService } from './projectService';
 import { StompService } from './stompService';
-import { UtilService } from './utilService';
 import { StudentDataService } from './studentDataService';
 
 @Injectable()
@@ -20,10 +19,9 @@ export class StudentNotificationService extends NotificationService {
     protected configService: ConfigService,
     protected projectService: ProjectService,
     private stompService: StompService,
-    private studentDataService: StudentDataService,
-    protected utilService: UtilService
+    private studentDataService: StudentDataService
   ) {
-    super(annotationService, dialog, http, configService, projectService, utilService);
+    super(annotationService, dialog, http, configService, projectService);
   }
 
   initialize(): void {

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -9,6 +9,7 @@ import { ComponentServiceLookupService } from './componentServiceLookupService';
 import { HttpClient } from '@angular/common/http';
 import { ConfigService } from './configService';
 import { PathService } from './pathService';
+import { RandomKeyService } from './randomKeyService';
 
 @Injectable()
 export class TeacherProjectService extends ProjectService {
@@ -1012,7 +1013,7 @@ export class TeacherProjectService extends ProjectService {
 
   addTeacherRemovalConstraint(node: any, periodId: number) {
     const lockConstraint = {
-      id: this.utilService.generateKey(),
+      id: RandomKeyService.generate(),
       action: 'makeThisNodeNotVisitable',
       targetId: node.id,
       removalConditional: 'any',
@@ -2820,10 +2821,7 @@ export class TeacherProjectService extends ProjectService {
    * @return a component id that isn't already being used in the project
    */
   getUnusedComponentId(componentIdsToSkip = []) {
-    // we want to make an id with 10 characters
-    const idLength = 10;
-
-    let newComponentId = this.utilService.generateKey(idLength);
+    let newComponentId = RandomKeyService.generate();
 
     // check if the component id is already used in the project
     if (this.isComponentIdUsed(newComponentId)) {
@@ -2838,7 +2836,7 @@ export class TeacherProjectService extends ProjectService {
        * one that isn't already being used
        */
       while (!alreadyUsed) {
-        newComponentId = this.utilService.generateKey(idLength);
+        newComponentId = RandomKeyService.generate();
 
         // check if the id is already being used in the project
         alreadyUsed = this.isComponentIdUsed(newComponentId);

--- a/src/assets/wise5/services/utilService.ts
+++ b/src/assets/wise5/services/utilService.ts
@@ -6,54 +6,7 @@ import '../lib/jquery/jquery-global';
 
 @Injectable()
 export class UtilService {
-  CHARS = [
-    'a',
-    'b',
-    'c',
-    'd',
-    'e',
-    'f',
-    'g',
-    'h',
-    'i',
-    'j',
-    'k',
-    'l',
-    'm',
-    'n',
-    'o',
-    'p',
-    'q',
-    'r',
-    's',
-    't',
-    'u',
-    'v',
-    'w',
-    'x',
-    'y',
-    'z',
-    '0',
-    '1',
-    '2',
-    '3',
-    '4',
-    '5',
-    '6',
-    '7',
-    '8',
-    '9'
-  ];
-
   constructor(@Inject(LOCALE_ID) private localeID: string) {}
-
-  generateKey(length = 10) {
-    let key = '';
-    for (let a = 0; a < length; a++) {
-      key += this.CHARS[Math.floor(Math.random() * (this.CHARS.length - 1))];
-    }
-    return key;
-  }
 
   convertStringToNumber(str) {
     if (str != null && str != '' && !isNaN(Number(str))) {

--- a/src/assets/wise5/themes/default/notebook/edit-notebook-item-dialog/edit-notebook-item-dialog.component.ts
+++ b/src/assets/wise5/themes/default/notebook/edit-notebook-item-dialog/edit-notebook-item-dialog.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms'
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { ConfigService } from '../../../../services/configService';
 import { ProjectService } from '../../../../services/projectService';
+import { RandomKeyService } from '../../../../services/randomKeyService';
 import { StudentAssetService } from '../../../../services/studentAssetService';
 import { UtilService } from '../../../../services/utilService';
 
@@ -56,7 +57,7 @@ export class EditNotebookItemDialogComponent implements OnInit {
 
       this.item = {
         id: null, // null id means we're creating a new notebook item.
-        localNotebookItemId: this.utilService.generateKey(10),
+        localNotebookItemId: RandomKeyService.generate(),
         type: 'note', // the notebook item type, TODO: once questions are enabled, don't hard code
         nodeId: this.nodeId,
         title: $localize`Note from ${currentNodeTitle}`,

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1181,7 +1181,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete this prompt rule?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-dynamic-prompt-rules/edit-dynamic-prompt-rules.component.ts</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9e17700f2c625176f13493163d00658ebaba13e8" datatype="html">
@@ -9243,11 +9243,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.ts</context>
-          <context context-type="linenumber">305</context>
+          <context context-type="linenumber">304</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-student.component.ts</context>
-          <context context-type="linenumber">398</context>
+          <context context-type="linenumber">399</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1944363997751399240" datatype="html">
@@ -11817,35 +11817,35 @@ Are you sure you want to proceed?</source>
         <source>You can only have Data Points or a Data Source. If you add a Data Point, the Data Source will be deleted. Are you sure you want to add a Data Point?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.ts</context>
-          <context context-type="linenumber">70</context>
+          <context context-type="linenumber">69</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7203076667104563785" datatype="html">
         <source>Are you sure you want to delete this data point?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.ts</context>
-          <context context-type="linenumber">87</context>
+          <context context-type="linenumber">86</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6653174637147992490" datatype="html">
         <source>Are you sure you want to delete this object?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.ts</context>
-          <context context-type="linenumber">144</context>
+          <context context-type="linenumber">143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="733310611368028406" datatype="html">
         <source>You can only have Data Points or a Data Source. If you add a Data Source, the Data Points will be deleted. Are you sure you want to add a Data Source?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.ts</context>
-          <context context-type="linenumber">158</context>
+          <context context-type="linenumber">157</context>
         </context-group>
       </trans-unit>
       <trans-unit id="484657266266590246" datatype="html">
         <source>Are you sure you want to delete the Data Source?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.ts</context>
-          <context context-type="linenumber">187</context>
+          <context context-type="linenumber">186</context>
         </context-group>
       </trans-unit>
       <trans-unit id="05906ead7fe8ab49cf23094f3e62ae43190c1ee7" datatype="html">
@@ -12270,14 +12270,14 @@ Are you ready to receive feedback on this answer?</source>
         <source>Are you sure you want to delete this feedback?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.ts</context>
-          <context context-type="linenumber">77</context>
+          <context context-type="linenumber">73</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7484685939884481783" datatype="html">
         <source>Are you sure you want to delete this feedback rule?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.ts</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="21a9fc818b21be4ca6e733d9cf3defc9b28f3879" datatype="html">
@@ -13048,28 +13048,28 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Dialog Guidance</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialogGuidanceService.ts</context>
-          <context context-type="linenumber">16</context>
+          <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7559493123326903347" datatype="html">
         <source>Discuss your answer with a thought buddy!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialogGuidanceService.ts</context>
-          <context context-type="linenumber">34</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="817739684653615188" datatype="html">
         <source>Hi there! It&apos;s nice to meet you. What do you think about...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialogGuidanceService.ts</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6832087445897716825" datatype="html">
         <source>Thought Buddy</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialogGuidanceService.ts</context>
-          <context context-type="linenumber">40</context>
+          <context context-type="linenumber">36</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1ade6bad596278cd9ac93e7778cc03c68f6a2897" datatype="html">
@@ -13347,7 +13347,7 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source><x id="PH" equiv-text="usernames"/> replied to a discussion you were in!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/discussion-student/discussion-student.component.ts</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">199</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6160972322896689559" datatype="html">
@@ -14451,46 +14451,46 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Are you sure you want to overwrite the current line data?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">235</context>
+          <context context-type="linenumber">236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6882380861047606832" datatype="html">
         <source>The series you are trying to add a point to is currently hidden. Please show the series by clicking the series name in the legend and try adding the point again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1054</context>
+          <context context-type="linenumber">1055</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2852989551014711458" datatype="html">
         <source>You can not edit this series. Please choose a series that can be edited.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1068</context>
+          <context context-type="linenumber">1069</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7053114367342967943" datatype="html">
         <source>Are you sure you want to reset the series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1346</context>
+          <context context-type="linenumber">1347</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7889560203726829643" datatype="html">
         <source>Are you sure you want to reset the &quot;<x id="PH" equiv-text="seriesName"/>&quot; series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1348</context>
+          <context context-type="linenumber">1349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6999515396807067782" datatype="html">
         <source>Trial</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1901</context>
+          <context context-type="linenumber">1902</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">2736</context>
+          <context context-type="linenumber">2737</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9070768663485888935" datatype="html">
@@ -14962,18 +14962,18 @@ Warning: This will delete all existing choices and buckets in this component.</s
         <source>Are you sure you want to delete this choice?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.ts</context>
-          <context context-type="linenumber">115</context>
+          <context context-type="linenumber">114</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.ts</context>
-          <context context-type="linenumber">71</context>
+          <context context-type="linenumber">70</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6683126302760629027" datatype="html">
         <source>Are you sure you want to delete this bucket?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.ts</context>
-          <context context-type="linenumber">173</context>
+          <context context-type="linenumber">172</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3db39135c783da4bb320d5826f4de893f62c7e1b" datatype="html">
@@ -15060,14 +15060,14 @@ Warning: This will delete all existing choices and buckets in this component.</s
         <source>Correct bucket but wrong position</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-student.component.ts</context>
-          <context context-type="linenumber">490</context>
+          <context context-type="linenumber">491</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7841430672042223267" datatype="html">
         <source>Correct</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-student.component.ts</context>
-          <context context-type="linenumber">500</context>
+          <context context-type="linenumber">501</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summary-display/summary-display.component.ts</context>
@@ -15082,7 +15082,7 @@ Warning: This will delete all existing choices and buckets in this component.</s
         <source>Incorrect</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-student.component.ts</context>
-          <context context-type="linenumber">502</context>
+          <context context-type="linenumber">503</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summary-display/summary-display.component.ts</context>
@@ -15734,7 +15734,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Open Response</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/openResponseService.ts</context>
-          <context context-type="linenumber">18</context>
+          <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2e0e07912515c250498d28841610709033392606" datatype="html">
@@ -15862,7 +15862,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Outside Resource</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/outsideURL/outsideURLService.ts</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
       <trans-unit id="69890220efa72f501c096cd863f5f9dcf16fd321" datatype="html">
@@ -15994,14 +15994,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Peer Chat</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peerChatService.ts</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">15</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4250948520990652627" datatype="html">
         <source>Teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peerChatService.ts</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">55</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3eadcc6c36867a6d135be94da38b992e5dbd2f2f" datatype="html">
@@ -16304,7 +16304,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Summary</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summaryService.ts</context>
-          <context context-type="linenumber">34</context>
+          <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f7d15493b0e51d441ca4b60ff28151b6de9b9ee2" datatype="html">
@@ -17053,7 +17053,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">93</context>
+          <context context-type="linenumber">94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7975589013595125523" datatype="html">
@@ -17064,11 +17064,11 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">105</context>
+          <context context-type="linenumber">106</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">147</context>
+          <context context-type="linenumber">148</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5946383547512220582" datatype="html">
@@ -17079,11 +17079,11 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">106</context>
+          <context context-type="linenumber">107</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">148</context>
+          <context context-type="linenumber">149</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3177789104763917185" datatype="html">
@@ -17101,7 +17101,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">115</context>
+          <context context-type="linenumber">116</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6590475405017990661" datatype="html">
@@ -17112,7 +17112,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">116</context>
+          <context context-type="linenumber">117</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7008439939460403347" datatype="html">
@@ -17123,28 +17123,28 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">117</context>
+          <context context-type="linenumber">118</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4200122564420479235" datatype="html">
         <source>You have new replies to your discussion post!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notificationService.ts</context>
-          <context context-type="linenumber">132</context>
+          <context context-type="linenumber">131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="199088045976822823" datatype="html">
         <source>You have new feedback from your teacher!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notificationService.ts</context>
-          <context context-type="linenumber">134</context>
+          <context context-type="linenumber">133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5013145827213980080" datatype="html">
         <source>You have new feedback!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notificationService.ts</context>
-          <context context-type="linenumber">149</context>
+          <context context-type="linenumber">148</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4484876679373170309" datatype="html">
@@ -17291,194 +17291,194 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Preview Student</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">137</context>
+          <context context-type="linenumber">138</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1967824796880640028" datatype="html">
         <source>StudentDataService.saveComponentEvent: component, category, event args must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">759</context>
+          <context context-type="linenumber">760</context>
         </context-group>
       </trans-unit>
       <trans-unit id="944638387659785956" datatype="html">
         <source>StudentDataService.saveComponentEvent: nodeId, componentId, componentType must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">769</context>
+          <context context-type="linenumber">770</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4924640921903672943" datatype="html">
         <source>StudentDataService.saveVLEEvent: category and event args must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">778</context>
+          <context context-type="linenumber">779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8725215606116054825" datatype="html">
         <source>First Lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2017855920890197640" datatype="html">
         <source>First Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">71</context>
+          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8104421162933956065" datatype="html">
         <source>Notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">107</context>
+          <context context-type="linenumber">108</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">149</context>
+          <context context-type="linenumber">150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5668531960608480573" datatype="html">
         <source>Final Report</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">124</context>
+          <context context-type="linenumber">125</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8604167983715964004" datatype="html">
         <source>Final summary report of what you learned in this unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">125</context>
+          <context context-type="linenumber">126</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4419148705442508208" datatype="html">
         <source>Use this space to write your final report using evidence from your notebook.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">126</context>
+          <context context-type="linenumber">127</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2128364009265696768" datatype="html">
         <source>&lt;h3&gt;This is a heading&lt;/h3&gt;&lt;p&gt;This is a paragraph.&lt;/p&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">127</context>
+          <context context-type="linenumber">128</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3712572360135341203" datatype="html">
         <source>Teacher Notebook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">135</context>
+          <context context-type="linenumber">136</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3422550137142657635" datatype="html">
         <source>teacher notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">157</context>
+          <context context-type="linenumber">158</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">158</context>
+          <context context-type="linenumber">159</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2558301014879118031" datatype="html">
         <source>Teacher Notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">159</context>
+          <context context-type="linenumber">160</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">166</context>
+          <context context-type="linenumber">167</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2841850575512700640" datatype="html">
         <source>Notes for the teacher as they&apos;re running the WISE unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">167</context>
+          <context context-type="linenumber">168</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4383493915104232758" datatype="html">
         <source>Use this space to take notes for this unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">168</context>
+          <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8373748870534083811" datatype="html">
         <source>&lt;p&gt;Use this space to take notes for this unit&lt;/p&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">169</context>
+          <context context-type="linenumber">170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4358283284933461426" datatype="html">
         <source>All steps after this one will not be visitable until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">994</context>
+          <context context-type="linenumber">995</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5548702737138673668" datatype="html">
         <source>All steps after this one will not be visible until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">997</context>
+          <context context-type="linenumber">998</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3112051127445790513" datatype="html">
         <source>All other steps will not be visitable until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">1000</context>
+          <context context-type="linenumber">1001</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2264443134334419091" datatype="html">
         <source>All other steps will not be visible until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">1003</context>
+          <context context-type="linenumber">1004</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6819040711904864999" datatype="html">
         <source>This step will not be visitable until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">1006</context>
+          <context context-type="linenumber">1007</context>
         </context-group>
       </trans-unit>
       <trans-unit id="816962217622004346" datatype="html">
         <source>This step will not be visible until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">1009</context>
+          <context context-type="linenumber">1010</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3124371804165766752" datatype="html">
         <source>Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">744</context>
+          <context context-type="linenumber">697</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5275881069346355759" datatype="html">
         <source>Auto Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">749</context>
+          <context context-type="linenumber">702</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2692433425768915750" datatype="html">
         <source>Submitted <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">754</context>
+          <context context-type="linenumber">707</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846fecebb7756c6127955bc2c08d2111dce64c3c" datatype="html">
@@ -17564,35 +17564,35 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Note from <x id="PH" equiv-text="currentNodeTitle"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/themes/default/notebook/edit-notebook-item-dialog/edit-notebook-item-dialog.component.ts</context>
-          <context context-type="linenumber">62</context>
+          <context context-type="linenumber">63</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8417917245707164827" datatype="html">
         <source>Edit <x id="PH" equiv-text="label"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/themes/default/notebook/edit-notebook-item-dialog/edit-notebook-item-dialog.component.ts</context>
-          <context context-type="linenumber">90</context>
+          <context context-type="linenumber">91</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5258595085525200029" datatype="html">
         <source>Add <x id="PH" equiv-text="label"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/themes/default/notebook/edit-notebook-item-dialog/edit-notebook-item-dialog.component.ts</context>
-          <context context-type="linenumber">92</context>
+          <context context-type="linenumber">93</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3296271610866256066" datatype="html">
         <source>View <x id="PH" equiv-text="label"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/themes/default/notebook/edit-notebook-item-dialog/edit-notebook-item-dialog.component.ts</context>
-          <context context-type="linenumber">95</context>
+          <context context-type="linenumber">96</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7033364046926512938" datatype="html">
         <source><x id="PH" equiv-text="noteTerm"/> text</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/themes/default/notebook/edit-notebook-item-dialog/edit-notebook-item-dialog.component.ts</context>
-          <context context-type="linenumber">98</context>
+          <context context-type="linenumber">99</context>
         </context-group>
         <note priority="1" from="description">Label for note text input</note>
       </trans-unit>


### PR DESCRIPTION
## Changes
- Move UtilService.generateKey() to RandomKeyService.generate() and make the function static
- Update classes that used the old code to call the new static function, and remove UtilService from constructor if no other code in the class depend on it.

## Test
-  AT (check that a random id or uniqueTag is generated for each of the following actions)
   - add new component: should generate random component id for new component
   - copy component: should generate random component id for copied component
   - Match: add choice/bucket: should generate new ids for choice/bucket
   - MC: add choice: should generate random id for choice
   - add new prompt rule: should generate random id for FeedbackRule
   - Milestone:
      - add milestone satisfy criteria
      - add template satisfy criteria
      - add milestone
   - PeerChat: create new PeerGrouping: should generate new uniqueTag for PeerGrouping
   - animation: add new object should generate random id
- Student VLE:
   - Match: Add choice should generate id for newly added choice
   - Creating new note should set localNotebookItemId
   - Saving events, student work create unique request token

Closes #892