### PR TITLE
refactor(EditAdvancedComponentComponent): Add type to authoringComponentContent

### DIFF
--- a/src/app/authoring-tool/edit-advanced-component/edit-advanced-component.component.ts
+++ b/src/app/authoring-tool/edit-advanced-component/edit-advanced-component.component.ts
@@ -1,22 +1,23 @@
 import { Directive, Input } from '@angular/core';
+import { ComponentContent } from '../../../assets/wise5/common/ComponentContent';
 import { NodeService } from '../../../assets/wise5/services/nodeService';
 import { NotebookService } from '../../../assets/wise5/services/notebookService';
 import { TeacherProjectService } from '../../../assets/wise5/services/teacherProjectService';
 
 @Directive()
 export abstract class EditAdvancedComponentComponent {
-  authoringComponentContent: any;
+  authoringComponentContent: ComponentContent;
   @Input() componentId: string;
   @Input() nodeId: string;
 
   constructor(
-    protected NodeService: NodeService,
-    protected NotebookService: NotebookService,
-    protected TeacherProjectService: TeacherProjectService
+    protected nodeService: NodeService,
+    protected notebookService: NotebookService,
+    protected teacherProjectService: TeacherProjectService
   ) {}
 
   ngOnInit() {
-    this.authoringComponentContent = this.TeacherProjectService.getComponent(
+    this.authoringComponentContent = this.teacherProjectService.getComponent(
       this.nodeId,
       this.componentId
     );
@@ -25,7 +26,7 @@ export abstract class EditAdvancedComponentComponent {
   setShowSubmitButtonValue(show: boolean = false): void {
     this.authoringComponentContent.showSaveButton = show;
     this.authoringComponentContent.showSubmitButton = show;
-    this.NodeService.broadcastComponentShowSubmitButtonValueChanged({
+    this.nodeService.broadcastComponentShowSubmitButtonValueChanged({
       nodeId: this.nodeId,
       componentId: this.componentId,
       showSubmitButton: show
@@ -33,7 +34,7 @@ export abstract class EditAdvancedComponentComponent {
   }
 
   isNotebookEnabled(): boolean {
-    return this.NotebookService.isNotebookEnabled();
+    return this.notebookService.isNotebookEnabled();
   }
 
   connectedComponentsChanged(connectedComponents: any[]): void {
@@ -42,16 +43,16 @@ export abstract class EditAdvancedComponentComponent {
   }
 
   componentChanged(): void {
-    this.TeacherProjectService.nodeChanged();
+    this.teacherProjectService.nodeChanged();
   }
 
   moveObjectUp(objects: any[], index: number): void {
-    this.TeacherProjectService.moveObjectUp(objects, index);
+    this.teacherProjectService.moveObjectUp(objects, index);
     this.componentChanged();
   }
 
   moveObjectDown(objects: any[], index: number): void {
-    this.TeacherProjectService.moveObjectDown(objects, index);
+    this.teacherProjectService.moveObjectDown(objects, index);
     this.componentChanged();
   }
 }

--- a/src/assets/wise5/common/ComponentContent.ts
+++ b/src/assets/wise5/common/ComponentContent.ts
@@ -8,5 +8,7 @@ export interface ComponentContent {
   maxScore?: number;
   prompt?: string;
   rubric?: string;
+  showSaveButton?: boolean;
+  showSubmitButton?: boolean;
   type: string;
 }

--- a/src/assets/wise5/components/conceptMap/ConceptMapContent.ts
+++ b/src/assets/wise5/components/conceptMap/ConceptMapContent.ts
@@ -1,7 +1,10 @@
 import { ComponentContent } from '../../common/ComponentContent';
 
 export interface ConceptMapContent extends ComponentContent {
+  customRuleEvaluator: any;
   links: any[];
   nodes: any[];
   rules?: any[];
+  showAutoFeedback: boolean;
+  showAutoScore: boolean;
 }

--- a/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.ts
+++ b/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.ts
@@ -3,7 +3,7 @@ import { EditAdvancedComponentComponent } from '../../../../../app/authoring-too
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
-import { UtilService } from '../../../services/utilService';
+import { ConceptMapContent } from '../ConceptMapContent';
 
 @Component({
   selector: 'edit-concept-map-advanced',
@@ -11,15 +11,15 @@ import { UtilService } from '../../../services/utilService';
   styleUrls: ['edit-concept-map-advanced.component.scss']
 })
 export class EditConceptMapAdvancedComponent extends EditAdvancedComponentComponent {
+  authoringComponentContent: ConceptMapContent;
   allowedConnectedComponentTypes = ['ConceptMap', 'Draw', 'Embedded', 'Graph', 'Label', 'Table'];
 
   constructor(
-    protected NodeService: NodeService,
-    protected NotebookService: NotebookService,
-    protected ProjectService: TeacherProjectService,
-    protected UtilService: UtilService
+    protected nodeService: NodeService,
+    protected notebookService: NotebookService,
+    protected projectService: TeacherProjectService
   ) {
-    super(NodeService, NotebookService, ProjectService);
+    super(nodeService, notebookService, projectService);
   }
 
   ruleTypeChanged(ruleIndex: number): void {

--- a/src/assets/wise5/components/embedded/EmbeddedContent.ts
+++ b/src/assets/wise5/components/embedded/EmbeddedContent.ts
@@ -1,5 +1,6 @@
 import { ComponentContent } from '../../common/ComponentContent';
 
 export interface EmbeddedContent extends ComponentContent {
+  parameters?: any;
   url: string;
 }

--- a/src/assets/wise5/components/embedded/edit-embedded-advanced/edit-embedded-advanced.component.ts
+++ b/src/assets/wise5/components/embedded/edit-embedded-advanced/edit-embedded-advanced.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { EditAdvancedComponentComponent } from '../../../../../app/authoring-tool/edit-advanced-component/edit-advanced-component.component';
+import { EmbeddedContent } from '../EmbeddedContent';
 
 @Component({
   template: 'edit-embedded-advanced',
@@ -21,4 +22,5 @@ export class EditEmbeddedAdvancedComponent extends EditAdvancedComponentComponen
     'OpenResponse',
     'Table'
   ];
+  authoringComponentContent: EmbeddedContent;
 }

--- a/src/assets/wise5/components/graph/GraphContent.ts
+++ b/src/assets/wise5/components/graph/GraphContent.ts
@@ -2,6 +2,13 @@ import { ComponentContent } from '../../common/ComponentContent';
 
 export interface GraphContent extends ComponentContent {
   backgroundImage?: string;
+  hideTrialSelect: boolean;
+  highlightXRangeFromZero: boolean;
+  saveMouseOverPoints: boolean;
+  showMouseXPlotLine: boolean;
+  showMouseYPlotLine: boolean;
+  subtitle: string;
+  useCustomLegend: boolean;
   xAxis: any;
   yAxis: any;
 }

--- a/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.ts
+++ b/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.ts
@@ -3,6 +3,7 @@ import { EditAdvancedComponentComponent } from '../../../../../app/authoring-too
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { GraphContent } from '../GraphContent';
 
 @Component({
   template: 'edit-graph-advanced',
@@ -19,13 +20,14 @@ export class EditGraphAdvancedComponent extends EditAdvancedComponentComponent {
     'Label',
     'Table'
   ];
+  authoringComponentContent: GraphContent;
 
   constructor(
-    protected NodeService: NodeService,
-    protected NotebookService: NotebookService,
-    protected TeacherProjectService: TeacherProjectService
+    protected nodeService: NodeService,
+    protected notebookService: NotebookService,
+    protected teacherProjectService: TeacherProjectService
   ) {
-    super(NodeService, NotebookService, TeacherProjectService);
+    super(nodeService, notebookService, teacherProjectService);
   }
 
   addXAxisPlotLine(): void {

--- a/src/assets/wise5/components/match/MatchContent.ts
+++ b/src/assets/wise5/components/match/MatchContent.ts
@@ -2,5 +2,6 @@ import { ComponentContent } from '../../common/ComponentContent';
 
 export interface MatchContent extends ComponentContent {
   buckets: any[];
+  canCreateChoices: boolean;
   choices: any[];
 }

--- a/src/assets/wise5/components/match/edit-match-advanced/edit-match-advanced.component.ts
+++ b/src/assets/wise5/components/match/edit-match-advanced/edit-match-advanced.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { EditAdvancedComponentComponent } from '../../../../../app/authoring-tool/edit-advanced-component/edit-advanced-component.component';
+import { MatchContent } from '../MatchContent';
 
 @Component({
   selector: 'edit-match-advanced',
@@ -8,4 +9,5 @@ import { EditAdvancedComponentComponent } from '../../../../../app/authoring-too
 })
 export class EditMatchAdvancedComponent extends EditAdvancedComponentComponent {
   allowedConnectedComponentTypes = ['Match'];
+  authoringComponentContent: MatchContent;
 }

--- a/src/assets/wise5/components/multipleChoice/MultipleChoiceContent.ts
+++ b/src/assets/wise5/components/multipleChoice/MultipleChoiceContent.ts
@@ -3,4 +3,5 @@ import { ComponentContent } from '../../common/ComponentContent';
 export interface MultipleChoiceContent extends ComponentContent {
   choices: any[];
   choiceType: 'checkbox' | 'radio';
+  showFeedback: boolean;
 }

--- a/src/assets/wise5/components/multipleChoice/edit-multiple-choice-advanced/edit-multiple-choice-advanced.component.ts
+++ b/src/assets/wise5/components/multipleChoice/edit-multiple-choice-advanced/edit-multiple-choice-advanced.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { EditAdvancedComponentComponent } from '../../../../../app/authoring-tool/edit-advanced-component/edit-advanced-component.component';
+import { MultipleChoiceContent } from '../MultipleChoiceContent';
 
 @Component({
   template: 'edit-multiple-choice-advanced',
@@ -8,4 +9,5 @@ import { EditAdvancedComponentComponent } from '../../../../../app/authoring-too
 })
 export class EditMultipleChoiceAdvancedComponent extends EditAdvancedComponentComponent {
   allowedConnectedComponentTypes = ['MultipleChoice'];
+  authoringComponentContent: MultipleChoiceContent;
 }

--- a/src/assets/wise5/components/openResponse/OpenResponseContent.ts
+++ b/src/assets/wise5/components/openResponse/OpenResponseContent.ts
@@ -1,0 +1,11 @@
+import { ComponentContent } from '../../common/ComponentContent';
+
+export interface OpenResponseContent extends ComponentContent {
+  completionCriteria: any;
+  cRater: any;
+  enableCRater: boolean;
+  enableNotifications: boolean;
+  isStudentAudioRecordingEnabled: boolean;
+  notificationSettings: any;
+  starterSentence: any;
+}

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
@@ -24,6 +24,7 @@ import { StudentTeacherCommonServicesModule } from '../../../../../app/student-t
 import { ComponentContent } from '../../../common/ComponentContent';
 import { NotebookService } from '../../../services/notebookService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { OpenResponseContent } from '../OpenResponseContent';
 import { EditOpenResponseAdvancedComponent } from './edit-open-response-advanced.component';
 
 let component: EditOpenResponseAdvancedComponent;
@@ -313,7 +314,7 @@ function addCompletionCriteria() {
         completionCriteria: {
           criteria: []
         }
-      };
+      } as OpenResponseContent;
       component.addCompletionCriteria();
       expect(component.authoringComponentContent.completionCriteria.criteria.length).toEqual(1);
     });
@@ -350,7 +351,7 @@ function deleteCompletionCriteria() {
         completionCriteria: {
           criteria: [completionCriteria1, completionCriteria2, completionCriteria3]
         }
-      };
+      } as OpenResponseContent;
       spyOn(window, 'confirm').and.returnValue(true);
       component.deleteCompletionCriteria(1);
       expect(component.authoringComponentContent.completionCriteria.criteria.length).toEqual(2);

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
@@ -4,7 +4,7 @@ import { CRaterService } from '../../../services/cRaterService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
-import { UtilService } from '../../../services/utilService';
+import { OpenResponseContent } from '../OpenResponseContent';
 
 @Component({
   selector: 'edit-open-response-advanced',
@@ -13,6 +13,7 @@ import { UtilService } from '../../../services/utilService';
 })
 export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComponent {
   allowedConnectedComponentTypes = ['OpenResponse'];
+  authoringComponentContent: OpenResponseContent;
   cRaterItemIdIsValid: boolean = null;
   initialFeedbackRules = [
     {
@@ -26,13 +27,12 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
   useCustomCompletionCriteria: boolean = false;
 
   constructor(
-    protected CRaterService: CRaterService,
-    protected NodeService: NodeService,
-    protected NotebookService: NotebookService,
-    protected TeacherProjectService: TeacherProjectService,
-    protected UtilService: UtilService
+    protected cRaterService: CRaterService,
+    protected nodeService: NodeService,
+    protected notebookService: NotebookService,
+    protected teacherProjectService: TeacherProjectService
   ) {
-    super(NodeService, NotebookService, TeacherProjectService);
+    super(nodeService, notebookService, teacherProjectService);
   }
 
   ngOnInit(): void {
@@ -40,7 +40,7 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
     if (this.authoringComponentContent.completionCriteria != null) {
       this.useCustomCompletionCriteria = true;
     }
-    this.nodeIds = this.TeacherProjectService.getFlattenedProjectAsNodeIds();
+    this.nodeIds = this.teacherProjectService.getFlattenedProjectAsNodeIds();
   }
 
   enableCRaterClicked(): void {
@@ -105,7 +105,7 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
   verifyCRaterItemId(itemId: string): void {
     this.cRaterItemIdIsValid = null;
     this.isVerifyingCRaterItemId = true;
-    this.CRaterService.makeCRaterVerifyRequest(itemId).then((response: any) => {
+    this.cRaterService.makeCRaterVerifyRequest(itemId).then((response: any) => {
       this.isVerifyingCRaterItemId = false;
       this.cRaterItemIdIsValid = response.available;
     });
@@ -265,15 +265,15 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
   }
 
   getComponents(nodeId: string): any[] {
-    return this.TeacherProjectService.getComponents(nodeId);
+    return this.teacherProjectService.getComponents(nodeId);
   }
 
   isApplicationNode(nodeId: string): boolean {
-    return this.TeacherProjectService.isApplicationNode(nodeId);
+    return this.teacherProjectService.isApplicationNode(nodeId);
   }
 
   getNodePositionAndTitle(nodeId: string): string {
-    return this.TeacherProjectService.getNodePositionAndTitle(nodeId);
+    return this.teacherProjectService.getNodePositionAndTitle(nodeId);
   }
 
   setFeedbackEnabled(feedbackEnabled: boolean): void {

--- a/src/assets/wise5/components/peerChat/edit-peer-chat-advanced-component/edit-peer-chat-advanced-component.component.ts
+++ b/src/assets/wise5/components/peerChat/edit-peer-chat-advanced-component/edit-peer-chat-advanced-component.component.ts
@@ -3,7 +3,6 @@ import { EditAdvancedComponentComponent } from '../../../../../app/authoring-too
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
-import { UtilService } from '../../../services/utilService';
 
 @Component({
   selector: 'edit-peer-chat-advanced-component',
@@ -12,11 +11,10 @@ import { UtilService } from '../../../services/utilService';
 })
 export class EditPeerChatAdvancedComponentComponent extends EditAdvancedComponentComponent {
   constructor(
-    protected NodeService: NodeService,
-    protected NotebookService: NotebookService,
-    protected ProjectService: TeacherProjectService,
-    protected UtilService: UtilService
+    protected nodeService: NodeService,
+    protected notebookService: NotebookService,
+    protected projectService: TeacherProjectService
   ) {
-    super(NodeService, NotebookService, ProjectService);
+    super(nodeService, notebookService, projectService);
   }
 }

--- a/src/assets/wise5/components/table/TableContent.ts
+++ b/src/assets/wise5/components/table/TableContent.ts
@@ -1,0 +1,15 @@
+import { ComponentContent } from '../../common/ComponentContent';
+
+export interface TableContent extends ComponentContent {
+  dataExplorerDataToColumn: any;
+  dataExplorerGraphTypes: any;
+  dataExplorerSeriesParams: any;
+  enableRowSelection: boolean;
+  isDataExplorerAxisLabelsEditable: boolean;
+  isDataExplorerEnabled: boolean;
+  numColumns: number;
+  numDataExplorerSeries: number;
+  numDataExplorerYAxis: number;
+  numRows: number;
+  tableData: any;
+}

--- a/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.ts
+++ b/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.ts
@@ -4,6 +4,7 @@ import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { UtilService } from '../../../services/utilService';
+import { TableContent } from '../TableContent';
 
 @Component({
   selector: 'edit-table-advanced',
@@ -14,6 +15,7 @@ export class EditTableAdvancedComponent extends EditAdvancedComponentComponent {
   MAX_ALLOWED_CELLS_IN_IMPORT = 2000;
 
   allowedConnectedComponentTypes = ['Embedded', 'Graph', 'Table'];
+  authoringComponentContent: TableContent;
   columnNames: string[] = [];
   isDataExplorerScatterPlotEnabled: boolean;
   isDataExplorerLineGraphEnabled: boolean;
@@ -23,12 +25,12 @@ export class EditTableAdvancedComponent extends EditAdvancedComponentComponent {
   importTableMessage: string;
 
   constructor(
-    protected NodeService: NodeService,
-    protected NotebookService: NotebookService,
-    protected TeacherProjectService: TeacherProjectService,
-    private UtilService: UtilService
+    protected nodeService: NodeService,
+    protected notebookService: NotebookService,
+    protected teacherProjectService: TeacherProjectService,
+    private utilService: UtilService
   ) {
-    super(NodeService, NotebookService, TeacherProjectService);
+    super(nodeService, notebookService, teacherProjectService);
   }
 
   ngOnInit(): void {
@@ -191,7 +193,7 @@ export class EditTableAdvancedComponent extends EditAdvancedComponentComponent {
       const reader: FileReader = new FileReader();
       reader.onload = () => {
         const fileContent = reader.result as string;
-        const tableContent = this.UtilService.CSVToArray(fileContent);
+        const tableContent = this.utilService.CSVToArray(fileContent);
         const numCells = this.getNumCells(tableContent);
         if (numCells > this.MAX_ALLOWED_CELLS_IN_IMPORT) {
           this.setImportTableMessage(

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -2056,10 +2056,6 @@ export class ProjectService {
     }
   }
 
-  componentExists(nodeId: string, componentId: string): boolean {
-    return this.getComponent(nodeId, componentId) != null;
-  }
-
   broadcastProjectChanged(): void {
     this.projectChangedSource.next();
   }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15590,7 +15590,7 @@ Warning: This will delete all existing choices in this component.</source>
         <source>Default feedback</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">21</context>
+          <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2839735751687486837" datatype="html">
@@ -16460,28 +16460,28 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Are you sure you want to overwrite the existing table?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.ts</context>
-          <context context-type="linenumber">188</context>
+          <context context-type="linenumber">190</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5497998297263821629" datatype="html">
         <source>Importing table...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.ts</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">192</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4805591784714355993" datatype="html">
         <source>Error: The table contains more than <x id="PH" equiv-text="this.MAX_ALLOWED_CELLS_IN_IMPORT"/> cells</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.ts</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">200</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8522934403801176161" datatype="html">
         <source>Successfully imported table</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.ts</context>
-          <context context-type="linenumber">202</context>
+          <context context-type="linenumber">204</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7f8e64261497f0b38cfb8aa12b8f77cbb01a179b" datatype="html">


### PR DESCRIPTION
## Changes
- Change type of EditAdvancedComponentComponent.authoringComponentContent from ```any``` to ```ComponentContent```
   - Type child classes of EditAdvancedComponentComponent as well, to be more specific to the component
   - Add more fields to the [OR/MC/...]Content.
- Clean up affected files
   - lower-case class variables like NodeService, NotebookService, TeacherProjectService
   - remove unused dependencies like UtilService
- No new feature was added

## Test
- Component advanced editing works as before: opening dialog, saving changes

Closes #895