### PR TITLE
refactor(Component): Pass in Component to Preview and Student VLE

### DIFF
--- a/src/assets/wise5/authoringTool/components/preview-component-dialog/preview-component-dialog.component.html
+++ b/src/assets/wise5/authoringTool/components/preview-component-dialog/preview-component-dialog.component.html
@@ -9,8 +9,7 @@
 <mat-divider></mat-divider>
 <mat-dialog-content>
   <preview-component
-      [nodeId]="nodeId"
-      [componentId]="componentId"
+      [component]="component"
       (starterStateChangedEvent)="updateStarterState($event)">
   </preview-component>
 </mat-dialog-content>

--- a/src/assets/wise5/authoringTool/components/preview-component-dialog/preview-component-dialog.component.ts
+++ b/src/assets/wise5/authoringTool/components/preview-component-dialog/preview-component-dialog.component.ts
@@ -1,25 +1,27 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { ProjectService } from '../../../services/projectService';
+import { Component as WISEComponent } from '../../../common/Component';
 
 @Component({
   templateUrl: 'preview-component-dialog.component.html',
   styleUrls: ['preview-component-dialog.component.scss']
 })
 export class PreviewComponentDialogComponent implements OnInit {
+  canSaveStarterState: boolean;
+  component: WISEComponent;
   @Input() componentId: string;
-  @Input() nodeId: string;
-
-  canSaveStarterState: boolean = false;
-
   componentTypesWithStarterStates = ['ConceptMap', 'Draw', 'Label'];
-
+  @Input() nodeId: string;
   starterState: any;
 
   constructor(private projectService: ProjectService) {}
 
   ngOnInit(): void {
-    const component = this.projectService.getComponent(this.nodeId, this.componentId);
-    this.canSaveStarterState = this.componentTypesWithStarterStates.includes(component.type);
+    const content = this.projectService.injectAssetPaths(
+      this.projectService.getComponent(this.nodeId, this.componentId)
+    );
+    this.canSaveStarterState = this.componentTypesWithStarterStates.includes(content.type);
+    this.component = new WISEComponent(content, this.nodeId);
   }
 
   updateStarterState(starterState: any): void {

--- a/src/assets/wise5/authoringTool/components/preview-component/preview-component.component.html
+++ b/src/assets/wise5/authoringTool/components/preview-component/preview-component.component.html
@@ -1,101 +1,54 @@
-<div [ngSwitch]="componentContent.type" class="component__wrapper">
-  <animation-student *ngSwitchCase="'Animation'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      mode="preview">
+<div [ngSwitch]="component.content.type" class="component__wrapper">
+  <animation-student *ngSwitchCase="'Animation'" [component]="component" mode="preview">
   </animation-student>
   <audio-oscillator-student *ngSwitchCase="'AudioOscillator'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       mode="preview">
   </audio-oscillator-student>
   <concept-map-student *ngSwitchCase="'ConceptMap'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       (starterStateChangedEvent)="updateStarterState($event)"
       mode="preview">
   </concept-map-student>
-  <dialog-guidance-student *ngSwitchCase="'DialogGuidance'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      mode="preview">
+  <dialog-guidance-student *ngSwitchCase="'DialogGuidance'" [component]="component" mode="preview">
   </dialog-guidance-student>
-  <discussion-student *ngSwitchCase="'Discussion'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      mode="preview">
+  <discussion-student *ngSwitchCase="'Discussion'" [component]="component" mode="preview">
   </discussion-student>
   <draw-student *ngSwitchCase="'Draw'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       (starterStateChangedEvent)="updateStarterState($event)"
       mode="preview">
   </draw-student>
-  <embedded-student *ngSwitchCase="'Embedded'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      mode="preview">
+  <embedded-student *ngSwitchCase="'Embedded'" [component]="component" mode="preview">
   </embedded-student>
-  <graph-student *ngSwitchCase="'Graph'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      mode="preview">
+  <graph-student *ngSwitchCase="'Graph'" [component]="component" mode="preview">
   </graph-student>
-  <html-student *ngSwitchCase="'HTML'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      mode="preview">
+  <html-student *ngSwitchCase="'HTML'" [component]="component" mode="preview">
   </html-student>
   <label-student *ngSwitchCase="'Label'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       (starterStateChangedEvent)="updateStarterState($event)"
       mode="preview">
   </label-student>
-  <match-student *ngSwitchCase="'Match'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      mode="preview">
+  <match-student *ngSwitchCase="'Match'" [component]="component" mode="preview">
   </match-student>
-  <multiple-choice-student *ngSwitchCase="'MultipleChoice'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      mode="preview">
+  <multiple-choice-student *ngSwitchCase="'MultipleChoice'" [component]="component" mode="preview">
   </multiple-choice-student>
-  <open-response-student *ngSwitchCase="'OpenResponse'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      mode="preview">
+  <open-response-student *ngSwitchCase="'OpenResponse'" [component]="component" mode="preview">
   </open-response-student>
-  <outside-url-student *ngSwitchCase="'OutsideURL'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      mode="preview">
+  <outside-url-student *ngSwitchCase="'OutsideURL'" [component]="component" mode="preview">
   </outside-url-student>
-  <peer-chat-student *ngSwitchCase="'PeerChat'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      mode="preview">
+  <peer-chat-student *ngSwitchCase="'PeerChat'" [component]="component" mode="preview">
   </peer-chat-student>
-  <show-group-work-student *ngSwitchCase="'ShowGroupWork'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      mode="preview">
+  <show-group-work-student *ngSwitchCase="'ShowGroupWork'" [component]="component" mode="preview">
   </show-group-work-student>
-  <show-my-work-student *ngSwitchCase="'ShowMyWork'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      mode="preview">
+  <show-my-work-student *ngSwitchCase="'ShowMyWork'" [component]="component" mode="preview">
   </show-my-work-student>
   <summary-student *ngSwitchCase="'Summary'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [periodId]="periodId"
       mode="preview">
   </summary-student>
-  <table-student *ngSwitchCase="'Table'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
-      mode="preview">
+  <table-student *ngSwitchCase="'Table'" [component]="component" mode="preview">
   </table-student>
 </div>

--- a/src/assets/wise5/authoringTool/components/preview-component/preview-component.component.ts
+++ b/src/assets/wise5/authoringTool/components/preview-component/preview-component.component.ts
@@ -1,24 +1,18 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { ProjectService } from '../../../services/projectService';
+import { Component as WISEComponent } from '../../../common/Component';
 
 @Component({
   selector: 'preview-component',
   templateUrl: 'preview-component.component.html'
 })
 export class PreviewComponentComponent implements OnInit {
-  componentContent: any;
-  @Input() componentId: string;
-  @Input() nodeId: string;
+  @Input() component: WISEComponent;
   @Input() periodId: number;
   @Output() starterStateChangedEvent: EventEmitter<any> = new EventEmitter<any>();
 
-  constructor(private projectService: ProjectService) {}
+  constructor() {}
 
-  ngOnInit() {
-    this.componentContent = this.projectService.injectAssetPaths(
-      this.projectService.getComponent(this.nodeId, this.componentId)
-    );
-  }
+  ngOnInit() {}
 
   updateStarterState(starterState: any) {
     this.starterStateChangedEvent.emit(starterState);

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/node-info/node-info.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/node-info/node-info.component.html
@@ -15,7 +15,7 @@
           class="accent-1 mat-body-2 gray-lightest-bg component-header">
         {{ component.assessmentItemIndex + ". " + component.typeLabel }}&nbsp;
       </h3>
-      <preview-component [nodeId]="nodeId" [componentId]="component.id" [periodId]="periodId">
+      <preview-component [component]="component.component" [periodId]="periodId">
       </preview-component>
       <mat-card *ngIf="component.rubric" class="rubric component-rubric mat-elevation-z0 notice-bg-bg">
         <mat-card-title class="mat-body-2" fxLayoutAlign="start center" fxLayoutGap="8px">

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/node-info/node-info.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/node-info/node-info.component.ts
@@ -5,6 +5,7 @@ import { ComponentServiceLookupService } from '../../../../services/componentSer
 import { ComponentTypeService } from '../../../../services/componentTypeService';
 import { TeacherDataService } from '../../../../services/teacherDataService';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
+import { Component as WISEComponent } from '../../../../common/Component';
 
 @Component({
   selector: 'node-info',
@@ -57,6 +58,10 @@ export class NodeInfoComponent {
       if (component.isStudentWorkGenerated) {
         component.assessmentItemIndex = assessmentItemIndex++;
       }
+      component.component = new WISEComponent(
+        this.projectService.injectAssetPaths(component),
+        this.nodeId
+      );
     }
   }
 

--- a/src/assets/wise5/components/animation/animation-student/animation-student.component.spec.ts
+++ b/src/assets/wise5/components/animation/animation-student/animation-student.component.spec.ts
@@ -3,6 +3,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { Component } from '../../../common/Component';
 import { AnnotationService } from '../../../services/annotationService';
 import { NodeService } from '../../../services/nodeService';
 import { AnimationService } from '../animationService';
@@ -49,19 +50,12 @@ describe('AnimationStudent', () => {
       schemas: [NO_ERRORS_SCHEMA]
     });
     fixture = TestBed.createComponent(AnimationStudent);
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
-      score: 0,
-      comment: ''
-    });
-    spyOn(TestBed.inject(NodeService), 'createNewComponentState').and.returnValue({
-      studentData: {}
-    });
     component = fixture.componentInstance;
-    component.nodeId = nodeId;
-    component.componentContent = TestBed.inject(AnimationService).createComponent();
-    component.componentContent.id = componentId;
-    component.componentContent.prompt = 'Play the animation.';
-    component.componentContent.objects = [object1];
+    const componentContent = TestBed.inject(AnimationService).createComponent();
+    componentContent.id = componentId;
+    componentContent.prompt = 'Play the animation.';
+    componentContent.objects = [object1];
+    component.component = new Component(componentContent, nodeId);
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});
     spyOn(component, 'broadcastDoneRenderingComponent').and.callFake(() => {});
     spyOn(component, 'isAddToNotebookEnabled').and.callFake(() => {

--- a/src/assets/wise5/components/animation/animation-student/animation-student.component.spec.ts
+++ b/src/assets/wise5/components/animation/animation-student/animation-student.component.spec.ts
@@ -4,8 +4,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { Component } from '../../../common/Component';
-import { AnnotationService } from '../../../services/annotationService';
-import { NodeService } from '../../../services/nodeService';
 import { AnimationService } from '../animationService';
 import { AnimationStudent } from './animation-student.component';
 

--- a/src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.spec.ts
+++ b/src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.spec.ts
@@ -11,11 +11,11 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
 import { ComponentHeader } from '../../../directives/component-header/component-header.component';
-import { AnnotationService } from '../../../services/annotationService';
 import { ProjectService } from '../../../services/projectService';
 import { AudioOscillatorStudent } from './audio-oscillator-student.component';
 import { AudioOscillatorStudentData } from '../AudioOscillatorStudentData';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { Component } from '../../../common/Component';
 
 let component: AudioOscillatorStudent;
 let fixture: ComponentFixture<AudioOscillatorStudent>;
@@ -46,14 +46,9 @@ describe('AudioOscillatorStudent', () => {
       declarations: [AudioOscillatorStudent, ComponentHeader, PossibleScoreComponent]
     });
     fixture = TestBed.createComponent(AudioOscillatorStudent);
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
-      comment: '',
-      score: 1
-    });
     spyOn(TestBed.inject(ProjectService), 'getThemeSettings').and.returnValue({});
     component = fixture.componentInstance;
-    component.nodeId = nodeId;
-    component.componentContent = {
+    const componentContent = {
       id: componentId,
       type: 'AudioOscillator',
       prompt: 'Listen to multiple frequencies.',
@@ -66,6 +61,7 @@ describe('AudioOscillatorStudent', () => {
       canStudentEditFrequency: true,
       canStudentViewFrequencyInput: true
     };
+    component.component = new Component(componentContent, nodeId);
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});
     spyOn(component, 'broadcastDoneRenderingComponent').and.callFake(() => {});
     spyOn(component, 'isAddToNotebookEnabled').and.callFake(() => {

--- a/src/assets/wise5/components/component-student.component.spec.ts
+++ b/src/assets/wise5/components/component-student.component.spec.ts
@@ -1,11 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentStudent } from './component-student.component';
-import { AnnotationService } from '../services/annotationService';
 import { NotebookService } from '../services/notebookService';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { StudentTeacherCommonServicesModule } from '../../../app/student-teacher-common-services.module';
+import { Component as WISEComponent } from '../common/Component';
 
 let component: ComponentStudent;
 let fixture: ComponentFixture<ComponentStudent>;
@@ -26,8 +26,8 @@ describe('ComponentStudentComponent', () => {
     fixture = TestBed.createComponent(ComponentStudentImpl);
     component = fixture.componentInstance;
     component.componentContent = {};
+    component.component = { content: {} } as WISEComponent;
     component.isSubmitDirty = true;
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue(null);
     spyOn(TestBed.inject(NotebookService), 'isNotebookEnabled').and.returnValue(false);
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});
     performSubmitSpy = spyOn(component, 'performSubmit');

--- a/src/assets/wise5/components/component-student.component.ts
+++ b/src/assets/wise5/components/component-student.component.ts
@@ -19,7 +19,7 @@ import { ComponentStateWrapper } from './ComponentStateWrapper';
 
 @Directive()
 export abstract class ComponentStudent {
-  @Input() componentContent: any;
+  @Input() component: Component;
   @Input() componentState: any;
   @Input() isDisabled: boolean = false;
   @Input() mode: string;
@@ -29,7 +29,7 @@ export abstract class ComponentStudent {
   @Output() starterStateChangedEvent = new EventEmitter<any>();
 
   attachments: any[] = [];
-  component: Component;
+  componentContent: any;
   componentId: string;
   componentType: string;
   prompt: SafeHtml;
@@ -66,7 +66,8 @@ export abstract class ComponentStudent {
   ) {}
 
   ngOnInit(): void {
-    this.component = new Component(this.componentContent, this.nodeId);
+    this.nodeId = this.component.nodeId;
+    this.componentContent = this.component.content;
     this.componentId = this.componentContent.id;
     this.componentType = this.componentContent.type;
     this.isSaveButtonVisible = this.componentContent.showSaveButton;

--- a/src/assets/wise5/components/component/component.component.html
+++ b/src/assets/wise5/components/component/component.component.html
@@ -8,142 +8,123 @@
       icon="info">
   </help-icon>
 </div>
-<div [ngSwitch]="componentContent.type" class="component__wrapper">
+<div [ngSwitch]="component.content.type" class="component__wrapper">
   <animation-student *ngSwitchCase="'Animation'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [componentState]="componentState"
       [workgroupId]="workgroupId"
       (saveComponentStateEvent)="saveComponentState($event)"
       mode="student">
   </animation-student>
   <audio-oscillator-student *ngSwitchCase="'AudioOscillator'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [componentState]="componentState"
       [workgroupId]="workgroupId"
       (saveComponentStateEvent)="saveComponentState($event)"
       mode="student">
   </audio-oscillator-student>
   <concept-map-student *ngSwitchCase="'ConceptMap'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [componentState]="componentState"
       [workgroupId]="workgroupId"
       (saveComponentStateEvent)="saveComponentState($event)"
       mode="student">
   </concept-map-student>
   <dialog-guidance-student *ngSwitchCase="'DialogGuidance'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [componentState]="componentState"
       [workgroupId]="workgroupId"
       mode="student">
   </dialog-guidance-student>
   <discussion-student *ngSwitchCase="'Discussion'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [componentState]="componentState"
       [workgroupId]="workgroupId"
       mode="student">
   </discussion-student>
   <draw-student *ngSwitchCase="'Draw'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [componentState]="componentState"
       [workgroupId]="workgroupId"
       (saveComponentStateEvent)="saveComponentState($event)"
       mode="student">
   </draw-student>
   <embedded-student *ngSwitchCase="'Embedded'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [componentState]="componentState"
       [workgroupId]="workgroupId"
       (saveComponentStateEvent)="saveComponentState($event)"
       mode="student">
   </embedded-student>
   <graph-student *ngSwitchCase="'Graph'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [componentState]="componentState"
       [workgroupId]="workgroupId"
       (saveComponentStateEvent)="saveComponentState($event)"
       mode="student">
   </graph-student>
   <html-student *ngSwitchCase="'HTML'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       mode="student">
   </html-student>
   <label-student *ngSwitchCase="'Label'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [componentState]="componentState"
       [workgroupId]="workgroupId"
       (saveComponentStateEvent)="saveComponentState($event)"
       mode="student">
   </label-student>
   <match-student *ngSwitchCase="'Match'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [componentState]="componentState"
       [workgroupId]="workgroupId"
       (saveComponentStateEvent)="saveComponentState($event)"
       mode="student">
   </match-student>
   <multiple-choice-student *ngSwitchCase="'MultipleChoice'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [componentState]="componentState"
       [workgroupId]="workgroupId"
       (saveComponentStateEvent)="saveComponentState($event)"
       mode="student">
   </multiple-choice-student>
   <open-response-student *ngSwitchCase="'OpenResponse'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [componentState]="componentState"
       [workgroupId]="workgroupId"
       (saveComponentStateEvent)="saveComponentState($event)"
       mode="student">
   </open-response-student>
   <outside-url-student *ngSwitchCase="'OutsideURL'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       mode="student">
   </outside-url-student>
   <peer-chat-student *ngSwitchCase="'PeerChat'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [componentState]="componentState"
       [workgroupId]="workgroupId"
       mode="student">
   </peer-chat-student>
   <show-group-work-student *ngSwitchCase="'ShowGroupWork'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [componentState]="componentState"
       [workgroupId]="workgroupId"
       [mode]="student">
   </show-group-work-student>
   <show-my-work-student *ngSwitchCase="'ShowMyWork'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [componentState]="componentState"
       [workgroupId]="workgroupId"
       [mode]="student">
   </show-my-work-student>
   <summary-student *ngSwitchCase="'Summary'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [componentState]="componentState"
       [workgroupId]="workgroupId"
       mode="student">
   </summary-student>
   <table-student *ngSwitchCase="'Table'"
-      [nodeId]="nodeId"
-      [componentContent]="componentContent"
+      [component]="component"
       [componentState]="componentState"
       [workgroupId]="workgroupId"
       (saveComponentStateEvent)="saveComponentState($event)"

--- a/src/assets/wise5/components/component/component.component.ts
+++ b/src/assets/wise5/components/component/component.component.ts
@@ -4,7 +4,7 @@ import { ConfigService } from '../../services/configService';
 import { NotebookService } from '../../services/notebookService';
 import { ProjectService } from '../../services/projectService';
 import { StudentDataService } from '../../services/studentDataService';
-import { ComponentContent } from '../../common/ComponentContent';
+import { Component as WISEComponent } from '../../common/Component';
 
 @Component({
   selector: 'component',
@@ -17,7 +17,7 @@ export class ComponentComponent {
   @Input() workgroupId: number;
   @Output() saveComponentStateEvent: EventEmitter<any> = new EventEmitter<any>();
 
-  componentContent: ComponentContent;
+  component: WISEComponent;
   pulseRubricIcon: boolean = true;
   rubric: string;
   showRubric: boolean;
@@ -40,24 +40,22 @@ export class ComponentComponent {
       this.nodeId = this.componentState.nodeId;
       this.componentId = this.componentState.componentId;
     }
-    this.setComponentContent();
-    this.rubric = this.projectService.replaceAssetPaths(this.componentContent.rubric);
+    this.setComponent();
+    this.rubric = this.projectService.replaceAssetPaths(this.component.content.rubric);
     this.showRubric = this.rubric != null && this.rubric != '' && this.configService.isPreview();
   }
 
-  setComponentContent(): void {
-    let componentContent = this.projectService.getComponent(this.nodeId, this.componentId);
-    componentContent = this.projectService.injectAssetPaths(componentContent);
-    componentContent = this.configService.replaceStudentNames(componentContent);
+  setComponent(): void {
+    let content = this.projectService.getComponent(this.nodeId, this.componentId);
+    content = this.projectService.injectAssetPaths(content);
+    content = this.configService.replaceStudentNames(content);
     if (
       this.notebookService.isNotebookEnabled() &&
       this.notebookService.isStudentNoteClippingEnabled()
     ) {
-      componentContent = this.clickToSnipImageService.injectClickToSnipImageListener(
-        componentContent
-      );
+      content = this.clickToSnipImageService.injectClickToSnipImageListener(content);
     }
-    this.componentContent = componentContent;
+    this.component = new WISEComponent(content, this.nodeId);
   }
 
   saveComponentState($event: any): void {

--- a/src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.spec.ts
+++ b/src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.spec.ts
@@ -3,7 +3,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
-import { AnnotationService } from '../../../services/annotationService';
+import { Component } from '../../../common/Component';
 import { NodeService } from '../../../services/nodeService';
 import { ConceptMapService } from '../conceptMapService';
 import { ConceptMapStudent } from './concept-map-student.component';
@@ -35,10 +35,6 @@ describe('ConceptMapStudent', () => {
       schemas: [NO_ERRORS_SCHEMA]
     });
     fixture = TestBed.createComponent(ConceptMapStudent);
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
-      score: 0,
-      comment: ''
-    });
     spyOn(TestBed.inject(NodeService), 'createNewComponentState').and.returnValue({
       studentData: {
         conceptMapData: {
@@ -48,10 +44,10 @@ describe('ConceptMapStudent', () => {
       }
     });
     component = fixture.componentInstance;
-    component.nodeId = nodeId;
-    component.componentContent = TestBed.inject(ConceptMapService).createComponent();
-    component.componentContent.id = componentId;
-    component.componentContent.prompt = 'Create nodes and links.';
+    const componentContent = TestBed.inject(ConceptMapService).createComponent();
+    componentContent.id = componentId;
+    componentContent.prompt = 'Create nodes and links.';
+    component.component = new Component(componentContent, nodeId);
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});
     spyOn(component, 'broadcastDoneRenderingComponent').and.callFake(() => {});
     spyOn(component, 'isAddToNotebookEnabled').and.callFake(() => {

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.spec.ts
@@ -11,7 +11,6 @@ import { PossibleScoreComponent } from '../../../../../app/possible-score/possib
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { ComputerAvatar } from '../../../common/ComputerAvatar';
 import { ComponentHeader } from '../../../directives/component-header/component-header.component';
-import { AnnotationService } from '../../../services/annotationService';
 import { ComputerAvatarService } from '../../../services/computerAvatarService';
 import { DialogGuidanceFeedbackService } from '../../../services/dialogGuidanceFeedbackService';
 import { ProjectService } from '../../../services/projectService';
@@ -24,6 +23,7 @@ import { CRaterScore } from '../../common/cRater/CRaterScore';
 import { DialogResponsesComponent } from '../dialog-responses/dialog-responses.component';
 import { DialogGuidanceService } from '../dialogGuidanceService';
 import { DialogGuidanceStudentComponent } from './dialog-guidance-student.component';
+import { Component } from '../../../common/Component';
 
 let component: DialogGuidanceStudentComponent;
 let fixture: ComponentFixture<DialogGuidanceStudentComponent>;
@@ -55,19 +55,16 @@ describe('DialogGuidanceStudentComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DialogGuidanceStudentComponent);
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
-      score: 0,
-      comment: ''
-    });
     spyOn(TestBed.inject(ProjectService), 'getThemeSettings').and.returnValue({});
     component = fixture.componentInstance;
-    component.componentContent = TestBed.inject(DialogGuidanceService).createComponent();
-    component.componentContent.feedbackRules = [
+    const componentContent = TestBed.inject(DialogGuidanceService).createComponent();
+    componentContent.feedbackRules = [
       {
         expression: 'isDefault',
         feedback: 'Default Feedback'
       }
     ];
+    component.component = new Component(componentContent, null);
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});
     spyOn(component, 'isNotebookEnabled').and.returnValue(false);
     fixture.detectChanges();

--- a/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.spec.ts
+++ b/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.spec.ts
@@ -5,7 +5,8 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { BrowserModule } from '@angular/platform-browser';
 import { of } from 'rxjs';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
-import { AnnotationService } from '../../../services/annotationService';
+import { Component } from '../../../common/Component';
+import { ComponentContent } from '../../../common/ComponentContent';
 import { ConfigService } from '../../../services/configService';
 import { NotificationService } from '../../../services/notificationService';
 import { ProjectService } from '../../../services/projectService';
@@ -33,10 +34,6 @@ describe('DiscussionStudentComponent', () => {
       schemas: [NO_ERRORS_SCHEMA]
     });
     fixture = TestBed.createComponent(DiscussionStudent);
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
-      score: 0,
-      comment: ''
-    });
     spyOn(TestBed.inject(ProjectService), 'isSpaceExists').and.returnValue(false);
     spyOn(TestBed.inject(ConfigService), 'getUserIdsStringByWorkgroupId').and.returnValue('1');
     saveNotificationToServerSpy = spyOn(
@@ -48,14 +45,11 @@ describe('DiscussionStudentComponent', () => {
       }
     );
     component = fixture.componentInstance;
-    component.nodeId = nodeId;
-    component.componentContent = {
-      cRater: {},
-      enableCRater: true,
-      gateClassmateResponses: true,
+    const componentContent = {
       id: componentId,
       prompt: 'Post your favorite ice cream flavor.'
-    };
+    } as ComponentContent;
+    component.component = new Component(componentContent, nodeId);
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});
     spyOn(component, 'broadcastDoneRenderingComponent').and.callFake(() => {});
     spyOn(component, 'isAddToNotebookEnabled').and.callFake(() => {

--- a/src/assets/wise5/components/draw/draw-student/draw-student.component.spec.ts
+++ b/src/assets/wise5/components/draw/draw-student/draw-student.component.spec.ts
@@ -3,7 +3,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
-import { AnnotationService } from '../../../services/annotationService';
+import { Component } from '../../../common/Component';
 import { ProjectService } from '../../../services/projectService';
 import { StudentDataService } from '../../../services/studentDataService';
 import { UtilService } from '../../../services/utilService';
@@ -24,16 +24,12 @@ describe('DrawStudentComponent', () => {
     });
     jasmine.clock().install();
     fixture = TestBed.createComponent(DrawStudent);
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
-      score: 0,
-      comment: ''
-    });
     spyOn(TestBed.inject(ProjectService), 'isSpaceExists').and.returnValue(false);
     component = fixture.componentInstance;
-    component.nodeId = 'node1';
     component.componentContent = TestBed.inject(DrawService).createComponent();
     component.componentContent.id = 'component1';
     component.componentContent.prompt = 'Draw some shapes.';
+    component.component = new Component(component.componentContent, 'node1');
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});
     spyOn(component, 'broadcastDoneRenderingComponent').and.callFake(() => {});
     spyOn(component, 'isAddToNotebookEnabled').and.callFake(() => {

--- a/src/assets/wise5/components/embedded/embedded-student/embedded-student.component.spec.ts
+++ b/src/assets/wise5/components/embedded/embedded-student/embedded-student.component.spec.ts
@@ -3,7 +3,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
-import { AnnotationService } from '../../../services/annotationService';
+import { Component } from '../../../common/Component';
 import { ProjectService } from '../../../services/projectService';
 import { StudentDataService } from '../../../services/studentDataService';
 import { EmbeddedService } from '../embeddedService';
@@ -36,16 +36,12 @@ describe('EmbeddedStudentComponent', () => {
       schemas: [NO_ERRORS_SCHEMA]
     });
     fixture = TestBed.createComponent(EmbeddedStudent);
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
-      score: 0,
-      comment: ''
-    });
     spyOn(TestBed.inject(ProjectService), 'isSpaceExists').and.returnValue(false);
     component = fixture.componentInstance;
-    component.nodeId = nodeId;
-    component.componentContent = TestBed.inject(EmbeddedService).createComponent();
-    component.componentContent.id = componentId;
-    component.componentContent.prompt = 'Play with the simulation.';
+    const componentContent = TestBed.inject(EmbeddedService).createComponent();
+    componentContent.id = componentId;
+    componentContent.prompt = 'Play with the simulation.';
+    component.component = new Component(componentContent, nodeId);
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});
     spyOn(component, 'broadcastDoneRenderingComponent').and.callFake(() => {});
     spyOn(component, 'isAddToNotebookEnabled').and.callFake(() => {

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
@@ -6,12 +6,12 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Point } from 'highcharts';
 import { HighchartsChartModule } from 'highcharts-angular';
-import { AnnotationService } from '../../../services/annotationService';
 import { ProjectService } from '../../../services/projectService';
 import { GraphService } from '../graphService';
 import { GraphStudent } from './graph-student.component';
 import { of } from 'rxjs';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { Component } from '../../../common/Component';
 
 let component: GraphStudent;
 const componentId = 'component1';
@@ -38,14 +38,10 @@ describe('GraphStudentComponent', () => {
       schemas: [NO_ERRORS_SCHEMA]
     });
     fixture = TestBed.createComponent(GraphStudent);
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
-      score: 0,
-      comment: ''
-    });
     spyOn(TestBed.inject(ProjectService), 'isSpaceExists').and.returnValue(false);
     component = fixture.componentInstance;
-    component.nodeId = nodeId;
-    component.componentContent = createComponentContent();
+    const componentContent = createComponentContent();
+    component.component = new Component(componentContent, nodeId);
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});
     spyOn(component, 'broadcastDoneRenderingComponent').and.callFake(() => {});
     spyOn(component, 'isAddToNotebookEnabled').and.callFake(() => {

--- a/src/assets/wise5/components/label/label-student/label-student.component.spec.ts
+++ b/src/assets/wise5/components/label/label-student/label-student.component.spec.ts
@@ -3,9 +3,9 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { AnnotationService } from '../../../services/annotationService';
 import { LabelStudent } from './label-student.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { Component } from '../../../common/Component';
 
 let component: LabelStudent;
 let fixture: ComponentFixture<LabelStudent>;
@@ -18,16 +18,15 @@ describe('LabelStudentComponent', () => {
       schemas: [NO_ERRORS_SCHEMA]
     });
     fixture = TestBed.createComponent(LabelStudent);
-    spyOn(TestBed.get(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({});
     component = fixture.componentInstance;
-    component.nodeId = 'node1';
-    component.componentContent = {
+    const componentContent = {
       id: 'component1',
       type: 'Label',
       prompt: 'Create some labels.',
       width: 800,
       height: 600
     };
+    component.component = new Component(componentContent, null);
     spyOn(component, 'giveFocusToLabelTextInput').and.callFake(() => {});
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});
     spyOn(component, 'broadcastDoneRenderingComponent').and.callFake(() => {});

--- a/src/assets/wise5/components/match/match-student/match-student.component.spec.ts
+++ b/src/assets/wise5/components/match/match-student/match-student.component.spec.ts
@@ -3,7 +3,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
-import { AnnotationService } from '../../../services/annotationService';
+import { Component } from '../../../common/Component';
 import { ClickToSnipImageService } from '../../../services/clickToSnipImageService';
 import { ProjectService } from '../../../services/projectService';
 import { MatchStudent } from './match-student.component';
@@ -53,12 +53,7 @@ describe('MatchStudentComponent', () => {
       schemas: [NO_ERRORS_SCHEMA]
     });
     fixture = TestBed.createComponent(MatchStudent);
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
-      score: 0,
-      comment: ''
-    });
     component = fixture.componentInstance;
-    component.nodeId = nodeId;
     choice1 = createChoice(choiceId1, choiceValue1);
     choice2 = createChoice(choiceId2, choiceValue2);
     choice3 = createChoice(choiceId3, choiceValue3);
@@ -95,7 +90,7 @@ describe('MatchStudentComponent', () => {
         ])
       ]
     };
-    component.componentContent = componentContent;
+    component.component = new Component(componentContent, nodeId);
     spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue(
       JSON.parse(JSON.stringify(componentContent))
     );

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.spec.ts
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.spec.ts
@@ -8,8 +8,8 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { Component } from '../../../common/Component';
 import { ComponentHeader } from '../../../directives/component-header/component-header.component';
-import { AnnotationService } from '../../../services/annotationService';
 import { ClickToSnipImageService } from '../../../services/clickToSnipImageService';
 import { ProjectService } from '../../../services/projectService';
 import { MultipleChoiceStudent } from './multiple-choice-student.component';
@@ -121,13 +121,8 @@ describe('MultipleChoiceStudentComponent', () => {
       declarations: [ComponentHeader, MultipleChoiceStudent, PossibleScoreComponent]
     });
     fixture = TestBed.createComponent(MultipleChoiceStudent);
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
-      score: 0,
-      comment: ''
-    });
     spyOn(TestBed.inject(ProjectService), 'getThemeSettings').and.returnValue({});
     component = fixture.componentInstance;
-    component.nodeId = nodeId;
     originalComponentContent = {
       id: componentId,
       type: multipleChoiceType,
@@ -139,7 +134,8 @@ describe('MultipleChoiceStudentComponent', () => {
       ],
       showFeedback: true
     };
-    component.componentContent = JSON.parse(JSON.stringify(originalComponentContent));
+    const componentContent = JSON.parse(JSON.stringify(originalComponentContent));
+    component.component = new Component(componentContent, nodeId);
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});
     spyOn(component, 'broadcastDoneRenderingComponent').and.callFake(() => {});
     spyOn(component, 'isAddToNotebookEnabled').and.callFake(() => {
@@ -195,6 +191,7 @@ function testMultipleAnswerComponent() {
   describe('multiple answer component', () => {
     beforeEach(() => {
       component.componentContent = JSON.parse(JSON.stringify(multipleAnswerComponent));
+      component.component = new Component(component.componentContent, nodeId);
       component.ngOnInit();
     });
     multipleAnswerComponentShouldShowCorrectWhenOnlyTheCorrectAnswersAreSubmitted();
@@ -211,6 +208,7 @@ function testSingleAnswerSingleCorrectAnswerComponent() {
       component.componentContent = JSON.parse(
         JSON.stringify(singleAnswerSingleCorrectAnswerComponent)
       );
+      component.component = new Component(component.componentContent, nodeId);
       component.ngOnInit();
     });
     singleAnswerSingleCorrectAnswerComponentShouldShowTheFeedbackOnTheSubmittedChoice();
@@ -225,6 +223,8 @@ function testSingleAnswerMultipleCorrectAnswersComponent() {
       component.componentContent = JSON.parse(
         JSON.stringify(singleAnswerMultipleCorrectAnswersComponent)
       );
+      component.component = new Component(component.componentContent, nodeId);
+
       component.ngOnInit();
     });
     singleAnswerMultipleCorrectAnswersComponentShouldShowCorrect();

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.spec.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.spec.ts
@@ -10,6 +10,7 @@ import { UpgradeModule } from '@angular/upgrade/static';
 import { of } from 'rxjs';
 import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { Component } from '../../../common/Component';
 import { ComponentHeader } from '../../../directives/component-header/component-header.component';
 import { ComponentSaveSubmitButtons } from '../../../directives/component-save-submit-buttons/component-save-submit-buttons.component';
 import { AnnotationService } from '../../../services/annotationService';
@@ -18,6 +19,7 @@ import { CRaterService } from '../../../services/cRaterService';
 import { NotebookService } from '../../../services/notebookService';
 import { ProjectService } from '../../../services/projectService';
 import { StudentDataService } from '../../../services/studentDataService';
+import { OpenResponseContent } from '../OpenResponseContent';
 import { OpenResponseService } from '../openResponseService';
 import { OpenResponseStudent } from './open-response-student.component';
 
@@ -55,22 +57,18 @@ describe('OpenResponseStudent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OpenResponseStudent);
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
-      score: 0,
-      comment: ''
-    });
     spyOn(TestBed.inject(ProjectService), 'isSpaceExists').and.returnValue(false);
     spyOn(TestBed.inject(ProjectService), 'getThemeSettings').and.returnValue({});
     component = fixture.componentInstance;
-    component.nodeId = nodeId;
-    component.componentContent = {
+    const componentContent = {
       cRater: {},
       enableCRater: true,
       id: componentId,
       prompt: 'How do plants obtain energy?',
       showSaveButton: true,
       showSubmitButton: true
-    };
+    } as OpenResponseContent;
+    component.component = new Component(componentContent, nodeId);
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});
     spyOn(component, 'broadcastDoneRenderingComponent').and.callFake(() => {});
     spyOn(component, 'isAddToNotebookEnabled').and.callFake(() => {

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.spec.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.spec.ts
@@ -13,7 +13,6 @@ import { StudentTeacherCommonServicesModule } from '../../../../../app/student-t
 import { Component } from '../../../common/Component';
 import { ComponentHeader } from '../../../directives/component-header/component-header.component';
 import { ComponentSaveSubmitButtons } from '../../../directives/component-save-submit-buttons/component-save-submit-buttons.component';
-import { AnnotationService } from '../../../services/annotationService';
 import { AudioRecorderService } from '../../../services/audioRecorderService';
 import { CRaterService } from '../../../services/cRaterService';
 import { NotebookService } from '../../../services/notebookService';

--- a/src/assets/wise5/components/outsideURL/outside-url-student/outside-url-student.component.spec.ts
+++ b/src/assets/wise5/components/outsideURL/outside-url-student/outside-url-student.component.spec.ts
@@ -7,7 +7,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
-import { AnnotationService } from '../../../services/annotationService';
 import { ProjectService } from '../../../services/projectService';
 import { OutsideUrlStudent } from './outside-url-student.component';
 
@@ -33,10 +32,6 @@ describe('OutsideUrlStudentComponent', () => {
       declarations: [OutsideUrlStudent]
     });
     fixture = TestBed.createComponent(OutsideUrlStudent);
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
-      score: 0,
-      comment: ''
-    });
     spyOn(TestBed.inject(ProjectService), 'isSpaceExists').and.returnValue(false);
     spyOn(TestBed.inject(ProjectService), 'getThemeSettings').and.returnValue({});
     component = fixture.componentInstance;

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.spec.ts
@@ -34,6 +34,7 @@ import { StudentTeacherCommonServicesModule } from '../../../../../app/student-t
 import { FeedbackRule } from '../../common/feedbackRule/FeedbackRule';
 import { DynamicPromptComponent } from '../../../directives/dynamic-prompt/dynamic-prompt.component';
 import { PromptComponent } from '../../../directives/prompt/prompt.component';
+import { Component } from '../../../common/Component';
 
 let component: PeerChatStudentComponent;
 const componentId = 'component1';
@@ -161,10 +162,6 @@ describe('PeerChatStudentComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PeerChatStudentComponent);
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
-      score: 0,
-      comment: ''
-    });
     const configService = TestBed.inject(ConfigService);
     spyOn(configService, 'getWorkgroupId').and.returnValue(studentWorkgroupId1);
     spyOn(configService, 'getTeacherWorkgroupIds').and.returnValue([teacherWorkgroupId]);
@@ -180,9 +177,7 @@ describe('PeerChatStudentComponent', () => {
       of([componentState1, componentState2])
     );
     component = fixture.componentInstance;
-    component.componentContent = componentContent;
-    component.nodeId = nodeId;
-    component.componentId = componentId;
+    component.component = new Component(componentContent, nodeId);
     component.workgroupId = studentWorkgroupId1;
     component.peerGroup = peerGroup;
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});

--- a/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.spec.ts
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-student/show-group-work-student.component.spec.ts
@@ -5,6 +5,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { of } from 'rxjs';
 import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { Component } from '../../../common/Component';
 import { AnnotationService } from '../../../services/annotationService';
 import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
@@ -73,22 +74,20 @@ describe('ShowGroupWorkStudentComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ShowGroupWorkStudentComponent);
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
-      score: 0,
-      comment: ''
-    });
     componentState1 = createComponentState(1);
     componentState2 = createComponentState(2);
     studentWork = [componentState1, componentState2];
     component = fixture.componentInstance;
-    component.componentContent = {
+    const componentContent = {
       id: 'abc',
       prompt: '',
       showSaveButton: true,
       showSubmitButton: true,
       isShowMyWork: true,
-      layout: 'row'
+      layout: 'row',
+      type: 'ShowGroupWork'
     };
+    component.component = new Component(componentContent, null);
     spyOn(TestBed.inject(ProjectService), 'injectAssetPaths').and.returnValue({
       type: 'OpenResponse'
     });

--- a/src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.spec.ts
+++ b/src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.spec.ts
@@ -4,7 +4,8 @@ import { MatCardModule } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
 import { of } from 'rxjs';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
-import { AnnotationService } from '../../../services/annotationService';
+import { Component } from '../../../common/Component';
+import { ComponentContent } from '../../../common/ComponentContent';
 import { NotebookService } from '../../../services/notebookService';
 
 import { ShowMyWorkStudentComponent } from './show-my-work-student.component';
@@ -36,17 +37,14 @@ describe('ShowMyWorkStudentComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ShowMyWorkStudentComponent);
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
-      score: 0,
-      comment: ''
-    });
     component = fixture.componentInstance;
-    component.componentContent = {
+    const componentContent = {
       id: 'abc',
       prompt: '',
       showSaveButton: true,
       showSubmitButton: true
-    };
+    } as ComponentContent;
+    component.component = new Component(componentContent, null);
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});
     fixture.detectChanges();
   });

--- a/src/assets/wise5/components/summary/summary-student/summary-student.component.spec.ts
+++ b/src/assets/wise5/components/summary/summary-student/summary-student.component.spec.ts
@@ -5,12 +5,12 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { BrowserModule } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
-import { AnnotationService } from '../../../services/annotationService';
 import { ConfigService } from '../../../services/configService';
 import { ProjectService } from '../../../services/projectService';
 import { StudentDataService } from '../../../services/studentDataService';
 import { SummaryStudent } from './summary-student.component';
 import { ComponentContent } from '../../../common/ComponentContent';
+import { Component } from '../../../common/Component';
 
 let component: SummaryStudent;
 const componentId = 'component1';
@@ -32,19 +32,14 @@ describe('SummaryStudentComponent', () => {
       schemas: [NO_ERRORS_SCHEMA]
     });
     fixture = TestBed.createComponent(SummaryStudent);
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
-      score: 0,
-      comment: ''
-    });
-    spyOn(TestBed.inject(ProjectService), 'isSpaceExists').and.returnValue(false);
     component = fixture.componentInstance;
-    component.nodeId = nodeId;
-    component.componentContent = {
+    const componentContent = {
       id: componentId,
       prompt: 'View the the graph of the choices your classmates chose.',
       showSaveButton: true,
       showSubmitButton: true
-    };
+    } as ComponentContent;
+    component.component = new Component(componentContent, nodeId);
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});
     spyOn(component, 'broadcastDoneRenderingComponent').and.callFake(() => {});
     spyOn(component, 'isAddToNotebookEnabled').and.callFake(() => {

--- a/src/assets/wise5/components/table/table-student/table-student.component.spec.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.spec.ts
@@ -5,6 +5,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { BrowserModule } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { Component } from '../../../common/Component';
 import { AnnotationService } from '../../../services/annotationService';
 import { ProjectService } from '../../../services/projectService';
 import { UtilService } from '../../../services/utilService';
@@ -36,14 +37,9 @@ describe('TableStudentComponent', () => {
       schemas: [NO_ERRORS_SCHEMA]
     });
     fixture = TestBed.createComponent(TableStudent);
-    spyOn(TestBed.inject(AnnotationService), 'getLatestComponentAnnotations').and.returnValue({
-      score: 0,
-      comment: ''
-    });
     spyOn(TestBed.inject(ProjectService), 'isSpaceExists').and.returnValue(false);
     component = fixture.componentInstance;
-    component.nodeId = nodeId;
-    component.componentContent = {
+    const componentContent = {
       cRater: {},
       dataExplorerGraphTypes: [{ name: 'Scatter Plot', value: 'scatter' }],
       dataExplorerDataToColumn: {
@@ -72,6 +68,7 @@ describe('TableStudentComponent', () => {
       tableData: createTestTableData(),
       type: 'Table'
     };
+    component.component = new Component(componentContent, nodeId);
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});
     spyOn(component, 'broadcastDoneRenderingComponent').and.callFake(() => {});
     spyOn(component, 'isAddToNotebookEnabled').and.callFake(() => {

--- a/src/assets/wise5/components/table/table-student/table-student.component.spec.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.spec.ts
@@ -6,7 +6,6 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { Component } from '../../../common/Component';
-import { AnnotationService } from '../../../services/annotationService';
 import { ProjectService } from '../../../services/projectService';
 import { UtilService } from '../../../services/utilService';
 import { TabulatorDataService } from '../tabulatorDataService';
@@ -119,22 +118,6 @@ describe('TableStudentComponent', () => {
   updateColumnNames();
   updateDataExplorerSeriesNames();
 });
-
-/**
- * Used for debugging.
- */
-function printTable(tableData: any[]): void {
-  for (const row of tableData) {
-    let rowValues = '';
-    for (const cell of row) {
-      if (rowValues !== '') {
-        rowValues += ',';
-      }
-      rowValues += cell.text;
-    }
-    console.log(rowValues);
-  }
-}
 
 function createCellObject(text: string = '', editable: boolean = true, size: number = null) {
   return {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -287,7 +287,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/preview-component-dialog/preview-component-dialog.component.html</context>
-          <context context-type="linenumber">19</context>
+          <context context-type="linenumber">18</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-dialog/select-peer-grouping-dialog.component.html</context>


### PR DESCRIPTION
## Changes
- Pass Component as input to PreviewComponentComponent and ComponentStudent instead of nodeId/componentContent. This simplifies the PreviewComponentComponent/ComponentStudent classes and clarifies that those components require a Component (which they both do in order to function)
- Update tests
- Remove unused code

## Test
- VLE, Preview, AT, and CM work as before

Closes #904