### PR TITLE
fix(Node Authoring): Component type label does not update

### DIFF
--- a/src/assets/wise5/authoringTool/node/nodeAuthoring.html
+++ b/src/assets/wise5/authoringTool/node/nodeAuthoring.html
@@ -146,7 +146,7 @@
       <md-checkbox ng-model='$ctrl.componentsToChecked[component.id]'
           ng-disabled='$ctrl.insertComponentMode'
           class='md-primary'>
-        <span style='font-weight:bold; margin-right:10px'>{{($index + 1)}}. {{::$ctrl.getComponentTypeLabel(component.type)}}</span>
+        <span style='font-weight:bold; margin-right:10px'>{{($index + 1)}}. {{$ctrl.getComponentTypeLabel(component.type)}}</span>
       </md-checkbox>
     </div>
     <div ng-if='!$ctrl.insertComponentMode && $ctrl.showComponentAuthoringViews'>

--- a/src/assets/wise5/authoringTool/node/nodeAuthoringComponent.ts
+++ b/src/assets/wise5/authoringTool/node/nodeAuthoringComponent.ts
@@ -417,7 +417,7 @@ class NodeAuthoringController {
     }
   }
 
-  insertComponentAfter(componentId) {
+  insertComponentAfter(componentId: string): void {
     if (this.moveComponentMode) {
       this.handleMoveComponent(componentId);
     } else if (this.copyComponentMode) {
@@ -431,9 +431,9 @@ class NodeAuthoringController {
    * id. If the componentId is not provided, we will put the components at the
    * beginning of the step.
    */
-  handleMoveComponent(componentId = null) {
+  private handleMoveComponent(componentId = null): void {
     const selectedComponentIds = this.getSelectedComponentIds();
-    if (selectedComponentIds != null && selectedComponentIds.indexOf(componentId) != -1) {
+    if (selectedComponentIds.indexOf(componentId) != -1) {
       if (selectedComponentIds.length === 1) {
         alert(this.$translate('youAreNotAllowedToInsertTheSelectedItemAfterItself'));
       } else if (selectedComponentIds.length > 1) {

--- a/src/assets/wise5/services/nodeService.ts
+++ b/src/assets/wise5/services/nodeService.ts
@@ -550,7 +550,7 @@ export class NodeService {
    * component id. If this argument is null, we will place the new
    * component(s) in the first position.
    */
-  moveComponent(nodeId, componentIds, insertAfterComponentId) {
+  moveComponent(nodeId: string, componentIds: string[], insertAfterComponentId: string): void {
     const node = this.ProjectService.getNodeById(nodeId);
     const components = node.components;
     const extractedComponents = this.extractComponents(components, componentIds);

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -6104,7 +6104,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/componentAnnotations/component-annotations.component.ts</context>
-          <context context-type="linenumber">213</context>
+          <context context-type="linenumber">192</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3de550daa9bf35829dbeb9099844614347d2dbc5" datatype="html">
@@ -13697,7 +13697,7 @@ Are you ready to receive feedback on this answer?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/componentAnnotations/component-annotations.component.ts</context>
-          <context context-type="linenumber">210</context>
+          <context context-type="linenumber">189</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2353574516166744013" datatype="html">
@@ -18765,14 +18765,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>You have been inactive for a long time. Do you want to stay logged in?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">133</context>
+          <context context-type="linenumber">137</context>
         </context-group>
       </trans-unit>
       <trans-unit id="537022937435161177" datatype="html">
         <source>Session Timeout</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">134</context>
+          <context context-type="linenumber">138</context>
         </context-group>
       </trans-unit>
     </body>


### PR DESCRIPTION
## Changes
- Component type labels update properly when
   - Moving a component
      - If you have two components in a step, say 1. Open Response and 2. Multiple Choice, and you move the Open Response after the Multiple Choice, the view will still show 1. Open Response and 2. Multiple Choice
   - Copying a component
   - Deleting a component
- Clean up related code
   - removed unnecessary null check 

## Test
- Test above scenarios and make sure the component type labels update properly

Closes #902