### PR TITLE
fix(HTML Authoring): Render previously-saved images in TinyMCE

### DIFF
--- a/src/assets/wise5/components/html/html-authoring/html-authoring.component.ts
+++ b/src/assets/wise5/components/html/html-authoring/html-authoring.component.ts
@@ -14,25 +14,25 @@ export class HtmlAuthoring extends ComponentAuthoring {
   html: string = '';
 
   constructor(
-    protected ConfigService: ConfigService,
-    protected NodeService: NodeService,
-    protected ProjectAssetService: ProjectAssetService,
-    protected ProjectService: TeacherProjectService,
-    protected UtilService: UtilService
+    protected configService: ConfigService,
+    protected nodeService: NodeService,
+    protected projectAssetService: ProjectAssetService,
+    protected projectService: TeacherProjectService,
+    protected utilService: UtilService
   ) {
-    super(ConfigService, NodeService, ProjectAssetService, ProjectService);
+    super(configService, nodeService, projectAssetService, projectService);
   }
 
   ngOnInit() {
     super.ngOnInit();
-    this.html = this.ProjectService.replaceAssetPaths(
-      this.UtilService.replaceWISELinks(this.componentContent.html)
+    this.html = this.projectService.replaceAssetPaths(
+      this.utilService.replaceWISELinks(this.componentContent.html)
     );
   }
 
   htmlChanged(): void {
-    this.componentContent.html = this.UtilService.insertWISELinks(
-      this.ConfigService.removeAbsoluteAssetPaths(this.html)
+    this.componentContent.html = this.utilService.insertWISELinks(
+      this.configService.removeAbsoluteAssetPaths(this.html)
     );
     this.componentChanged();
   }

--- a/src/assets/wise5/components/html/html-authoring/html-authoring.component.ts
+++ b/src/assets/wise5/components/html/html-authoring/html-authoring.component.ts
@@ -25,7 +25,9 @@ export class HtmlAuthoring extends ComponentAuthoring {
 
   ngOnInit() {
     super.ngOnInit();
-    this.html = this.UtilService.replaceWISELinks(this.componentContent.html);
+    this.html = this.ProjectService.replaceAssetPaths(
+      this.UtilService.replaceWISELinks(this.componentContent.html)
+    );
   }
 
   htmlChanged(): void {


### PR DESCRIPTION
## Changes
- Previously-saved images render in the TinyMCE window in HTML component authoring

## Test
- Images render in the TinyMCE window in HTML component authoring
   - images saved previously
   - images just added 

Closes #928