### PR TITLE
refactor(PeerChat): Create PeerChatComponent class

### DIFF
--- a/src/assets/wise5/common/ComponentFactory.spec.ts
+++ b/src/assets/wise5/common/ComponentFactory.spec.ts
@@ -1,5 +1,6 @@
 import { DialogGuidanceComponent } from '../components/dialogGuidance/DialogGuidanceComponent';
 import { MultipleChoiceComponent } from '../components/multipleChoice/MultipleChoiceComponent';
+import { PeerChatComponent } from '../components/peerChat/PeerChatComponent';
 import { Component } from './Component';
 import { ComponentContent } from './ComponentContent';
 import { ComponentFactory } from './ComponentFactory';
@@ -21,6 +22,11 @@ function getComponent() {
         type: 'MultipleChoice',
         instance: MultipleChoiceComponent,
         message: 'should return MultipleChoiceComponent if content.type is MultipleChoice'
+      },
+      {
+        type: 'PeerChat',
+        instance: PeerChatComponent,
+        message: 'should return PeerChatComponent if content.type is PeerChat'
       },
       {
         type: 'HTML',

--- a/src/assets/wise5/common/ComponentFactory.ts
+++ b/src/assets/wise5/common/ComponentFactory.ts
@@ -1,5 +1,6 @@
 import { DialogGuidanceComponent } from '../components/dialogGuidance/DialogGuidanceComponent';
 import { MultipleChoiceComponent } from '../components/multipleChoice/MultipleChoiceComponent';
+import { PeerChatComponent } from '../components/peerChat/PeerChatComponent';
 import { Component } from './Component';
 import { ComponentContent } from './ComponentContent';
 
@@ -9,6 +10,8 @@ export class ComponentFactory {
       return new DialogGuidanceComponent(content, nodeId);
     } else if (content.type === 'MultipleChoice') {
       return new MultipleChoiceComponent(content, nodeId);
+    } else if (content.type === 'PeerChat') {
+      return new PeerChatComponent(content, nodeId);
     } else {
       return new Component(content, nodeId);
     }

--- a/src/assets/wise5/components/peerChat/PeerChatComponent.ts
+++ b/src/assets/wise5/components/peerChat/PeerChatComponent.ts
@@ -1,0 +1,18 @@
+import { Component } from '../../common/Component';
+import { QuestionBank } from './peer-chat-question-bank/QuestionBank';
+import { QuestionBankContent } from './peer-chat-question-bank/QuestionBankContent';
+import { PeerChatContent } from './PeerChatContent';
+
+export class PeerChatComponent extends Component {
+  content: PeerChatContent;
+
+  getPeerGroupingTag(): string {
+    return this.content.peerGroupingTag;
+  }
+
+  getQuestionBankContent(): QuestionBankContent {
+    return this.content.questionBank != null
+      ? new QuestionBankContent(this.nodeId, this.id, new QuestionBank(this.content.questionBank))
+      : null;
+  }
+}

--- a/src/assets/wise5/components/peerChat/PeerChatContent.ts
+++ b/src/assets/wise5/components/peerChat/PeerChatContent.ts
@@ -1,0 +1,5 @@
+import { ComponentContent } from '../../common/ComponentContent';
+
+export interface PeerChatContent extends ComponentContent {
+  peerGroupingTag: string;
+}

--- a/src/assets/wise5/components/peerChat/PeerGroup.ts
+++ b/src/assets/wise5/components/peerChat/PeerGroup.ts
@@ -12,4 +12,8 @@ export class PeerGroup {
     this.members = members;
     this.peerGrouping = peerGrouping;
   }
+
+  getWorkgroupIds(): number[] {
+    return this.members.map((member) => member.id);
+  }
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.ts
@@ -45,7 +45,7 @@ export class PeerChatGradingComponent extends PeerChatShowWorkComponent {
     const notificationType = 'PeerChatMessage';
     const teacherWorkgroupId = this.configService.getWorkgroupId();
     const message = 'Your teacher sent a chat message';
-    for (const workgroupId of this.getPeerGroupWorkgroupIds(peerGroup)) {
+    for (const workgroupId of peerGroup.getWorkgroupIds()) {
       const notification = this.notificationService.createNewNotification(
         runId,
         periodId,
@@ -58,10 +58,6 @@ export class PeerChatGradingComponent extends PeerChatShowWorkComponent {
       );
       this.notificationService.saveNotificationToServer(notification);
     }
-  }
-
-  private getPeerGroupWorkgroupIds(peerGroup: PeerGroup): number[] {
-    return peerGroup.members.map((member: any) => member.id);
   }
 
   private createComponentState(response: string): ComponentState {

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.spec.ts
@@ -34,7 +34,7 @@ import { StudentTeacherCommonServicesModule } from '../../../../../app/student-t
 import { FeedbackRule } from '../../common/feedbackRule/FeedbackRule';
 import { DynamicPromptComponent } from '../../../directives/dynamic-prompt/dynamic-prompt.component';
 import { PromptComponent } from '../../../directives/prompt/prompt.component';
-import { Component } from '../../../common/Component';
+import { PeerChatComponent } from '../PeerChatComponent';
 
 let component: PeerChatStudentComponent;
 const componentId = 'component1';
@@ -176,7 +176,7 @@ describe('PeerChatStudentComponent', () => {
       of([componentState1, componentState2])
     );
     component = fixture.componentInstance;
-    component.component = new Component(componentContent, nodeId);
+    component.component = new PeerChatComponent(componentContent, nodeId);
     component.workgroupId = studentWorkgroupId1;
     component.peerGroup = peerGroup;
     spyOn(component, 'subscribeToSubscriptions').and.callFake(() => {});

--- a/src/assets/wise5/services/peerGroupService.ts
+++ b/src/assets/wise5/services/peerGroupService.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { PeerGroupStudentData } from '../../../app/domain/peerGroupStudentData';
 import { Node } from '../common/Node';
 import { PeerGroup } from '../components/peerChat/PeerGroup';
@@ -27,9 +28,11 @@ export class PeerGroupService {
   retrievePeerGroup(
     peerGroupingTag: string,
     workgroupId = this.configService.getWorkgroupId()
-  ): Observable<any> {
+  ): Observable<PeerGroup> {
     const runId = this.configService.isPreview() ? 1 : this.configService.getRunId();
-    return this.http.get(`/api/peer-group/${runId}/${workgroupId}/${peerGroupingTag}`);
+    return this.http
+      .get<PeerGroup>(`/api/peer-group/${runId}/${workgroupId}/${peerGroupingTag}`)
+      .pipe(map((value) => new PeerGroup(value.id, value.members, value.peerGrouping)));
   }
 
   retrievePeerGroupWork(

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -16899,7 +16899,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>You have new chat messages</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts</context>
-          <context context-type="linenumber">227</context>
+          <context context-type="linenumber">216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6310961320545154131" datatype="html">


### PR DESCRIPTION
## Changes
- Create a new PeerChatComponent class that extends the Component class and has PeerChat-specific methods like getPeerGroupingTag(), getQuestionBankContent(),...  Move those functions from PeerChatStudentComponent to to the new class.
- Create PeerChatContent to represent content fields that are specific to PeerChat
- Refactor PeerGroupService.retrievePeerGroup() to return an instance of PeerGroup instead of a JSON object
- Clean up related code
- No new feature was added

## Test
- PeerChat student
   - can view student chat history
   - can see QuestionBank and DynamicPrompt
   - can participate in chat as student
- PeerChat grading
   - can view student chat history
   - can participate in chat as teacher

Closes #939