### PR TITLE
refactor(ProjectService): Create Transition and TransitionLogic classes

### DIFF
--- a/src/assets/wise5/common/Node.ts
+++ b/src/assets/wise5/common/Node.ts
@@ -1,3 +1,5 @@
+import { TransitionLogic } from './TransitionLogic';
+
 export class Node {
   components: any[] = [];
   icons: any;
@@ -7,6 +9,7 @@ export class Node {
   showSaveButton: boolean;
   showSubmitButton: boolean;
   title: string;
+  transitionLogic?: TransitionLogic;
   type: string;
 
   getIcon(): any {
@@ -52,5 +55,14 @@ export class Node {
 
   hasComponent(componentId: string): boolean {
     return this.components.some((component) => component.id === componentId);
+  }
+
+  getTransitionLogic(): TransitionLogic {
+    if (this.transitionLogic == null) {
+      this.transitionLogic = {
+        transitions: []
+      };
+    }
+    return this.transitionLogic;
   }
 }

--- a/src/assets/wise5/common/Transition.ts
+++ b/src/assets/wise5/common/Transition.ts
@@ -1,0 +1,4 @@
+export interface Transition {
+  criteria?: any[];
+  to: string;
+}

--- a/src/assets/wise5/common/TransitionLogic.ts
+++ b/src/assets/wise5/common/TransitionLogic.ts
@@ -1,0 +1,7 @@
+import { Transition } from './Transition';
+
+export interface TransitionLogic {
+  canChangePath?: boolean;
+  howToChooseAmongAvailablePaths?: string;
+  transitions: Transition[];
+}

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -20,7 +20,6 @@ export class ProjectService {
   additionalProcessingFunctionsMap: any = {};
   allPaths: string[] = [];
   applicationNodes: any = [];
-  filters: any[] = [{ name: 'all', label: 'All' }];
   flattenedProjectAsNodeIds: any = null;
   groupNodes: any[] = [];
   idToNode: any = {};
@@ -74,10 +73,6 @@ export class ProjectService {
 
   getStyle(): any {
     return this.project.style;
-  }
-
-  getFilters(): any[] {
-    return this.filters;
   }
 
   getProjectTitle(): string {

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -12,6 +12,8 @@ import { BranchService } from './branchService';
 import { PathService } from './pathService';
 import { ComponentContent } from '../common/ComponentContent';
 import { MultipleChoiceContent } from '../components/multipleChoice/MultipleChoiceContent';
+import { TransitionLogic } from '../common/TransitionLogic';
+import { Transition } from '../common/Transition';
 
 @Injectable()
 export class ProjectService {
@@ -36,7 +38,7 @@ export class ProjectService {
   nodeIdToBranchPathLetter: any = {};
   project: any = null;
   rootNode: any = null;
-  transitions: any = [];
+  transitions: Transition[] = [];
   private projectChangedSource: Subject<any> = new Subject<any>();
   public projectChanged$: Observable<any> = this.projectChangedSource.asObservable();
 
@@ -54,12 +56,14 @@ export class ProjectService {
   }
 
   clearProjectFields(): void {
-    this.transitions = [];
+    this.allPaths = [];
     this.applicationNodes = [];
+    this.flattenedProjectAsNodeIds = null;
     this.inactiveStepNodes = [];
     this.inactiveGroupNodes = [];
     this.groupNodes = [];
     this.idToNode = {};
+    this.isNodeAffectedByConstraintResult = {};
     this.metadata = {};
     this.activeConstraints = [];
     this.rootNode = null;
@@ -67,6 +71,7 @@ export class ProjectService {
     this.nodeCount = 0;
     this.nodeIdToIsInBranchPath = {};
     this.nodeIdsInAnyBranch = [];
+    this.nodes = {};
     this.achievements = [];
     this.branchService.clearBranchesCache();
   }
@@ -774,9 +779,8 @@ export class ProjectService {
    * @returns {boolean} True iff nodeId comes after groupId.
    */
   private isNodeAfterGroup(groupId: string, nodeId: string): boolean {
-    const transitions = this.getTransitionsByFromNodeId(groupId);
     try {
-      for (let transition of transitions) {
+      for (const transition of this.getTransitionsByFromNodeId(groupId)) {
         const pathFromGroupToEnd = this.getAllPaths([], transition.to, true);
         for (let pathToEnd of pathFromGroupToEnd) {
           if (pathToEnd.indexOf(nodeId) != -1) {
@@ -793,14 +797,8 @@ export class ProjectService {
    * @param fromNodeId the from node id
    * @returns the transition logic object
    */
-  getTransitionLogicByFromNodeId(fromNodeId: string): any {
-    const node = this.getNodeById(fromNodeId);
-    if (node.transitionLogic == null) {
-      node.transitionLogic = {
-        transitions: []
-      };
-    }
-    return node.transitionLogic;
+  getTransitionLogicByFromNodeId(fromNodeId: string): TransitionLogic {
+    return this.getNode(fromNodeId).getTransitionLogic();
   }
 
   /**
@@ -808,9 +806,9 @@ export class ProjectService {
    * @param fromNodeId the node to get transitions from
    * @returns {Array} an array of transitions
    */
-  getTransitionsByFromNodeId(fromNodeId: string) {
+  getTransitionsByFromNodeId(fromNodeId: string): Transition[] {
     const transitionLogic = this.getTransitionLogicByFromNodeId(fromNodeId);
-    return transitionLogic.transitions;
+    return transitionLogic.transitions ?? [];
   }
 
   /**
@@ -848,16 +846,10 @@ export class ProjectService {
    * @param toNodeId We are looking for a transition to this node id.
    * @returns Whether the node has a transition to the given nodeId.
    */
-  nodeHasTransitionToNodeId(node: any, toNodeId: string): boolean {
-    const transitions = this.getTransitionsByFromNodeId(node.id);
-    if (transitions != null) {
-      for (let transition of transitions) {
-        if (toNodeId === transition.to) {
-          return true;
-        }
-      }
-    }
-    return false;
+  nodeHasTransitionToNodeId(node: Node, toNodeId: string): boolean {
+    return this.getTransitionsByFromNodeId(node.id).some(
+      (transition) => transition.to === toNodeId
+    );
   }
 
   /**
@@ -958,169 +950,164 @@ export class ProjectService {
     if (this.isApplicationNode(nodeId)) {
       const path = [];
       const transitions = this.getTransitionsByFromNodeId(nodeId);
-      if (transitions != null) {
-        if (includeGroups) {
-          const parentGroup = this.getParentGroup(nodeId);
-          if (parentGroup != null) {
-            const parentGroupId = parentGroup.id;
-            if (parentGroupId != null && pathSoFar.indexOf(parentGroupId) == -1) {
-              pathSoFar.push(parentGroup.id);
+      if (includeGroups) {
+        const parentGroup = this.getParentGroup(nodeId);
+        if (parentGroup != null) {
+          const parentGroupId = parentGroup.id;
+          if (parentGroupId != null && pathSoFar.indexOf(parentGroupId) == -1) {
+            pathSoFar.push(parentGroup.id);
+          }
+        }
+      }
+
+      /*
+       * add the node id to the path so far so we can later check
+       * which nodes are already in the path to prevent looping
+       * back in the path
+       */
+      pathSoFar.push(nodeId);
+
+      if (transitions.length === 0) {
+        /*
+         * there are no transitions from the node id so we will
+         * look for a transition in the parent group
+         */
+
+        let addedCurrentNodeId = false;
+        const parentGroupId = this.getParentGroupId(nodeId);
+        const parentGroupTransitions = this.getTransitionsByFromNodeId(parentGroupId);
+        for (const parentGroupTransition of parentGroupTransitions) {
+          if (parentGroupTransition != null) {
+            const toNodeId = parentGroupTransition.to;
+            if (pathSoFar.indexOf(toNodeId) == -1) {
+              /*
+               * recursively get the paths by getting all
+               * the paths for the to node
+               */
+              const allPathsFromToNode = this.getAllPaths(pathSoFar, toNodeId, includeGroups);
+
+              for (let tempPath of allPathsFromToNode) {
+                tempPath.unshift(nodeId);
+                allPaths.push(tempPath);
+                addedCurrentNodeId = true;
+              }
             }
           }
         }
 
-        /*
-         * add the node id to the path so far so we can later check
-         * which nodes are already in the path to prevent looping
-         * back in the path
-         */
-        pathSoFar.push(nodeId);
-
-        if (transitions.length === 0) {
+        if (!addedCurrentNodeId) {
           /*
-           * there are no transitions from the node id so we will
-           * look for a transition in the parent group
+           * if the parent group doesn't have any transitions we will
+           * need to add the current node id to the path
            */
+          path.push(nodeId);
+          allPaths.push(path);
+        }
+      } else {
+        // there are transitions from this node id
 
-          let addedCurrentNodeId = false;
-          const parentGroupId = this.getParentGroupId(nodeId);
-          const parentGroupTransitions = this.getTransitionsByFromNodeId(parentGroupId);
+        for (let transition of transitions) {
+          if (transition != null) {
+            const toNodeId = transition.to;
+            if (toNodeId != null && pathSoFar.indexOf(toNodeId) == -1) {
+              // we have not found the to node in the path yet so we can traverse it
 
-          if (parentGroupTransitions != null) {
-            for (let parentGroupTransition of parentGroupTransitions) {
-              if (parentGroupTransition != null) {
-                const toNodeId = parentGroupTransition.to;
-                if (pathSoFar.indexOf(toNodeId) == -1) {
-                  /*
-                   * recursively get the paths by getting all
-                   * the paths for the to node
-                   */
-                  const allPathsFromToNode = this.getAllPaths(pathSoFar, toNodeId, includeGroups);
+              /*
+               * recursively get the paths by getting all
+               * the paths from the to node
+               */
+              const allPathsFromToNode = this.getAllPaths(pathSoFar, toNodeId, includeGroups);
 
-                  for (let tempPath of allPathsFromToNode) {
-                    tempPath.unshift(nodeId);
-                    allPaths.push(tempPath);
-                    addedCurrentNodeId = true;
-                  }
-                }
-              }
-            }
-          }
+              if (allPathsFromToNode != null) {
+                for (let tempPath of allPathsFromToNode) {
+                  if (includeGroups) {
+                    // we need to add the group id to the path
 
-          if (!addedCurrentNodeId) {
-            /*
-             * if the parent group doesn't have any transitions we will
-             * need to add the current node id to the path
-             */
-            path.push(nodeId);
-            allPaths.push(path);
-          }
-        } else {
-          // there are transitions from this node id
-
-          for (let transition of transitions) {
-            if (transition != null) {
-              const toNodeId = transition.to;
-              if (toNodeId != null && pathSoFar.indexOf(toNodeId) == -1) {
-                // we have not found the to node in the path yet so we can traverse it
-
-                /*
-                 * recursively get the paths by getting all
-                 * the paths from the to node
-                 */
-                const allPathsFromToNode = this.getAllPaths(pathSoFar, toNodeId, includeGroups);
-
-                if (allPathsFromToNode != null) {
-                  for (let tempPath of allPathsFromToNode) {
-                    if (includeGroups) {
-                      // we need to add the group id to the path
-
-                      if (tempPath.length > 0) {
-                        const firstNodeId = tempPath[0];
-                        const firstParentGroupId = this.getParentGroupId(firstNodeId);
-                        const parentGroupId = this.getParentGroupId(nodeId);
-                        if (parentGroupId != firstParentGroupId) {
-                          /*
-                           * the parent ids are different which means this is a boundary
-                           * between two groups. for example if the project looked like
-                           * group1>node1>node2>group2>node3>node4
-                           * and the current node was node2 then the first node in the
-                           * path would be node3 which means we would need to place
-                           * group2 on the path before node3
-                           */
-                          tempPath.unshift(firstParentGroupId);
-                        }
+                    if (tempPath.length > 0) {
+                      const firstNodeId = tempPath[0];
+                      const firstParentGroupId = this.getParentGroupId(firstNodeId);
+                      const parentGroupId = this.getParentGroupId(nodeId);
+                      if (parentGroupId != firstParentGroupId) {
+                        /*
+                         * the parent ids are different which means this is a boundary
+                         * between two groups. for example if the project looked like
+                         * group1>node1>node2>group2>node3>node4
+                         * and the current node was node2 then the first node in the
+                         * path would be node3 which means we would need to place
+                         * group2 on the path before node3
+                         */
+                        tempPath.unshift(firstParentGroupId);
                       }
                     }
-
-                    tempPath.unshift(nodeId);
-                    allPaths.push(tempPath);
                   }
+
+                  tempPath.unshift(nodeId);
+                  allPaths.push(tempPath);
                 }
-              } else {
-                /*
-                 * the node is already in the path so far which means
-                 * the transition is looping back to a previous node.
-                 * we do not want to take this transition because
-                 * it will lead to an infinite loop. we will just
-                 * add the current node id to the path and not take
-                 * the transition which essentially ends the path.
-                 */
-                path.push(nodeId);
-                allPaths.push(path);
               }
+            } else {
+              /*
+               * the node is already in the path so far which means
+               * the transition is looping back to a previous node.
+               * we do not want to take this transition because
+               * it will lead to an infinite loop. we will just
+               * add the current node id to the path and not take
+               * the transition which essentially ends the path.
+               */
+              path.push(nodeId);
+              allPaths.push(path);
             }
           }
         }
+      }
 
-        if (pathSoFar.length > 0) {
-          const lastNodeId = pathSoFar[pathSoFar.length - 1];
-          if (this.isGroupNode(lastNodeId)) {
-            /*
-             * the last node id is a group id so we will remove it
-             * since we are moving back up the path as we traverse
-             * the nodes depth first
-             */
-            pathSoFar.pop();
-          }
+      if (pathSoFar.length > 0) {
+        const lastNodeId = pathSoFar[pathSoFar.length - 1];
+        if (this.isGroupNode(lastNodeId)) {
+          /*
+           * the last node id is a group id so we will remove it
+           * since we are moving back up the path as we traverse
+           * the nodes depth first
+           */
+          pathSoFar.pop();
         }
+      }
 
-        /*
-         * remove the latest node id (this will be a step node id)
-         * since we are moving back up the path as we traverse the
-         * nodes depth first
-         */
-        pathSoFar.pop();
+      /*
+       * remove the latest node id (this will be a step node id)
+       * since we are moving back up the path as we traverse the
+       * nodes depth first
+       */
+      pathSoFar.pop();
 
-        if (includeGroups) {
-          if (pathSoFar.length == 1) {
-            /*
-             * we are including groups and we have traversed
-             * back up to the start node id for the project.
-             * the only node id left in pathSoFar is now the
-             * parent group of the start node id. we will
-             * now add this parent group of the start node id
-             * to all of the paths
-             */
+      if (includeGroups) {
+        if (pathSoFar.length == 1) {
+          /*
+           * we are including groups and we have traversed
+           * back up to the start node id for the project.
+           * the only node id left in pathSoFar is now the
+           * parent group of the start node id. we will
+           * now add this parent group of the start node id
+           * to all of the paths
+           */
 
-            for (let path of allPaths) {
-              if (path != null) {
-                /*
-                 * prepend the parent group of the start node id
-                 * to the path
-                 */
-                path.unshift(pathSoFar[0]);
-              }
+          for (let path of allPaths) {
+            if (path != null) {
+              /*
+               * prepend the parent group of the start node id
+               * to the path
+               */
+              path.unshift(pathSoFar[0]);
             }
-
-            /*
-             * remove the parent group of the start node id from
-             * pathSoFar which leaves us with an empty pathSoFar
-             * which means we are completely done with
-             * calculating all the paths
-             */
-            pathSoFar.pop();
           }
+
+          /*
+           * remove the parent group of the start node id from
+           * pathSoFar which leaves us with an empty pathSoFar
+           * which means we are completely done with
+           * calculating all the paths
+           */
+          pathSoFar.pop();
         }
       }
     } else {
@@ -1139,7 +1126,7 @@ export class ProjectService {
           // TODO? there is no start id so we will loop through all the child nodes
 
           const transitions = this.getTransitionsByFromNodeId(groupNode.id);
-          if (transitions != null && transitions.length > 0) {
+          if (transitions.length > 0) {
             for (let transition of transitions) {
               if (transition != null) {
                 const toNodeId = transition.to;
@@ -2017,7 +2004,7 @@ export class ProjectService {
     return tags;
   }
 
-  getTransitionsFromNode(node: any): any[] {
+  getTransitionsFromNode(node: any): Transition[] {
     const transitionLogic = node.transitionLogic;
     if (transitionLogic == null) {
       return [];
@@ -2026,7 +2013,7 @@ export class ProjectService {
     }
   }
 
-  getCriteriaArrayFromTransition(transition: any): any[] {
+  getCriteriaArrayFromTransition(transition: Transition): any[] {
     if (transition.criteria == null) {
       return [];
     } else {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15708,11 +15708,11 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
 <x id="PH" equiv-text="label.text"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-authoring/label-authoring.component.ts</context>
-          <context context-type="linenumber">65</context>
+          <context context-type="linenumber">66</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-student/label-student.component.ts</context>
-          <context context-type="linenumber">721</context>
+          <context context-type="linenumber">744</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d0416d769e2f5f38e271f36c0e263f02e2f3b603" datatype="html">
@@ -15733,21 +15733,21 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>A New Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-student/label-student.component.ts</context>
-          <context context-type="linenumber">465</context>
+          <context context-type="linenumber">486</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4546757591980718173" datatype="html">
         <source>Are you sure you want to reset to the initial state?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-student/label-student.component.ts</context>
-          <context context-type="linenumber">827</context>
+          <context context-type="linenumber">850</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4725019513729542053" datatype="html">
         <source>Are you sure you want to delete the background image?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-student/label-student.component.ts</context>
-          <context context-type="linenumber">888</context>
+          <context context-type="linenumber">911</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4077520913910941990" datatype="html">
@@ -18081,112 +18081,112 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Complete &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1280</context>
+          <context context-type="linenumber">1275</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4750375498606149231" datatype="html">
         <source>Visit &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1286</context>
+          <context context-type="linenumber">1281</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6126058561630526429" datatype="html">
         <source>Correctly answer &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1292</context>
+          <context context-type="linenumber">1287</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7085241847460263487" datatype="html">
         <source>Obtain a score of &lt;b&gt;<x id="PH" equiv-text="scoresString"/>&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1307</context>
+          <context context-type="linenumber">1302</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5469027549306748048" datatype="html">
         <source>You must choose &quot;<x id="PH" equiv-text="choiceText"/>&quot; on &quot;<x id="PH_1" equiv-text="nodeTitle"/>&quot;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1315</context>
+          <context context-type="linenumber">1310</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6293177000168372990" datatype="html">
         <source>Submit &lt;b&gt;<x id="PH" equiv-text="requiredSubmitCount"/>&lt;/b&gt; time on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1327</context>
+          <context context-type="linenumber">1322</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4693324974790890133" datatype="html">
         <source>Submit &lt;b&gt;<x id="PH" equiv-text="requiredSubmitCount"/>&lt;/b&gt; times on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1329</context>
+          <context context-type="linenumber">1324</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8416169412912074869" datatype="html">
         <source>Take the branch path from &lt;b&gt;<x id="PH" equiv-text="fromNodeTitle"/>&lt;/b&gt; to &lt;b&gt;<x id="PH_1" equiv-text="toNodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1336</context>
+          <context context-type="linenumber">1331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8087029188038414167" datatype="html">
         <source>Write &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfWords"/>&lt;/b&gt; words on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1342</context>
+          <context context-type="linenumber">1337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="22049568725715518" datatype="html">
         <source>&quot;<x id="PH" equiv-text="nodeTitle"/>&quot; is visible</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1348</context>
+          <context context-type="linenumber">1343</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5023130174506669799" datatype="html">
         <source>&quot;<x id="PH" equiv-text="nodeTitle"/>&quot; is visitable</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1354</context>
+          <context context-type="linenumber">1349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1185133360670447094" datatype="html">
         <source>Add &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfNotes"/>&lt;/b&gt; note on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1361</context>
+          <context context-type="linenumber">1356</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5985921753090789216" datatype="html">
         <source>Add &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfNotes"/>&lt;/b&gt; notes on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1363</context>
+          <context context-type="linenumber">1358</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4560070803879446782" datatype="html">
         <source>You must fill in &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfFilledRows"/>&lt;/b&gt; row in the &lt;b&gt;Table&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1370</context>
+          <context context-type="linenumber">1365</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2804292280751903227" datatype="html">
         <source>You must fill in &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfFilledRows"/>&lt;/b&gt; rows in the &lt;b&gt;Table&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1372</context>
+          <context context-type="linenumber">1367</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4171523921205906508" datatype="html">
         <source>Wait for your teacher to unlock the item</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1375</context>
+          <context context-type="linenumber">1370</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8770055323459972095" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -18081,112 +18081,112 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Complete &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1275</context>
+          <context context-type="linenumber">1262</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4750375498606149231" datatype="html">
         <source>Visit &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1281</context>
+          <context context-type="linenumber">1268</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6126058561630526429" datatype="html">
         <source>Correctly answer &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1287</context>
+          <context context-type="linenumber">1274</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7085241847460263487" datatype="html">
         <source>Obtain a score of &lt;b&gt;<x id="PH" equiv-text="scoresString"/>&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1302</context>
+          <context context-type="linenumber">1289</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5469027549306748048" datatype="html">
         <source>You must choose &quot;<x id="PH" equiv-text="choiceText"/>&quot; on &quot;<x id="PH_1" equiv-text="nodeTitle"/>&quot;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1310</context>
+          <context context-type="linenumber">1297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6293177000168372990" datatype="html">
         <source>Submit &lt;b&gt;<x id="PH" equiv-text="requiredSubmitCount"/>&lt;/b&gt; time on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1322</context>
+          <context context-type="linenumber">1309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4693324974790890133" datatype="html">
         <source>Submit &lt;b&gt;<x id="PH" equiv-text="requiredSubmitCount"/>&lt;/b&gt; times on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1324</context>
+          <context context-type="linenumber">1311</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8416169412912074869" datatype="html">
         <source>Take the branch path from &lt;b&gt;<x id="PH" equiv-text="fromNodeTitle"/>&lt;/b&gt; to &lt;b&gt;<x id="PH_1" equiv-text="toNodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1331</context>
+          <context context-type="linenumber">1318</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8087029188038414167" datatype="html">
         <source>Write &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfWords"/>&lt;/b&gt; words on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1337</context>
+          <context context-type="linenumber">1324</context>
         </context-group>
       </trans-unit>
       <trans-unit id="22049568725715518" datatype="html">
         <source>&quot;<x id="PH" equiv-text="nodeTitle"/>&quot; is visible</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1343</context>
+          <context context-type="linenumber">1330</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5023130174506669799" datatype="html">
         <source>&quot;<x id="PH" equiv-text="nodeTitle"/>&quot; is visitable</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1349</context>
+          <context context-type="linenumber">1336</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1185133360670447094" datatype="html">
         <source>Add &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfNotes"/>&lt;/b&gt; note on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1356</context>
+          <context context-type="linenumber">1343</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5985921753090789216" datatype="html">
         <source>Add &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfNotes"/>&lt;/b&gt; notes on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1358</context>
+          <context context-type="linenumber">1345</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4560070803879446782" datatype="html">
         <source>You must fill in &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfFilledRows"/>&lt;/b&gt; row in the &lt;b&gt;Table&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1365</context>
+          <context context-type="linenumber">1352</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2804292280751903227" datatype="html">
         <source>You must fill in &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfFilledRows"/>&lt;/b&gt; rows in the &lt;b&gt;Table&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1367</context>
+          <context context-type="linenumber">1354</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4171523921205906508" datatype="html">
         <source>Wait for your teacher to unlock the item</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1370</context>
+          <context context-type="linenumber">1357</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8770055323459972095" datatype="html">


### PR DESCRIPTION
## Changes
- Create Transition and TransitionLogic interfaces
   - add transitionLogic field to Node
- ```ProjectService.getTransitionsByFromNodeId()```: return empty array instead of null to reduce null-checks
- Clean up code
   - remove unused ```filters``` field from ProjectService
   - add types to function params and return 

## Test
- VLE, CM, AT work as before, with different units
   - units with branches
   - units with constraints 

Closes #949