### PR TITLE
refactor(Advanced Component Authoring): Pass in Component

### DIFF
--- a/src/app/authoring-tool/edit-advanced-component/edit-advanced-component.component.ts
+++ b/src/app/authoring-tool/edit-advanced-component/edit-advanced-component.component.ts
@@ -1,11 +1,13 @@
 import { Directive, Input } from '@angular/core';
 import { ComponentContent } from '../../../assets/wise5/common/ComponentContent';
+import { Component } from '../../../assets/wise5/common/Component';
 import { NodeService } from '../../../assets/wise5/services/nodeService';
 import { NotebookService } from '../../../assets/wise5/services/notebookService';
 import { TeacherProjectService } from '../../../assets/wise5/services/teacherProjectService';
 
 @Directive()
 export abstract class EditAdvancedComponentComponent {
+  component: Component;
   componentContent: ComponentContent;
   @Input() componentId: string;
   @Input() nodeId: string;
@@ -18,6 +20,7 @@ export abstract class EditAdvancedComponentComponent {
 
   ngOnInit() {
     this.componentContent = this.teacherProjectService.getComponent(this.nodeId, this.componentId);
+    this.component = new Component(this.componentContent, this.nodeId);
   }
 
   setShowSubmitButtonValue(show: boolean = false): void {

--- a/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.html
+++ b/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.html
@@ -5,7 +5,7 @@
 </edit-component-submit-button>
 <edit-component-max-submit
     *ngIf="component.content.showSubmitButton"
-    [(maxSubmitCount)]="componentContent.maxSubmitCount"
+    [(maxSubmitCount)]="component.content.maxSubmitCount"
     (maxSubmitCountChange)="maxSubmitCountChanged($event)">
 </edit-component-max-submit>
 <edit-component-default-feedback

--- a/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.html
+++ b/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.html
@@ -1,34 +1,34 @@
-<edit-component-save-button [componentContent]="componentContent">
+<edit-component-save-button [componentContent]="component.content">
 </edit-component-save-button>
 <br/>
-<edit-component-submit-button [componentContent]="componentContent">
+<edit-component-submit-button [componentContent]="component.content">
 </edit-component-submit-button>
 <edit-component-max-submit
-    *ngIf="componentContent.showSubmitButton"
+    *ngIf="component.content.showSubmitButton"
     [(maxSubmitCount)]="componentContent.maxSubmitCount"
     (maxSubmitCountChange)="maxSubmitCountChanged($event)">
 </edit-component-max-submit>
 <edit-component-default-feedback
-    [componentContent]="componentContent">
+    [componentContent]="component.content">
 </edit-component-default-feedback>
 <div fxLayout="column" fxLayoutAlign="start start">
-  <edit-component-max-score [componentContent]="componentContent">
+  <edit-component-max-score [componentContent]="component.content">
   </edit-component-max-score>
-  <edit-component-exclude-from-total-score [componentContent]="componentContent">
+  <edit-component-exclude-from-total-score [componentContent]="component.content">
   </edit-component-exclude-from-total-score>
-  <edit-component-width [componentContent]="componentContent">
+  <edit-component-width [componentContent]="component.content">
   </edit-component-width>
-  <edit-component-rubric [componentContent]="componentContent">
+  <edit-component-rubric [componentContent]="component.content">
   </edit-component-rubric>
-  <edit-component-tags [componentContent]="componentContent">
+  <edit-component-tags [componentContent]="component.content">
   </edit-component-tags>
 </div>
 <edit-connected-components
-    [nodeId]="nodeId"
-    [componentId]="componentId"
+    [nodeId]="component.nodeId"
+    [componentId]="component.id"
     [allowedConnectedComponentTypes]="allowedConnectedComponentTypes"
-    [componentContent]="componentContent"
-    [connectedComponents]="componentContent.connectedComponents"
+    [componentContent]="component.content"
+    [connectedComponents]="component.content.connectedComponents"
     (connectedComponentsChanged)="connectedComponentsChanged($event)">
 </edit-connected-components>
-<edit-component-json [nodeId]="nodeId" [componentId]="componentId"></edit-component-json>
+<edit-component-json [component]="component"></edit-component-json>

--- a/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.spec.ts
+++ b/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.spec.ts
@@ -7,6 +7,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { Component } from '../../../assets/wise5/common/Component';
 import { TeacherProjectService } from '../../../assets/wise5/services/teacherProjectService';
 import { StudentTeacherCommonServicesModule } from '../../student-teacher-common-services.module';
 import { EditComponentExcludeFromTotalScoreComponent } from '../edit-component-exclude-from-total-score/edit-component-exclude-from-total-score.component';
@@ -58,7 +59,7 @@ describe('EditCommonAdvancedComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(EditCommonAdvancedComponent);
     component = fixture.componentInstance;
-    component.componentContent = {};
+    component.component = { content: {} } as Component;
     fixture.detectChanges();
   });
 

--- a/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.ts
+++ b/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { Component as WISEComponent } from '../../../assets/wise5/common/Component';
 import { TeacherProjectService } from '../../../assets/wise5/services/teacherProjectService';
 
 @Component({
@@ -7,24 +8,15 @@ import { TeacherProjectService } from '../../../assets/wise5/services/teacherPro
   styleUrls: ['./edit-common-advanced.component.scss']
 })
 export class EditCommonAdvancedComponent implements OnInit {
-  @Input()
-  allowedConnectedComponentTypes: string[] = [];
+  @Input() allowedConnectedComponentTypes: string[] = [];
+  @Input() component: WISEComponent;
 
-  @Input()
-  componentContent: any;
-
-  @Input()
-  componentId: string;
-
-  @Input()
-  nodeId: string;
-
-  constructor(protected ProjectService: TeacherProjectService) {}
+  constructor(protected projectService: TeacherProjectService) {}
 
   ngOnInit(): void {}
 
   connectedComponentsChanged(connectedComponents: any[]): void {
-    this.componentContent.connectedComponents = connectedComponents;
+    this.component.content.connectedComponents = connectedComponents;
     this.componentChanged();
   }
 
@@ -33,6 +25,6 @@ export class EditCommonAdvancedComponent implements OnInit {
   }
 
   componentChanged(): void {
-    this.ProjectService.nodeChanged();
+    this.projectService.nodeChanged();
   }
 }

--- a/src/assets/wise5/authoringTool/components/edit-component-advanced.html
+++ b/src/assets/wise5/authoringTool/components/edit-component-advanced.html
@@ -6,7 +6,7 @@
   </md-toolbar>
   <md-dialog-content>
     <div class="md-dialog-content">
-      <ng-content ng-switch="::$ctrl.component.type">
+      <ng-content ng-switch="::$ctrl.component.content.type">
         <edit-animation-advanced ng-switch-when="Animation" node-id='{{$ctrl.nodeId}}' component-id='{{$ctrl.component.id}}'></edit-animation-advanced>
         <edit-audio-oscillator-advanced ng-switch-when="AudioOscillator" node-id='{{$ctrl.nodeId}}' component-id='{{$ctrl.component.id}}'></edit-audio-oscillator-advanced>
         <edit-concept-map-advanced ng-switch-when="ConceptMap" node-id='{{$ctrl.nodeId}}' component-id='{{$ctrl.component.id}}'></edit-concept-map-advanced>
@@ -22,7 +22,7 @@
         <edit-open-response-advanced ng-switch-when="OpenResponse" node-id='{{$ctrl.nodeId}}' component-id='{{$ctrl.component.id}}'></edit-open-response-advanced>
         <edit-outside-url-advanced ng-switch-when="OutsideURL" node-id='{{$ctrl.nodeId}}' component-id='{{$ctrl.component.id}}'></edit-outside-url-advanced>
         <edit-peer-chat-advanced ng-switch-when="PeerChat" node-id='{{$ctrl.nodeId}}' component-id='{{$ctrl.component.id}}'></edit-peer-chat-advanced>
-        <edit-component-json ng-switch-when="ShowGroupWork|ShowMyWork" ng-switch-when-separator="|" node-id='{{$ctrl.nodeId}}' component-id='{{$ctrl.component.id}}'></edit-component-json>
+        <edit-component-json ng-switch-when="ShowGroupWork|ShowMyWork" ng-switch-when-separator="|" [component]="$ctrl.component"></edit-component-json>
         <edit-summary-advanced ng-switch-when="Summary" node-id='{{$ctrl.nodeId}}' component-id='{{$ctrl.component.id}}'></edit-summary-advanced>
         <edit-table-advanced ng-switch-when="Table" node-id='{{$ctrl.nodeId}}' component-id='{{$ctrl.component.id}}'></edit-table-advanced>
       </ng-content>

--- a/src/assets/wise5/authoringTool/node/nodeAuthoringComponent.ts
+++ b/src/assets/wise5/authoringTool/node/nodeAuthoringComponent.ts
@@ -14,6 +14,8 @@ import { Directive } from '@angular/core';
 import { Node } from '../../common/Node';
 import { ComponentServiceLookupService } from '../../services/componentServiceLookupService';
 import { ComponentTypeService } from '../../services/componentTypeService';
+import { ComponentContent } from '../../common/ComponentContent';
+import { Component } from '../../common/Component';
 
 @Directive()
 class NodeAuthoringController {
@@ -587,7 +589,8 @@ class NodeAuthoringController {
     return componentObjects;
   }
 
-  showComponentAdvancedAuthoring(component: any) {
+  showComponentAdvancedAuthoring(componentContent: ComponentContent) {
+    const component = new Component(componentContent, this.nodeId);
     this.$mdDialog.show({
       templateUrl: 'assets/wise5/authoringTool/components/edit-component-advanced.html',
       controller: [

--- a/src/assets/wise5/components/animation/edit-animation-advanced/edit-animation-advanced.component.html
+++ b/src/assets/wise5/components/animation/edit-animation-advanced/edit-animation-advanced.component.html
@@ -1,6 +1,4 @@
 <edit-common-advanced
-    [nodeId]="nodeId"
-    [componentId]="componentId"
-    [allowedConnectedComponentTypes]="allowedConnectedComponentTypes"
-    [componentContent]="componentContent">
+    [component]="component"
+    [allowedConnectedComponentTypes]="allowedConnectedComponentTypes">
 </edit-common-advanced>

--- a/src/assets/wise5/components/audioOscillator/edit-audio-oscillator-advanced/edit-audio-oscillator-advanced.component.html
+++ b/src/assets/wise5/components/audioOscillator/edit-audio-oscillator-advanced/edit-audio-oscillator-advanced.component.html
@@ -1,6 +1,4 @@
 <edit-common-advanced
-    [nodeId]="nodeId"
-    [componentId]="componentId"
-    [allowedConnectedComponentTypes]="allowedConnectedComponentTypes"
-    [componentContent]="componentContent">
+    [component]="component"
+    [allowedConnectedComponentTypes]="allowedConnectedComponentTypes">
 </edit-common-advanced>

--- a/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.html
+++ b/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.html
@@ -176,8 +176,6 @@
   </div>
 </div>
 <edit-common-advanced
-    [nodeId]="nodeId"
-    [componentId]="componentId"
-    [allowedConnectedComponentTypes]="allowedConnectedComponentTypes"
-    [componentContent]="componentContent">
+    [component]="component"
+    [allowedConnectedComponentTypes]="allowedConnectedComponentTypes">
 </edit-common-advanced>

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-advanced/edit-dialog-guidance-advanced.component.html
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-advanced/edit-dialog-guidance-advanced.component.html
@@ -1,1 +1,1 @@
-<edit-component-json [nodeId]="nodeId" [componentId]="componentId"></edit-component-json>
+<edit-component-json [component]="component"></edit-component-json>

--- a/src/assets/wise5/components/discussion/edit-discussion-advanced/edit-discussion-advanced.component.html
+++ b/src/assets/wise5/components/discussion/edit-discussion-advanced/edit-discussion-advanced.component.html
@@ -13,4 +13,4 @@
     [connectedComponents]="componentContent.connectedComponents"
     (connectedComponentsChanged)="connectedComponentsChanged($event)">
 </edit-discussion-connected-components>
-<edit-component-json [nodeId]="nodeId" [componentId]="componentId"></edit-component-json>
+<edit-component-json [component]="component"></edit-component-json>

--- a/src/assets/wise5/components/draw/edit-draw-advanced/edit-draw-advanced.component.html
+++ b/src/assets/wise5/components/draw/edit-draw-advanced/edit-draw-advanced.component.html
@@ -35,4 +35,4 @@
     [connectedComponents]="componentContent.connectedComponents"
     (connectedComponentsChanged)="connectedComponentsChanged($event)">
 </edit-draw-connected-components>
-<edit-component-json [nodeId]="nodeId" [componentId]="componentId"></edit-component-json>
+<edit-component-json [component]="component"></edit-component-json>

--- a/src/assets/wise5/components/embedded/edit-embedded-advanced/edit-embedded-advanced.component.html
+++ b/src/assets/wise5/components/embedded/edit-embedded-advanced/edit-embedded-advanced.component.html
@@ -11,8 +11,6 @@
   </edit-component-add-to-notebook-button>
 </div>
 <edit-common-advanced
-    [nodeId]="nodeId"
-    [componentId]="componentId"
-    [allowedConnectedComponentTypes]="allowedConnectedComponentTypes"
-    [componentContent]="componentContent">
+    [component]="component"
+    [allowedConnectedComponentTypes]="allowedConnectedComponentTypes">
 </edit-common-advanced>

--- a/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.html
+++ b/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.html
@@ -195,4 +195,4 @@
     [connectedComponents]="componentContent.connectedComponents"
     (connectedComponentsChanged)="connectedComponentsChanged($event)">
 </edit-graph-connected-components>
-<edit-component-json [nodeId]="nodeId" [componentId]="componentId"></edit-component-json>
+<edit-component-json [component]="component"></edit-component-json>

--- a/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.ts
+++ b/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.ts
@@ -1,8 +1,5 @@
 import { Component } from '@angular/core';
 import { EditAdvancedComponentComponent } from '../../../../../app/authoring-tool/edit-advanced-component/edit-advanced-component.component';
-import { NodeService } from '../../../services/nodeService';
-import { NotebookService } from '../../../services/notebookService';
-import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { GraphContent } from '../GraphContent';
 
 @Component({
@@ -21,14 +18,6 @@ export class EditGraphAdvancedComponent extends EditAdvancedComponentComponent {
     'Table'
   ];
   componentContent: GraphContent;
-
-  constructor(
-    protected nodeService: NodeService,
-    protected notebookService: NotebookService,
-    protected teacherProjectService: TeacherProjectService
-  ) {
-    super(nodeService, notebookService, teacherProjectService);
-  }
 
   addXAxisPlotLine(): void {
     if (this.componentContent.xAxis.plotLines == null) {

--- a/src/assets/wise5/components/html/edit-html-advanced/edit-html-advanced.component.html
+++ b/src/assets/wise5/components/html/edit-html-advanced/edit-html-advanced.component.html
@@ -1,3 +1,3 @@
 <edit-component-width [componentContent]="componentContent"></edit-component-width>
 <edit-component-rubric [componentContent]="componentContent"></edit-component-rubric>
-<edit-component-json [nodeId]="nodeId" [componentId]="componentId"></edit-component-json>
+<edit-component-json [component]="component"></edit-component-json>

--- a/src/assets/wise5/components/label/edit-label-advanced/edit-label-advanced.component.html
+++ b/src/assets/wise5/components/label/edit-label-advanced/edit-label-advanced.component.html
@@ -35,4 +35,4 @@
     [connectedComponents]="componentContent.connectedComponents"
     (connectedComponentsChanged)="connectedComponentsChanged($event)">
 </edit-label-connected-components>
-<edit-component-json [nodeId]="nodeId" [componentId]="componentId"></edit-component-json>
+<edit-component-json [component]="component"></edit-component-json>

--- a/src/assets/wise5/components/match/edit-match-advanced/edit-match-advanced.component.html
+++ b/src/assets/wise5/components/match/edit-match-advanced/edit-match-advanced.component.html
@@ -51,4 +51,4 @@
     [connectedComponents]="componentContent.connectedComponents"
     (connectedComponentsChanged)="connectedComponentsChanged($event)">
 </edit-match-connected-components>
-<edit-component-json [nodeId]="nodeId" [componentId]="componentId"></edit-component-json>
+<edit-component-json [component]="component"></edit-component-json>

--- a/src/assets/wise5/components/multipleChoice/edit-multiple-choice-advanced/edit-multiple-choice-advanced.component.html
+++ b/src/assets/wise5/components/multipleChoice/edit-multiple-choice-advanced/edit-multiple-choice-advanced.component.html
@@ -40,4 +40,4 @@
     [connectedComponents]="componentContent.connectedComponents"
     (connectedComponentsChanged)="connectedComponentsChanged($event)">
 </edit-multiple-choice-connected-components>
-<edit-component-json [nodeId]="nodeId" [componentId]="componentId"></edit-component-json>
+<edit-component-json [component]="component"></edit-component-json>

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
@@ -460,8 +460,6 @@
   </edit-component-add-to-notebook-button>
 </div>
 <edit-common-advanced
-    [nodeId]="nodeId"
-    [componentId]="componentId"
-    [allowedConnectedComponentTypes]="allowedConnectedComponentTypes"
-    [componentContent]="componentContent">
+    [component]="component"
+    [allowedConnectedComponentTypes]="allowedConnectedComponentTypes">
 </edit-common-advanced>

--- a/src/assets/wise5/components/outsideURL/edit-outside-url-advanced/edit-outside-url-advanced.component.html
+++ b/src/assets/wise5/components/outsideURL/edit-outside-url-advanced/edit-outside-url-advanced.component.html
@@ -1,3 +1,3 @@
 <edit-component-width [componentContent]="componentContent"></edit-component-width>
 <edit-component-rubric [componentContent]="componentContent"></edit-component-rubric>
-<edit-component-json [nodeId]="nodeId" [componentId]="componentId"></edit-component-json>
+<edit-component-json [component]="component"></edit-component-json>

--- a/src/assets/wise5/components/peerChat/edit-peer-chat-advanced-component/edit-peer-chat-advanced-component.component.html
+++ b/src/assets/wise5/components/peerChat/edit-peer-chat-advanced-component/edit-peer-chat-advanced-component.component.html
@@ -1,1 +1,1 @@
-<edit-component-json [nodeId]="nodeId" [componentId]="componentId"></edit-component-json>
+<edit-component-json [component]="component"></edit-component-json>

--- a/src/assets/wise5/components/peerChat/edit-peer-chat-advanced-component/edit-peer-chat-advanced-component.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/edit-peer-chat-advanced-component/edit-peer-chat-advanced-component.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { PeerChatContent } from '../PeerChatContent';
 import { EditPeerChatAdvancedComponentComponent } from './edit-peer-chat-advanced-component.component';
 
 describe('EditPeerChatAdvancedComponentComponent', () => {
@@ -18,6 +19,9 @@ describe('EditPeerChatAdvancedComponentComponent', () => {
   });
 
   beforeEach(() => {
+    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue(
+      {} as PeerChatContent
+    );
     fixture = TestBed.createComponent(EditPeerChatAdvancedComponentComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/assets/wise5/components/summary/edit-summary-advanced/edit-summary-advanced.component.html
+++ b/src/assets/wise5/components/summary/edit-summary-advanced/edit-summary-advanced.component.html
@@ -5,5 +5,5 @@
   </edit-component-rubric>
   <edit-component-tags [componentContent]="componentContent">
   </edit-component-tags>
-  <edit-component-json [nodeId]="nodeId" [componentId]="componentId"></edit-component-json>
+  <edit-component-json [component]="component"></edit-component-json>
 </div>

--- a/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html
+++ b/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html
@@ -204,4 +204,4 @@
     [connectedComponents]="componentContent.connectedComponents"
     (connectedComponentsChanged)="connectedComponentsChanged($event)">
 </edit-table-connected-components>
-<edit-component-json [nodeId]="nodeId" [componentId]="componentId"></edit-component-json>
+<edit-component-json [component]="component"></edit-component-json>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -884,7 +884,7 @@ Click &quot;OK&quot; to revert back to the last valid JSON.
 Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-component-json/edit-component-json.component.ts</context>
-          <context context-type="linenumber">64</context>
+          <context context-type="linenumber">61</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/advanced/advanced-project-authoring.component.ts</context>


### PR DESCRIPTION
### Changes
- Pass in ```Component``` to ```EditCommonAdvancedComponent``` and ```EditComponentJsonComponent``` instead of nodeId and componentId. This will reduce duplication and organize/cleanup the inputs to components.
- Clean up related code

## Test
- Advanced component authoring works as before for all components
   - Edit rubric, connected components, component width, etc.
   - Edit component JSON

Closes #951