### PR TITLE
fix(User Registration): Form now properly shows up in Safari browser

### DIFF
--- a/src/app/register/register-student-form/register-student-form.component.ts
+++ b/src/app/register/register-student-form/register-student-form.component.ts
@@ -52,14 +52,8 @@ export class RegisterStudentFormComponent extends RegisterUserFormComponent impl
     { validator: this.passwordMatchValidator }
   );
   createStudentAccountFormGroup: FormGroup = this.fb.group({
-    firstName: new FormControl('', [
-      Validators.required,
-      Validators.pattern('^(?![ -])[a-zA-Z -]+(?<![ -])$')
-    ]),
-    lastName: new FormControl('', [
-      Validators.required,
-      Validators.pattern('^(?![ -])[a-zA-Z -]+(?<![ -])$')
-    ]),
+    firstName: new FormControl('', [Validators.required, Validators.pattern(this.NAME_REGEX)]),
+    lastName: new FormControl('', [Validators.required, Validators.pattern(this.NAME_REGEX)]),
     gender: new FormControl('', [Validators.required]),
     birthMonth: new FormControl('', [Validators.required]),
     birthDay: new FormControl({ value: '', disabled: true }, [Validators.required])

--- a/src/app/register/register-teacher-form/register-teacher-form.component.ts
+++ b/src/app/register/register-teacher-form/register-teacher-form.component.ts
@@ -39,14 +39,8 @@ export class RegisterTeacherFormComponent extends RegisterUserFormComponent impl
   );
   createTeacherAccountFormGroup: FormGroup = this.fb.group(
     {
-      firstName: new FormControl('', [
-        Validators.required,
-        Validators.pattern('^(?![ -])[a-zA-Z -]+(?<![ -])$')
-      ]),
-      lastName: new FormControl('', [
-        Validators.required,
-        Validators.pattern('^(?![ -])[a-zA-Z -]+(?<![ -])$')
-      ]),
+      firstName: new FormControl('', [Validators.required, Validators.pattern(this.NAME_REGEX)]),
+      lastName: new FormControl('', [Validators.required, Validators.pattern(this.NAME_REGEX)]),
       email: new FormControl('', [Validators.required, Validators.email]),
       city: new FormControl('', [Validators.required]),
       state: new FormControl('', [Validators.required]),

--- a/src/app/register/register-user-form/register-user-form.component.ts
+++ b/src/app/register/register-user-form/register-user-form.component.ts
@@ -1,4 +1,6 @@
 export class RegisterUserFormComponent {
+  NAME_REGEX = '^[a-zA-Z]+([ -]?[a-zA-Z]+)*$';
+
   translateCreateAccountErrorMessageCode(messageCode: string) {
     switch (messageCode) {
       case 'invalidFirstAndLastName':


### PR DESCRIPTION
## Changes

In the user registration pages, changed name validation regex to not use lookahead and lookbehind because Safari does not support them yet.

## Test

- Make sure you can register new student accounts and new teacher accounts when using Safari
- Make sure you can use spaces and dashes in the first and last name
- Make sure the name validation still works how we want it to

Closes #959