### PR TITLE
feat(QuestionBank): Choose questions from multiple matched rules up to max

### DIFF
--- a/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html
+++ b/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html
@@ -9,6 +9,12 @@
     </mat-checkbox>
   </div>
   <div *ngIf="componentContent.questionBank?.enabled">
+    <div class="max-questions-to-show-div">
+      <mat-form-field class="form-field-no-hint" appearance="fill">
+        <mat-label i18n>Number of Questions to Show</mat-label>
+        <input matInput [(ngModel)]="componentContent.questionBank.maxQuestionsToShow" (ngModelChange)='saveChanges()' />
+      </mat-form-field>
+    </div>
     <div class="reference-component-div"
         fxLayout="row wrap"
         fxLayoutAlign="start center"

--- a/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html
+++ b/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html
@@ -13,6 +13,7 @@
       <mat-form-field appearance="fill">
         <mat-label i18n>Max Number of Questions</mat-label>
         <input matInput
+            type="number"
             [(ngModel)]="componentContent.questionBank.maxQuestionsToShow"
             (ngModelChange)='saveChanges()' />
       </mat-form-field>

--- a/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html
+++ b/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html
@@ -1,5 +1,5 @@
 <div class="section-container">
-  <div class="enable-question-bank-div">
+  <div>
     <mat-checkbox
         [checked]="componentContent.questionBank?.enabled"
         (change)="toggleComponent($event)"
@@ -9,15 +9,15 @@
     </mat-checkbox>
   </div>
   <div *ngIf="componentContent.questionBank?.enabled">
-    <div class="max-questions-to-show-div">
-      <mat-form-field class="form-field-no-hint" appearance="fill">
-        <mat-label i18n>Max Number of Questions to Show</mat-label>
+    <div class="max-questions">
+      <mat-form-field appearance="fill">
+        <mat-label i18n>Max Number of Questions</mat-label>
         <input matInput
             [(ngModel)]="componentContent.questionBank.maxQuestionsToShow"
             (ngModelChange)='saveChanges()' />
       </mat-form-field>
     </div>
-    <div class="reference-component-div"
+    <div class="reference-component"
         fxLayout="row wrap"
         fxLayoutAlign="start center"
         fxLayoutGap="20px">
@@ -36,7 +36,7 @@
           [componentContent]="componentContent.questionBank">
       </edit-component-peer-grouping-tag>
     </div>
-    <div class="feedback-rules-div">
+    <div class="feedback-rules">
       <edit-question-bank-rules [feedbackRules]="componentContent.questionBank.rules">
       </edit-question-bank-rules>
     </div>

--- a/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html
+++ b/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html
@@ -11,8 +11,10 @@
   <div *ngIf="componentContent.questionBank?.enabled">
     <div class="max-questions-to-show-div">
       <mat-form-field class="form-field-no-hint" appearance="fill">
-        <mat-label i18n>Number of Questions to Show</mat-label>
-        <input matInput [(ngModel)]="componentContent.questionBank.maxQuestionsToShow" (ngModelChange)='saveChanges()' />
+        <mat-label i18n>Max Number of Questions to Show</mat-label>
+        <input matInput
+            [(ngModel)]="componentContent.questionBank.maxQuestionsToShow"
+            (ngModelChange)='saveChanges()' />
       </mat-form-field>
     </div>
     <div class="reference-component-div"

--- a/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.scss
+++ b/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.scss
@@ -8,14 +8,14 @@
   padding: 16px;
   border: 2px solid #dddddd;
   border-radius: $card-border-radius;
-  margin-top: 20px;
-  margin-bottom: 20px;
+  margin-top: 16px;
+  margin-bottom: 16px;
 }
 
-.reference-component-div, .max-questions-to-show-div {
-  margin-top: 10px;
+.reference-component, .max-questions {
+  margin-top: 16px;
 }
 
-.feedback-rules-div {
-  margin-bottom: 20px;
+.feedback-rules {
+  margin-bottom: 16px;
 }

--- a/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.scss
+++ b/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.scss
@@ -12,7 +12,7 @@
   margin-bottom: 20px;
 }
 
-.reference-component-div {
+.reference-component-div, .max-questions-to-show-div {
   margin-top: 10px;
 }
 

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.spec.ts
@@ -22,32 +22,32 @@ import { FeedbackRuleComponent } from '../../feedbackRule/FeedbackRuleComponent'
 
 const defaultFeedbackRules = [
   new FeedbackRule({
-    id: '14ha07sykh',
+    id: 'finalSubmit',
     expression: 'isFinalSubmit',
     feedback: 'This is a generic response that is shown on a final submission'
   }),
   new FeedbackRule({
-    id: '57vmi2nn9r',
+    id: 'secondToLastSubmit',
     expression: 'isSecondToLastSubmit',
     feedback: 'This is a generic response that is shown on the second to last submission'
   }),
   new FeedbackRule({
-    id: 'opzd40hwh9',
+    id: 'thirdSubmit',
     expression: 'isSubmitNumber(3)',
     feedback: 'Is third submit'
   }),
   new FeedbackRule({
-    id: 'w73he0hwwt',
+    id: 'isNonScorable',
     expression: 'isNonScorable',
     feedback: 'isNonScorable'
   }),
   new FeedbackRule({
-    id: 'ig6xhcv0if',
+    id: 'idea1 && idea2',
     expression: 'idea1 && idea2',
     feedback: 'You hit idea1 and idea2'
   }),
   new FeedbackRule({
-    id: 'a9dck3r00h',
+    id: 'idea2 && idea3 && idea4',
     expression: 'idea2 && idea3 && idea4',
     feedback: 'You hit idea2, idea3 and idea4'
   }),
@@ -57,37 +57,37 @@ const defaultFeedbackRules = [
     feedback: 'You hit idea5 or idea6'
   }),
   new FeedbackRule({
-    id: '08cffyudvd',
+    id: 'idea7 || idea8 && idea9',
     expression: 'idea7 || idea8 && idea9',
     feedback: 'You hit idea7 or idea8 and idea9'
   }),
   new FeedbackRule({
-    id: 'wron2aclbi',
+    id: 'idea7 && idea8 || idea9',
     expression: 'idea7 && idea8 || idea9',
     feedback: 'You hit idea7 and idea8 or idea9'
   }),
   new FeedbackRule({
-    id: 'enj6k184y7',
+    id: 'idea1',
     expression: 'idea1',
     feedback: 'You hit idea1'
   }),
   new FeedbackRule({
-    id: 'th3xlzbab2',
+    id: '!idea10',
     expression: '!idea10',
     feedback: '!idea10'
   }),
   new FeedbackRule({
-    id: 'd3plb1ki1t',
+    id: 'idea10 && !idea11',
     expression: 'idea10 && !idea11',
     feedback: 'idea10 && !idea11'
   }),
   new FeedbackRule({
-    id: '322szvaki6',
+    id: '!idea11 || idea12',
     expression: '!idea11 || idea12',
     feedback: '!idea11 || idea12'
   }),
   new FeedbackRule({
-    id: 'vm4o1ms080',
+    id: 'default',
     expression: 'isDefault',
     feedback: 'This is a default feedback'
   })
@@ -126,6 +126,7 @@ describe('FeedbackRuleEvaluator', () => {
     evaluator = new FeedbackRuleEvaluator(new FeedbackRuleComponent(defaultFeedbackRules, 5, true));
   });
   matchRule_OneIdea();
+  matchRules_OneIdea();
   matchRule_MultipleIdeasUsingAnd();
   matchRule_MultipleIdeasUsingOr();
   matchRule_MultipleIdeasUsingAndOr();
@@ -143,6 +144,15 @@ describe('FeedbackRuleEvaluator', () => {
 function matchRule_OneIdea() {
   it('should find first rule matching one idea', () => {
     expectFeedback(['idea1'], [KI_SCORE_1], 1, 'You hit idea1');
+  });
+}
+
+function matchRules_OneIdea() {
+  it('should find all rules matching one idea', () => {
+    expectRules(
+      [createCRaterResponse(['idea1'], [KI_SCORE_1], 1)],
+      ['idea1', '!idea10', '!idea11 || idea12', 'default']
+    );
   });
 }
 
@@ -181,22 +191,22 @@ function matchRule_hasKIScore() {
     beforeEach(() => {
       const feedbackRules = [
         new FeedbackRule({
-          id: 'y4khoby3th',
+          id: 'hasKIScore(1)',
           expression: 'hasKIScore(1)',
           feedback: 'hasKIScore(1)'
         }),
         new FeedbackRule({
-          id: '58vuvj4o2m',
+          id: 'hasKIScore(3)',
           expression: 'hasKIScore(3)',
           feedback: 'hasKIScore(3)'
         }),
         new FeedbackRule({
-          id: '82xd4w3x34',
+          id: 'hasKIScore(5)',
           expression: 'hasKIScore(5)',
           feedback: 'hasKIScore(5)'
         }),
         new FeedbackRule({
-          id: 'mf6gt64j3i',
+          id: 'default',
           expression: 'isDefault',
           feedback: 'isDefault'
         })
@@ -204,6 +214,7 @@ function matchRule_hasKIScore() {
       evaluator = new FeedbackRuleEvaluator(new FeedbackRuleComponent(feedbackRules, 5, true));
     });
     matchRule_hasKIScoreScoreInRange_ShouldMatchRule();
+    matchRules_hasKIScoreScoreInRange_ShouldMatchRule();
     matchRule_hasKIScoreScoreNotInRange_ShouldNotMatchRule();
   });
 }
@@ -216,10 +227,19 @@ function matchRule_hasKIScoreScoreInRange_ShouldMatchRule() {
   });
 }
 
+function matchRules_hasKIScoreScoreInRange_ShouldMatchRule() {
+  it('should match all rules if KI score is in range [1-5]', () => {
+    expectRules([createCRaterResponse([], [KI_SCORE_1], 1)], ['hasKIScore(1)', 'default']);
+    expectRules([createCRaterResponse([], [KI_SCORE_3], 1)], ['hasKIScore(3)', 'default']);
+    expectRules([createCRaterResponse([], [KI_SCORE_5], 1)], ['hasKIScore(5)', 'default']);
+  });
+}
+
 function matchRule_hasKIScoreScoreNotInRange_ShouldNotMatchRule() {
   it('should not match rule if KI score is out of range [1-5]', () => {
     expectFeedback([], [KI_SCORE_0], 1, 'isDefault');
     expectFeedback([], [KI_SCORE_6], 1, 'isDefault');
+    expectRules([createCRaterResponse([], [KI_SCORE_6], 1)], ['default']);
   });
 }
 
@@ -268,24 +288,29 @@ function matchNoRule_NoDefaultFeedbackAuthored_ReturnApplicationDefault() {
       authored`, () => {
     evaluator = new FeedbackRuleEvaluator(new FeedbackRuleComponent([], 5, true));
     expectFeedback(['idea10', 'idea11'], [KI_SCORE_1], 1, evaluator.defaultFeedback);
+    expectRules([createCRaterResponse(['idea10', 'idea11'], [KI_SCORE_1], 1)], ['default']);
   });
 }
 
 function thirdSubmit() {
   it('should return third submit rule when this is the third submit', () => {
-    expectFeedback(['idea1'], [KI_SCORE_1], 3, 'Is third submit');
+    expectFeedback([], [KI_SCORE_1], 3, 'Is third submit');
+    expectRules(
+      [createCRaterResponse([], [KI_SCORE_1], 3)],
+      ['thirdSubmit', '!idea10', '!idea11 || idea12', 'default']
+    );
   });
 }
 
 function secondToLastSubmit() {
   it('should return second to last submit rule when there is one submit left', () => {
-    expectFeedback(['idea1'], [KI_SCORE_1], 4, 'second to last submission');
+    expectFeedback([], [KI_SCORE_1], 4, 'second to last submission');
   });
 }
 
 function finalSubmit() {
   it('should return final submit rule when no more submits left', () => {
-    expectFeedback(['idea1'], [KI_SCORE_1], 5, 'final submission');
+    expectFeedback([], [KI_SCORE_1], 5, 'final submission');
   });
 }
 
@@ -295,22 +320,19 @@ function nonScorable() {
   });
 }
 
+function expectRules(response: CRaterResponse[], expectedRuleIds: string[]): void {
+  const matchedRules = evaluator.getFeedbackRules(response);
+  expect(matchedRules.map((rule) => rule.id)).toEqual(expectedRuleIds);
+}
+
 function expectFeedback(
   ideas: string[],
   scores: CRaterScore[],
   submitCounter: number,
   expectedFeedback: string
 ) {
-  const rule = getFeedbackRule(ideas, scores, submitCounter);
+  const rule = evaluator.getFeedbackRule(createCRaterResponse(ideas, scores, submitCounter));
   expect(rule.feedback).toContain(expectedFeedback);
-}
-
-function getFeedbackRule(
-  ideas: string[],
-  scores: CRaterScore[],
-  submitCounter: number
-): FeedbackRule {
-  return evaluator.getFeedbackRule(createCRaterResponse(ideas, scores, submitCounter));
 }
 
 function createCRaterResponse(

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.spec.ts
@@ -151,7 +151,7 @@ function matchRules_OneIdea() {
   it('should find all rules matching one idea', () => {
     expectRules(
       [createCRaterResponse(['idea1'], [KI_SCORE_1], 1)],
-      ['idea1', '!idea10', '!idea11 || idea12', 'default']
+      ['idea1', '!idea10', '!idea11 || idea12']
     );
   });
 }
@@ -229,9 +229,9 @@ function matchRule_hasKIScoreScoreInRange_ShouldMatchRule() {
 
 function matchRules_hasKIScoreScoreInRange_ShouldMatchRule() {
   it('should match all rules if KI score is in range [1-5]', () => {
-    expectRules([createCRaterResponse([], [KI_SCORE_1], 1)], ['hasKIScore(1)', 'default']);
-    expectRules([createCRaterResponse([], [KI_SCORE_3], 1)], ['hasKIScore(3)', 'default']);
-    expectRules([createCRaterResponse([], [KI_SCORE_5], 1)], ['hasKIScore(5)', 'default']);
+    expectRules([createCRaterResponse([], [KI_SCORE_1], 1)], ['hasKIScore(1)']);
+    expectRules([createCRaterResponse([], [KI_SCORE_3], 1)], ['hasKIScore(3)']);
+    expectRules([createCRaterResponse([], [KI_SCORE_5], 1)], ['hasKIScore(5)']);
   });
 }
 
@@ -280,6 +280,7 @@ function matchRule_ideaCount_MatchRulesBasedOnNumIdeasFound() {
 function matchNoRule_ReturnDefault() {
   it('should return default idea when no rule is matched', () => {
     expectFeedback(['idea10', 'idea11'], [KI_SCORE_1], 1, 'default feedback');
+    expectRules([createCRaterResponse(['idea10', 'idea11'], [KI_SCORE_1], 1)], ['default']);
   });
 }
 
@@ -297,7 +298,7 @@ function thirdSubmit() {
     expectFeedback([], [KI_SCORE_1], 3, 'Is third submit');
     expectRules(
       [createCRaterResponse([], [KI_SCORE_1], 3)],
-      ['thirdSubmit', '!idea10', '!idea11 || idea12', 'default']
+      ['thirdSubmit', '!idea10', '!idea11 || idea12']
     );
   });
 }

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.ts
@@ -23,8 +23,9 @@ export class FeedbackRuleEvaluator {
     const matchedRules = this.component
       .getFeedbackRules()
       .filter((rule) => this.satisfiesRule(response, Object.assign(new FeedbackRule(), rule)));
-    matchedRules.push(this.getDefaultRule(this.component.getFeedbackRules()));
-    return matchedRules;
+    return matchedRules.length > 0
+      ? matchedRules
+      : [this.getDefaultRule(this.component.getFeedbackRules())];
   }
 
   private satisfiesRule(

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.ts
@@ -19,6 +19,14 @@ export class FeedbackRuleEvaluator {
     return this.getDefaultRule(this.component.getFeedbackRules());
   }
 
+  getFeedbackRules(response: CRaterResponse[]): FeedbackRule[] {
+    const matchedRules = this.component
+      .getFeedbackRules()
+      .filter((rule) => this.satisfiesRule(response, Object.assign(new FeedbackRule(), rule)));
+    matchedRules.push(this.getDefaultRule(this.component.getFeedbackRules()));
+    return matchedRules;
+  }
+
   private satisfiesRule(
     response: CRaterResponse | CRaterResponse[],
     feedbackRule: FeedbackRule
@@ -176,6 +184,7 @@ export class FeedbackRuleEvaluator {
     return (
       feedbackRules.find((rule) => FeedbackRule.isDefaultRule(rule)) ||
       Object.assign(new FeedbackRule(), {
+        id: 'default',
         expression: 'isDefault',
         feedback: this.component.isMultipleFeedbackTextsForSameRuleAllowed()
           ? [this.defaultFeedback]

--- a/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.html
@@ -2,13 +2,13 @@
   <div *ngIf="dynamicPrompt != null" [innerHTML]="dynamicPrompt.prompt" class="dynamic-prompt">
   </div>
   <div fxLayout="column" fxLayout.gt-md="row" fxLayoutAlign.gt-md="start start" fxLayoutGap="16px">
-    <div *ngIf="questionBankRule != null"
+    <div *ngIf="questionBankRules != null"
         fxFlex
         fxFlex.gt-md="40"
         fxFlexOrder="1"
         fxFlexOrder.gt-md="2">
         <peer-chat-question-bank *ngIf="componentContent.questionBank?.enabled"
-            [displayedQuestionBankRule]="questionBankRule"></peer-chat-question-bank>
+            [displayedQuestionBankRules]="questionBankRules"></peer-chat-question-bank>
     </div>
     <div fxFlex
         [fxFlex.gt-md]="componentContent.questionBank.length > 0 ? 60 : 100"

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/QuestionBank.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/QuestionBank.ts
@@ -2,5 +2,6 @@ import { ReferenceComponentRules } from '../../common/ReferenceComponentRules';
 import { QuestionBankRule } from './QuestionBankRule';
 
 export class QuestionBank extends ReferenceComponentRules {
+  maxQuestionsToShow: number;
   rules: QuestionBankRule[];
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.spec.ts
@@ -14,6 +14,11 @@ let component: PeerChatQuestionBankComponent;
 let fixture: ComponentFixture<PeerChatQuestionBankComponent>;
 let peerGroupService: PeerGroupService;
 let projectService: ProjectService;
+const defaultQuestionBankRule = {
+  id: 'default',
+  expression: 'isDefault',
+  questions: ['default question']
+} as QuestionBankRule;
 describe('PeerChatQuestionBankComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -28,9 +33,10 @@ describe('PeerChatQuestionBankComponent', () => {
       componentId: 'def',
       nodeId: 'node2',
       questionBank: new QuestionBank({
+        maxQuestionsToShow: null,
         peerGroupingTag: 'tag1',
         referenceComponent: { nodeId: 'node1', componentId: 'abc' },
-        rules: []
+        rules: [defaultQuestionBankRule]
       })
     };
   });
@@ -74,7 +80,7 @@ function ngOnInit_displayedQuestionBankRulesNotSet_EvaluatePeerGroupDataAndSetQu
       expect(getComponentSpy).toHaveBeenCalledWith('node1', 'abc');
       expect(retrievePeerGroupSpy).toHaveBeenCalledWith('tag1');
       expect(retrieveStudentDataSpy).toHaveBeenCalledWith(1, 'node2', 'def');
-      expect(component.displayedQuestionBankRules).toEqual([]);
+      expect(component.displayedQuestionBankRules).toEqual([defaultQuestionBankRule]);
     });
   });
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.spec.ts
@@ -5,28 +5,76 @@ import { PeerChatQuestionBankComponent } from './peer-chat-question-bank.compone
 import { ProjectService } from '../../../services/projectService';
 import { QuestionBank } from './QuestionBank';
 import { ComponentContent } from '../../../common/ComponentContent';
+import { QuestionBankRule } from './QuestionBankRule';
+import { PeerGroupService } from '../../../services/peerGroupService';
+import { PeerGroup } from '../PeerGroup';
+import { of } from 'rxjs';
 
 let component: PeerChatQuestionBankComponent;
 let fixture: ComponentFixture<PeerChatQuestionBankComponent>;
-
+let peerGroupService: PeerGroupService;
+let projectService: ProjectService;
 describe('PeerChatQuestionBankComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, StudentTeacherCommonServicesModule],
       declarations: [PeerChatQuestionBankComponent]
     }).compileComponents();
-    spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({} as ComponentContent);
     fixture = TestBed.createComponent(PeerChatQuestionBankComponent);
+    peerGroupService = TestBed.inject(PeerGroupService);
+    projectService = TestBed.inject(ProjectService);
     component = fixture.componentInstance;
     component.content = {
-      componentId: 'abc',
-      nodeId: 'node1',
-      questionBank: new QuestionBank({ referenceComponent: {} })
+      componentId: 'def',
+      nodeId: 'node2',
+      questionBank: new QuestionBank({
+        peerGroupingTag: 'tag1',
+        referenceComponent: { nodeId: 'node1', componentId: 'abc' },
+        rules: []
+      })
     };
-    fixture.detectChanges();
   });
-
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+  ngOnInit();
 });
+
+function ngOnInit() {
+  describe('ngOnInit()', () => {
+    ngOnInit_displayedQuestionBankRulesSet_SetQuestions();
+    ngOnInit_displayedQuestionBankRulesNotSet_EvaluatePeerGroupDataAndSetQuestions();
+  });
+}
+
+function ngOnInit_displayedQuestionBankRulesSet_SetQuestions() {
+  describe('displayedQuestionBankRules is set', () => {
+    it('should set questions', () => {
+      component.displayedQuestionBankRules = [
+        { questions: ['q1', 'q2', 'q3'] },
+        { questions: ['q4'] }
+      ] as QuestionBankRule[];
+      component.ngOnInit();
+      expect(component.questions).toEqual(['q1', 'q2', 'q3', 'q4']);
+    });
+  });
+}
+
+function ngOnInit_displayedQuestionBankRulesNotSet_EvaluatePeerGroupDataAndSetQuestions() {
+  describe('displayedQuestionBankRules is not set', () => {
+    it('should evaluate PeerGroup data and set questions', () => {
+      const getComponentSpy = spyOn(projectService, 'getComponent').and.returnValue({
+        type: 'OpenResponse'
+      } as ComponentContent);
+      const retrievePeerGroupSpy = spyOn(peerGroupService, 'retrievePeerGroup').and.returnValue(
+        of({ id: 1 } as PeerGroup)
+      );
+      const retrieveStudentDataSpy = spyOn(
+        peerGroupService,
+        'retrieveQuestionBankStudentData'
+      ).and.returnValue(of([]));
+      component.ngOnInit();
+      expect(getComponentSpy).toHaveBeenCalledWith('node1', 'abc');
+      expect(retrievePeerGroupSpy).toHaveBeenCalledWith('tag1');
+      expect(retrieveStudentDataSpy).toHaveBeenCalledWith(1, 'node2', 'def');
+      expect(component.displayedQuestionBankRules).toEqual([]);
+    });
+  });
+}

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
@@ -91,19 +91,20 @@ export class PeerChatQuestionBankComponent implements OnInit {
     questionBankRules: QuestionBankRule[],
     maxQuestionsToShow: number
   ): QuestionBankRule[] {
-    const filteredRules: QuestionBankRule[] = JSON.parse(JSON.stringify(questionBankRules));
+    const rules = JSON.parse(JSON.stringify(questionBankRules));
+    const filteredRules: QuestionBankRule[] = JSON.parse(JSON.stringify(rules));
     filteredRules.forEach((rule) => (rule.questions = []));
     let numAdded = 0;
     let ruleIndex = 0;
-    const totalNumQuestions = questionBankRules.map((rule) => rule.questions).flat().length;
+    const totalNumQuestions = rules.map((rule) => rule.questions).flat().length;
     const maxQuestions = maxQuestionsToShow ?? totalNumQuestions;
     while (numAdded < maxQuestions && numAdded != totalNumQuestions) {
-      if (questionBankRules[ruleIndex].questions.length > 0) {
-        const question = questionBankRules[ruleIndex].questions.shift();
+      if (rules[ruleIndex].questions.length > 0) {
+        const question = rules[ruleIndex].questions.shift();
         filteredRules[ruleIndex].questions.push(question);
         numAdded++;
       }
-      ruleIndex = (ruleIndex + 1) % questionBankRules.length;
+      ruleIndex = (ruleIndex + 1) % rules.length;
     }
     return filteredRules.filter((rule) => rule.questions.length > 0);
   }

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
@@ -21,20 +21,20 @@ import { QuestionBankContent } from './QuestionBankContent';
 })
 export class PeerChatQuestionBankComponent implements OnInit {
   @Input() content: QuestionBankContent;
-  @Input() displayedQuestionBankRule: QuestionBankRule;
-  @Output() displayedQuestionBankRuleChange = new EventEmitter<QuestionBankRule>();
+  @Input() displayedQuestionBankRules: QuestionBankRule[];
+  @Output() displayedQuestionBankRulesChange = new EventEmitter<QuestionBankRule[]>();
   questions: string[];
 
   constructor(private peerGroupService: PeerGroupService, private projectService: ProjectService) {}
 
   ngOnInit(): void {
-    if (this.displayedQuestionBankRule != null) {
-      this.questions = this.displayedQuestionBankRule.questions;
-    } else {
+    if (this.displayedQuestionBankRules == null) {
       const referenceComponent = this.getReferenceComponent(this.content.questionBank);
       if (referenceComponent.content.type === 'OpenResponse') {
         this.evaluate(referenceComponent);
       }
+    } else {
+      this.setQuestions();
     }
   }
 
@@ -56,26 +56,55 @@ export class PeerChatQuestionBankComponent implements OnInit {
       this.content.nodeId,
       this.content.componentId
     ).subscribe((peerGroupStudentData: PeerGroupStudentData[]) => {
-      const cRaterResponses = peerGroupStudentData.map((peerMemberData: PeerGroupStudentData) => {
-        return new CRaterResponse({
-          ideas: peerMemberData.annotation.data.ideas,
-          scores: peerMemberData.annotation.data.scores,
-          submitCounter: peerMemberData.studentWork.studentData.submitCounter
-        });
-      });
-      const feedbackRuleEvaluator = new FeedbackRuleEvaluator(
-        new FeedbackRuleComponent(
-          this.content.questionBank.getRules(),
-          (referenceComponent.content as OpenResponseContent).maxSubmitCount,
-          false
-        )
+      const questionBankRules = this.chooseQuestionBankRulesToDisplay(
+        referenceComponent,
+        peerGroupStudentData
       );
-      const feedbackRule: QuestionBankRule = feedbackRuleEvaluator.getFeedbackRule(
-        cRaterResponses
-      ) as QuestionBankRule;
-      this.questions = feedbackRule.questions;
-      this.displayedQuestionBankRuleChange.emit(feedbackRule);
+      this.displayedQuestionBankRules = questionBankRules;
+      this.displayedQuestionBankRulesChange.emit(questionBankRules);
+      this.setQuestions();
     });
+  }
+
+  private chooseQuestionBankRulesToDisplay(
+    referenceComponent: WISEComponent,
+    peerGroupStudentData: PeerGroupStudentData[]
+  ): QuestionBankRule[] {
+    const cRaterResponses = peerGroupStudentData.map((peerMemberData: PeerGroupStudentData) => {
+      return new CRaterResponse({
+        ideas: peerMemberData.annotation.data.ideas,
+        scores: peerMemberData.annotation.data.scores,
+        submitCounter: peerMemberData.studentWork.studentData.submitCounter
+      });
+    });
+    const feedbackRuleEvaluator = new FeedbackRuleEvaluator(
+      new FeedbackRuleComponent(
+        this.content.questionBank.getRules(),
+        (referenceComponent.content as OpenResponseContent).maxSubmitCount,
+        false
+      )
+    );
+    return this.filterQuestions(
+      feedbackRuleEvaluator.getFeedbackRules(cRaterResponses) as QuestionBankRule[]
+    );
+  }
+
+  private filterQuestions(questionBankRules: QuestionBankRule[]): QuestionBankRule[] {
+    const filteredRules: QuestionBankRule[] = JSON.parse(JSON.stringify(questionBankRules));
+    filteredRules.forEach((rule) => (rule.questions = []));
+    let numAdded = 0;
+    let ruleIndex = 0;
+    const totalNumQuestions = questionBankRules.map((rule) => rule.questions).flat().length;
+    const maxQuestionsToShow = this.content.questionBank.maxQuestionsToShow;
+    while (numAdded < maxQuestionsToShow && numAdded != totalNumQuestions) {
+      if (questionBankRules[ruleIndex].questions.length > 0) {
+        const question = questionBankRules[ruleIndex].questions.shift();
+        filteredRules[ruleIndex].questions.push(question);
+        numAdded++;
+      }
+      ruleIndex = (ruleIndex + 1) % questionBankRules.length;
+    }
+    return filteredRules.filter((rule) => rule.questions.length > 0);
   }
 
   private getPeerGroupData(
@@ -94,5 +123,9 @@ export class PeerChatQuestionBankComponent implements OnInit {
           );
       })
     );
+  }
+
+  private setQuestions(): void {
+    this.questions = this.displayedQuestionBankRules.flatMap((rule) => rule.questions);
   }
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
@@ -96,7 +96,8 @@ export class PeerChatQuestionBankComponent implements OnInit {
     let numAdded = 0;
     let ruleIndex = 0;
     const totalNumQuestions = questionBankRules.map((rule) => rule.questions).flat().length;
-    while (numAdded < maxQuestionsToShow && numAdded != totalNumQuestions) {
+    const maxQuestions = maxQuestionsToShow ?? totalNumQuestions;
+    while (numAdded < maxQuestions && numAdded != totalNumQuestions) {
       if (questionBankRules[ruleIndex].questions.length > 0) {
         const question = questionBankRules[ruleIndex].questions.shift();
         filteredRules[ruleIndex].questions.push(question);

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
@@ -30,8 +30,11 @@ export class PeerChatQuestionBankComponent implements OnInit {
   ngOnInit(): void {
     if (this.displayedQuestionBankRules == null) {
       const referenceComponent = this.getReferenceComponent(this.content.questionBank);
-      if (referenceComponent.content.type === 'OpenResponse') {
-        this.evaluate(referenceComponent);
+      if (
+        this.content.questionBank.isPeerGroupingTagSpecified() &&
+        referenceComponent.content.type === 'OpenResponse'
+      ) {
+        this.evaluatePeerGroup(referenceComponent);
       }
     } else {
       this.setQuestions();
@@ -42,12 +45,6 @@ export class PeerChatQuestionBankComponent implements OnInit {
     const nodeId = questionBank.getReferenceNodeId();
     const componentId = questionBank.getReferenceComponentId();
     return new WISEComponent(this.projectService.getComponent(nodeId, componentId), nodeId);
-  }
-
-  private evaluate(referenceComponent: WISEComponent): void {
-    if (this.content.questionBank.isPeerGroupingTagSpecified()) {
-      this.evaluatePeerGroup(referenceComponent);
-    }
   }
 
   private evaluatePeerGroup(referenceComponent: WISEComponent): void {

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
@@ -37,7 +37,7 @@ export class PeerChatQuestionBankComponent implements OnInit {
         this.evaluatePeerGroup(referenceComponent);
       }
     } else {
-      this.setQuestions();
+      this.setQuestions(this.displayedQuestionBankRules);
     }
   }
 
@@ -59,7 +59,7 @@ export class PeerChatQuestionBankComponent implements OnInit {
       );
       this.displayedQuestionBankRules = questionBankRules;
       this.displayedQuestionBankRulesChange.emit(questionBankRules);
-      this.setQuestions();
+      this.setQuestions(questionBankRules);
     });
   }
 
@@ -82,17 +82,20 @@ export class PeerChatQuestionBankComponent implements OnInit {
       )
     );
     return this.filterQuestions(
-      feedbackRuleEvaluator.getFeedbackRules(cRaterResponses) as QuestionBankRule[]
+      feedbackRuleEvaluator.getFeedbackRules(cRaterResponses) as QuestionBankRule[],
+      this.content.questionBank.maxQuestionsToShow
     );
   }
 
-  private filterQuestions(questionBankRules: QuestionBankRule[]): QuestionBankRule[] {
+  private filterQuestions(
+    questionBankRules: QuestionBankRule[],
+    maxQuestionsToShow: number
+  ): QuestionBankRule[] {
     const filteredRules: QuestionBankRule[] = JSON.parse(JSON.stringify(questionBankRules));
     filteredRules.forEach((rule) => (rule.questions = []));
     let numAdded = 0;
     let ruleIndex = 0;
     const totalNumQuestions = questionBankRules.map((rule) => rule.questions).flat().length;
-    const maxQuestionsToShow = this.content.questionBank.maxQuestionsToShow;
     while (numAdded < maxQuestionsToShow && numAdded != totalNumQuestions) {
       if (questionBankRules[ruleIndex].questions.length > 0) {
         const question = questionBankRules[ruleIndex].questions.shift();
@@ -122,7 +125,7 @@ export class PeerChatQuestionBankComponent implements OnInit {
     );
   }
 
-  private setQuestions(): void {
-    this.questions = this.displayedQuestionBankRules.flatMap((rule) => rule.questions);
+  private setQuestions(rules: QuestionBankRule[]): void {
+    this.questions = rules.flatMap((rule) => rule.questions);
   }
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.html
@@ -6,7 +6,7 @@
         fxFlexOrder="1"
         fxFlexOrder.gt-md="2">
       <peer-chat-question-bank *ngIf="componentContent.questionBank?.enabled"
-          [displayedQuestionBankRule]="questionBankRule"></peer-chat-question-bank>
+          [displayedQuestionBankRules]="questionBankRules"></peer-chat-question-bank>
     </div>
     <div fxFlex fxFlex.gt-md="60" fxFlexOrder="2" fxFlexOrder.gt-md="1">
       <peer-chat-chat-box [messages]="peerChatMessages"

--- a/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.ts
@@ -10,6 +10,7 @@ import { PeerGroup } from '../PeerGroup';
 import { PeerGroupMember } from '../PeerGroupMember';
 import { NodeService } from '../../../services/nodeService';
 import { FeedbackRule } from '../../common/feedbackRule/FeedbackRule';
+import { QuestionBankRule } from '../peer-chat-question-bank/QuestionBankRule';
 
 @Component({
   selector: 'peer-chat-show-work',
@@ -22,7 +23,7 @@ export class PeerChatShowWorkComponent extends ComponentShowWorkDirective {
   peerChatWorkgroupIds: Set<number> = new Set<number>();
   peerChatWorkgroupInfos: any = {};
   peerGroup: PeerGroup;
-  questionBankRule: string[];
+  questionBankRules: QuestionBankRule[];
   requestTimeout: number = 10000;
 
   @Input() workgroupId: number;
@@ -85,7 +86,7 @@ export class PeerChatShowWorkComponent extends ComponentShowWorkDirective {
     this.peerChatMessages = [];
     this.peerChatService.setPeerChatMessages(this.peerChatMessages, componentStates);
     this.dynamicPrompt = this.getDynamicPrompt(componentStates);
-    this.questionBankRule = this.getQuestionBankRule(componentStates);
+    this.questionBankRules = this.getQuestionBankRule(componentStates);
   }
 
   private getDynamicPrompt(componentStates: any[]): FeedbackRule {
@@ -98,7 +99,7 @@ export class PeerChatShowWorkComponent extends ComponentShowWorkDirective {
     return null;
   }
 
-  private getQuestionBankRule(componentStates: any[]): string[] {
+  private getQuestionBankRule(componentStates: any[]): QuestionBankRule[] {
     for (let c = componentStates.length - 1; c >= 0; c--) {
       const questionBank = componentStates[c].studentData.questionBank;
       if (questionBank != null) {

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html
@@ -17,7 +17,7 @@
         fxFlexOrder.gt-sm="2">
       <peer-chat-question-bank *ngIf="questionBankContent.questionBank?.enabled"
           [content]="questionBankContent"
-          [(displayedQuestionBankRule)]="displayedQuestionBankRule"></peer-chat-question-bank>
+          [(displayedQuestionBankRules)]="displayedQuestionBankRules"></peer-chat-question-bank>
     </div>
     <div fxFlex
         fxFlex.gt-sm="60"

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
@@ -28,7 +28,7 @@ import { PeerGroup } from '../PeerGroup';
 })
 export class PeerChatStudentComponent extends ComponentStudent {
   component: PeerChatComponent;
-  displayedQuestionBankRule: QuestionBankRule;
+  displayedQuestionBankRules: QuestionBankRule[];
   dynamicPrompt: FeedbackRule;
   isPeerChatWorkgroupsResponseReceived: boolean;
   isPeerChatWorkgroupsAvailable: boolean;
@@ -167,8 +167,8 @@ export class PeerChatStudentComponent extends ComponentStudent {
     if (this.dynamicPrompt != null) {
       componentState.studentData.dynamicPrompt = this.dynamicPrompt;
     }
-    if (this.displayedQuestionBankRule != null) {
-      componentState.studentData.questionBank = this.displayedQuestionBankRule;
+    if (this.displayedQuestionBankRules != null) {
+      componentState.studentData.questionBank = this.displayedQuestionBankRules;
     }
     componentState.componentType = 'PeerChat';
     componentState.nodeId = this.component.nodeId;

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1263,7 +1263,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html</context>
-          <context context-type="linenumber">22</context>
+          <context context-type="linenumber">24</context>
         </context-group>
       </trans-unit>
       <trans-unit id="865b518ad09c5909b84301e6fd1443519f02795c" datatype="html">
@@ -1357,8 +1357,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">7,9</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8632a932f5c307dc148ba6ad491fa0804a30fa30" datatype="html">
-        <source>Number of Questions to Show</source>
+      <trans-unit id="04246ddceb217efd6b3ba918d84e609ca92a1594" datatype="html">
+        <source>Max Number of Questions to Show</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html</context>
           <context context-type="linenumber">14</context>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -8487,7 +8487,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherDataService.ts</context>
-          <context context-type="linenumber">634</context>
+          <context context-type="linenumber">636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d9b2ffb3e1ce1ca42a3db04d00ea072777898eb3" datatype="html">
@@ -11720,7 +11720,7 @@ Are you sure you want to proceed?</source>
         <source>Downloading Export</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">2115</context>
+          <context context-type="linenumber">2121</context>
         </context-group>
       </trans-unit>
       <trans-unit id="18a393cd6211a7e1f51159db6b49637ee7c61490" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1357,8 +1357,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">7,9</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="04246ddceb217efd6b3ba918d84e609ca92a1594" datatype="html">
-        <source>Max Number of Questions to Show</source>
+      <trans-unit id="896589cbf4473a405f00a4068706375829758d92" datatype="html">
+        <source>Max Number of Questions</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html</context>
           <context context-type="linenumber">14</context>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1263,7 +1263,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html</context>
-          <context context-type="linenumber">16</context>
+          <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
       <trans-unit id="865b518ad09c5909b84301e6fd1443519f02795c" datatype="html">
@@ -1355,6 +1355,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html</context>
           <context context-type="linenumber">7,9</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8632a932f5c307dc148ba6ad491fa0804a30fa30" datatype="html">
+        <source>Number of Questions to Show</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html</context>
+          <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e8c21747e8604f974b3ed6ecf6089306b7cc0aae" datatype="html">
@@ -9902,7 +9909,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete this Peer Grouping?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.ts</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="aba67b55d7f550e72a7134adf3dee25d2be00f9b" datatype="html">


### PR DESCRIPTION
## Changes
- Add a new ```maxQuestionsToShow: number``` field to  QuestionBank content. Use this number to choose questions to show in the QuestionBank, up to the specified number. The algorithm works as follows
   - First find all rules that match (including the default rule)
   - Next, choose one question from each matched rule in round-robin order until maxQuestionsToShow is reached, or until all the questions have been used
   
For example, if matched rules looked like this:
```
Rule 1 questions: ["q1", "q2", "q3"]
Rule 2 questions: ["q4"]
Rule 3 questions: ["q5", "q6"]
```
and ```maxQuestionsToShow=4```, it should choose 
```
Rule 1 questions: ["q1", "q2"]
Rule 2 questions: ["q4"]
Rule 3 questions: ["q5"]
```
- Store matched rules and chosen questions within those rules along with PeerChat student work

## Test
- In PeerChat authoring, enable QuestionBank and set "Number of Questions to Show" to a number
- As a student, go to the PeerChat step and verify that QuestionBank shows up to that many questions
   - The questions should be chosen in round-robin fashion from all the rules that match
   - Type some text in the chatbox to trigger saving the QuestionBank items 
- As a teacher, verify that the QuestionBank questions appear in the grade-by-step view 

Closes #961