### PR TITLE
feat(Authoring): Add JSON authoring view for when project is broken

### DIFF
--- a/src/app/domain/nodeRecoveryAnalysis.ts
+++ b/src/app/domain/nodeRecoveryAnalysis.ts
@@ -1,0 +1,30 @@
+export class NodeRecoveryAnalysis {
+  hasTransitionToNull: boolean = false;
+  nodeId: string;
+  referencedIdsThatAreDuplicated: string[] = [];
+  referencedIdsThatDoNotExist: string[] = [];
+
+  constructor(nodeId: string) {
+    this.nodeId = nodeId;
+  }
+
+  addReferencedIdThatIsDuplicated(nodeId: string): void {
+    this.referencedIdsThatAreDuplicated.push(nodeId);
+  }
+
+  addReferencedIdThatDoesNotExist(nodeId: string): void {
+    this.referencedIdsThatDoNotExist.push(nodeId);
+  }
+
+  setHasTransitionToNull(value: boolean): void {
+    this.hasTransitionToNull = value;
+  }
+
+  hasProblem(): boolean {
+    return (
+      this.referencedIdsThatAreDuplicated.length > 0 ||
+      this.referencedIdsThatDoNotExist.length > 0 ||
+      this.hasTransitionToNull
+    );
+  }
+}

--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -21,6 +21,7 @@ import { ComponentAuthoringModule } from './component-authoring.module';
 import { ComponentStudentModule } from '../../assets/wise5/components/component/component-student.module';
 import { PreviewComponentModule } from '../../assets/wise5/authoringTool/components/preview-component/preview-component.module';
 import { StudentTeacherCommonModule } from '../student-teacher-common.module';
+import { RecoveryAuthoringComponent } from '../../assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component';
 
 @NgModule({
   declarations: [
@@ -39,6 +40,7 @@ import { StudentTeacherCommonModule } from '../student-teacher-common.module';
     NodeAdvancedJsonAuthoringComponent,
     NodeAdvancedPathAuthoringComponent,
     NodeIconChooserDialog,
+    RecoveryAuthoringComponent,
     RequiredErrorLabelComponent,
     RubricAuthoringComponent
   ],

--- a/src/assets/wise5/authoringTool/project/project-authoring.module.ts
+++ b/src/assets/wise5/authoringTool/project/project-authoring.module.ts
@@ -11,6 +11,7 @@ import { ProjectAssetService } from '../../../../app/services/projectAssetServic
 import { ProjectAuthoringComponent } from '../../authoringTool/project/projectAuthoringComponent';
 import { ProjectInfoAuthoringComponent } from '../../authoringTool/info/projectInfoAuthoringComponent';
 import { RubricAuthoringComponent } from '../../authoringTool/rubric/rubric-authoring.component';
+import { RecoveryAuthoringComponent } from '../recovery-authoring/recovery-authoring.component';
 
 export default angular
   .module('projectAuthoringModule', [])
@@ -29,6 +30,10 @@ export default angular
   .directive(
     'rubricAuthoringComponent',
     downgradeComponent({ component: RubricAuthoringComponent }) as angular.IDirectiveFactory
+  )
+  .directive(
+    'recoveryAuthoringComponent',
+    downgradeComponent({ component: RecoveryAuthoringComponent })
   )
   .factory('ProjectAssetService', downgradeInjectable(ProjectAssetService))
   .config([
@@ -106,6 +111,31 @@ export default angular
         .state('root.at.project.milestones', {
           url: '/milestones',
           component: 'milestonesAuthoringComponent'
+        })
+        .state('root.at.recovery', {
+          url: '/unit/:projectId/recovery',
+          component: 'recoveryAuthoringComponent',
+          resolve: {
+            projectConfig: [
+              'ConfigService',
+              'SessionService',
+              '$stateParams',
+              (ConfigService, SessionService, $stateParams) => {
+                return ConfigService.retrieveConfig(
+                  `/api/author/config/${$stateParams.projectId}`
+                ).then(() => {
+                  SessionService.initializeSession();
+                });
+              }
+            ],
+            project: [
+              'ProjectService',
+              'projectConfig',
+              (ProjectService, projectConfig) => {
+                return ProjectService.retrieveProject(false);
+              }
+            ]
+          }
         });
     }
   ]);

--- a/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html
+++ b/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html
@@ -1,0 +1,51 @@
+<div id="top" class="view-content view-content--with-sidemenu">
+  <div class="l-constrained" layout="column">
+    <div class="node-content md-whiteframe-1dp main-box">
+      <div class="top-div">
+        <div class="save-bar" fxLayout="row" fxLayoutAlign="space-between center">
+          <button mat-raised-button
+              color="primary"
+              (click)="save()"
+              [disabled]="!saveButtonEnabled"
+              i18n>
+            Save
+          </button>
+          <div fxLayout="row">
+            <div *ngIf="jsonIsValid" class="valid" i18n>JSON Valid</div>
+            <div *ngIf="!jsonIsValid" class="invalid" i18n>JSON Invalid</div>
+            <div *ngIf="globalMessage != null">
+              <div class="component__actions__info md-caption global-message">
+                {{ globalMessage.text }} {{ globalMessage.time | date:'medium' }}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="warning-div" i18n>Warning: Modifying the JSON may break the project. Please make a backup copy of the JSON before you modify it.</div>
+        <div *ngIf="badNodes.length > 0" class="potential-problems-div">
+          <div class="potential-problems-header" i18n>Potential Problems</div>
+          <div *ngFor="let badNode of badNodes" class="bad-node">
+            <div class="node-id">{{ badNode.nodeId }}</div>
+            <div *ngIf="badNode.referencedIdsThatDoNotExist.length > 0" i18n>
+              This group references the node ID but the node does not exist: {{ badNode.referencedIdsThatDoNotExist }}
+            </div>
+            <div *ngIf="badNode.referencedIdsThatAreDuplicated.length > 0" i18n>
+              This group references the same node ID multiple times: {{ badNode.referencedIdsThatAreDuplicated }}
+            </div>
+            <div *ngIf="badNode.hasTransitionToNull" i18n>This node has a transition to null</div>
+          </div>
+        </div>
+      </div>
+      <div>
+        <mat-form-field fxFlex appearance="outline">
+          <mat-label i18n>Edit Unit JSON</mat-label>
+          <textarea class="mat-body-1"
+              matInput
+              cdkTextareaAutosize
+              [(ngModel)]="projectJSONString"
+              (ngModelChange)="projectJSONChanged()">
+          </textarea>
+        </mat-form-field>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html
+++ b/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html
@@ -3,13 +3,21 @@
     <div class="node-content md-whiteframe-1dp main-box">
       <div class="top-div">
         <div class="save-bar" fxLayout="row" fxLayoutAlign="space-between center">
-          <button mat-raised-button
-              color="primary"
-              (click)="save()"
-              [disabled]="!saveButtonEnabled"
-              i18n>
-            Save
-          </button>
+          <div fxLayoutGap="20px">
+            <button mat-raised-button
+                color="primary"
+                (click)="save()"
+                [disabled]="!saveButtonEnabled"
+                i18n>
+              Save
+            </button>
+            <button mat-raised-button
+                color="primary"
+                (click)="goToAuthoringView()"
+                i18n>
+              Go to Authoring View
+            </button>
+          </div>
           <div fxLayout="row">
             <div *ngIf="jsonIsValid" class="valid" i18n>JSON Valid</div>
             <div *ngIf="!jsonIsValid" class="invalid" i18n>JSON Invalid</div>

--- a/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.scss
+++ b/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.scss
@@ -1,0 +1,50 @@
+.main-box {
+  position: relative;
+  padding: 16px !important;
+}
+
+.top-div {
+  background-color: white;
+  position: sticky;
+  top: 0px;
+  z-index: 2;
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.save-bar {
+  margin-bottom: 20px;
+}
+
+.valid {
+  color: green;
+}
+
+.invalid {
+  color: red;
+}
+
+.warning-div {
+  margin-bottom: 20px;
+  color: red;
+}
+
+.potential-problems-div {
+  color: red;
+}
+
+.potential-problems-header {
+  text-decoration: underline;
+  margin-bottom: 8px;
+}
+
+.bad-node {
+  border: 1px solid red;
+  border-radius: 8px;
+  padding: 8px;
+  margin-bottom: 4px;
+}
+
+.node-id {
+  font-weight: bold;
+}

--- a/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.spec.ts
@@ -65,49 +65,58 @@ describe('RecoveryAuthoringComponent', () => {
 });
 
 function projectJSONChanged() {
-  describe('projectJSONChanged', () => {
-    it('should detect json is invalid and disable save button', () => {
-      setProjectJSONStringAndTriggerChange('abc');
-      expect(component.jsonIsValid).toBeFalsy();
-      expect(component.saveButtonEnabled).toBeFalsy();
-    });
+  describe('projectJSONChanged()', () => {
+    detectJSONValidity();
+    detectPotentialProblems();
+  });
+}
 
-    it('should detect json is valid and enable save button', () => {
-      setProjectJSONStringAndTriggerChange('{ "nodes": [] }');
-      expect(component.jsonIsValid).toBeTruthy();
-      expect(component.saveButtonEnabled).toBeTruthy();
-    });
+function detectJSONValidity() {
+  it('should detect json is invalid and disable save button', () => {
+    setJSONAndExpect('abc', false, false);
+  });
 
-    it('should detect potential problem transition to null', () => {
-      const projectJSON = {
-        nodes: [new Node(nodeId1, null, [{ to: null }])]
-      };
-      setProjectJSONStringAndTriggerChange(JSON.stringify(projectJSON));
-      expect(component.badNodes.length).toEqual(1);
-      expect(component.badNodes[0].hasTransitionToNull).toEqual(true);
-    });
+  it('should detect json is valid and enable save button', () => {
+    setJSONAndExpect('{ "nodes": [] }', true, true);
+  });
+}
 
-    it('should detect potential problem reference to node id that does not exist', () => {
-      const projectJSON = {
-        nodes: [new Node(groupId1, [nodeId1, nodeId2], []), new Node(nodeId1, null, [])]
-      };
-      setProjectJSONStringAndTriggerChange(JSON.stringify(projectJSON));
-      expect(component.badNodes.length).toEqual(1);
-      expect(component.badNodes[0].referencedIdsThatDoNotExist).toEqual([nodeId2]);
-    });
+function setJSONAndExpect(json: string, jsonIsValid: boolean, saveButtonEnabled: boolean) {
+  setProjectJSONStringAndTriggerChange(json);
+  expect(component.jsonIsValid).toEqual(jsonIsValid);
+  expect(component.saveButtonEnabled).toEqual(saveButtonEnabled);
+}
 
-    it('should detect potential problem reference to node id duplicate', () => {
-      const projectJSON = {
-        nodes: [
-          new Node(groupId1, [nodeId1, nodeId1], []),
-          new Node(nodeId1, null, [{ to: nodeId2 }]),
-          new Node(nodeId2, null, [])
-        ]
-      };
-      setProjectJSONStringAndTriggerChange(JSON.stringify(projectJSON));
-      expect(component.badNodes.length).toEqual(1);
-      expect(component.badNodes[0].referencedIdsThatAreDuplicated).toEqual([nodeId1]);
-    });
+function detectPotentialProblems() {
+  it('should detect potential problem transition to null', () => {
+    const projectJSON = {
+      nodes: [new Node(nodeId1, null, [{ to: null }])]
+    };
+    setProjectJSONStringAndTriggerChange(JSON.stringify(projectJSON));
+    expect(component.badNodes.length).toEqual(1);
+    expect(component.badNodes[0].hasTransitionToNull).toEqual(true);
+  });
+
+  it('should detect potential problem reference to node id that does not exist', () => {
+    const projectJSON = {
+      nodes: [new Node(groupId1, [nodeId1, nodeId2], []), new Node(nodeId1, null, [])]
+    };
+    setProjectJSONStringAndTriggerChange(JSON.stringify(projectJSON));
+    expect(component.badNodes.length).toEqual(1);
+    expect(component.badNodes[0].referencedIdsThatDoNotExist).toEqual([nodeId2]);
+  });
+
+  it('should detect potential problem reference to node id duplicate', () => {
+    const projectJSON = {
+      nodes: [
+        new Node(groupId1, [nodeId1, nodeId1], []),
+        new Node(nodeId1, null, [{ to: nodeId2 }]),
+        new Node(nodeId2, null, [])
+      ]
+    };
+    setProjectJSONStringAndTriggerChange(JSON.stringify(projectJSON));
+    expect(component.badNodes.length).toEqual(1);
+    expect(component.badNodes[0].referencedIdsThatAreDuplicated).toEqual([nodeId1]);
   });
 }
 
@@ -117,7 +126,7 @@ function setProjectJSONStringAndTriggerChange(jsonString: string): void {
 }
 
 function save() {
-  describe('save', () => {
+  describe('save()', () => {
     it('should save and disable save button', () => {
       component.saveButtonEnabled = true;
       component.save();

--- a/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.spec.ts
@@ -1,0 +1,45 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatInputModule } from '@angular/material/input';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
+import { TeacherProjectService } from '../../services/teacherProjectService';
+import { RecoveryAuthoringComponent } from './recovery-authoring.component';
+
+class MockTeacherProjectService {
+  project = {
+    nodes: []
+  };
+}
+
+describe('RecoveryAuthoringComponent', () => {
+  let component: RecoveryAuthoringComponent;
+  let fixture: ComponentFixture<RecoveryAuthoringComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [RecoveryAuthoringComponent],
+      imports: [
+        BrowserAnimationsModule,
+        FormsModule,
+        HttpClientTestingModule,
+        MatDialogModule,
+        MatInputModule,
+        StudentTeacherCommonServicesModule
+      ],
+      providers: [{ provide: TeacherProjectService, useClass: MockTeacherProjectService }]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RecoveryAuthoringComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.spec.ts
@@ -67,15 +67,13 @@ describe('RecoveryAuthoringComponent', () => {
 function projectJSONChanged() {
   describe('projectJSONChanged', () => {
     it('should detect json is invalid and disable save button', () => {
-      component.projectJSONString = 'abc';
-      component.projectJSONChanged();
+      setProjectJSONStringAndTriggerChange('abc');
       expect(component.jsonIsValid).toBeFalsy();
       expect(component.saveButtonEnabled).toBeFalsy();
     });
 
     it('should detect json is valid and enable save button', () => {
-      component.projectJSONString = '{ "nodes": [] }';
-      component.projectJSONChanged();
+      setProjectJSONStringAndTriggerChange('{ "nodes": [] }');
       expect(component.jsonIsValid).toBeTruthy();
       expect(component.saveButtonEnabled).toBeTruthy();
     });
@@ -84,8 +82,7 @@ function projectJSONChanged() {
       const projectJSON = {
         nodes: [new Node(nodeId1, null, [{ to: null }])]
       };
-      component.projectJSONString = JSON.stringify(projectJSON);
-      component.projectJSONChanged();
+      setProjectJSONStringAndTriggerChange(JSON.stringify(projectJSON));
       expect(component.badNodes.length).toEqual(1);
       expect(component.badNodes[0].hasTransitionToNull).toEqual(true);
     });
@@ -94,8 +91,7 @@ function projectJSONChanged() {
       const projectJSON = {
         nodes: [new Node(groupId1, [nodeId1, nodeId2], []), new Node(nodeId1, null, [])]
       };
-      component.projectJSONString = JSON.stringify(projectJSON);
-      component.projectJSONChanged();
+      setProjectJSONStringAndTriggerChange(JSON.stringify(projectJSON));
       expect(component.badNodes.length).toEqual(1);
       expect(component.badNodes[0].referencedIdsThatDoNotExist).toEqual([nodeId2]);
     });
@@ -108,12 +104,16 @@ function projectJSONChanged() {
           new Node(nodeId2, null, [])
         ]
       };
-      component.projectJSONString = JSON.stringify(projectJSON);
-      component.projectJSONChanged();
+      setProjectJSONStringAndTriggerChange(JSON.stringify(projectJSON));
       expect(component.badNodes.length).toEqual(1);
       expect(component.badNodes[0].referencedIdsThatAreDuplicated).toEqual([nodeId1]);
     });
   });
+}
+
+function setProjectJSONStringAndTriggerChange(jsonString: string): void {
+  component.projectJSONString = jsonString;
+  component.projectJSONChanged();
 }
 
 function save() {

--- a/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.spec.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { UpgradeModule } from '@angular/upgrade/static';
 import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { RecoveryAuthoringComponent } from './recovery-authoring.component';
@@ -12,12 +13,31 @@ class MockTeacherProjectService {
   project = {
     nodes: []
   };
+
+  saveProject() {}
 }
 
-describe('RecoveryAuthoringComponent', () => {
-  let component: RecoveryAuthoringComponent;
-  let fixture: ComponentFixture<RecoveryAuthoringComponent>;
+class Node {
+  id: string;
+  ids: string[];
+  transitionLogic: any;
 
+  constructor(id: string, ids: string[], transitions: any[]) {
+    this.id = id;
+    this.ids = ids;
+    this.transitionLogic = {
+      transitions: transitions
+    };
+  }
+}
+
+let component: RecoveryAuthoringComponent;
+let fixture: ComponentFixture<RecoveryAuthoringComponent>;
+const groupId1 = 'group1';
+const nodeId1 = 'node1';
+const nodeId2 = 'node2';
+
+describe('RecoveryAuthoringComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [RecoveryAuthoringComponent],
@@ -27,7 +47,8 @@ describe('RecoveryAuthoringComponent', () => {
         HttpClientTestingModule,
         MatDialogModule,
         MatInputModule,
-        StudentTeacherCommonServicesModule
+        StudentTeacherCommonServicesModule,
+        UpgradeModule
       ],
       providers: [{ provide: TeacherProjectService, useClass: MockTeacherProjectService }]
     }).compileComponents();
@@ -39,7 +60,68 @@ describe('RecoveryAuthoringComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+  projectJSONChanged();
+  save();
 });
+
+function projectJSONChanged() {
+  describe('projectJSONChanged', () => {
+    it('should detect json is invalid and disable save button', () => {
+      component.projectJSONString = 'abc';
+      component.projectJSONChanged();
+      expect(component.jsonIsValid).toBeFalsy();
+      expect(component.saveButtonEnabled).toBeFalsy();
+    });
+
+    it('should detect json is valid and enable save button', () => {
+      component.projectJSONString = '{ "nodes": [] }';
+      component.projectJSONChanged();
+      expect(component.jsonIsValid).toBeTruthy();
+      expect(component.saveButtonEnabled).toBeTruthy();
+    });
+
+    it('should detect potential problem transition to null', () => {
+      const projectJSON = {
+        nodes: [new Node(nodeId1, null, [{ to: null }])]
+      };
+      component.projectJSONString = JSON.stringify(projectJSON);
+      component.projectJSONChanged();
+      expect(component.badNodes.length).toEqual(1);
+      expect(component.badNodes[0].hasTransitionToNull).toEqual(true);
+    });
+
+    it('should detect potential problem reference to node id that does not exist', () => {
+      const projectJSON = {
+        nodes: [new Node(groupId1, [nodeId1, nodeId2], []), new Node(nodeId1, null, [])]
+      };
+      component.projectJSONString = JSON.stringify(projectJSON);
+      component.projectJSONChanged();
+      expect(component.badNodes.length).toEqual(1);
+      expect(component.badNodes[0].referencedIdsThatDoNotExist).toEqual([nodeId2]);
+    });
+
+    it('should detect potential problem reference to node id duplicate', () => {
+      const projectJSON = {
+        nodes: [
+          new Node(groupId1, [nodeId1, nodeId1], []),
+          new Node(nodeId1, null, [{ to: nodeId2 }]),
+          new Node(nodeId2, null, [])
+        ]
+      };
+      component.projectJSONString = JSON.stringify(projectJSON);
+      component.projectJSONChanged();
+      expect(component.badNodes.length).toEqual(1);
+      expect(component.badNodes[0].referencedIdsThatAreDuplicated).toEqual([nodeId1]);
+    });
+  });
+}
+
+function save() {
+  describe('save', () => {
+    it('should save and disable save button', () => {
+      component.saveButtonEnabled = true;
+      component.save();
+      expect(component.saveButtonEnabled).toBeFalsy();
+    });
+  });
+}

--- a/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.ts
@@ -1,0 +1,92 @@
+import { Component, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { NotificationService } from '../../services/notificationService';
+import { TeacherProjectService } from '../../services/teacherProjectService';
+import { UtilService } from '../../services/utilService';
+import { NodeRecoveryAnalysis } from '../../../../app/domain/nodeRecoveryAnalysis';
+
+@Component({
+  selector: 'recovery-authoring',
+  templateUrl: './recovery-authoring.component.html',
+  styleUrls: ['./recovery-authoring.component.scss']
+})
+export class RecoveryAuthoringComponent implements OnInit {
+  badNodes: NodeRecoveryAnalysis[] = [];
+  globalMessage: any;
+  projectJSONString: string;
+  saveButtonEnabled: boolean = false;
+  subscriptions: Subscription = new Subscription();
+  jsonIsValid: boolean;
+
+  constructor(
+    private notificationService: NotificationService,
+    private projectService: TeacherProjectService,
+    private utilService: UtilService
+  ) {}
+
+  subscribeToGlobalMessage(): void {
+    this.subscriptions.add(
+      this.notificationService.setGlobalMessage$.subscribe(({ globalMessage }) => {
+        this.globalMessage = globalMessage;
+      })
+    );
+  }
+
+  ngOnInit(): void {
+    this.projectJSONString = JSON.stringify(this.projectService.project, null, 4);
+    this.checkProjectJSONValidity();
+    this.subscribeToGlobalMessage();
+    this.checkNodes();
+  }
+
+  ngDestroy(): void {}
+
+  projectJSONChanged(): void {
+    this.checkProjectJSONValidity();
+    this.saveButtonEnabled = this.jsonIsValid;
+    this.checkNodes();
+  }
+
+  checkProjectJSONValidity(): void {
+    this.jsonIsValid = this.utilService.isValidJSONString(this.projectJSONString);
+  }
+
+  checkNodes(): void {
+    const project = JSON.parse(this.projectJSONString);
+    const nodeIdsFound = project.nodes.map((node: any) => {
+      return node.id;
+    });
+    this.badNodes = [];
+    for (const node of project.nodes) {
+      const nodeRecoveryAnalysis = new NodeRecoveryAnalysis(node.id);
+      if (node.ids != null) {
+        const nodesReferencesInGroup = new Map();
+        for (const referencedId of node.ids) {
+          if (!nodeIdsFound.includes(referencedId)) {
+            nodeRecoveryAnalysis.addReferencedIdThatDoesNotExist(referencedId);
+          }
+          if (nodesReferencesInGroup.get(referencedId)) {
+            nodeRecoveryAnalysis.addReferencedIdThatIsDuplicated(referencedId);
+          }
+          nodesReferencesInGroup.set(referencedId, true);
+        }
+      }
+      nodeRecoveryAnalysis.setHasTransitionToNull(this.hasNullTransition(node));
+      if (nodeRecoveryAnalysis.hasProblem()) {
+        this.badNodes.push(nodeRecoveryAnalysis);
+      }
+    }
+  }
+
+  hasNullTransition(node: any): boolean {
+    return node.transitionLogic.transitions.some((transition: any) => {
+      return transition.to == null;
+    });
+  }
+
+  save(): void {
+    this.projectService.project = JSON.parse(this.projectJSONString);
+    this.projectService.saveProject();
+    this.saveButtonEnabled = false;
+  }
+}

--- a/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.ts
@@ -76,19 +76,27 @@ export class RecoveryAuthoringComponent implements OnInit {
   private getNodeRecoveryAnalysis(node: any, nodeIdsFound: string[]): NodeRecoveryAnalysis {
     const nodeRecoveryAnalysis = new NodeRecoveryAnalysis(node.id);
     if (node.ids != null) {
-      const nodesReferencesInGroup = new Map();
-      for (const referencedId of node.ids) {
-        if (!nodeIdsFound.includes(referencedId)) {
-          nodeRecoveryAnalysis.addReferencedIdThatDoesNotExist(referencedId);
-        }
-        if (nodesReferencesInGroup.get(referencedId)) {
-          nodeRecoveryAnalysis.addReferencedIdThatIsDuplicated(referencedId);
-        }
-        nodesReferencesInGroup.set(referencedId, true);
-      }
+      this.analyzeGroupChildIds(node, nodeIdsFound, nodeRecoveryAnalysis);
     }
     nodeRecoveryAnalysis.setHasTransitionToNull(this.hasTransitionToNull(node));
     return nodeRecoveryAnalysis;
+  }
+
+  private analyzeGroupChildIds(
+    node: any,
+    nodeIdsFound: string[],
+    nodeRecoveryAnalysis: NodeRecoveryAnalysis
+  ): void {
+    const nodesReferencesInGroup = new Map();
+    for (const referencedId of node.ids) {
+      if (!nodeIdsFound.includes(referencedId)) {
+        nodeRecoveryAnalysis.addReferencedIdThatDoesNotExist(referencedId);
+      }
+      if (nodesReferencesInGroup.get(referencedId)) {
+        nodeRecoveryAnalysis.addReferencedIdThatIsDuplicated(referencedId);
+      }
+      nodesReferencesInGroup.set(referencedId, true);
+    }
   }
 
   private hasTransitionToNull(node: any): boolean {

--- a/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.ts
@@ -4,6 +4,8 @@ import { NotificationService } from '../../services/notificationService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { UtilService } from '../../services/utilService';
 import { NodeRecoveryAnalysis } from '../../../../app/domain/nodeRecoveryAnalysis';
+import { UpgradeModule } from '@angular/upgrade/static';
+import { ConfigService } from '../../services/configService';
 
 @Component({
   selector: 'recovery-authoring',
@@ -13,24 +15,18 @@ import { NodeRecoveryAnalysis } from '../../../../app/domain/nodeRecoveryAnalysi
 export class RecoveryAuthoringComponent implements OnInit {
   badNodes: NodeRecoveryAnalysis[] = [];
   globalMessage: any;
+  jsonIsValid: boolean;
   projectJSONString: string;
   saveButtonEnabled: boolean = false;
   subscriptions: Subscription = new Subscription();
-  jsonIsValid: boolean;
 
   constructor(
+    private configService: ConfigService,
     private notificationService: NotificationService,
     private projectService: TeacherProjectService,
+    private upgrade: UpgradeModule,
     private utilService: UtilService
   ) {}
-
-  subscribeToGlobalMessage(): void {
-    this.subscriptions.add(
-      this.notificationService.setGlobalMessage$.subscribe(({ globalMessage }) => {
-        this.globalMessage = globalMessage;
-      })
-    );
-  }
 
   ngOnInit(): void {
     this.projectJSONString = JSON.stringify(this.projectService.project, null, 4);
@@ -39,46 +35,63 @@ export class RecoveryAuthoringComponent implements OnInit {
     this.checkNodes();
   }
 
-  ngDestroy(): void {}
+  ngDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
 
   projectJSONChanged(): void {
     this.checkProjectJSONValidity();
     this.saveButtonEnabled = this.jsonIsValid;
-    this.checkNodes();
+    if (this.jsonIsValid) {
+      this.checkNodes();
+    }
   }
 
-  checkProjectJSONValidity(): void {
+  private checkProjectJSONValidity(): void {
     this.jsonIsValid = this.utilService.isValidJSONString(this.projectJSONString);
   }
 
-  checkNodes(): void {
+  private subscribeToGlobalMessage(): void {
+    this.subscriptions.add(
+      this.notificationService.setGlobalMessage$.subscribe(({ globalMessage }) => {
+        this.globalMessage = globalMessage;
+      })
+    );
+  }
+
+  private checkNodes(): void {
     const project = JSON.parse(this.projectJSONString);
     const nodeIdsFound = project.nodes.map((node: any) => {
       return node.id;
     });
     this.badNodes = [];
     for (const node of project.nodes) {
-      const nodeRecoveryAnalysis = new NodeRecoveryAnalysis(node.id);
-      if (node.ids != null) {
-        const nodesReferencesInGroup = new Map();
-        for (const referencedId of node.ids) {
-          if (!nodeIdsFound.includes(referencedId)) {
-            nodeRecoveryAnalysis.addReferencedIdThatDoesNotExist(referencedId);
-          }
-          if (nodesReferencesInGroup.get(referencedId)) {
-            nodeRecoveryAnalysis.addReferencedIdThatIsDuplicated(referencedId);
-          }
-          nodesReferencesInGroup.set(referencedId, true);
-        }
-      }
-      nodeRecoveryAnalysis.setHasTransitionToNull(this.hasNullTransition(node));
+      const nodeRecoveryAnalysis = this.getNodeRecoveryAnalysis(node, nodeIdsFound);
       if (nodeRecoveryAnalysis.hasProblem()) {
         this.badNodes.push(nodeRecoveryAnalysis);
       }
     }
   }
 
-  hasNullTransition(node: any): boolean {
+  private getNodeRecoveryAnalysis(node: any, nodeIdsFound: string[]): NodeRecoveryAnalysis {
+    const nodeRecoveryAnalysis = new NodeRecoveryAnalysis(node.id);
+    if (node.ids != null) {
+      const nodesReferencesInGroup = new Map();
+      for (const referencedId of node.ids) {
+        if (!nodeIdsFound.includes(referencedId)) {
+          nodeRecoveryAnalysis.addReferencedIdThatDoesNotExist(referencedId);
+        }
+        if (nodesReferencesInGroup.get(referencedId)) {
+          nodeRecoveryAnalysis.addReferencedIdThatIsDuplicated(referencedId);
+        }
+        nodesReferencesInGroup.set(referencedId, true);
+      }
+    }
+    nodeRecoveryAnalysis.setHasTransitionToNull(this.hasTransitionToNull(node));
+    return nodeRecoveryAnalysis;
+  }
+
+  private hasTransitionToNull(node: any): boolean {
     return node.transitionLogic.transitions.some((transition: any) => {
       return transition.to == null;
     });
@@ -88,5 +101,11 @@ export class RecoveryAuthoringComponent implements OnInit {
     this.projectService.project = JSON.parse(this.projectJSONString);
     this.projectService.saveProject();
     this.saveButtonEnabled = false;
+  }
+
+  goToAuthoringView(): void {
+    this.upgrade.$injector
+      .get('$state')
+      .go('root.at.project', { projectId: this.configService.getProjectId() });
   }
 }

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -870,7 +870,7 @@ export class ProjectService {
    * Retrieves the project JSON from Config.projectURL and returns it.
    * If Config.projectURL is undefined, returns null.
    */
-  retrieveProject(): any {
+  retrieveProject(parseProject: boolean = true): any {
     let projectURL = this.configService.getConfigParam('projectURL');
     if (projectURL == null) {
       return null;
@@ -879,8 +879,13 @@ export class ProjectService {
     return this.http
       .get(projectURL, { headers: headers })
       .toPromise()
-      .then((projectJSON) => {
-        this.setProject(projectJSON);
+      .then((projectJSON: any) => {
+        if (parseProject) {
+          this.setProject(projectJSON);
+        } else {
+          this.project = projectJSON;
+          this.metadata = projectJSON.metadata;
+        }
         return projectJSON;
       });
   }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1263,7 +1263,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="865b518ad09c5909b84301e6fd1443519f02795c" datatype="html">
@@ -6998,21 +6998,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Error: First Name and Last Name must only contain characters A-Z, a-z, spaces, or dashes and can not start or end with a space or dash</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-user-form/register-user-form.component.ts</context>
-          <context context-type="linenumber">5</context>
+          <context context-type="linenumber">7</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1084197907437634069" datatype="html">
         <source>Error: First Name must only contain characters A-Z, a-z, spaces, or dashes and can not start or end with a space or dash</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-user-form/register-user-form.component.ts</context>
-          <context context-type="linenumber">7</context>
+          <context context-type="linenumber">9</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5970926747435723642" datatype="html">
         <source>Error: Last Name must only contain characters A-Z, a-z, spaces, or dashes and can not start or end with a space or dash</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-user-form/register-user-form.component.ts</context>
-          <context context-type="linenumber">9</context>
+          <context context-type="linenumber">11</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2599853012922890508" datatype="html">
@@ -8658,6 +8658,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/assets/wise5/authoringTool/advanced/advanced-project-authoring.component.html</context>
           <context context-type="linenumber">16</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="9203b05eb7515e937cc5e5d8cbc8a03195bb2d7f" datatype="html">
         <source>Script Filename</source>
@@ -9994,6 +9998,69 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-option/select-peer-grouping-option.component.html</context>
           <context context-type="linenumber">23</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5c898139e1b9909bedbacfb2fc2758773fd0cde3" datatype="html">
+        <source> Save </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
+          <context context-type="linenumber">11,13</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="b04371f86293ecd786f25f21a6bf5974b552258f" datatype="html">
+        <source> Go to Authoring View </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
+          <context context-type="linenumber">17,19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="e1cb0d996371ebffafe43d0b31533c5abc1df249" datatype="html">
+        <source>JSON Valid</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="e2dfb6ef44ed682083e2134c987104526aee896d" datatype="html">
+        <source>JSON Invalid</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="c360b4600cd965d992a0c3de57f802bae76c74a1" datatype="html">
+        <source>Warning: Modifying the JSON may break the project. Please make a backup copy of the JSON before you modify it.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5f462e9a8a700a6c7bf878514a1ff79ef71431f7" datatype="html">
+        <source>Potential Problems</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="dfe704dc98449cf8afae1d3e55d0331106fcf544" datatype="html">
+        <source> This group references the node ID but the node does not exist: <x id="INTERPOLATION" equiv-text="{{ badNode.referencedIdsThatDoNotExist }}"/> </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
+          <context context-type="linenumber">36,38</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6ee2c5e7be97e0020601e431ae87bee18d4b1788" datatype="html">
+        <source> This group references the same node ID multiple times: <x id="INTERPOLATION" equiv-text="{{ badNode.referencedIdsThatAreDuplicated }}"/> </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
+          <context context-type="linenumber">39,41</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="96d19c7b193e83ea80c75c0696ab059d43008164" datatype="html">
+        <source>This node has a transition to null</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
+          <context context-type="linenumber">42</context>
         </context-group>
       </trans-unit>
       <trans-unit id="92328333ea9c72926ca7c631e9e1c0f081cbf565" datatype="html">
@@ -18167,112 +18234,112 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Complete &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1262</context>
+          <context context-type="linenumber">1267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4750375498606149231" datatype="html">
         <source>Visit &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1268</context>
+          <context context-type="linenumber">1273</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6126058561630526429" datatype="html">
         <source>Correctly answer &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1274</context>
+          <context context-type="linenumber">1279</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7085241847460263487" datatype="html">
         <source>Obtain a score of &lt;b&gt;<x id="PH" equiv-text="scoresString"/>&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1289</context>
+          <context context-type="linenumber">1294</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5469027549306748048" datatype="html">
         <source>You must choose &quot;<x id="PH" equiv-text="choiceText"/>&quot; on &quot;<x id="PH_1" equiv-text="nodeTitle"/>&quot;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1297</context>
+          <context context-type="linenumber">1302</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6293177000168372990" datatype="html">
         <source>Submit &lt;b&gt;<x id="PH" equiv-text="requiredSubmitCount"/>&lt;/b&gt; time on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1309</context>
+          <context context-type="linenumber">1314</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4693324974790890133" datatype="html">
         <source>Submit &lt;b&gt;<x id="PH" equiv-text="requiredSubmitCount"/>&lt;/b&gt; times on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1311</context>
+          <context context-type="linenumber">1316</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8416169412912074869" datatype="html">
         <source>Take the branch path from &lt;b&gt;<x id="PH" equiv-text="fromNodeTitle"/>&lt;/b&gt; to &lt;b&gt;<x id="PH_1" equiv-text="toNodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1318</context>
+          <context context-type="linenumber">1323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8087029188038414167" datatype="html">
         <source>Write &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfWords"/>&lt;/b&gt; words on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1324</context>
+          <context context-type="linenumber">1329</context>
         </context-group>
       </trans-unit>
       <trans-unit id="22049568725715518" datatype="html">
         <source>&quot;<x id="PH" equiv-text="nodeTitle"/>&quot; is visible</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1330</context>
+          <context context-type="linenumber">1335</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5023130174506669799" datatype="html">
         <source>&quot;<x id="PH" equiv-text="nodeTitle"/>&quot; is visitable</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1336</context>
+          <context context-type="linenumber">1341</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1185133360670447094" datatype="html">
         <source>Add &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfNotes"/>&lt;/b&gt; note on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1343</context>
+          <context context-type="linenumber">1348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5985921753090789216" datatype="html">
         <source>Add &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfNotes"/>&lt;/b&gt; notes on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1345</context>
+          <context context-type="linenumber">1350</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4560070803879446782" datatype="html">
         <source>You must fill in &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfFilledRows"/>&lt;/b&gt; row in the &lt;b&gt;Table&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1352</context>
+          <context context-type="linenumber">1357</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2804292280751903227" datatype="html">
         <source>You must fill in &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfFilledRows"/>&lt;/b&gt; rows in the &lt;b&gt;Table&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1354</context>
+          <context context-type="linenumber">1359</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4171523921205906508" datatype="html">
         <source>Wait for your teacher to unlock the item</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1357</context>
+          <context context-type="linenumber">1362</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8770055323459972095" datatype="html">


### PR DESCRIPTION
## Changes

- Added recovery view to allow editing the project JSON without loading the project
- The recovery view also tries to detect and display potential problems

## Test

1. Go to the recovery authoring view for a project.
```http://localhost:81/teacher/edit/unit/<unit id>/recovery```
2. Modify the JSON so that it becomes invalid, the upper right message should say "JSON Invalid" and the "Save" button should be disabled.
3. Modify the JSON so that it becomes valid, the upper right message should say "JSON Valid" and the "Save" button should be enabled.
4. Modify the project so that a node has a null transition and make sure the potential problem is detected.
```
        {
            "id": "node1",
            "transitionLogic": {
                "transitions": [
                    {
                        "to": null
                    }
                ]
            }
        }
```
5. Modify the project so that a group references a node id that does not exist and make sure the potential problem is detected.
```
        {
            "id": "group1",
            "ids": [
                "node1",
                "node9999"
            ]
        }
```
6. Modify the project so that a group references a node id multiple times and make sure the potential problem is detected.
```
        {
            "id": "group1",
            "ids": [
                "node1",
                "node1"
            ]
        }
```
7. Make sure the "Go to Authoring View" button works if the project has no problems.

Closes #922