### PR TITLE
chore(ng generate): Create components without app prefix

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -237,11 +237,11 @@
   },
   "schematics": {
     "@schematics/angular:component": {
-      "prefix": "app",
+      "prefix": "",
       "style": "scss"
     },
     "@schematics/angular:directive": {
-      "prefix": "app"
+      "prefix": ""
     }
   },
   "cli": {

--- a/tslint.json
+++ b/tslint.json
@@ -138,13 +138,13 @@
     "directive-selector": [
       true,
       "attribute",
-      "app",
+      "",
       "camelCase"
     ],
     "component-selector": [
       true,
       "element",
-      "app",
+      "",
       "kebab-case"
     ],
     "no-output-on-prefix": true,


### PR DESCRIPTION
## Changes

When generating a new component with `ng generate component`, the `app-` prefix is no longer added to the component selector.

## Test

- Run `ng generate component` and make sure it creates a component without `app-` in the selector.
- Run `ng generate directive` and make sure it creates a directive without `app-` in the selector.

Closes #965