### PR TITLE
fix(VLE): Update account menu scores on node status changes

### DIFF
--- a/src/assets/wise5/vle/student-account-menu/student-account-menu.component.html
+++ b/src/assets/wise5/vle/student-account-menu/student-account-menu.component.html
@@ -26,7 +26,7 @@
     </div>
   </div>
   <mat-divider class="divider"></mat-divider>
-  <div class="menu-section" *ngIf="maxScore != null">
+  <div class="menu-section" *ngIf="showScore">
     <div fxLayout="row" fxLayoutAlign="start center">
       <div fxLayout="column">
         <span class="mat-body-2" i18n>Total Score</span>

--- a/src/assets/wise5/vle/student-account-menu/student-account-menu.component.spec.ts
+++ b/src/assets/wise5/vle/student-account-menu/student-account-menu.component.spec.ts
@@ -22,7 +22,7 @@ class MockProjectService {
   }
 }
 
-fdescribe('StudentAccountMenuComponent', () => {
+describe('StudentAccountMenuComponent', () => {
   let component: StudentAccountMenuComponent;
   let fixture: ComponentFixture<StudentAccountMenuComponent>;
 

--- a/src/assets/wise5/vle/student-account-menu/student-account-menu.component.spec.ts
+++ b/src/assets/wise5/vle/student-account-menu/student-account-menu.component.spec.ts
@@ -22,7 +22,7 @@ class MockProjectService {
   }
 }
 
-describe('StudentAccountMenuComponent', () => {
+fdescribe('StudentAccountMenuComponent', () => {
   let component: StudentAccountMenuComponent;
   let fixture: ComponentFixture<StudentAccountMenuComponent>;
 

--- a/src/assets/wise5/vle/student-account-menu/student-account-menu.component.ts
+++ b/src/assets/wise5/vle/student-account-menu/student-account-menu.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
 import { MatMenu } from '@angular/material/menu';
+import { Subscription } from 'rxjs';
 import { ConfigService } from '../../services/configService';
 import { ProjectService } from '../../services/projectService';
 import { SessionService } from '../../services/sessionService';
@@ -11,7 +12,7 @@ import { StudentDataService } from '../../services/studentDataService';
   styleUrls: ['./student-account-menu.component.scss'],
   encapsulation: ViewEncapsulation.None
 })
-export class StudentAccountMenuComponent implements OnInit {
+export class StudentAccountMenuComponent implements OnInit, OnDestroy {
   @ViewChild(MatMenu, { static: true })
   menu: MatMenu;
 
@@ -22,6 +23,7 @@ export class StudentAccountMenuComponent implements OnInit {
   rootNode: any;
   rootNodeStatus: any;
   scorePercentage: number;
+  subscriptions: Subscription = new Subscription();
   themeSettings: any;
   totalScoreNum: number;
   totalScore: string;
@@ -43,11 +45,26 @@ export class StudentAccountMenuComponent implements OnInit {
     this.rootNodeStatus = this.nodeStatuses[this.rootNode.id];
     this.workgroupId = this.configService.getWorkgroupId();
     this.usersInWorkgroup = this.configService.getUsernamesByWorkgroupId(this.workgroupId);
+    this.usernamesDisplay = this.getUsernamesDisplay(this.usersInWorkgroup);
+    this.updateScores();
+    if (this.maxScore != null) {
+      this.subscriptions.add(
+        this.studentDataService.nodeStatusesChanged$.subscribe(() => {
+          this.updateScores();
+        })
+      );
+    }
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
+  }
+
+  updateScores(): void {
     this.totalScoreNum = this.studentDataService.getTotalScore();
     this.totalScore = typeof this.totalScoreNum === 'number' ? this.totalScoreNum.toString() : '-';
     this.maxScore = this.studentDataService.maxScore;
     this.scorePercentage = Math.ceil((100 * this.totalScoreNum) / this.maxScore);
-    this.usernamesDisplay = this.getUsernamesDisplay(this.usersInWorkgroup);
   }
 
   getUsernamesDisplay(users: any[]): string {

--- a/src/assets/wise5/vle/student-account-menu/student-account-menu.component.ts
+++ b/src/assets/wise5/vle/student-account-menu/student-account-menu.component.ts
@@ -23,6 +23,7 @@ export class StudentAccountMenuComponent implements OnInit, OnDestroy {
   rootNode: any;
   rootNodeStatus: any;
   scorePercentage: number;
+  showScore: boolean;
   subscriptions: Subscription = new Subscription();
   themeSettings: any;
   totalScoreNum: number;
@@ -46,8 +47,10 @@ export class StudentAccountMenuComponent implements OnInit, OnDestroy {
     this.workgroupId = this.configService.getWorkgroupId();
     this.usersInWorkgroup = this.configService.getUsernamesByWorkgroupId(this.workgroupId);
     this.usernamesDisplay = this.getUsernamesDisplay(this.usersInWorkgroup);
-    this.updateScores();
-    if (this.maxScore != null) {
+    this.maxScore = this.studentDataService.maxScore;
+    this.showScore = this.maxScore != null;
+    if (this.showScore) {
+      this.updateScores();
       this.subscriptions.add(
         this.studentDataService.nodeStatusesChanged$.subscribe(() => {
           this.updateScores();


### PR DESCRIPTION
## Changes
Adds a subscription in StudentAccountMenu to `studentDataService.nodeStatusesChanged$`. Updates scores on each change.

Note that the account menu score displays do not update in real time when a new teacher score annotation is added. Student needs to navigate to a new step or submit some work for the scores to update. This should probably be fixed in a separate issue relating to websocket messages.

Resolves #971.

## Test
1. Launch a unit with a c-rater auto-scored item in preview mode.
2. Submit a response to the c-rater item.
3. Check that total score and score % update in the student account menu.
4. Launch a run with a c-rater item as a student.
5. Submit a response to the c-rater item.
6. Check that total score and score % update in the student account menu.
7. As a teacher, create a new score annotation for any component in the run.
8. As the student, navigate to a new step or submit some work.
9. Check that total score and score % update in the student account menu.