### PR TITLE
refactor(UtilService): Move getImageObjectFromBase64String()

### DIFF
--- a/src/assets/wise5/common/canvas/canvas.spec.ts
+++ b/src/assets/wise5/common/canvas/canvas.spec.ts
@@ -1,0 +1,12 @@
+import { convertToPNGFile } from './canvas';
+
+describe('canvas', () => {
+  describe('convertToPNGFile()', () => {
+    it('should convert canvas element to png image file', () => {
+      const pngFile = convertToPNGFile(document.createElement('canvas'));
+      expect(pngFile instanceof File).toBeTrue();
+      expect(pngFile.type).toEqual('image/png');
+      expect(pngFile.name).toMatch('picture_(\\d+)\\.png');
+    });
+  });
+});

--- a/src/assets/wise5/common/canvas/canvas.ts
+++ b/src/assets/wise5/common/canvas/canvas.ts
@@ -1,0 +1,27 @@
+export function convertToPNGFile(canvas: HTMLCanvasElement): File {
+  const img_b64 = canvas.toDataURL('image/png');
+  const blob = dataURItoBlob(img_b64);
+  const now = new Date().getTime();
+  const filename = encodeURIComponent('picture_' + now + '.png');
+  return new File([blob], filename, {
+    lastModified: now, // optional - default = now
+    type: 'image/png' // optional - default = ''
+  });
+}
+
+/**
+ * Convert base64/URLEncoded data component to raw binary data held in a string
+ * @param dataURI base64/URLEncoded data
+ * @returns a Blob object
+ */
+function dataURItoBlob(dataURI: string): Blob {
+  let byteString;
+  if (dataURI.split(',')[0].indexOf('base64') >= 0) byteString = atob(dataURI.split(',')[1]);
+  else byteString = unescape(dataURI.split(',')[1]);
+  const mimeString = dataURI.split(',')[0].split(':')[1].split(';')[0];
+  const ia = new Uint8Array(byteString.length);
+  for (let i = 0; i < byteString.length; i++) {
+    ia[i] = byteString.charCodeAt(i);
+  }
+  return new Blob([ia], { type: mimeString });
+}

--- a/src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts
+++ b/src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts
@@ -15,6 +15,7 @@ import { ComponentService } from '../../componentService';
 import { ConceptMapService } from '../conceptMapService';
 import { DialogWithCloseComponent } from '../../../directives/dialog-with-close/dialog-with-close.component';
 import { copy } from '../../../common/object/object';
+import { convertToPNGFile } from '../../../common/canvas/canvas';
 
 @Component({
   selector: 'concept-map-student',
@@ -1456,15 +1457,13 @@ export class ConceptMapStudent extends ComponentStudent {
     const domURL: any = self.URL || (self as any).webkitURL || self;
     const url = domURL.createObjectURL(svg);
     const image = new Image();
-    const thisUtilService = this.UtilService;
     image.onload = (event) => {
       const image: any = event.target;
       myCanvas.width = image.width;
       myCanvas.height = image.height;
       ctx.drawImage(image, 0, 0);
-      const base64Image = myCanvas.toDataURL('image/png');
-      const imageObject = thisUtilService.getImageObjectFromBase64String(base64Image);
-      this.NotebookService.addNote(this.StudentDataService.getCurrentNodeId(), imageObject);
+      const pngFile = convertToPNGFile(myCanvas);
+      this.NotebookService.addNote(this.StudentDataService.getCurrentNodeId(), pngFile);
     };
     image.src = url;
   }

--- a/src/assets/wise5/components/conceptMap/conceptMapService.ts
+++ b/src/assets/wise5/components/conceptMap/conceptMapService.ts
@@ -7,15 +7,13 @@ import { StudentAssetService } from '../../services/studentAssetService';
 import ConceptMapNode from './conceptMapNode';
 import ConceptMapLink from './conceptMapLink';
 import { Injectable } from '@angular/core';
-import { UtilService } from '../../services/utilService';
 import { convertToPNGFile } from '../../common/canvas/canvas';
 
 @Injectable()
 export class ConceptMapService extends ComponentService {
   constructor(
     private ConfigService: ConfigService,
-    private StudentAssetService: StudentAssetService,
-    protected UtilService: UtilService
+    private StudentAssetService: StudentAssetService
   ) {
     super();
   }
@@ -798,12 +796,6 @@ export class ConceptMapService extends ComponentService {
           const domURL: any = self.URL || (self as any).webkitURL || self;
           const url = domURL.createObjectURL(svg);
           const image = new Image();
-
-          /*
-           * set the UtilService in a local variable so we can access it
-           * in the onload callback function
-           */
-          const thisUtilService = this.UtilService;
 
           // the function that is called after the image is fully loaded
           image.onload = (event) => {

--- a/src/assets/wise5/components/conceptMap/conceptMapService.ts
+++ b/src/assets/wise5/components/conceptMap/conceptMapService.ts
@@ -8,6 +8,7 @@ import ConceptMapNode from './conceptMapNode';
 import ConceptMapLink from './conceptMapLink';
 import { Injectable } from '@angular/core';
 import { UtilService } from '../../services/utilService';
+import { convertToPNGFile } from '../../common/canvas/canvas';
 
 @Injectable()
 export class ConceptMapService extends ComponentService {
@@ -814,14 +815,8 @@ export class ConceptMapService extends ComponentService {
             myCanvas.height = image.height;
             ctx.drawImage(image, 0, 0);
 
-            // get the canvas as a Base64 string
-            const base64Image = myCanvas.toDataURL('image/png');
-
-            // get the image object
-            const imageObject = thisUtilService.getImageObjectFromBase64String(base64Image);
-
-            // create a student asset image
-            this.StudentAssetService.uploadAsset(imageObject).then((unreferencedAsset) => {
+            const pngFile = convertToPNGFile(myCanvas);
+            this.StudentAssetService.uploadAsset(pngFile).then((unreferencedAsset) => {
               /*
                * make a copy of the unreferenced asset so that we
                * get a referenced asset
@@ -1170,14 +1165,8 @@ export class ConceptMapService extends ComponentService {
             myCanvas.height = image.height;
             ctx.drawImage(image, 0, 0);
 
-            // get the canvas as a Base64 string
-            const base64Image = myCanvas.toDataURL('image/png');
-
-            // get the image object
-            const imageObject = this.UtilService.getImageObjectFromBase64String(base64Image);
-
-            // add the image to the student assets
-            this.StudentAssetService.uploadAsset(imageObject).then((asset) => {
+            const pngFile = convertToPNGFile(myCanvas);
+            this.StudentAssetService.uploadAsset(pngFile).then((asset) => {
               resolve(asset);
             });
           };

--- a/src/assets/wise5/components/draw/draw-student/draw-student.component.ts
+++ b/src/assets/wise5/components/draw/draw-student/draw-student.component.ts
@@ -13,6 +13,7 @@ import { ComponentService } from '../../componentService';
 import { DrawService } from '../drawService';
 import { MatDialog } from '@angular/material/dialog';
 import { copy } from '../../../common/object/object';
+import { convertToPNGFile } from '../../../common/canvas/canvas';
 
 @Component({
   selector: 'draw-student',
@@ -342,15 +343,10 @@ export class DrawStudent extends ComponentStudent {
   }
 
   addNoteWithImage(componentStateId: number) {
-    const image = this.generateImageFromCanvas();
-    this.NotebookService.addNote(this.StudentDataService.getCurrentNodeId(), image, null, [
+    const pngFile = convertToPNGFile(this.getCanvas());
+    this.NotebookService.addNote(this.StudentDataService.getCurrentNodeId(), pngFile, null, [
       componentStateId
     ]);
-  }
-
-  generateImageFromCanvas(): any {
-    const canvasBase64Image = this.getCanvas().toDataURL('image/png');
-    return this.UtilService.getImageObjectFromBase64String(canvasBase64Image);
   }
 
   getCanvas(): any {

--- a/src/assets/wise5/components/draw/drawService.ts
+++ b/src/assets/wise5/components/draw/drawService.ts
@@ -9,7 +9,7 @@ import DrawingTool from 'drawing-tool/dist/drawing-tool';
 import { ComponentService } from '../componentService';
 import { StudentAssetService } from '../../services/studentAssetService';
 import { Injectable } from '@angular/core';
-import { UtilService } from '../../services/utilService';
+import { convertToPNGFile } from '../../common/canvas/canvas';
 
 @Injectable()
 export class DrawService extends ComponentService {
@@ -31,10 +31,7 @@ export class DrawService extends ComponentService {
     delete: 'Delete selected objects'
   };
 
-  constructor(
-    private StudentAssetService: StudentAssetService,
-    protected UtilService: UtilService
-  ) {
+  constructor(private StudentAssetService: StudentAssetService) {
     super();
   }
 
@@ -159,9 +156,8 @@ export class DrawService extends ComponentService {
         componentState
       );
       const canvas = this.getDrawingToolCanvas(this.getDrawingToolId(domIdEnding));
-      const canvasBase64String = canvas.toDataURL('image/png');
-      const imageObject = this.UtilService.getImageObjectFromBase64String(canvasBase64String);
-      this.StudentAssetService.uploadAsset(imageObject).then((asset) => {
+      const pngFile = convertToPNGFile(canvas);
+      this.StudentAssetService.uploadAsset(pngFile).then((asset) => {
         resolve(asset);
       });
     });

--- a/src/assets/wise5/components/embedded/embedded-student/embedded-student.component.ts
+++ b/src/assets/wise5/components/embedded/embedded-student/embedded-student.component.ts
@@ -6,13 +6,13 @@ import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
 import { StudentAssetService } from '../../../services/studentAssetService';
 import { StudentDataService } from '../../../services/studentDataService';
-import { UtilService } from '../../../services/utilService';
 import { ComponentStudent } from '../../component-student.component';
 import { ComponentService } from '../../componentService';
 import { EmbeddedService } from '../embeddedService';
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 import { MatDialog } from '@angular/material/dialog';
 import { copy } from '../../../common/object/object';
+import { convertToPNGFile } from '../../../common/canvas/canvas';
 
 @Component({
   selector: 'embedded-student',
@@ -78,8 +78,7 @@ export class EmbeddedStudent extends ComponentStudent {
     protected NotebookService: NotebookService,
     private saniztizer: DomSanitizer,
     protected StudentAssetService: StudentAssetService,
-    protected StudentDataService: StudentDataService,
-    protected UtilService: UtilService
+    protected StudentDataService: StudentDataService
   ) {
     super(
       AnnotationService,
@@ -340,9 +339,8 @@ export class EmbeddedStudent extends ComponentStudent {
       if (modelElement != null && modelElement.length > 0) {
         modelElement = modelElement[0];
         html2canvas(modelElement).then((canvas) => {
-          const base64Image = canvas.toDataURL('image/png');
-          const imageObject = this.UtilService.getImageObjectFromBase64String(base64Image);
-          this.NotebookService.addNote(this.StudentDataService.getCurrentNodeId(), imageObject);
+          const pngFile = convertToPNGFile(canvas);
+          this.NotebookService.addNote(this.StudentDataService.getCurrentNodeId(), pngFile);
         });
       }
     }

--- a/src/assets/wise5/components/embedded/embeddedService.ts
+++ b/src/assets/wise5/components/embedded/embeddedService.ts
@@ -5,9 +5,9 @@ import * as html2canvas from 'html2canvas';
 import { ComponentService } from '../componentService';
 import { StudentAssetService } from '../../services/studentAssetService';
 import { Injectable } from '@angular/core';
-import { UtilService } from '../../services/utilService';
 import { ConfigService } from '../../services/configService';
 import { copy } from '../../common/object/object';
+import { convertToPNGFile } from '../../common/canvas/canvas';
 
 @Injectable()
 export class EmbeddedService extends ComponentService {
@@ -17,8 +17,7 @@ export class EmbeddedService extends ComponentService {
 
   constructor(
     protected ConfigService: ConfigService,
-    protected StudentAssetService: StudentAssetService,
-    protected UtilService: UtilService
+    protected StudentAssetService: StudentAssetService
   ) {
     super();
   }
@@ -98,9 +97,8 @@ export class EmbeddedService extends ComponentService {
     const modelElement = this.getModelElement(componentState.componentId);
     return new Promise((resolve, reject) => {
       html2canvas(modelElement).then((canvas) => {
-        const base64Image = canvas.toDataURL('image/png');
-        const imageObject = this.UtilService.getImageObjectFromBase64String(base64Image);
-        this.StudentAssetService.uploadAsset(imageObject).then((asset) => {
+        const pngFile = convertToPNGFile(canvas);
+        this.StudentAssetService.uploadAsset(pngFile).then((asset) => {
           resolve(asset);
         });
       });

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -18,6 +18,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { GraphContent } from '../GraphContent';
 import { RandomKeyService } from '../../../services/randomKeyService';
 import { copy } from '../../../common/object/object';
+import { convertToPNGFile } from '../../../common/canvas/canvas';
 
 const Draggable = require('highcharts/modules/draggable-points.js');
 Draggable(Highcharts);
@@ -2508,9 +2509,8 @@ export class GraphStudent extends ComponentStudent {
     const hiddenCanvas: any = document.getElementById(this.hiddenCanvasId);
     canvg(hiddenCanvas, svgString, {
       renderCallback: () => {
-        const base64Image = hiddenCanvas.toDataURL('image/png');
-        const imageObject = this.UtilService.getImageObjectFromBase64String(base64Image);
-        this.NotebookService.addNote(this.StudentDataService.getCurrentNodeId(), imageObject);
+        const pngFile = convertToPNGFile(hiddenCanvas);
+        this.NotebookService.addNote(this.StudentDataService.getCurrentNodeId(), pngFile);
       }
     });
   }

--- a/src/assets/wise5/components/graph/graphService.ts
+++ b/src/assets/wise5/components/graph/graphService.ts
@@ -7,6 +7,7 @@ import { StudentAssetService } from '../../services/studentAssetService';
 import { UtilService } from '../../services/utilService';
 import { ConfigService } from '../../services/configService';
 import { HttpClient } from '@angular/common/http';
+import { convertToPNGFile } from '../../common/canvas/canvas';
 
 @Injectable()
 export class GraphService extends ComponentService {
@@ -306,9 +307,8 @@ export class GraphService extends ComponentService {
     return new Promise((resolve, reject) => {
       const highchartsDiv = this.getHighchartsDiv(componentState.componentId);
       html2canvas(highchartsDiv).then((canvas) => {
-        const base64Image = canvas.toDataURL('image/png');
-        const imageObject = this.UtilService.getImageObjectFromBase64String(base64Image);
-        this.StudentAssetService.uploadAsset(imageObject).then((asset) => {
+        const pngFile = convertToPNGFile(canvas);
+        this.StudentAssetService.uploadAsset(pngFile).then((asset) => {
           resolve(asset);
         });
       });

--- a/src/assets/wise5/components/label/label-student/label-student.component.ts
+++ b/src/assets/wise5/components/label/label-student/label-student.component.ts
@@ -11,6 +11,7 @@ import { ComponentService } from '../../componentService';
 import { LabelService } from '../labelService';
 import { StudentAssetService } from '../../../services/studentAssetService';
 import { MatDialog } from '@angular/material/dialog';
+import { convertToPNGFile } from '../../../common/canvas/canvas';
 
 @Component({
   selector: 'label-student',
@@ -726,15 +727,10 @@ export class LabelStudent extends ComponentStudent {
     canvas.remove(label.text);
   }
 
-  getStudentDataImageObject(): any {
-    const base64String = this.canvas.toDataURL('image/png');
-    return this.UtilService.getImageObjectFromBase64String(base64String);
-  }
-
   snipImage(): void {
     this.NotebookService.addNote(
       this.StudentDataService.getCurrentNodeId(),
-      this.getStudentDataImageObject()
+      convertToPNGFile(this.canvas)
     );
   }
 

--- a/src/assets/wise5/components/label/labelService.ts
+++ b/src/assets/wise5/components/label/labelService.ts
@@ -6,6 +6,7 @@ import { ComponentService } from '../componentService';
 import { StudentAssetService } from '../../services/studentAssetService';
 import { Injectable } from '@angular/core';
 import { UtilService } from '../../services/utilService';
+import { convertToPNGFile } from '../../common/canvas/canvas';
 
 @Injectable()
 export class LabelService extends ComponentService {
@@ -284,18 +285,14 @@ export class LabelService extends ComponentService {
     const domURL = self.URL || (self as any).webkitURL || self;
     const url = domURL.createObjectURL(svg);
     const image = new Image();
-    const thisUtilService = this.UtilService;
     return new Promise((resolve, reject) => {
       image.onload = (event) => {
         const image: any = event.target;
         myCanvas.width = image.width;
         myCanvas.height = image.height;
         ctx.drawImage(image, 0, 0);
-        const base64Image = myCanvas.toDataURL('image/png');
-        const imageObject = thisUtilService.getImageObjectFromBase64String(base64Image);
-
-        // create a student asset image
-        this.StudentAssetService.uploadAsset(imageObject).then((unreferencedAsset) => {
+        const pngFile = convertToPNGFile(myCanvas);
+        this.StudentAssetService.uploadAsset(pngFile).then((unreferencedAsset) => {
           /*
            * make a copy of the unreferenced asset so that we
            * get a referenced asset
@@ -352,9 +349,8 @@ export class LabelService extends ComponentService {
   generateImageFromRenderedComponentState(componentState: any) {
     return new Promise((resolve, reject) => {
       const canvas = this.getCanvas(componentState);
-      const img_b64 = canvas.toDataURL('image/png');
-      const imageObject = this.UtilService.getImageObjectFromBase64String(img_b64);
-      this.StudentAssetService.uploadAsset(imageObject).then((asset: any) => {
+      const pngFile = convertToPNGFile(canvas);
+      this.StudentAssetService.uploadAsset(pngFile).then((asset: any) => {
         resolve(asset);
       });
     });

--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -16,6 +16,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { TabulatorData } from '../TabulatorData';
 import { TabulatorDataService } from '../tabulatorDataService';
 import { copy } from '../../../common/object/object';
+import { convertToPNGFile } from '../../../common/canvas/canvas';
 
 @Component({
   selector: 'table-student',
@@ -897,9 +898,8 @@ export class TableStudent extends ComponentStudent {
       true
     );
     html2canvas(tableElement).then((canvas: any) => {
-      const base64Image = canvas.toDataURL('image/png');
-      const imageObject = this.UtilService.getImageObjectFromBase64String(base64Image);
-      this.NotebookService.addNote(this.StudentDataService.getCurrentNodeId(), imageObject);
+      const pngFile = convertToPNGFile(canvas);
+      this.NotebookService.addNote(this.StudentDataService.getCurrentNodeId(), pngFile);
     });
   }
 

--- a/src/assets/wise5/components/table/tableService.ts
+++ b/src/assets/wise5/components/table/tableService.ts
@@ -3,15 +3,12 @@
 import * as html2canvas from 'html2canvas';
 import { ComponentService } from '../componentService';
 import { StudentAssetService } from '../../services/studentAssetService';
-import { UtilService } from '../../services/utilService';
 import { Injectable } from '@angular/core';
+import { convertToPNGFile } from '../../common/canvas/canvas';
 
 @Injectable()
 export class TableService extends ComponentService {
-  constructor(
-    private StudentAssetService: StudentAssetService,
-    protected UtilService: UtilService
-  ) {
+  constructor(private StudentAssetService: StudentAssetService) {
     super();
   }
 
@@ -223,14 +220,8 @@ export class TableService extends ComponentService {
       if (tableElement != null) {
         // convert the table element to a canvas element
         html2canvas(tableElement).then((canvas) => {
-          // get the canvas as a base64 string
-          const img_b64 = canvas.toDataURL('image/png');
-
-          // get the image object
-          const imageObject = this.UtilService.getImageObjectFromBase64String(img_b64);
-
-          // add the image to the student assets
-          this.StudentAssetService.uploadAsset(imageObject).then((asset) => {
+          const pngFile = convertToPNGFile(canvas);
+          this.StudentAssetService.uploadAsset(pngFile).then((asset) => {
             resolve(asset);
           });
         });

--- a/src/assets/wise5/services/utilService.ts
+++ b/src/assets/wise5/services/utilService.ts
@@ -2,6 +2,7 @@
 
 import { formatDate } from '@angular/common';
 import { Inject, Injectable, LOCALE_ID } from '@angular/core';
+import { convertToPNGFile } from '../common/canvas/canvas';
 import { copy } from '../common/object/object';
 import '../lib/jquery/jquery-global';
 
@@ -16,34 +17,6 @@ export class UtilService {
     return str;
   }
 
-  getImageObjectFromBase64String(img_b64) {
-    const blob = this.dataURItoBlob(img_b64);
-    const now = new Date().getTime();
-    const filename = encodeURIComponent('picture_' + now + '.png');
-    const pngFile = new File([blob], filename, {
-      lastModified: now, // optional - default = now
-      type: 'image/png' // optional - default = ''
-    });
-    return pngFile;
-  }
-
-  /**
-   * Convert base64/URLEncoded data component to raw binary data held in a string
-   * @param dataURI base64/URLEncoded data
-   * @returns a Blob object
-   */
-  dataURItoBlob(dataURI) {
-    let byteString;
-    if (dataURI.split(',')[0].indexOf('base64') >= 0) byteString = atob(dataURI.split(',')[1]);
-    else byteString = unescape(dataURI.split(',')[1]);
-    const mimeString = dataURI.split(',')[0].split(':')[1].split(';')[0];
-    const ia = new Uint8Array(byteString.length);
-    for (let i = 0; i < byteString.length; i++) {
-      ia[i] = byteString.charCodeAt(i);
-    }
-    return new Blob([ia], { type: mimeString });
-  }
-
   /**
    * Get an image object from an image element
    * @param imageElement an image element (<img src='abc.jpg'/>)
@@ -55,8 +28,7 @@ export class UtilService {
     canvas.height = imageElement.naturalHeight;
     const ctx = canvas.getContext('2d');
     ctx.drawImage(imageElement, 0, 0);
-    const dataURL = canvas.toDataURL('image/png');
-    return this.getImageObjectFromBase64String(dataURL);
+    return convertToPNGFile(canvas);
   }
 
   isImage(fileName: string): boolean {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13883,7 +13883,7 @@ Are you ready to receive feedback on this answer?</source>
         <source>Concept Map</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/conceptMapService.ts</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4d5d5b4e6b3c3a79914e4c5a72054018599ac2c4" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -8860,7 +8860,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">396</context>
+          <context context-type="linenumber">397</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8352660755693654653" datatype="html">
@@ -13035,7 +13035,7 @@ Are you ready to receive feedback on this answer?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7885570895165894241" datatype="html">
@@ -13841,7 +13841,7 @@ Label: <x id="PH" equiv-text="linkLabel"/></source>
         <source>You have no more chances to receive feedback on your answer.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">324</context>
+          <context context-type="linenumber">325</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1088900768760788337" datatype="html">
@@ -13850,7 +13850,7 @@ Label: <x id="PH" equiv-text="linkLabel"/></source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">327</context>
+          <context context-type="linenumber">328</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
@@ -13861,11 +13861,11 @@ Are you ready to receive feedback on this answer?</source>
         <source>Feedback</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">405</context>
+          <context context-type="linenumber">406</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">414</context>
+          <context context-type="linenumber">415</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/componentAnnotations/component-annotations.component.ts</context>
@@ -13876,14 +13876,14 @@ Are you ready to receive feedback on this answer?</source>
         <source>Are you sure you want to reset your work?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">1413</context>
+          <context context-type="linenumber">1414</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3948212117337409586" datatype="html">
         <source>Concept Map</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/conceptMapService.ts</context>
-          <context context-type="linenumber">23</context>
+          <context context-type="linenumber">24</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4d5d5b4e6b3c3a79914e4c5a72054018599ac2c4" datatype="html">
@@ -14705,21 +14705,21 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Are you sure you want to clear your drawing?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/draw/draw-student/draw-student.component.ts</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">199</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7020890278107204483" datatype="html">
         <source>Do you want to update the connected drawing?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/draw/draw-student/draw-student.component.ts</context>
-          <context context-type="linenumber">285</context>
+          <context context-type="linenumber">286</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8647687729200262691" datatype="html">
         <source>Draw</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/draw/drawService.ts</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4712f427e9539919676da90b406d1ca87f18ec22" datatype="html">
@@ -14797,7 +14797,7 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Embedded (Custom)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/embedded/embeddedService.ts</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cc50767a953f7987117890731c4a78c74f735016" datatype="html">
@@ -15603,42 +15603,42 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Are you sure you want to overwrite the current line data?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">236</context>
+          <context context-type="linenumber">237</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6882380861047606832" datatype="html">
         <source>The series you are trying to add a point to is currently hidden. Please show the series by clicking the series name in the legend and try adding the point again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1089</context>
+          <context context-type="linenumber">1090</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2852989551014711458" datatype="html">
         <source>You can not edit this series. Please choose a series that can be edited.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1103</context>
+          <context context-type="linenumber">1104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7053114367342967943" datatype="html">
         <source>Are you sure you want to reset the series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1381</context>
+          <context context-type="linenumber">1382</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7889560203726829643" datatype="html">
         <source>Are you sure you want to reset the &quot;<x id="PH" equiv-text="seriesName"/>&quot; series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1383</context>
+          <context context-type="linenumber">1384</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6999515396807067782" datatype="html">
         <source>Trial</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1936</context>
+          <context context-type="linenumber">1937</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
@@ -15649,42 +15649,42 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Graph</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graphService.ts</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">26</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7500488806315952979" datatype="html">
         <source>Time (seconds)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graphService.ts</context>
-          <context context-type="linenumber">47</context>
+          <context context-type="linenumber">48</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2155832126259145609" datatype="html">
         <source>s</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graphService.ts</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2074112513968400781" datatype="html">
         <source>Position (meters)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graphService.ts</context>
-          <context context-type="linenumber">59</context>
+          <context context-type="linenumber">60</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8033953731717586115" datatype="html">
         <source>m</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graphService.ts</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">73</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2165011258157601810" datatype="html">
         <source>Prediction</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graphService.ts</context>
-          <context context-type="linenumber">78</context>
+          <context context-type="linenumber">79</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1391027585017325946" datatype="html">
@@ -15883,7 +15883,7 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-student/label-student.component.ts</context>
-          <context context-type="linenumber">743</context>
+          <context context-type="linenumber">739</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d0416d769e2f5f38e271f36c0e263f02e2f3b603" datatype="html">
@@ -15904,28 +15904,28 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>A New Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-student/label-student.component.ts</context>
-          <context context-type="linenumber">485</context>
+          <context context-type="linenumber">486</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4546757591980718173" datatype="html">
         <source>Are you sure you want to reset to the initial state?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-student/label-student.component.ts</context>
-          <context context-type="linenumber">849</context>
+          <context context-type="linenumber">845</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4725019513729542053" datatype="html">
         <source>Are you sure you want to delete the background image?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-student/label-student.component.ts</context>
-          <context context-type="linenumber">910</context>
+          <context context-type="linenumber">906</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4077520913910941990" datatype="html">
         <source>Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/labelService.ts</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">26</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a7d56850122574ce933b94051d73d65817e8369b" datatype="html">
@@ -17851,7 +17851,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Table</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/tableService.ts</context>
-          <context context-type="linenumber">19</context>
+          <context context-type="linenumber">16</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9e0eaab2042cd18d46b66c7fafc914b7e54b91c3" datatype="html">
@@ -18574,21 +18574,21 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">672</context>
+          <context context-type="linenumber">644</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5275881069346355759" datatype="html">
         <source>Auto Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">677</context>
+          <context context-type="linenumber">649</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2692433425768915750" datatype="html">
         <source>Submitted <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">682</context>
+          <context context-type="linenumber">654</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846fecebb7756c6127955bc2c08d2111dce64c3c" datatype="html">


### PR DESCRIPTION
## Changes
- Move ```UtilService.getImageObjectFromBase64String(string)``` to ```convertToPNGFile(HTMLCanvasElement)``` in new canvas.ts file
- Update references
   - Remove UtilService dependency from classes if class no longer uses it
- Add test for new function

## Test
- Snipping images to notebook works as before from components like table, graph, draw
- Import work that uses this function works as before, like 
   - [table/graph/draw] -> draw
   - draw -> graph
   - draw -> label

Closes #998