### PR TITLE
fix(Authoring): Select step drop down

### DIFF
--- a/src/assets/wise5/authoringTool/authoring-tool.module.ts
+++ b/src/assets/wise5/authoringTool/authoring-tool.module.ts
@@ -16,6 +16,7 @@ import { ProjectLibraryService } from '../services/projectLibraryService';
 import { AuthoringToolComponent } from '../authoringTool/authoringToolComponent';
 import { MainAuthoringComponent } from '../authoringTool/main/mainAuthoringComponent';
 import { WiseAuthoringTinymceEditorComponent } from '../directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component';
+import { StepToolsComponent } from '../common/stepTools/step-tools.component';
 
 export default angular
   .module('authoringTool', [
@@ -31,6 +32,10 @@ export default angular
     'structureAuthoringModule',
     'ui.router'
   ])
+  .directive(
+    'stepTools',
+    downgradeComponent({ component: StepToolsComponent }) as angular.IDirectiveFactory
+  )
   .directive(
     'wiseAuthoringTinymceEditor',
     downgradeComponent({


### PR DESCRIPTION
## Changes

Added back select step drop down to Authoring Tool.

## Test

Make sure the select step drop down shows up near the top of the Authoring Tool and lets you jump to steps.

Closes #1017