### PR TITLE
fix(Config): Retrieve config when new workgroup joins run

### DIFF
--- a/src/assets/wise5/services/classroomStatusService.ts
+++ b/src/assets/wise5/services/classroomStatusService.ts
@@ -76,14 +76,19 @@ export class ClassroomStatusService {
     return null;
   }
 
-  setStudentStatus(studentStatus) {
+  setStudentStatus(studentStatus: any): void {
+    let isStudentStatusFound = false;
     const studentStatuses = this.getStudentStatuses();
     for (let x = 0; x < studentStatuses.length; x++) {
       const aStudentStatus = studentStatuses[x];
       if (aStudentStatus.workgroupId === studentStatus.workgroupId) {
         studentStatuses.splice(x, 1, studentStatus);
+        isStudentStatusFound = true;
         break;
       }
+    }
+    if (!isStudentStatusFound) {
+      studentStatuses.push(studentStatus);
     }
   }
 

--- a/src/assets/wise5/services/studentWebSocketService.ts
+++ b/src/assets/wise5/services/studentWebSocketService.ts
@@ -9,11 +9,13 @@ import { ProjectService } from './projectService';
 import { Message } from '@stomp/stompjs';
 import { NotebookService } from './notebookService';
 import { StompService } from './stompService';
+import { ConfigService } from './configService';
 
 @Injectable()
 export class StudentWebSocketService {
   constructor(
     private AnnotationService: AnnotationService,
+    private configService: ConfigService,
     private NodeService: NodeService,
     private notebookService: NotebookService,
     private ProjectService: ProjectService,
@@ -28,44 +30,46 @@ export class StudentWebSocketService {
   }
 
   subscribeToClassroomTopic(): void {
-    this.stompService.periodMessage$
-      .subscribe((message: Message) => {
-        const body = JSON.parse(message.body);
-        if (body.type === 'studentWork') {
-          const studentWork = JSON.parse(body.content);
-          this.StudentDataService.broadcastStudentWorkReceived(studentWork);
-        } else if (body.type === 'annotation') {
-          const annotation = JSON.parse(body.content);
-          this.AnnotationService.broadcastAnnotationReceived({ annotation: annotation });
-        } else if (body.type === 'goToNode') {
-          this.goToStep(body.content);
-        } else if (body.type === 'node') {
-          this.updateNode(body.content);
-        }
-      });
+    this.stompService.periodMessage$.subscribe((message: Message) => {
+      const body = JSON.parse(message.body);
+      if (body.type === 'studentWork') {
+        const studentWork = JSON.parse(body.content);
+        this.StudentDataService.broadcastStudentWorkReceived(studentWork);
+      } else if (body.type === 'annotation') {
+        const annotation = JSON.parse(body.content);
+        this.AnnotationService.broadcastAnnotationReceived({ annotation: annotation });
+      } else if (body.type === 'goToNode') {
+        this.goToStep(body.content);
+      } else if (body.type === 'node') {
+        this.updateNode(body.content);
+      } else if (body.type === 'newWorkgroupJoinedRun') {
+        this.configService.retrieveConfig(
+          `/api/config/studentRun/${this.configService.getRunId()}`
+        );
+      }
+    });
   }
 
   subscribeToWorkgroupTopic(): void {
-    this.stompService.workgroupMessage$
-      .subscribe((message: Message) => {
-        const body = JSON.parse(message.body);
-        if (body.type === 'annotation') {
-          const annotationData = JSON.parse(body.content);
-          this.AnnotationService.addOrUpdateAnnotation(annotationData);
-          this.handleAnnotationReceived(annotationData);
-        } else if (body.type === 'tagsToWorkgroup') {
-          const tags = JSON.parse(body.content);
-          this.TagService.setTags(tags);
-          this.StudentDataService.updateNodeStatuses();
-          this.NodeService.evaluateTransitionLogic();
-        } else if (body.type === 'goToNode') {
-          this.goToStep(body.content);
-        } else if (body.type === 'goToNextNode') {
-          this.goToNextStep();
-        } else if (body.type === 'classmateStudentWork') {
-          this.StudentDataService.broadcastStudentWorkReceived(JSON.parse(body.content));
-        }
-      });
+    this.stompService.workgroupMessage$.subscribe((message: Message) => {
+      const body = JSON.parse(message.body);
+      if (body.type === 'annotation') {
+        const annotationData = JSON.parse(body.content);
+        this.AnnotationService.addOrUpdateAnnotation(annotationData);
+        this.handleAnnotationReceived(annotationData);
+      } else if (body.type === 'tagsToWorkgroup') {
+        const tags = JSON.parse(body.content);
+        this.TagService.setTags(tags);
+        this.StudentDataService.updateNodeStatuses();
+        this.NodeService.evaluateTransitionLogic();
+      } else if (body.type === 'goToNode') {
+        this.goToStep(body.content);
+      } else if (body.type === 'goToNextNode') {
+        this.goToNextStep();
+      } else if (body.type === 'classmateStudentWork') {
+        this.StudentDataService.broadcastStudentWorkReceived(JSON.parse(body.content));
+      }
+    });
   }
 
   handleAnnotationReceived(annotation: any): void {


### PR DESCRIPTION
Test with
- https://github.com/WISE-Community/WISE-API/pull/208

## Changes

Listen for a websocket message when a new workgroup is created and then re-retrieve the config to get the new workgroup information.

## Test

Student test
1. Create a run or use an existing run that contains a Discussion step
2. Have workgroup 1 launch the run and go to the Discussion step
3. In another browser, have a new student (workgroup 2) add the unit and launch the run
4. Have workgroup 2 go to the Discussion step and submit a message
5. Go back to the workgroup 1 browser and make sure the Discussion message from workgroup 2 contains workgroup 2's name

Teacher test
1. Sign in as a teacher
2. Load the Classroom Monitor for a run
3. Go to the Manage Students view
4. In another browser, have a new student add the unit and launch the run
5. Go back to the teacher browser and make sure the new workgroup automatically shows up in the Manage Students view

Closes #1021