### PR TITLE
build(NPM): Run npm install inside Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,6 @@
-FROM node:14.17-alpine
-RUN apk add chromium
-ENV CHROME_BIN='/usr/bin/chromium-browser'
-RUN apk --no-cache add --virtual native-deps \
-    g++ gcc libgcc libstdc++ linux-headers make python3 && \
-    npm install --quiet node-gyp -g
-
+FROM node:18
+RUN apt-get update && apt-get install build-essential \
+    libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev -y
 WORKDIR /app
-
-COPY package*.json ./
-RUN npm install --prefer-dedupe
-
-COPY . .
 
 CMD ["npm", "run", "serve-dev"]

--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
     "webpack-node-externals": "^1.7.2"
   },
   "scripts": {
-    "serve-dev": "node --max_old_space_size=6144 ./node_modules/@angular/cli/bin/ng serve --hmr --host 0.0.0.0",
+    "install-dev-deps": "(node -e \"if (! require('fs').existsSync('./node_modules')){process.exit(1)} \" || npm ci)",
+    "serve-dev": "npm run install-dev-deps && node --max_old_space_size=6144 ./node_modules/@angular/cli/bin/ng serve --hmr --host 0.0.0.0",
     "build-prod": "node --max_old_space_size=6144 ./node_modules/@angular/cli/bin/ng build --configuration production; gulp copy-site-styles",
     "bundle-report": "node ./node_modules/webpack-bundle-analyzer/lib/bin/analyzer.js dist/stats.json",
     "prettier-format": "prettier --config .prettierrc 'src' --write",

--- a/src/app/services/wiseLinkService.ts
+++ b/src/app/services/wiseLinkService.ts
@@ -32,7 +32,7 @@ export class WiseLinkService {
   }
 
   removeWiseLinkClickedListener(): void {
-    this.getWiseLinkCommunicator().removeEventListener(
+    this.getWiseLinkCommunicator()?.removeEventListener(
       this.wiseLinkClickedEventName,
       this.wiseLinkClickedHandler
     );

--- a/src/app/teacher/classroom-monitor.module.ts
+++ b/src/app/teacher/classroom-monitor.module.ts
@@ -149,13 +149,17 @@ import { ShowNodeInfoDialogComponent } from '../classroom-monitor/show-node-info
 })
 export class ClassroomMonitorModule {
   constructor(private injector: Injector) {
-    customElements.define(
-      'milestone-report-data',
-      createCustomElement(MilestoneReportDataComponent, { injector: this.injector })
-    );
-    customElements.define(
-      'milestone-report-graph',
-      createCustomElement(MilestoneReportGraphComponent, { injector: this.injector })
-    );
+    if (!customElements.get('milestone-report-data')) {
+      customElements.define(
+        'milestone-report-data',
+        createCustomElement(MilestoneReportDataComponent, { injector: this.injector })
+      );
+    }
+    if (!customElements.get('milestone-report-graph')) {
+      customElements.define(
+        'milestone-report-graph',
+        createCustomElement(MilestoneReportGraphComponent, { injector: this.injector })
+      );
+    }
   }
 }


### PR DESCRIPTION
## Changes
- Run ```npm install``` inside the wise-client Docker container. Before, we were running it on our different devices/OS's, which resulted in hard-to-reproduce behaviors. This will make the development environment more similar for all developers, which should make it easier for us to troubleshoot issues in the future. 
- Upgrade Node inside the wise-client container from 14 to 18.
- Use Debian base image instead of Alpine base image for wise-client container. This results in a bigger container size, but makes troubleshooting issues much easier because there are more resources for Debian compared to Alpine. I made this change after struggling on an issue related to building canvas from source using Alpine libraries.
- Fix issues related to hot reload (see notes below)

## Test Prep
In WISE-Docker-Dev/docker-compose.yml, change 
```
  wise-client:
    image: wiseberkeley/wise-client-dev:latest
```
to
```
  wise-client:
    image: wiseberkeley/wise-client-dev:v9
```

Until this PR is merged into develop, remember to set it back to latest when you switch branches.

## Test
- Remove node_modules folder, then run ```docker compose up``` in WISE-Docker-Dev folder to start up the applications. WISE should start up after some time because it will run ```npm install``` (it took me about 4 min 15 sec). 
   - Test that WISE works as before. Make small changes and see that it does a hot reload.
- Stop the Docker processes and then run ```docker compose up``` in WISE-Docker-Dev folder to start up the applications again. This time, it shouldn't take as much time to start because we don't need to run ```npm install```. 
   - Test that WISE works as before. Make small changes and see that it does a hot reload.

## A note about hot reload during development
The new node version (14->18) created an unexpected behavior in the VLE and CM when a hot reload occurs during development. I fixed the VLE (see wiseLinkeService.ts) and the CM (see classroom-monitor.module.ts) so that the pages load and display correctly. Without those changes, the application threw js errors and did not render the pages completely.

One issue still remains, which is related to using customElements for MilestoneReportGraph and MilestoneReportData (see classroom-monitor.module.ts). The check that I added allows the CM to display correctly on hot-reload, but the elements do not render when you open the Milestone. If you need to test either of those elements, the worked-around for now is to refresh the page. 

Closes #1023