### PR TITLE
fix(Access Code): Remove error message when access code is valid

### DIFF
--- a/src/app/student/add-project-dialog/add-project-dialog.component.ts
+++ b/src/app/student/add-project-dialog/add-project-dialog.component.ts
@@ -86,6 +86,7 @@ export class AddProjectDialogComponent implements OnInit {
       if (runInfo.wiseVersion === 4) {
         this.setInvalidRunCode();
       } else {
+        this.addProjectForm.controls['runCode'].setErrors(null);
         this.registerRunPeriods = runInfo.periods;
         this.addProjectForm.controls['period'].enable();
       }


### PR DESCRIPTION
## Changes

Remove error message when access code is quickly changed to a valid value.

## Test

1. Get the Access Code for a run (we will use the example Panda1234)
2. Sign in as a student
3. Click "Add Unit"
4. In the "Access Code" input type in Panda1235. You should correctly see the "Invalid Access Code" error message.
5. Quickly delete the 5 and type 4. Previously sometimes you would still see the "Invalid Access Code" error message even though you shouldn't because the Access Code is now correct. Try this quickly several times to make sure the error code properly goes away when the Access Code becomes valid.

Closes #1028