### PR TITLE
fix(Export): Incorrect student work order

### DIFF
--- a/src/assets/wise5/services/teacherDataService.ts
+++ b/src/assets/wise5/services/teacherDataService.ts
@@ -269,9 +269,16 @@ export class TeacherDataService extends DataService {
   }
 
   processComponentStates(componentStates) {
+    this.initializeComponentStatesDataStructures();
     for (const componentState of componentStates) {
       this.addOrUpdateComponentState(componentState);
     }
+  }
+
+  initializeComponentStatesDataStructures(): void {
+    this.studentData.componentStatesByWorkgroupId = {};
+    this.studentData.componentStatesByNodeId = {};
+    this.studentData.componentStatesByComponentId = {};
   }
 
   processEvents(events) {
@@ -306,12 +313,18 @@ export class TeacherDataService extends DataService {
   }
 
   processAnnotations(annotations) {
+    this.initializeAnnotationsDataStructures();
     this.studentData.annotations = annotations;
     for (const annotation of annotations) {
       this.addAnnotationToAnnotationsToWorkgroupId(annotation);
       this.addAnnotationToAnnotationsByNodeId(annotation);
     }
     this.AnnotationService.setAnnotations(this.studentData.annotations);
+  }
+
+  initializeAnnotationsDataStructures(): void {
+    this.studentData.annotationsByNodeId = {};
+    this.studentData.annotationsToWorkgroupId = {};
   }
 
   addAnnotationToAnnotationsToWorkgroupId(annotation) {


### PR DESCRIPTION
## Changes

Clear out the component state and annotation data structures before loading in the component state and annotation data retrieved from the server.

## Test

1. Sign in as a teacher and open the Classroom Monitor for a run
2. In another browser or incognito, sign in as a student to that run and save work (like 'Hello World1' in an Open Response)
3. Go back to the teacher browser and go to the Data Export view
4. Click "Export All Work"
5. Click "Export". Previously, the new student work 'Hello World 1' would show up at the top of the export rows for that workgroup but it should be at the bottom. With this fix it should now properly show up at the bottom for that workgroup since it's the newest student work.

Closes #1040