### PR TITLE
refactor(UtilService): Move wordWrap()

### DIFF
--- a/src/assets/wise5/common/string/string.spec.ts
+++ b/src/assets/wise5/common/string/string.spec.ts
@@ -1,4 +1,4 @@
-import { isValidJSONString } from './string';
+import { isValidJSONString, wordWrap } from './string';
 
 describe('isValidJSONString()', () => {
   it('should return true if json string is valid', () => {
@@ -11,5 +11,12 @@ describe('isValidJSONString()', () => {
   it('should return false for invalid json strings', () => {
     const invalidJSON = '{"a":1,"b":2';
     expect(isValidJSONString(invalidJSON)).toBeFalsy();
+  });
+});
+
+describe('wordWrap()', () => {
+  it('should break string into multiple lines', () => {
+    const string = 'A string with more than 20 characters.';
+    expect(wordWrap(string, 20)).toEqual('A string with more\nthan 20 characters.');
   });
 });

--- a/src/assets/wise5/common/string/string.spec.ts
+++ b/src/assets/wise5/common/string/string.spec.ts
@@ -19,4 +19,9 @@ describe('wordWrap()', () => {
     const string = 'A string with more than 20 characters.';
     expect(wordWrap(string, 20)).toEqual('A string with more\nthan 20 characters.');
   });
+
+  it('should not break string into multiple lines if string is same length or shorter than the wrap limit', () => {
+    const string = 'A short string.';
+    expect(wordWrap(string, 20)).toEqual('A short string.');
+  });
 });

--- a/src/assets/wise5/common/string/string.ts
+++ b/src/assets/wise5/common/string/string.ts
@@ -6,3 +6,52 @@ export function isValidJSONString(str: string): boolean {
     return false;
   }
 }
+
+/**
+ * Takes a string and breaks it up into multiple lines so that the length of
+ * each line does not exceed a certain number of characters. This code was
+ * found on stackoverflow.
+ * https://stackoverflow.com/questions/14484787/wrap-text-in-javascript
+ * @param str The string to break up.
+ * @param maxWidth The max width of a line.
+ * @return A string that has been broken up into multiple lines using \n.
+ */
+export function wordWrap(str, maxWidth) {
+  if (str.length <= maxWidth) {
+    return str;
+  }
+  let newLineStr = '\n';
+  let done = false;
+  let res = '';
+  do {
+    let found = false;
+    // Inserts new line at first whitespace of the line
+    for (let i = maxWidth - 1; i >= 0; i--) {
+      if (testWhite(str.charAt(i))) {
+        res = res + [str.slice(0, i), newLineStr].join('');
+        str = str.slice(i + 1);
+        found = true;
+        break;
+      }
+    }
+    // Inserts new line at maxWidth position, the word is too long to wrap
+    if (!found) {
+      res += [str.slice(0, maxWidth), newLineStr].join('');
+      str = str.slice(maxWidth);
+    }
+
+    if (str.length < maxWidth) done = true;
+  } while (!done);
+
+  return res + str;
+}
+
+/**
+ * Helper function for wordWrap().
+ * @param x A single character string.
+ * @return Whether the single character is a whitespace character.
+ */
+function testWhite(x) {
+  let white = new RegExp(/^\s$/);
+  return white.test(x.charAt(0));
+}

--- a/src/assets/wise5/components/label/label-student/label-student.component.ts
+++ b/src/assets/wise5/components/label/label-student/label-student.component.ts
@@ -12,6 +12,7 @@ import { LabelService } from '../labelService';
 import { StudentAssetService } from '../../../services/studentAssetService';
 import { MatDialog } from '@angular/material/dialog';
 import { convertToPNGFile } from '../../../common/canvas/canvas';
+import { wordWrap } from '../../../common/string/string';
 
 @Component({
   selector: 'label-student',
@@ -711,7 +712,7 @@ export class LabelStudent extends ComponentStudent {
   wrapTextIfNecessary(text: string): string {
     let wrappedText = text;
     if (this.componentContent.labelWidth != null && this.componentContent.labelWidth !== '') {
-      wrappedText = this.UtilService.wordWrap(text, this.componentContent.labelWidth);
+      wrappedText = wordWrap(text, this.componentContent.labelWidth);
     }
     return wrappedText;
   }

--- a/src/assets/wise5/components/label/labelService.ts
+++ b/src/assets/wise5/components/label/labelService.ts
@@ -7,6 +7,7 @@ import { StudentAssetService } from '../../services/studentAssetService';
 import { Injectable } from '@angular/core';
 import { UtilService } from '../../services/utilService';
 import { convertToPNGFile } from '../../common/canvas/canvas';
+import { wordWrap } from '../../common/string/string';
 
 @Injectable()
 export class LabelService extends ComponentService {
@@ -233,7 +234,7 @@ export class LabelService extends ComponentService {
      * Line wrap the text so that each line does not exceed the max number of
      * characters.
      */
-    const textWrapped = this.UtilService.wordWrap(text, maxCharactersPerLine);
+    const textWrapped = wordWrap(text, maxCharactersPerLine);
 
     // create a div to draw the SVG in
     const svgElement = document.createElement('div');
@@ -487,7 +488,7 @@ export class LabelService extends ComponentService {
 
     let wrappedTextString = textString;
     if (labelWidth != null) {
-      wrappedTextString = this.UtilService.wordWrap(textString, labelWidth);
+      wrappedTextString = wordWrap(textString, labelWidth);
     }
 
     // create an editable text element

--- a/src/assets/wise5/services/utilService.ts
+++ b/src/assets/wise5/services/utilService.ts
@@ -171,55 +171,6 @@ export class UtilService {
   }
 
   /**
-   * Takes a string and breaks it up into multiple lines so that the length of
-   * each line does not exceed a certain number of characters. This code was
-   * found on stackoverflow.
-   * https://stackoverflow.com/questions/14484787/wrap-text-in-javascript
-   * @param str The string to break up.
-   * @param maxWidth The max width of a line.
-   * @return A string that has been broken up into multiple lines using \n.
-   */
-  wordWrap(str, maxWidth) {
-    if (str.length <= maxWidth) {
-      return str;
-    }
-    let newLineStr = '\n';
-    let done = false;
-    let res = '';
-    do {
-      let found = false;
-      // Inserts new line at first whitespace of the line
-      for (let i = maxWidth - 1; i >= 0; i--) {
-        if (this.testWhite(str.charAt(i))) {
-          res = res + [str.slice(0, i), newLineStr].join('');
-          str = str.slice(i + 1);
-          found = true;
-          break;
-        }
-      }
-      // Inserts new line at maxWidth position, the word is too long to wrap
-      if (!found) {
-        res += [str.slice(0, maxWidth), newLineStr].join('');
-        str = str.slice(maxWidth);
-      }
-
-      if (str.length < maxWidth) done = true;
-    } while (!done);
-
-    return res + str;
-  }
-
-  /**
-   * Helper function for wordWrap().
-   * @param x A single character string.
-   * @return Whether the single character is a whitespace character.
-   */
-  testWhite(x) {
-    let white = new RegExp(/^\s$/);
-    return white.test(x.charAt(0));
-  }
-
-  /**
    * Get the number of words in the string.
    * @param str The string.
    * @return The number of words in the string.

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15983,7 +15983,7 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-student/label-student.component.ts</context>
-          <context context-type="linenumber">739</context>
+          <context context-type="linenumber">740</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d0416d769e2f5f38e271f36c0e263f02e2f3b603" datatype="html">
@@ -16004,28 +16004,28 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>A New Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-student/label-student.component.ts</context>
-          <context context-type="linenumber">486</context>
+          <context context-type="linenumber">487</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4546757591980718173" datatype="html">
         <source>Are you sure you want to reset to the initial state?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-student/label-student.component.ts</context>
-          <context context-type="linenumber">845</context>
+          <context context-type="linenumber">846</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4725019513729542053" datatype="html">
         <source>Are you sure you want to delete the background image?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-student/label-student.component.ts</context>
-          <context context-type="linenumber">906</context>
+          <context context-type="linenumber">907</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4077520913910941990" datatype="html">
         <source>Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/labelService.ts</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a7d56850122574ce933b94051d73d65817e8369b" datatype="html">
@@ -18681,21 +18681,21 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">352</context>
+          <context context-type="linenumber">303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5275881069346355759" datatype="html">
         <source>Auto Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">357</context>
+          <context context-type="linenumber">308</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2692433425768915750" datatype="html">
         <source>Submitted <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">362</context>
+          <context context-type="linenumber">313</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846fecebb7756c6127955bc2c08d2111dce64c3c" datatype="html">


### PR DESCRIPTION
## Changes
- Move UtilService.wordWrap() to string.ts and update references

## Test
- Add a label to a Label component with more than 20 characters and make sure the text wraps so no lines are longer than 20 characters.
- Create a Label component that imports from an Open Response. Make sure the background image that is generated from the OR content wraps at the specified number of characters.

Closes #1025