### PR TITLE
fix(Peer Chat): Preview get annotations console error

### DIFF
--- a/src/app/services/studentPeerGroupService.spec.ts
+++ b/src/app/services/studentPeerGroupService.spec.ts
@@ -53,35 +53,37 @@ describe('StudentPeerGroupService', () => {
   retrievePeerGroupWork();
   retrieveQuestionBankStudentData();
   retrieveDynamicPromptStudentData();
+  retrievePeerGroupAnnotations();
 });
 
-function setIsPreviewAndIsSignedInAsTeacher(isPreview: boolean, isSignedInUserATeacher: boolean) {
+function setIsPreview(isPreview: boolean) {
   spyOn(configService, 'isPreview').and.returnValue(isPreview);
-  spyOn(configService, 'isSignedInUserATeacher').and.returnValue(isSignedInUserATeacher);
 }
 
 function spyOnHttpGetAndReturnObservableOfValue(value: any) {
-  return spyOn(http, 'get').and.returnValue(of(peerGroup1));
+  return spyOn(http, 'get').and.returnValue(of(value));
 }
 
 function retrievePeerGroup() {
-  it('should retrieve peer group in preview', () => {
-    setIsPreviewAndIsSignedInAsTeacher(true, false);
-    retrieveAndExpectDummyPeerGroup();
-  });
+  describe('retrievePeerGroup()', () => {
+    it('should retrieve peer group in preview', () => {
+      setIsPreview(true);
+      retrieveAndExpectDummyPeerGroup();
+    });
 
-  it('should retrieve peer group for teacher preview', () => {
-    setIsPreviewAndIsSignedInAsTeacher(false, true);
-    retrieveAndExpectDummyPeerGroup();
-  });
+    it('should retrieve peer group for teacher preview', () => {
+      setIsPreview(false);
+      retrieveAndExpectDummyPeerGroup();
+    });
 
-  it('should retrieve peer group from api', () => {
-    setIsPreviewAndIsSignedInAsTeacher(false, false);
-    const httpGetSpy = spyOnHttpGetAndReturnObservableOfValue(peerGroup1);
-    service.retrievePeerGroup(peerGroupingTag1, workgroupId1).subscribe(() => {
-      expect(httpGetSpy).toHaveBeenCalledWith(
-        `/api/peer-group/${runId1}/${workgroupId1}/${peerGroupingTag1}`
-      );
+    it('should retrieve peer group from api', () => {
+      setIsPreview(false);
+      const httpGetSpy = spyOnHttpGetAndReturnObservableOfValue(peerGroup1);
+      service.retrievePeerGroup(peerGroupingTag1, workgroupId1).subscribe(() => {
+        expect(httpGetSpy).toHaveBeenCalledWith(
+          `/api/peer-group/${runId1}/${workgroupId1}/${peerGroupingTag1}`
+        );
+      });
     });
   });
 }
@@ -96,85 +98,134 @@ function retrieveAndExpectDummyPeerGroup() {
 }
 
 function retrievePeerGroupWork() {
-  it('should retrieve peer group work in preview', () => {
-    setIsPreviewAndIsSignedInAsTeacher(true, false);
-    spyOn(studentDataService, 'getComponentStatesByNodeIdAndComponentId').and.returnValue([
-      dummyStudentData
-    ]);
-    service.retrievePeerGroupWork(peerGroup1, nodeId1, componentId1).subscribe((peerGroupWork) => {
-      expect(peerGroupWork.length).toEqual(1);
-      expect(peerGroupWork).toEqual([dummyStudentData]);
+  describe('retrievePeerGroupWork()', () => {
+    it('should retrieve peer group work in preview', () => {
+      setIsPreview(true);
+      spyOn(studentDataService, 'getComponentStatesByNodeIdAndComponentId').and.returnValue([
+        dummyStudentData
+      ]);
+      service
+        .retrievePeerGroupWork(peerGroup1, nodeId1, componentId1)
+        .subscribe((peerGroupWork) => {
+          expect(peerGroupWork.length).toEqual(1);
+          expect(peerGroupWork).toEqual([dummyStudentData]);
+        });
     });
-  });
 
-  it('should retrieve peer group work for teacher preview', () => {
-    setIsPreviewAndIsSignedInAsTeacher(false, true);
-    service.retrievePeerGroupWork(peerGroup1, nodeId1, componentId1).subscribe((peerGroupWork) => {
-      expect(peerGroupWork.length).toEqual(0);
+    it('should retrieve peer group work for teacher preview', () => {
+      setIsPreview(false);
+      service
+        .retrievePeerGroupWork(peerGroup1, nodeId1, componentId1)
+        .subscribe((peerGroupWork) => {
+          expect(peerGroupWork.length).toEqual(0);
+        });
     });
-  });
 
-  it('should retrieve peer group work from api', () => {
-    setIsPreviewAndIsSignedInAsTeacher(false, false);
-    const httpGetSpy = spyOnHttpGetAndReturnObservableOfValue(dummyStudentData);
-    service.retrievePeerGroupWork(peerGroup1, nodeId1, componentId1).subscribe(() => {
-      expect(httpGetSpy).toHaveBeenCalledWith(
-        `/api/peer-group/${peerGroup1.id}/${nodeId1}/${componentId1}/student-work`
-      );
+    it('should retrieve peer group work from api', () => {
+      setIsPreview(false);
+      const httpGetSpy = spyOnHttpGetAndReturnObservableOfValue(dummyStudentData);
+      service.retrievePeerGroupWork(peerGroup1, nodeId1, componentId1).subscribe(() => {
+        expect(httpGetSpy).toHaveBeenCalledWith(
+          `/api/peer-group/${peerGroup1.id}/${nodeId1}/${componentId1}/student-work`
+        );
+      });
     });
   });
 }
 
 function retrieveQuestionBankStudentData() {
-  it('should retrieve question bank student data in preview', () => {
-    setIsPreviewAndIsSignedInAsTeacher(true, false);
-    spyOn(projectService, 'getReferenceComponent').and.returnValue({
-      nodeId: nodeId1,
-      componentId: componentId1
-    });
-    spyOn(studentDataService, 'getLatestComponentStateByNodeIdAndComponentId').and.returnValue(
-      dummyStudentData
-    );
-    spyOn(annotationService, 'getLatestScoreAnnotation').and.returnValue(dummyAnnotation);
-    service
-      .retrieveQuestionBankStudentData(peerGroup1.id, nodeId1, componentId1)
-      .subscribe((peerGroupStudentData) => {
-        expect(peerGroupStudentData.length).toEqual(1);
-        expect(peerGroupStudentData[0].workgroup.id).toEqual(workgroupId1);
-        expect(peerGroupStudentData[0].workgroup.periodId).toEqual(periodId1);
-        expect(peerGroupStudentData[0].studentWork).toEqual(dummyStudentData);
-        expect(peerGroupStudentData[0].annotation).toEqual(dummyAnnotation);
+  describe('retrieveQuestionBankStudentData()', () => {
+    it('should retrieve question bank student data in preview', () => {
+      setIsPreview(true);
+      spyOn(projectService, 'getReferenceComponent').and.returnValue({
+        nodeId: nodeId1,
+        componentId: componentId1
       });
-  });
-
-  it('should retrieve question bank student data for teacher preview', () => {
-    setIsPreviewAndIsSignedInAsTeacher(false, true);
-    service
-      .retrieveQuestionBankStudentData(peerGroup1.id, nodeId1, componentId1)
-      .subscribe((peerGroupStudentData) => {
-        expect(peerGroupStudentData.length).toEqual(0);
-      });
-  });
-
-  it('should retrieve question bank student data from api', () => {
-    setIsPreviewAndIsSignedInAsTeacher(false, false);
-    const httpGetSpy = spyOnHttpGetAndReturnObservableOfValue(dummyStudentData);
-    service.retrieveQuestionBankStudentData(peerGroup1.id, nodeId1, componentId1).subscribe(() => {
-      expect(httpGetSpy).toHaveBeenCalledWith(
-        `/api/peer-group/${peerGroup1.id}/${nodeId1}/${componentId1}/student-data/question-bank`
+      spyOn(studentDataService, 'getLatestComponentStateByNodeIdAndComponentId').and.returnValue(
+        dummyStudentData
       );
+      spyOn(annotationService, 'getLatestScoreAnnotation').and.returnValue(dummyAnnotation);
+      service
+        .retrieveQuestionBankStudentData(peerGroup1.id, nodeId1, componentId1)
+        .subscribe((peerGroupStudentData) => {
+          expect(peerGroupStudentData.length).toEqual(1);
+          expect(peerGroupStudentData[0].workgroup.id).toEqual(workgroupId1);
+          expect(peerGroupStudentData[0].workgroup.periodId).toEqual(periodId1);
+          expect(peerGroupStudentData[0].studentWork).toEqual(dummyStudentData);
+          expect(peerGroupStudentData[0].annotation).toEqual(dummyAnnotation);
+        });
+    });
+
+    it('should retrieve question bank student data for teacher preview', () => {
+      setIsPreview(false);
+      service
+        .retrieveQuestionBankStudentData(peerGroup1.id, nodeId1, componentId1)
+        .subscribe((peerGroupStudentData) => {
+          expect(peerGroupStudentData.length).toEqual(0);
+        });
+    });
+
+    it('should retrieve question bank student data from api', () => {
+      setIsPreview(false);
+      const httpGetSpy = spyOnHttpGetAndReturnObservableOfValue(dummyStudentData);
+      service
+        .retrieveQuestionBankStudentData(peerGroup1.id, nodeId1, componentId1)
+        .subscribe(() => {
+          expect(httpGetSpy).toHaveBeenCalledWith(
+            `/api/peer-group/${peerGroup1.id}/${nodeId1}/${componentId1}/student-data/question-bank`
+          );
+        });
     });
   });
 }
 
 function retrieveDynamicPromptStudentData() {
-  it('should retrieve dynamic prompt student data from api', () => {
-    setIsPreviewAndIsSignedInAsTeacher(false, false);
-    const httpGetSpy = spyOnHttpGetAndReturnObservableOfValue(dummyStudentData);
-    service.retrieveDynamicPromptStudentData(peerGroup1.id, nodeId1, componentId1).subscribe(() => {
+  describe('retrieveDynamicPromptStudentData()', () => {
+    it('should retrieve dynamic prompt student data from api', () => {
+      setIsPreview(false);
+      const httpGetSpy = spyOnHttpGetAndReturnObservableOfValue(dummyStudentData);
+      service
+        .retrieveDynamicPromptStudentData(peerGroup1.id, nodeId1, componentId1)
+        .subscribe(() => {
+          expect(httpGetSpy).toHaveBeenCalledWith(
+            `/api/peer-group/${peerGroup1.id}/${nodeId1}/${componentId1}/student-data/dynamic-prompt`
+          );
+        });
+    });
+  });
+}
+
+function retrievePeerGroupAnnotations() {
+  describe('retrievePeerGroupAnnotations()', () => {
+    it('should retrieve peer group annotations in preview and return empty array', () => {
+      setIsPreview(true);
+      service.retrievePeerGroupAnnotations(peerGroup1, nodeId1, componentId1);
+    });
+
+    it('should retrieve peer group annotations from api request and get annotations array', () => {
+      setIsPreview(false);
+      const annotations = [
+        createAnnotation(workgroupId1, 'Delete'),
+        createAnnotation(workgroupId1, 'Undo Delete')
+      ];
+      const httpGetSpy = spyOnHttpGetAndReturnObservableOfValue(annotations);
+      service
+        .retrievePeerGroupAnnotations(peerGroup1, nodeId1, componentId1)
+        .subscribe((result) => {
+          expect(result).toEqual(annotations);
+        });
       expect(httpGetSpy).toHaveBeenCalledWith(
-        `/api/peer-group/${peerGroup1.id}/${nodeId1}/${componentId1}/student-data/dynamic-prompt`
+        `/api/peer-group/${peerGroup1.id}/${nodeId1}/${componentId1}/annotations`
       );
     });
   });
+}
+
+function createAnnotation(toWorkgroupId: number, action: string): any {
+  return {
+    componentId: componentId1,
+    data: { action: action },
+    nodeId: nodeId1,
+    toWorkgroupId: toWorkgroupId
+  };
 }

--- a/src/app/student-teacher-common-services.module.ts
+++ b/src/app/student-teacher-common-services.module.ts
@@ -48,6 +48,7 @@ import { TabulatorDataService } from '../assets/wise5/components/table/tabulator
 import { StompService } from '../assets/wise5/services/stompService';
 import { ClickToSnipImageService } from '../assets/wise5/services/clickToSnipImageService';
 import { StudentPeerGroupService } from '../assets/wise5/services/studentPeerGroupService';
+import { PeerGroupService } from '../assets/wise5/services/peerGroupService';
 
 @NgModule({
   providers: [
@@ -82,6 +83,7 @@ import { StudentPeerGroupService } from '../assets/wise5/services/studentPeerGro
     OpenResponseService,
     PathService,
     PeerChatService,
+    PeerGroupService,
     ProjectLibraryService,
     { provide: ProjectService, useExisting: VLEProjectService },
     SessionService,

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.spec.ts
@@ -6,7 +6,7 @@ import { ProjectService } from '../../../services/projectService';
 import { QuestionBank } from './QuestionBank';
 import { ComponentContent } from '../../../common/ComponentContent';
 import { QuestionBankRule } from './QuestionBankRule';
-import { StudentPeerGroupService } from '../../../services/studentPeerGroupService';
+import { PeerGroupService } from '../../../services/peerGroupService';
 import { PeerGroup } from '../PeerGroup';
 import { of } from 'rxjs';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -15,7 +15,7 @@ import { MatIconModule } from '@angular/material/icon';
 
 let component: PeerChatQuestionBankComponent;
 let fixture: ComponentFixture<PeerChatQuestionBankComponent>;
-let peerGroupService: StudentPeerGroupService;
+let peerGroupService: PeerGroupService;
 let projectService: ProjectService;
 const defaultQuestionBankRule = {
   id: 'default',
@@ -35,7 +35,7 @@ describe('PeerChatQuestionBankComponent', () => {
       declarations: [PeerChatQuestionBankComponent]
     }).compileComponents();
     fixture = TestBed.createComponent(PeerChatQuestionBankComponent);
-    peerGroupService = TestBed.inject(StudentPeerGroupService);
+    peerGroupService = TestBed.inject(PeerGroupService);
     projectService = TestBed.inject(ProjectService);
     component = fixture.componentInstance;
     component.content = {

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Observable } from 'rxjs';
-import { StudentPeerGroupService } from '../../../services/studentPeerGroupService';
+import { PeerGroupService } from '../../../services/peerGroupService';
 import { ProjectService } from '../../../services/projectService';
 import { OpenResponseContent } from '../../openResponse/OpenResponseContent';
 import { QuestionBank } from './QuestionBank';
@@ -26,10 +26,7 @@ export class PeerChatQuestionBankComponent implements OnInit {
   @Output() displayedQuestionBankRulesChange = new EventEmitter<QuestionBankRule[]>();
   questions: string[];
 
-  constructor(
-    private peerGroupService: StudentPeerGroupService,
-    private projectService: ProjectService
-  ) {}
+  constructor(private peerGroupService: PeerGroupService, private projectService: ProjectService) {}
 
   ngOnInit(): void {
     if (this.displayedQuestionBankRules == null) {

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.spec.ts
@@ -5,7 +5,7 @@ import { AnnotationService } from '../../../services/annotationService';
 import { ConfigService } from '../../../services/configService';
 import { NotebookService } from '../../../services/notebookService';
 import { NotificationService } from '../../../services/notificationService';
-import { StudentPeerGroupService } from '../../../services/studentPeerGroupService';
+import { PeerGroupService } from '../../../services/peerGroupService';
 import { ProjectService } from '../../../services/projectService';
 import { SessionService } from '../../../services/sessionService';
 import { StudentAssetService } from '../../../services/studentAssetService';
@@ -150,7 +150,6 @@ describe('PeerChatStudentComponent', () => {
         SessionService,
         StudentAssetService,
         StudentDataService,
-        StudentPeerGroupService,
         StudentWebSocketService,
         TagService
       ]
@@ -166,16 +165,14 @@ describe('PeerChatStudentComponent', () => {
       return workgroupId === teacherWorkgroupId;
     });
     spyOn(TestBed.inject(ProjectService), 'getThemeSettings').and.returnValue({});
-    retrievePeerGroupSpy = spyOn(TestBed.inject(StudentPeerGroupService), 'retrievePeerGroup');
+    retrievePeerGroupSpy = spyOn(TestBed.inject(PeerGroupService), 'retrievePeerGroup');
     retrievePeerGroupSpy.and.callFake(() => {
       return of(peerGroup);
     });
-    spyOn(TestBed.inject(StudentPeerGroupService), 'retrievePeerGroupWork').and.returnValue(
+    spyOn(TestBed.inject(PeerGroupService), 'retrievePeerGroupWork').and.returnValue(
       of([componentState1, componentState2])
     );
-    spyOn(TestBed.inject(StudentPeerGroupService), 'retrievePeerGroupAnnotations').and.returnValue(
-      of([])
-    );
+    spyOn(TestBed.inject(PeerGroupService), 'retrievePeerGroupAnnotations').and.returnValue(of([]));
     component = fixture.componentInstance;
     component.component = new PeerChatComponent(componentContent, nodeId);
     component.workgroupId = studentWorkgroupId1;

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
@@ -7,7 +7,7 @@ import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
 import { NotificationService } from '../../../services/notificationService';
-import { StudentPeerGroupService } from '../../../services/studentPeerGroupService';
+import { PeerGroupService } from '../../../services/peerGroupService';
 import { StudentAssetService } from '../../../services/studentAssetService';
 import { StudentDataService } from '../../../services/studentDataService';
 import { StudentWebSocketService } from '../../../services/studentWebSocketService';
@@ -50,8 +50,8 @@ export class PeerChatStudentComponent extends ComponentStudent {
     protected nodeService: NodeService,
     protected notebookService: NotebookService,
     private notificationService: NotificationService,
-    private peerGroupService: StudentPeerGroupService,
     private peerChatService: PeerChatService,
+    private peerGroupService: PeerGroupService,
     protected studentAssetService: StudentAssetService,
     protected studentDataService: StudentDataService,
     private studentWebSocketService: StudentWebSocketService

--- a/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.spec.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.spec.ts
@@ -6,7 +6,7 @@ import { PeerGroupStudentData } from '../../../../app/domain/peerGroupStudentDat
 import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
 import { ComponentContent } from '../../common/ComponentContent';
 import { AnnotationService } from '../../services/annotationService';
-import { StudentPeerGroupService } from '../../services/studentPeerGroupService';
+import { PeerGroupService } from '../../services/peerGroupService';
 import { ProjectService } from '../../services/projectService';
 import { StudentDataService } from '../../services/studentDataService';
 import { DynamicPromptComponent } from './dynamic-prompt.component';
@@ -26,8 +26,7 @@ describe('DynamicPromptComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [DynamicPromptComponent],
-      imports: [HttpClientTestingModule, MatDialogModule, StudentTeacherCommonServicesModule],
-      providers: []
+      imports: [HttpClientTestingModule, MatDialogModule, StudentTeacherCommonServicesModule]
     }).compileComponents();
   });
 
@@ -79,11 +78,11 @@ function peerGroupingTagEnabled(): void {
   describe('peerGroupingTagEnabled', () => {
     beforeEach(() => {
       component.dynamicPrompt.peerGroupingTag = 'apple';
-      spyOn(TestBed.inject(StudentPeerGroupService), 'retrievePeerGroup').and.returnValue(
+      spyOn(TestBed.inject(PeerGroupService), 'retrievePeerGroup').and.returnValue(
         of(createPeerGroup())
       );
       retrieveStudentDataSpy = spyOn(
-        TestBed.inject(StudentPeerGroupService),
+        TestBed.inject(PeerGroupService),
         'retrieveDynamicPromptStudentData'
       );
     });

--- a/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.ts
@@ -11,7 +11,7 @@ import { OpenResponseContent } from '../../components/openResponse/OpenResponseC
 import { PeerGroup } from '../../components/peerChat/PeerGroup';
 import { AnnotationService } from '../../services/annotationService';
 import { ConfigService } from '../../services/configService';
-import { StudentPeerGroupService } from '../../services/studentPeerGroupService';
+import { PeerGroupService } from '../../services/peerGroupService';
 import { ProjectService } from '../../services/projectService';
 import { StudentDataService } from '../../services/studentDataService';
 import { DynamicPrompt } from './DynamicPrompt';
@@ -31,7 +31,7 @@ export class DynamicPromptComponent implements OnInit {
   constructor(
     private annotationService: AnnotationService,
     private configService: ConfigService,
-    private peerGroupService: StudentPeerGroupService,
+    private peerGroupService: PeerGroupService,
     private projectService: ProjectService,
     private studentDataService: StudentDataService
   ) {}

--- a/src/assets/wise5/services/peerGroupService.ts
+++ b/src/assets/wise5/services/peerGroupService.ts
@@ -1,7 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { PeerGroupStudentData } from '../../../app/domain/peerGroupStudentData';
 import { Node } from '../common/Node';
 import { PeerGroup } from '../components/peerChat/PeerGroup';
 import { PeerGroupMember } from '../components/peerChat/PeerGroupMember';
@@ -76,7 +77,7 @@ export class PeerGroupService {
     nodeId: string,
     componentId: string
   ): Observable<any> {
-    return this.http.get(`/api/peer-group/${peerGroup.id}/${nodeId}/${componentId}/annotations`);
+    return of([]);
   }
 
   retrievePeerGroupInfo(peerGroupingTag: string): Observable<any> {
@@ -96,5 +97,21 @@ export class PeerGroupService {
 
   removeWorkgroupFromGroup(workgroupId: number, groupId: number): Observable<any> {
     return this.http.delete(`/api/peer-group/membership/${groupId}/${workgroupId}`);
+  }
+
+  retrieveQuestionBankStudentData(
+    peerGroupId: number,
+    nodeId: string,
+    componentId: string
+  ): Observable<PeerGroupStudentData[]> {
+    return of([]);
+  }
+
+  retrieveDynamicPromptStudentData(
+    peerGroupId: number,
+    nodeId: string,
+    componentId: string
+  ): Observable<PeerGroupStudentData[]> {
+    return of([]);
   }
 }

--- a/src/assets/wise5/services/studentPeerGroupService.ts
+++ b/src/assets/wise5/services/studentPeerGroupService.ts
@@ -149,12 +149,7 @@ export class StudentPeerGroupService extends PeerGroupService {
     componentId: string
   ): Observable<any> {
     if (this.configService.isPreview()) {
-      const latestScoreAnnotation = this.annotationService.getLatestScoreAnnotation(
-        nodeId,
-        componentId,
-        this.configService.getWorkgroupId()
-      );
-      return latestScoreAnnotation != null ? of([latestScoreAnnotation]) : of([]);
+      return of([]);
     }
     return this.http.get(`/api/peer-group/${peerGroup.id}/${nodeId}/${componentId}/annotations`);
   }

--- a/src/assets/wise5/services/studentPeerGroupService.ts
+++ b/src/assets/wise5/services/studentPeerGroupService.ts
@@ -142,4 +142,20 @@ export class StudentPeerGroupService extends PeerGroupService {
       showWorkComponentId
     );
   }
+
+  retrievePeerGroupAnnotations(
+    peerGroup: PeerGroup,
+    nodeId: string,
+    componentId: string
+  ): Observable<any> {
+    if (this.configService.isPreview()) {
+      const latestScoreAnnotation = this.annotationService.getLatestScoreAnnotation(
+        nodeId,
+        componentId,
+        this.configService.getWorkgroupId()
+      );
+      return latestScoreAnnotation != null ? of([latestScoreAnnotation]) : of([]);
+    }
+    return this.http.get(`/api/peer-group/${peerGroup.id}/${nodeId}/${componentId}/annotations`);
+  }
 }


### PR DESCRIPTION
## Changes

Peer Chat preview no longer tries to make an api request to retrieve annotations and instead obtains the local latest score annotation or an empty array.

## Test

Preview a Peer Chat that has a Dynamic Prompt and Question Bank. Make sure it no longer throws a console error trying to retrieve annotations.

This is the console error that used to occur
```
GET http://localhost:81/api/peer-group/1/node7/vczu5hmvvs/annotations 403 peer-chat-student.component.ts:118
```

Closes #1046