### PR TITLE
refactor(UtilService): Move getImageObjectFromImageElement()

### DIFF
--- a/src/assets/wise5/services/notebookService.ts
+++ b/src/assets/wise5/services/notebookService.ts
@@ -91,7 +91,7 @@ export class NotebookService {
 
   addNote(
     nodeId: string,
-    file: any = null,
+    file: File = null,
     text: string = null,
     studentWorkIds: number[] = null,
     isEditTextEnabled: boolean = true,

--- a/src/assets/wise5/services/utilService.ts
+++ b/src/assets/wise5/services/utilService.ts
@@ -2,7 +2,6 @@
 
 import { formatDate } from '@angular/common';
 import { Inject, Injectable, LOCALE_ID } from '@angular/core';
-import { convertToPNGFile } from '../common/canvas/canvas';
 import { copy } from '../common/object/object';
 import '../lib/jquery/jquery-global';
 
@@ -15,20 +14,6 @@ export class UtilService {
       return Number(str);
     }
     return str;
-  }
-
-  /**
-   * Get an image object from an image element
-   * @param imageElement an image element (<img src='abc.jpg'/>)
-   * @returns an image object
-   */
-  getImageObjectFromImageElement(imageElement: any): any {
-    const canvas = document.createElement('canvas');
-    canvas.width = imageElement.naturalWidth;
-    canvas.height = imageElement.naturalHeight;
-    const ctx = canvas.getContext('2d');
-    ctx.drawImage(imageElement, 0, 0);
-    return convertToPNGFile(canvas);
   }
 
   isImage(fileName: string): boolean {

--- a/src/assets/wise5/vle/vle.component.ts
+++ b/src/assets/wise5/vle/vle.component.ts
@@ -10,9 +10,9 @@ import { StudentDataService } from '../services/studentDataService';
 import { VLEProjectService } from './vleProjectService';
 import { DialogWithConfirmComponent } from '../directives/dialog-with-confirm/dialog-with-confirm.component';
 import { AnnotationService } from '../services/annotationService';
-import { UtilService } from '../services/utilService';
 import { ActivatedRoute, Router } from '@angular/router';
 import { WiseLinkService } from '../../../app/services/wiseLinkService';
+import { convertToPNGFile } from '../common/canvas/canvas';
 
 @Component({
   selector: 'vle',
@@ -49,7 +49,6 @@ export class VLEComponent implements AfterViewInit {
     private router: Router,
     private sessionService: SessionService,
     private studentDataService: StudentDataService,
-    private utilService: UtilService,
     private wiseLinkService: WiseLinkService
   ) {}
 
@@ -109,11 +108,19 @@ export class VLEComponent implements AfterViewInit {
   }
 
   @HostListener('window:snip-image', ['$event.detail.target'])
-  snipImage(image: Element): void {
+  snipImage(image: HTMLImageElement): void {
     this.notebookService.addNote(
       this.studentDataService.getCurrentNodeId(),
-      this.utilService.getImageObjectFromImageElement(image)
+      this.getImageObjectFromImageElement(image)
     );
+  }
+
+  private getImageObjectFromImageElement(image: HTMLImageElement): File {
+    const canvas = document.createElement('canvas');
+    canvas.width = image.naturalWidth;
+    canvas.height = image.naturalHeight;
+    canvas.getContext('2d').drawImage(image, 0, 0);
+    return convertToPNGFile(canvas);
   }
 
   closeNotes(): void {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -5921,7 +5921,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/componentAnnotations/component-annotations.component.ts</context>
-          <context context-type="linenumber">192</context>
+          <context context-type="linenumber">205</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3de550daa9bf35829dbeb9099844614347d2dbc5" datatype="html">
@@ -10064,7 +10064,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">137</context>
+          <context context-type="linenumber">145</context>
         </context-group>
       </trans-unit>
       <trans-unit id="537022937435161177" datatype="html">
@@ -10075,7 +10075,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">138</context>
+          <context context-type="linenumber">146</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3023661788238273336" datatype="html">
@@ -13983,7 +13983,7 @@ Are you ready to receive feedback on this answer?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/componentAnnotations/component-annotations.component.ts</context>
-          <context context-type="linenumber">189</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2353574516166744013" datatype="html">
@@ -18695,21 +18695,21 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">266</context>
+          <context context-type="linenumber">251</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5275881069346355759" datatype="html">
         <source>Auto Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">271</context>
+          <context context-type="linenumber">256</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2692433425768915750" datatype="html">
         <source>Submitted <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">276</context>
+          <context context-type="linenumber">261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846fecebb7756c6127955bc2c08d2111dce64c3c" datatype="html">


### PR DESCRIPTION
## Changes
- Move UtilService.getImageObjectFromImageElement() to VLEComponent and made it private
- Remove unused UtilService from VLEComponent
- Add type to referenced code

## Test
- Snip image (e.g. images embedded in HTML content) works as before
- Snip draw/graph/etc works as before

Closes #999