### PR TITLE
refactor(UtilService): Move hasNodeEnteredEvent() to ComponentService

### DIFF
--- a/src/assets/wise5/components/componentService.ts
+++ b/src/assets/wise5/components/componentService.ts
@@ -153,4 +153,10 @@ export class ComponentService {
   isSubmitRequired(node: any, component: any) {
     return node.showSubmitButton || (component.showSubmitButton && !node.showSaveButton);
   }
+
+  hasNodeEnteredEvent(nodeEvents: any[]): boolean {
+    return nodeEvents.some((nodeEvent: any) => {
+      return nodeEvent.event === 'nodeEntered';
+    });
+  }
 }

--- a/src/assets/wise5/components/discussion/discussionService.ts
+++ b/src/assets/wise5/components/discussion/discussionService.ts
@@ -77,10 +77,6 @@ export class DiscussionService extends ComponentService {
     );
   }
 
-  private hasNodeEnteredEvent(nodeEvents: any[]): boolean {
-    return nodeEvents.some((nodeEvent) => nodeEvent.event === 'nodeEntered');
-  }
-
   getClassmateResponsesFromComponents(
     runId: number,
     periodId: number,

--- a/src/assets/wise5/components/embedded/embeddedService.ts
+++ b/src/assets/wise5/components/embedded/embeddedService.ts
@@ -70,15 +70,6 @@ export class EmbeddedService extends ComponentService {
     return false;
   }
 
-  hasNodeEnteredEvent(nodeEvents: any[]) {
-    for (const nodeEvent of nodeEvents) {
-      if (nodeEvent.event === 'nodeEntered') {
-        return true;
-      }
-    }
-    return false;
-  }
-
   componentHasWork(component: any): boolean {
     return component.hasWork;
   }

--- a/src/assets/wise5/components/graph/graphService.ts
+++ b/src/assets/wise5/components/graph/graphService.ts
@@ -94,7 +94,7 @@ export class GraphService extends ComponentService {
     if (this.canEdit(component)) {
       return this.hasCompletedComponentState(componentStates, node, component);
     } else {
-      return this.UtilService.hasNodeEnteredEvent(nodeEvents);
+      return this.hasNodeEnteredEvent(nodeEvents);
     }
   }
 

--- a/src/assets/wise5/components/label/labelService.ts
+++ b/src/assets/wise5/components/label/labelService.ts
@@ -49,7 +49,7 @@ export class LabelService extends ComponentService {
   }
 
   isCompleted(component: any, componentStates: any[], nodeEvents: any[], node: any) {
-    if (!this.canEdit(component) && this.UtilService.hasNodeEnteredEvent(nodeEvents)) {
+    if (!this.canEdit(component) && this.hasNodeEnteredEvent(nodeEvents)) {
       return true;
     }
     if (componentStates != null && componentStates.length > 0) {

--- a/src/assets/wise5/services/utilService.ts
+++ b/src/assets/wise5/services/utilService.ts
@@ -169,20 +169,6 @@ export class UtilService {
   }
 
   /**
-   * Check if there is a 'nodeEntered' event in the array of events.
-   * @param events An array of events.
-   * @return Whether there is a 'nodeEntered' event in the array of events.
-   */
-  hasNodeEnteredEvent(events) {
-    for (let event of events) {
-      if (event.event == 'nodeEntered') {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
    * Determine whether the component has been authored to import work.
    * @param componentContent The component content.
    * @return Whether to import work in this component.


### PR DESCRIPTION
## Changes

Moved hasNodeEnteredEvent() from UtilService to ComponentService.

## Test

Make sure the places that use hasNodeEnteredEvent still work properly. It is used to check if a component is completed by the student. To Test it out
1. Create two steps and in the first step add a component like Discussion.
2. In the second step add the same component type (in this case Discussion) and set the connected component to point to the Discussion in the first step and make it Show Work.
3. Preview the project.
4. Submit a post in the first Discussion step.
5. Go to the second Discussion step. You should see the completed check mark near the step select drop down. This can be tested with all 4 component types below.
- Discussion
- Embedded
- Graph
- Label

Closes #1057