### PR TITLE
build(Docker): Build image on release

### DIFF
--- a/.github/workflows/publish-docker-image-prod.yml
+++ b/.github/workflows/publish-docker-image-prod.yml
@@ -16,14 +16,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: wiseberkeley/wise-client-server
           flavor: latest=true
@@ -32,7 +32,7 @@ jobs:
             type=sha
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true

--- a/.github/workflows/publish-docker-image-prod.yml
+++ b/.github/workflows/publish-docker-image-prod.yml
@@ -3,6 +3,9 @@ name: Publish Docker image
 on:
   release:
     types: [published]
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   push_to_registry:

--- a/.github/workflows/publish-docker-image-prod.yml
+++ b/.github/workflows/publish-docker-image-prod.yml
@@ -3,9 +3,6 @@ name: Publish Docker image
 on:
   release:
     types: [published]
-  pull_request:
-    branches:
-      - develop
 
 jobs:
   push_to_registry:

--- a/.github/workflows/publish-docker-image-prod.yml
+++ b/.github/workflows/publish-docker-image-prod.yml
@@ -1,0 +1,37 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: wiseberkeley/wise-client-server
+          flavor: latest=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM node:18
+# Stage 1: build application
+FROM node:latest as node
 RUN apt-get update && apt-get install build-essential \
-    chromium libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev -y
-ENV CHROME_BIN='/usr/bin/chromium'
+    libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev -y
 WORKDIR /app
+COPY . .
+RUN npm ci
+RUN npm run build-prod
 
-CMD ["npm", "run", "serve-dev"]
+# Stage 2: Copy to Nginx
+FROM nginx:latest
+RUN mkdir /usr/share/nginx/html/wise-client
+COPY --from=node /app/dist /usr/share/nginx/html/wise-client

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,7 @@
+FROM node:18
+RUN apt-get update && apt-get install build-essential \
+    chromium libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev -y
+ENV CHROME_BIN='/usr/bin/chromium'
+WORKDIR /app
+
+CMD ["npm", "run", "serve-dev"]

--- a/scripts/docker-build-prod-image.sh
+++ b/scripts/docker-build-prod-image.sh
@@ -1,0 +1,3 @@
+commit_id=$(git rev-parse --short HEAD)
+echo "Commit ID: ${commit_id}"
+docker buildx build --push -t wiseberkeley/wise-client-server:latest -t wiseberkeley/wise-client-server:${commit_id} .


### PR DESCRIPTION
## Changes
- Run GitHub action to build docker image and publish to Docker Hub
- Create Dockerfile, which creates the docker image
- Move existing Dockerfile to Dockerfile.dev, which creates the development docker image
- Create scripts/docker-build-prod-image.sh, which can be run to build and push production Docker image manually