### PR TITLE
fix(Unit Library): Create run does not redirect to Class Schedule

### DIFF
--- a/src/app/teacher/create-run-dialog/create-run-dialog.component.spec.ts
+++ b/src/app/teacher/create-run-dialog/create-run-dialog.component.spec.ts
@@ -29,8 +29,6 @@ export class MockTeacherService {
     });
   }
 
-  broadcastRunChanges() {}
-
   setTabIndex() {}
 
   checkClassroomAuthorization(): Observable<string> {

--- a/src/app/teacher/create-run-dialog/create-run-dialog.component.ts
+++ b/src/app/teacher/create-run-dialog/create-run-dialog.component.ts
@@ -8,6 +8,7 @@ import { UserService } from '../../services/user.service';
 import { ConfigService } from '../../services/config.service';
 import { ListClassroomCoursesDialogComponent } from '../list-classroom-courses-dialog/list-classroom-courses-dialog.component';
 import { TeacherRun } from '../teacher-run';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'create-run-dialog',
@@ -29,13 +30,14 @@ export class CreateRunDialogComponent {
   run: TeacherRun = null;
 
   constructor(
+    private configService: ConfigService,
+    @Inject(MAT_DIALOG_DATA) public data: any,
     public dialog: MatDialog,
     public dialogRef: MatDialogRef<CreateRunDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    private fb: FormBuilder,
+    private router: Router,
     private teacherService: TeacherService,
-    private userService: UserService,
-    private configService: ConfigService,
-    private fb: FormBuilder
+    private userService: UserService
   ) {
     this.project = data.project;
     this.maxStudentsPerTeam = 3;
@@ -127,8 +129,10 @@ export class CreateRunDialogComponent {
       )
       .subscribe((newRun: TeacherRun) => {
         this.run = new TeacherRun(newRun);
-        this.dialogRef.afterClosed().subscribe((result) => {
-          this.teacherService.broadcastRunChanges(this.run);
+        this.dialogRef.afterClosed().subscribe(() => {
+          this.router.navigate(['/teacher/home/schedule'], {
+            queryParams: { newRunId: newRun.id }
+          });
         });
         this.isCreated = true;
       });

--- a/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
+++ b/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
@@ -200,7 +200,7 @@ export class TeacherRunListComponent implements OnInit {
     this.route.queryParams.subscribe((queryParams: Params) => {
       if (queryParams.newRunId != null) {
         const newRunId = parseInt(queryParams.newRunId);
-        if (newRunId != null) {
+        if (!isNaN(newRunId)) {
           const newRun = this.runs.find((run) => {
             return run.id === newRunId;
           });

--- a/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
+++ b/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
@@ -51,6 +51,7 @@ export class TeacherRunListComponent implements OnInit {
       .subscribe((runs: TeacherRun[]) => {
         this.setRuns(runs);
         this.processRuns();
+        this.highlightNewRunIfNecessary();
         this.loaded = true;
       });
   }
@@ -95,7 +96,6 @@ export class TeacherRunListComponent implements OnInit {
     this.periods.sort();
     this.populateFilterOptions();
     this.performSearchAndFilter();
-    this.highlightNewRun();
   }
 
   sortByStartTimeDesc(a: TeacherRun, b: TeacherRun): number {
@@ -196,19 +196,24 @@ export class TeacherRunListComponent implements OnInit {
     return run.isActive(this.configService.getCurrentServerTime());
   }
 
-  private highlightNewRun(): void {
+  private highlightNewRunIfNecessary(): void {
     this.route.queryParams.subscribe((queryParams: Params) => {
       if (queryParams.newRunId != null) {
         const newRunId = parseInt(queryParams.newRunId);
         if (!isNaN(newRunId)) {
-          const newRun = this.runs.find((run) => {
-            return run.id === newRunId;
-          });
-          newRun.isHighlighted = true;
-          // remove the newRunId parameter from the url
-          this.router.navigate(['/teacher/home/schedule'], { queryParams: { newRunId: null } });
+          this.highlightNewRun(newRunId);
         }
+        // remove the newRunId parameter from the url
+        this.router.navigate(['/teacher/home/schedule'], { queryParams: { newRunId: null } });
       }
     });
+  }
+
+  private highlightNewRun(runId: number): void {
+    for (const run of this.runs) {
+      if (run.id === runId) {
+        run.isHighlighted = true;
+      }
+    }
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -8383,7 +8383,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>All Periods</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list/teacher-run-list.component.ts</context>
-          <context context-type="linenumber">153</context>
+          <context context-type="linenumber">117</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts</context>


### PR DESCRIPTION
## Changes

When a run is created and the Create Run dialog is closed, we no longer broadcastRunChanges() but instead navigate to the Class Schedule route. The TeacherRunListComponent is no longer rendered when the user is in the Unit Library. Maybe in the past it used to be but now it no longer is maybe because it's now lazy loaded. This means the TeacherRunListComponent subscription to the teacherService.runs$ does not exist at that time, and therefore the subscription that contains the code that used to handle changing to the Class Schedule and highlighting the new run no longer gets called.

## Test

1. Go to the Unit Library
2. Create a run and you should be shown the Run Code
3. Close the create run dialog popup and you should be redirected to the Class Schedule view and the new run card should be highlighted

Closes #1066