### PR TITLE
fix(News): Only show Discourse news on home page if discourse_url is set

### DIFF
--- a/src/app/domain/config.ts
+++ b/src/app/domain/config.ts
@@ -8,5 +8,6 @@ export class Config {
   currentTime: number;
   wiseHostname?: string;
   wise4Hostname?: string;
+  discourseNewsCategory?: string;
   discourseURL?: string;
 }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -37,11 +37,11 @@
         Integrated science learning and teaching with technology
       </div>
     </ng-template>
-    <ng-template #sideTemplate>
+    <ng-template #sideTemplate *ngIf="isDiscourseNewsAvailable">
       <discourse-latest-news
         [@bounceIn]="{ value: '*', params: { duration: '1.25s', delay: '3500ms' } }"
-        baseUrl="https://wise-discuss.berkeley.edu"
-        category="c/news-announcements/7"
+        [baseUrl]="discourseUrl"
+        [category]="discourseNewsCategory"
         queryString="order=latest"
       >
       </discourse-latest-news>

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -1,18 +1,23 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { HomeComponent } from './home.component';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ConfigService } from '../services/config.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [HomeComponent],
-      imports: [],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [HomeComponent],
+        imports: [HttpClientTestingModule],
+        providers: [ConfigService],
+        schemas: [NO_ERRORS_SCHEMA]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HomeComponent);

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -99,15 +99,13 @@ export class HomeComponent implements OnInit {
       if (config != null) {
         this.discourseUrl = this.configService.getDiscourseURL();
         this.discourseNewsCategory = this.configService.getDiscourseNewsCategory();
-        if (
-          this.discourseUrl != null &&
-          this.discourseUrl !== '' &&
-          this.discourseNewsCategory != null &&
-          this.discourseNewsCategory !== ''
-        ) {
-          this.isDiscourseNewsAvailable = true;
-        }
+        this.isDiscourseNewsAvailable =
+          this.isSet(this.discourseUrl) && this.isSet(this.discourseNewsCategory);
       }
     });
+  }
+
+  private isSet(str: string): boolean {
+    return str != null && str !== '';
   }
 }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit, SecurityContext } from '@angular/core';
 import { bounceIn, flipInX, flipInY, jackInTheBox, rotateIn, zoomIn } from '../animations';
 import { DomSanitizer } from '@angular/platform-browser';
+import { ConfigService } from '../services/config.service';
+import { Config } from '../domain/config';
 
 @Component({
   selector: 'app-home',
@@ -9,6 +11,9 @@ import { DomSanitizer } from '@angular/platform-browser';
   animations: [bounceIn, flipInX, flipInY, jackInTheBox, rotateIn, zoomIn]
 })
 export class HomeComponent implements OnInit {
+  discourseNewsCategory: string;
+  discourseUrl: string;
+  isDiscourseNewsAvailable: boolean = false;
   loaded: boolean = false;
   hero = {
     imgSrc: 'assets/img/wise-students-hero.jpg',
@@ -87,7 +92,22 @@ export class HomeComponent implements OnInit {
     }
   ];
 
-  constructor(private sanitizer: DomSanitizer) {}
+  constructor(private configService: ConfigService, private sanitizer: DomSanitizer) {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.configService.getConfig().subscribe((config: Config) => {
+      if (config != null) {
+        this.discourseUrl = this.configService.getDiscourseURL();
+        this.discourseNewsCategory = this.configService.getDiscourseNewsCategory();
+        if (
+          this.discourseUrl != null &&
+          this.discourseUrl !== '' &&
+          this.discourseNewsCategory != null &&
+          this.discourseNewsCategory !== ''
+        ) {
+          this.isDiscourseNewsAvailable = true;
+        }
+      }
+    });
+  }
 }

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -35,6 +35,10 @@ export class ConfigService {
     return this.config$.getValue().discourseURL;
   }
 
+  getDiscourseNewsCategory() {
+    return this.config$.getValue().discourseNewsCategory;
+  }
+
   getGoogleAnalyticsId() {
     return this.config$.getValue().googleAnalyticsId;
   }


### PR DESCRIPTION
## Changes

Only show Discourse news on home page if Discourse property values have been set in the API application.properties.

## Test

Test with
- https://github.com/WISE-Community/WISE-API/pull/221

Test these situations
- when discourse_url and discourse_news_category are not in application.properties, then you should not see the news on the home page
- when discourse_url and discourse_news_category are in application.properties but have no values, then you should not see the news on the home page
- when discourse_url and discourse_news_category are in application.properties and have values, then you should see the news on the home page

Closes #1081