### PR TITLE
refactor(UtilService): Move trimToLength()

### DIFF
--- a/src/app/services/utilService.spec.ts
+++ b/src/app/services/utilService.spec.ts
@@ -10,7 +10,6 @@ describe('UtilService', () => {
     service = TestBed.inject(UtilService);
   });
   calculateMeanTests();
-  trimToLength();
   removeHTMLTags();
   replaceImgTagWithFileName();
 });
@@ -25,18 +24,6 @@ function calculateMeanTests() {
     it('should calculate the mean when there are multiple values', () => {
       const values = [1, 2, 3, 4, 10];
       expect(service.calculateMean(values)).toEqual(4);
-    });
-  });
-}
-
-function trimToLength() {
-  describe('trimToLength()', () => {
-    it('should keep strings intact if its length is equal to or less than max length', () => {
-      expect(service.trimToLength('123456789', 9)).toEqual('123456789');
-      expect(service.trimToLength('123456789', 10)).toEqual('123456789');
-    });
-    it('should trim length and add ellipses if length is longer than max length', () => {
-      expect(service.trimToLength('123456789', 7)).toEqual('1234...');
     });
   });
 }

--- a/src/app/teacher/milestone/milestone-report-graph/milestone-report-graph.component.ts
+++ b/src/app/teacher/milestone/milestone-report-graph/milestone-report-graph.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { UtilService } from '../../../../assets/wise5/services/utilService';
 import * as Highcharts from 'highcharts';
 import { rgbToHex } from '../../../../assets/wise5/common/color/color';
 import { trimToLength } from '../../../../assets/wise5/common/string/string';
@@ -24,7 +23,7 @@ export class MilestoneReportGraphComponent implements OnInit {
   series: any[];
   @Input() titleColor: string;
 
-  constructor(private utilService: UtilService) {}
+  constructor() {}
 
   ngOnInit(): void {
     this.data = JSON.parse(this.data.replace(/\'/g, '"'));

--- a/src/app/teacher/milestone/milestone-report-graph/milestone-report-graph.component.ts
+++ b/src/app/teacher/milestone/milestone-report-graph/milestone-report-graph.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { UtilService } from '../../../../assets/wise5/services/utilService';
 import * as Highcharts from 'highcharts';
 import { rgbToHex } from '../../../../assets/wise5/common/color/color';
+import { trimToLength } from '../../../../assets/wise5/common/string/string';
 
 @Component({
   selector: 'milestone-report-graph',
@@ -100,7 +101,7 @@ export class MilestoneReportGraphComponent implements OnInit {
     for (const componentData of this.getDataToGraph(this.data, this.locations)) {
       opacity += step;
       const singleSeries = {
-        name: this.utilService.trimToLength(componentData.stepTitle, 26),
+        name: trimToLength(componentData.stepTitle, 26),
         color: rgbToHex(color, opacity),
         data: this.getComponentSeriesData(componentData)
       };

--- a/src/assets/wise5/common/string/string.spec.ts
+++ b/src/assets/wise5/common/string/string.spec.ts
@@ -1,4 +1,4 @@
-import { isValidJSONString, wordWrap } from './string';
+import { isValidJSONString, trimToLength, wordWrap } from './string';
 
 describe('isValidJSONString()', () => {
   it('should return true if json string is valid', () => {
@@ -23,5 +23,15 @@ describe('wordWrap()', () => {
   it('should not break string into multiple lines if string is same length or shorter than the wrap limit', () => {
     const string = 'A short string.';
     expect(wordWrap(string, 20)).toEqual('A short string.');
+  });
+});
+
+describe('trimToLength()', () => {
+  it('should keep string intact if its length is equal to or less than max length', () => {
+    expect(trimToLength('123456789', 9)).toEqual('123456789');
+    expect(trimToLength('123456789', 10)).toEqual('123456789');
+  });
+  it('should trim string and add ellipses if length is longer than max length', () => {
+    expect(trimToLength('123456789', 7)).toEqual('1234...');
   });
 });

--- a/src/assets/wise5/common/string/string.ts
+++ b/src/assets/wise5/common/string/string.ts
@@ -55,3 +55,7 @@ function testWhite(x) {
   let white = new RegExp(/^\s$/);
   return white.test(x.charAt(0));
 }
+
+export function trimToLength(str: string, maxLength: number): string {
+  return str.length > maxLength ? `${str.substring(0, maxLength - 3)}...` : str;
+}

--- a/src/assets/wise5/services/utilService.ts
+++ b/src/assets/wise5/services/utilService.ts
@@ -133,10 +133,6 @@ export class UtilService {
     return JSON.stringify(array1Copy) == JSON.stringify(array2Copy);
   }
 
-  trimToLength(str: string, maxLength: number): string {
-    return str.length > maxLength ? `${str.substring(0, maxLength - 3)}...` : str;
-  }
-
   /**
    * Determine whether the component has been authored to import work.
    * @param componentContent The component content.

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -7803,7 +7803,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Teams</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/milestone/milestone-report-graph/milestone-report-graph.component.ts</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">71</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9c83559c416a8e596b51a342566efdb2868f2404" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -4597,49 +4597,49 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>WISE students in classroom</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/home/home.component.ts</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="linenumber">20</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4788492906571844304" datatype="html">
         <source>WISE students building</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/home/home.component.ts</context>
-          <context context-type="linenumber">41</context>
+          <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="399164538965188389" datatype="html">
         <source>Free, standards-aligned, and research-based inquiry curricula that address <x id="START_LINK" ctype="x-a" equiv-text="this.ngssLink.startTag"/>NGSS 3D proficiency<x id="CLOSE_LINK" ctype="x-a" equiv-text="this.ngssLink.closeTag"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/home/home.component.ts</context>
-          <context context-type="linenumber">55</context>
+          <context context-type="linenumber">60</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2488461351187724080" datatype="html">
         <source>WISE unit on laptop</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/home/home.component.ts</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">65</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6104474954962536234" datatype="html">
         <source>Interactive scientific models plus hands-on activities, personalized guidance, and rich embedded assessments</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/home/home.component.ts</context>
-          <context context-type="linenumber">70</context>
+          <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5655885224951904964" datatype="html">
         <source>WISE students and teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/home/home.component.ts</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">79</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2643991125797499080" datatype="html">
         <source>Robust teacher grading and management tools supporting individualized and customized learning</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/home/home.component.ts</context>
-          <context context-type="linenumber">86</context>
+          <context context-type="linenumber">91</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1934952699406892664" datatype="html">
@@ -7803,7 +7803,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Teams</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/milestone/milestone-report-graph/milestone-report-graph.component.ts</context>
-          <context context-type="linenumber">71</context>
+          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9c83559c416a8e596b51a342566efdb2868f2404" datatype="html">
@@ -18695,21 +18695,21 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">206</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5275881069346355759" datatype="html">
         <source>Auto Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">211</context>
+          <context context-type="linenumber">207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2692433425768915750" datatype="html">
         <source>Submitted <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">216</context>
+          <context context-type="linenumber">212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846fecebb7756c6127955bc2c08d2111dce64c3c" datatype="html">


### PR DESCRIPTION
## Changes
- Move UtilService.trimToLength() to ConstraintService
- Update references and remove UtilService dependency

## Test
Make sure that MilestoneReportGraph series names are still trimmed to 26 characters max including ellipses.

![Screenshot 2023-03-07 at 9 41 58 AM](https://user-images.githubusercontent.com/297450/223509838-1e37f4b5-b27d-4748-805c-f3f01db5aa1f.png)

Closes #1071.