### PR TITLE
refactor(ConstraintService): Extract criteria constraint evaluation logic part 1

### DIFF
--- a/src/app/services/constraintService.spec.ts
+++ b/src/app/services/constraintService.spec.ts
@@ -21,7 +21,6 @@ let isVisitedCriteria: any;
 let isVisitedAfterCriteria: any;
 let isRevisedAfterCriteria: any;
 let scoreCriteria: any;
-let usedXSubmitsCriteria: any;
 let addXNumberOfNotesOnThisStepCriteria: any;
 let addXNumberOfNotesOnThisStepNotebook: any;
 
@@ -83,13 +82,6 @@ describe('ConstraintService', () => {
         scores: [1, 2, 3]
       }
     };
-    usedXSubmitsCriteria = {
-      params: {
-        nodeId: 'node1',
-        componentId: 'component1',
-        requiredSubmitCount: 2
-      }
-    };
     addXNumberOfNotesOnThisStepCriteria = {
       params: {
         nodeId: 'node1',
@@ -119,7 +111,6 @@ describe('ConstraintService', () => {
   evaluateIsRevisedAfterCriteria();
   evaluateIsVisitedAndRevisedAfterCriteria();
   evaluateScoreCriteria();
-  evaluateUsedXSubmitsCriteria();
   evaluateAddXNumberOfNotesOnThisStepCriteria();
   evaluateCriterias();
 });
@@ -282,19 +273,6 @@ function evaluateScoreCriteria() {
   it('should evaluate score criteria true', () => {
     scoreCriteriaSpies(3);
     expect(service.evaluateScoreCriteria(scoreCriteria)).toEqual(true);
-  });
-}
-
-function evaluateUsedXSubmitsCriteria() {
-  it('should evaluate used x submits criteria false', () => {
-    const componentStates = [{ studentData: { submitCounter: 1 } }];
-    spyOn(dataService, 'getComponentStatesByNodeIdAndComponentId').and.returnValue(componentStates);
-    expect(service.evaluateUsedXSubmitsCriteria(usedXSubmitsCriteria)).toEqual(false);
-  });
-  it('should evaluate used x submits criteria true', () => {
-    const componentStates = [{ studentData: { submitCounter: 2 } }];
-    spyOn(dataService, 'getComponentStatesByNodeIdAndComponentId').and.returnValue(componentStates);
-    expect(service.evaluateUsedXSubmitsCriteria(usedXSubmitsCriteria)).toEqual(true);
   });
 }
 

--- a/src/app/services/constraintService.spec.ts
+++ b/src/app/services/constraintService.spec.ts
@@ -124,7 +124,6 @@ describe('ConstraintService', () => {
   evaluateNodeConstraintWithTwoRemovalCriteria();
   evaluateIsCorrectCriteriaFalseWhenNoComponentStates();
   evaluateIsCorrectCriteria();
-  evaluateBranchPathTaken();
   evaluateIsVisitedCriteria();
   evaluateIsVisitedAfterCriteria();
   evaluateIsRevisedAfterCriteria();
@@ -199,30 +198,6 @@ function evaluateIsCorrectCriteria() {
     const componentStates = [{ studentData: { isCorrect: true } }];
     spyOn(dataService, 'getComponentStatesByNodeIdAndComponentId').and.returnValue(componentStates);
     expect(service.evaluateIsCorrectCriteria(criteria)).toEqual(true);
-  });
-}
-
-function evaluateBranchPathTaken() {
-  const criteria = {
-    params: {
-      fromNodeId: 'node1',
-      toNodeId: 'node2'
-    }
-  };
-  it('should evaluate branch path taken false', () => {
-    const branchPathTakenEvents = [{ data: { fromNodeId: 'node1', toNodeId: 'node3' } }];
-    spyOn(dataService, 'getBranchPathTakenEventsByNodeId').and.returnValue(branchPathTakenEvents);
-    expect(service.evaluateBranchPathTakenCriteria(criteria)).toEqual(false);
-  });
-  it('should evaluate branch path taken true', () => {
-    const branchPathTakenEvents = [{ data: { fromNodeId: 'node1', toNodeId: 'node2' } }];
-    spyOn(dataService, 'getBranchPathTakenEventsByNodeId').and.returnValue(branchPathTakenEvents);
-    expect(service.evaluateBranchPathTakenCriteria(criteria)).toEqual(true);
-  });
-  it('should evaluate branch path taken', () => {
-    const branchPathTakenEvents = [];
-    spyOn(dataService, 'getBranchPathTakenEventsByNodeId').and.returnValue(branchPathTakenEvents);
-    expect(service.evaluateBranchPathTakenCriteria(criteria)).toEqual(false);
   });
 }
 

--- a/src/app/services/constraintService.spec.ts
+++ b/src/app/services/constraintService.spec.ts
@@ -22,7 +22,6 @@ let isVisitedAfterCriteria: any;
 let isRevisedAfterCriteria: any;
 let scoreCriteria: any;
 let usedXSubmitsCriteria: any;
-let numberOfWordsWrittenCriteria: any;
 let addXNumberOfNotesOnThisStepCriteria: any;
 let addXNumberOfNotesOnThisStepNotebook: any;
 
@@ -91,13 +90,6 @@ describe('ConstraintService', () => {
         requiredSubmitCount: 2
       }
     };
-    numberOfWordsWrittenCriteria = {
-      params: {
-        nodeId: 'node1',
-        componentId: 'component1',
-        requiredNumberOfWords: 10
-      }
-    };
     addXNumberOfNotesOnThisStepCriteria = {
       params: {
         nodeId: 'node1',
@@ -130,7 +122,6 @@ describe('ConstraintService', () => {
   evaluateIsVisitedAndRevisedAfterCriteria();
   evaluateScoreCriteria();
   evaluateUsedXSubmitsCriteria();
-  evaluateNumberOfWordsWrittenCriteria();
   evaluateAddXNumberOfNotesOnThisStepCriteria();
   evaluateCriterias();
 });
@@ -339,28 +330,6 @@ function evaluateUsedXSubmitsCriteria() {
     const componentStates = [{ studentData: { submitCounter: 2 } }];
     spyOn(dataService, 'getComponentStatesByNodeIdAndComponentId').and.returnValue(componentStates);
     expect(service.evaluateUsedXSubmitsCriteria(usedXSubmitsCriteria)).toEqual(true);
-  });
-}
-
-function evaluateNumberOfWordsWrittenCriteria() {
-  function numberOfWordsWrittenSpies(componentState: any): void {
-    spyOn(dataService, 'getLatestComponentStateByNodeIdAndComponentId').and.returnValue(
-      componentState
-    );
-  }
-  it('should evaluate number of words written criteria false', () => {
-    const componentState = { studentData: { response: 'one two three four five' } };
-    numberOfWordsWrittenSpies(componentState);
-    expect(service.evaluateNumberOfWordsWrittenCriteria(numberOfWordsWrittenCriteria)).toEqual(
-      false
-    );
-  });
-  it('should evaluate number of words written criteria true', () => {
-    const componentState = { studentData: { response: '1 2 3 4 5 6 7 8 9 0' } };
-    numberOfWordsWrittenSpies(componentState);
-    expect(service.evaluateNumberOfWordsWrittenCriteria(numberOfWordsWrittenCriteria)).toEqual(
-      true
-    );
   });
 }
 

--- a/src/app/services/constraintService.spec.ts
+++ b/src/app/services/constraintService.spec.ts
@@ -114,8 +114,6 @@ describe('ConstraintService', () => {
 
   evaluateNodeConstraintWithOneRemovalCriteria();
   evaluateNodeConstraintWithTwoRemovalCriteria();
-  evaluateIsCorrectCriteriaFalseWhenNoComponentStates();
-  evaluateIsCorrectCriteria();
   evaluateIsVisitedCriteria();
   evaluateIsVisitedAfterCriteria();
   evaluateIsRevisedAfterCriteria();
@@ -156,39 +154,6 @@ function evaluateNodeConstraintWithTwoRemovalCriteria() {
     isCompletedSpy();
     nodeConstraintTwoRemovalCriteria.removalConditional = 'any';
     expect(service.evaluateNodeConstraint(nodeConstraintTwoRemovalCriteria)).toEqual(true);
-  });
-}
-
-function evaluateIsCorrectCriteriaFalseWhenNoComponentStates() {
-  it('should evaluate is correct criteria false when no component states', () => {
-    const componentStates = [];
-    spyOn(dataService, 'getComponentStatesByNodeIdAndComponentId').and.returnValue(componentStates);
-    const criteria = {
-      params: {
-        nodeId: 'node1',
-        componentId: 'component1'
-      }
-    };
-    expect(service.evaluateIsCorrectCriteria(criteria)).toEqual(false);
-  });
-}
-
-function evaluateIsCorrectCriteria() {
-  const criteria = {
-    params: {
-      nodeId: 'node1',
-      componentId: 'component1'
-    }
-  };
-  it('should evaluate is correct criteria false', () => {
-    const componentStates = [{ studentData: { isCorrect: false } }];
-    spyOn(dataService, 'getComponentStatesByNodeIdAndComponentId').and.returnValue(componentStates);
-    expect(service.evaluateIsCorrectCriteria(criteria)).toEqual(false);
-  });
-  it('should evaluate is correct criteria true', () => {
-    const componentStates = [{ studentData: { isCorrect: true } }];
-    spyOn(dataService, 'getComponentStatesByNodeIdAndComponentId').and.returnValue(componentStates);
-    expect(service.evaluateIsCorrectCriteria(criteria)).toEqual(true);
   });
 }
 

--- a/src/assets/wise5/common/constraint/strategies/BranchPathTakenConstraintStrategy.spec.ts
+++ b/src/assets/wise5/common/constraint/strategies/BranchPathTakenConstraintStrategy.spec.ts
@@ -1,0 +1,45 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { StudentDataService } from '../../../services/studentDataService';
+import { BranchPathTakenConstraintStrategy } from './BranchPathTakenConstraintStrategy';
+
+let dataService: StudentDataService;
+let strategy: BranchPathTakenConstraintStrategy;
+
+describe('BranchPathTakenConstraintStrategy', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, StudentTeacherCommonServicesModule]
+    });
+    dataService = TestBed.inject(StudentDataService);
+    strategy = new BranchPathTakenConstraintStrategy();
+    strategy.dataService = dataService;
+  });
+  evaluate();
+});
+
+function evaluate() {
+  describe('evaluate()', () => {
+    const criteria = {
+      params: {
+        fromNodeId: 'node1',
+        toNodeId: 'node2'
+      }
+    };
+    it('should return false when there are no branch path taken events', () => {
+      expectEvaluate(criteria, [], false);
+    });
+    it('should return false when fromNodeId and toNodeId do not match any branch path taken', () => {
+      expectEvaluate(criteria, [{ data: { fromNodeId: 'node1', toNodeId: 'node3' } }], false);
+    });
+    it('should return true when fromNodeId and toNodeId match a branch path taken', () => {
+      expectEvaluate(criteria, [{ data: { fromNodeId: 'node1', toNodeId: 'node2' } }], true);
+    });
+  });
+}
+
+function expectEvaluate(criteria: any, branchPathTaken: any[], expected: boolean): void {
+  spyOn(dataService, 'getBranchPathTakenEventsByNodeId').and.returnValue(branchPathTaken);
+  expect(strategy.evaluate(criteria)).toEqual(expected);
+}

--- a/src/assets/wise5/common/constraint/strategies/BranchPathTakenConstraintStrategy.ts
+++ b/src/assets/wise5/common/constraint/strategies/BranchPathTakenConstraintStrategy.ts
@@ -1,0 +1,14 @@
+import { AbstractConstraintStrategy } from './AbstractConstraintStrategy';
+
+export class BranchPathTakenConstraintStrategy extends AbstractConstraintStrategy {
+  evaluate(criteria: any): boolean {
+    const branchPathTakenEvents = this.dataService.getBranchPathTakenEventsByNodeId(
+      criteria.params.fromNodeId
+    );
+    return branchPathTakenEvents.some(
+      (event) =>
+        event.data.fromNodeId === criteria.params.fromNodeId &&
+        event.data.toNodeId === criteria.params.toNodeId
+    );
+  }
+}

--- a/src/assets/wise5/common/constraint/strategies/IsCorrectConstraintStrategy.spec.ts
+++ b/src/assets/wise5/common/constraint/strategies/IsCorrectConstraintStrategy.spec.ts
@@ -1,0 +1,45 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { StudentDataService } from '../../../services/studentDataService';
+import { IsCorrectConstraintStrategy } from './IsCorrectConstraintStrategy';
+
+let dataService: StudentDataService;
+let strategy: IsCorrectConstraintStrategy;
+
+describe('IsCorrectConstraintStrategy', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, StudentTeacherCommonServicesModule]
+    });
+    dataService = TestBed.inject(StudentDataService);
+    strategy = new IsCorrectConstraintStrategy();
+    strategy.dataService = dataService;
+  });
+  evaluate();
+});
+
+function evaluate() {
+  describe('evaluate()', () => {
+    const criteria = {
+      params: {
+        nodeId: 'node1',
+        componentId: 'component1'
+      }
+    };
+    it('should return false when no component states', () => {
+      expectEvaluate(criteria, [], false);
+    });
+    it('should return false when there is no correct data', () => {
+      expectEvaluate(criteria, [{ studentData: { isCorrect: false } }], false);
+    });
+    it('should return true when there is correct data', () => {
+      expectEvaluate(criteria, [{ studentData: { isCorrect: true } }], true);
+    });
+  });
+}
+
+function expectEvaluate(criteria: any, componentStates: any[], expected: boolean): void {
+  spyOn(dataService, 'getComponentStatesByNodeIdAndComponentId').and.returnValue(componentStates);
+  expect(strategy.evaluate(criteria)).toEqual(expected);
+}

--- a/src/assets/wise5/common/constraint/strategies/IsCorrectConstraintStrategy.ts
+++ b/src/assets/wise5/common/constraint/strategies/IsCorrectConstraintStrategy.ts
@@ -1,0 +1,11 @@
+import { AbstractConstraintStrategy } from './AbstractConstraintStrategy';
+
+export class IsCorrectConstraintStrategy extends AbstractConstraintStrategy {
+  evaluate(criteria: any): boolean {
+    const componentStates = this.dataService.getComponentStatesByNodeIdAndComponentId(
+      criteria.params.nodeId,
+      criteria.params.componentId
+    );
+    return componentStates.some((componentState) => componentState.studentData.isCorrect);
+  }
+}

--- a/src/assets/wise5/common/constraint/strategies/UsedXSubmitsConstraintStrategy.spec.ts
+++ b/src/assets/wise5/common/constraint/strategies/UsedXSubmitsConstraintStrategy.spec.ts
@@ -1,0 +1,43 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { StudentDataService } from '../../../services/studentDataService';
+import { UsedXSubmitsConstraintStrategy } from './UsedXSubmitsConstraintStrategy';
+
+let dataService: StudentDataService;
+let strategy: UsedXSubmitsConstraintStrategy;
+
+describe('UsedXSubmitsConstraintStrategy', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, StudentTeacherCommonServicesModule]
+    });
+    dataService = TestBed.inject(StudentDataService);
+    strategy = new UsedXSubmitsConstraintStrategy();
+    strategy.dataService = dataService;
+  });
+  evaluate();
+});
+
+function evaluate() {
+  describe('evaluate()', () => {
+    const criteria = {
+      params: {
+        nodeId: 'node1',
+        componentId: 'component1',
+        requiredSubmitCount: 2
+      }
+    };
+    it('should return false when submitCount is less than required count', () => {
+      expectEvaluate(criteria, [{ studentData: { submitCounter: 1 } }], false);
+    });
+    it('should return true when submitCount is the required count', () => {
+      expectEvaluate(criteria, [{ studentData: { submitCounter: 2 } }], true);
+    });
+  });
+}
+
+function expectEvaluate(criteria: any, componentStates: any[], expected: boolean): void {
+  spyOn(dataService, 'getComponentStatesByNodeIdAndComponentId').and.returnValue(componentStates);
+  expect(strategy.evaluate(criteria)).toEqual(expected);
+}

--- a/src/assets/wise5/common/constraint/strategies/UsedXSubmitsConstraintStrategy.ts
+++ b/src/assets/wise5/common/constraint/strategies/UsedXSubmitsConstraintStrategy.ts
@@ -1,0 +1,31 @@
+import { AbstractConstraintStrategy } from './AbstractConstraintStrategy';
+
+export class UsedXSubmitsConstraintStrategy extends AbstractConstraintStrategy {
+  evaluate(criteria: any): boolean {
+    const componentStates = this.dataService.getComponentStatesByNodeIdAndComponentId(
+      criteria.params.nodeId,
+      criteria.params.componentId
+    );
+    return this.getSubmitCount(componentStates) >= criteria.params.requiredSubmitCount;
+  }
+
+  private getSubmitCount(componentStates: any[]): number {
+    /*
+     * We are counting with two submit counters for backwards compatibility.
+     * Some componentStates only have isSubmit=true and do not keep an
+     * updated submitCounter for the number of submits.
+     */
+    let manualSubmitCounter = 0;
+    let highestSubmitCounter = 0;
+    for (const componentState of componentStates) {
+      if (componentState.isSubmit) {
+        manualSubmitCounter++;
+      }
+      const studentData = componentState.studentData;
+      if (studentData.submitCounter > highestSubmitCounter) {
+        highestSubmitCounter = studentData.submitCounter;
+      }
+    }
+    return Math.max(manualSubmitCounter, highestSubmitCounter);
+  }
+}

--- a/src/assets/wise5/common/constraint/strategies/WroteXNumberOfWordsConstraintStrategy.spec.ts
+++ b/src/assets/wise5/common/constraint/strategies/WroteXNumberOfWordsConstraintStrategy.spec.ts
@@ -1,0 +1,45 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { StudentDataService } from '../../../services/studentDataService';
+import { WroteXNumberOfWordsConstraintStrategy } from './WroteXNumberOfWordsConstraintStrategy';
+
+let dataService: StudentDataService;
+let strategy: WroteXNumberOfWordsConstraintStrategy;
+
+describe('WroteXNumberOfWordsConstraintStrategy', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, StudentTeacherCommonServicesModule]
+    });
+    dataService = TestBed.inject(StudentDataService);
+    strategy = new WroteXNumberOfWordsConstraintStrategy();
+    strategy.dataService = dataService;
+  });
+  evaluate();
+});
+
+function evaluate() {
+  describe('evaluate()', () => {
+    const criteria = {
+      params: {
+        nodeId: 'node1',
+        componentId: 'component1',
+        requiredNumberOfWords: 10
+      }
+    };
+    it('should return false when less than required words were written', () => {
+      expectEvaluate(criteria, { studentData: { response: 'one two three four five' } }, false);
+    });
+    it('should return true when at least required words were written', () => {
+      expectEvaluate(criteria, { studentData: { response: '1 2 3 4 5 6 7 8 9 0' } }, true);
+    });
+  });
+}
+
+function expectEvaluate(criteria: any, componentState: any, expected: boolean): void {
+  spyOn(dataService, 'getLatestComponentStateByNodeIdAndComponentId').and.returnValue(
+    componentState
+  );
+  expect(strategy.evaluate(criteria)).toEqual(expected);
+}

--- a/src/assets/wise5/common/constraint/strategies/WroteXNumberOfWordsConstraintStrategy.ts
+++ b/src/assets/wise5/common/constraint/strategies/WroteXNumberOfWordsConstraintStrategy.ts
@@ -1,0 +1,27 @@
+import { AbstractConstraintStrategy } from './AbstractConstraintStrategy';
+
+export class WroteXNumberOfWordsConstraintStrategy extends AbstractConstraintStrategy {
+  evaluate(criteria: any): boolean {
+    const params = criteria.params;
+    const nodeId = params.nodeId;
+    const componentId = params.componentId;
+    const requiredNumberOfWords = params.requiredNumberOfWords;
+    const componentState = this.dataService.getLatestComponentStateByNodeIdAndComponentId(
+      nodeId,
+      componentId
+    );
+    if (componentState != null) {
+      const studentData = componentState.studentData;
+      const response = studentData.response;
+      const numberOfWords = this.wordCount(response);
+      if (numberOfWords >= requiredNumberOfWords) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private wordCount(str: string): number {
+    return str.trim().split(/\s+/).length;
+  }
+}

--- a/src/assets/wise5/services/constraintService.ts
+++ b/src/assets/wise5/services/constraintService.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { EvaluateConstraintContext } from '../common/constraint/EvaluateConstraintContext';
 import { BranchPathTakenConstraintStrategy } from '../common/constraint/strategies/BranchPathTakenConstraintStrategy';
 import { IsCompletedConstraintStrategy } from '../common/constraint/strategies/IsCompletedConstraintStrategy';
+import { IsCorrectConstraintStrategy } from '../common/constraint/strategies/IsCorrectConstraintStrategy';
 import { WroteXNumberOfWordsConstraintStrategy } from '../common/constraint/strategies/WroteXNumberOfWordsConstraintStrategy';
 import { AnnotationService } from './annotationService';
 import { ComponentServiceLookupService } from './componentServiceLookupService';
@@ -15,6 +16,7 @@ export class ConstraintService {
   criteriaFunctionNameToStrategy = {
     branchPathTaken: new BranchPathTakenConstraintStrategy(),
     isCompleted: new IsCompletedConstraintStrategy(),
+    isCorrect: new IsCorrectConstraintStrategy(),
     wroteXNumberOfWords: new WroteXNumberOfWordsConstraintStrategy()
   };
 
@@ -36,9 +38,6 @@ export class ConstraintService {
     },
     isVisitedAndRevisedAfter: (criteria) => {
       return this.evaluateIsVisitedAndRevisedAfterCriteria(criteria);
-    },
-    isCorrect: (criteria) => {
-      return this.evaluateIsCorrectCriteria(criteria);
     },
     choiceChosen: (criteria) => {
       return this.evaluateChoiceChosenCriteria(criteria);
@@ -142,7 +141,9 @@ export class ConstraintService {
   }
 
   private evaluateCriteria(criteria: any): boolean {
-    if (['isCompleted', 'branchPathTaken', 'wroteXNumberOfWords'].includes(criteria.name)) {
+    if (
+      ['branchPathTaken', 'isCompleted', 'isCorrect', 'wroteXNumberOfWords'].includes(criteria.name)
+    ) {
       this.evaluateConstraintContext.setStrategy(
         this.criteriaFunctionNameToStrategy[criteria.name]
       );
@@ -243,19 +244,6 @@ export class ConstraintService {
         event.clientSaveTime
       )
     );
-  }
-
-  evaluateIsCorrectCriteria(criteria) {
-    const componentStates = this.dataService.getComponentStatesByNodeIdAndComponentId(
-      criteria.params.nodeId,
-      criteria.params.componentId
-    );
-    for (const componentState of componentStates) {
-      if (componentState.studentData.isCorrect) {
-        return true;
-      }
-    }
-    return false;
   }
 
   evaluateChoiceChosenCriteria(criteria: any): boolean {

--- a/src/assets/wise5/services/constraintService.ts
+++ b/src/assets/wise5/services/constraintService.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { EvaluateConstraintContext } from '../common/constraint/EvaluateConstraintContext';
 import { BranchPathTakenConstraintStrategy } from '../common/constraint/strategies/BranchPathTakenConstraintStrategy';
 import { IsCompletedConstraintStrategy } from '../common/constraint/strategies/IsCompletedConstraintStrategy';
+import { WroteXNumberOfWordsConstraintStrategy } from '../common/constraint/strategies/WroteXNumberOfWordsConstraintStrategy';
 import { AnnotationService } from './annotationService';
 import { ComponentServiceLookupService } from './componentServiceLookupService';
 import { ConfigService } from './configService';
@@ -12,8 +13,9 @@ import { TagService } from './tagService';
 @Injectable()
 export class ConstraintService {
   criteriaFunctionNameToStrategy = {
+    branchPathTaken: new BranchPathTakenConstraintStrategy(),
     isCompleted: new IsCompletedConstraintStrategy(),
-    branchPathTaken: new BranchPathTakenConstraintStrategy()
+    wroteXNumberOfWords: new WroteXNumberOfWordsConstraintStrategy()
   };
 
   criteriaFunctionNameToFunction = {
@@ -49,9 +51,6 @@ export class ConstraintService {
     },
     usedXSubmits: (criteria) => {
       return this.evaluateUsedXSubmitsCriteria(criteria);
-    },
-    wroteXNumberOfWords: (criteria) => {
-      return this.evaluateNumberOfWordsWrittenCriteria(criteria);
     },
     addXNumberOfNotesOnThisStep: (criteria) => {
       return this.evaluateAddXNumberOfNotesOnThisStepCriteria(criteria);
@@ -143,7 +142,7 @@ export class ConstraintService {
   }
 
   private evaluateCriteria(criteria: any): boolean {
-    if (['isCompleted', 'branchPathTaken'].includes(criteria.name)) {
+    if (['isCompleted', 'branchPathTaken', 'wroteXNumberOfWords'].includes(criteria.name)) {
       this.evaluateConstraintContext.setStrategy(
         this.criteriaFunctionNameToStrategy[criteria.name]
       );
@@ -322,30 +321,6 @@ export class ConstraintService {
       }
     }
     return Math.max(manualSubmitCounter, highestSubmitCounter);
-  }
-
-  evaluateNumberOfWordsWrittenCriteria(criteria: any): boolean {
-    const params = criteria.params;
-    const nodeId = params.nodeId;
-    const componentId = params.componentId;
-    const requiredNumberOfWords = params.requiredNumberOfWords;
-    const componentState = this.dataService.getLatestComponentStateByNodeIdAndComponentId(
-      nodeId,
-      componentId
-    );
-    if (componentState != null) {
-      const studentData = componentState.studentData;
-      const response = studentData.response;
-      const numberOfWords = this.wordCount(response);
-      if (numberOfWords >= requiredNumberOfWords) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private wordCount(str: string): number {
-    return str.trim().split(/\s+/).length;
   }
 
   evaluateAddXNumberOfNotesOnThisStepCriteria(criteria: any): boolean {

--- a/src/assets/wise5/services/constraintService.ts
+++ b/src/assets/wise5/services/constraintService.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { EvaluateConstraintContext } from '../common/constraint/EvaluateConstraintContext';
+import { BranchPathTakenConstraintStrategy } from '../common/constraint/strategies/BranchPathTakenConstraintStrategy';
 import { IsCompletedConstraintStrategy } from '../common/constraint/strategies/IsCompletedConstraintStrategy';
 import { AnnotationService } from './annotationService';
 import { ComponentServiceLookupService } from './componentServiceLookupService';
@@ -11,13 +12,11 @@ import { TagService } from './tagService';
 @Injectable()
 export class ConstraintService {
   criteriaFunctionNameToStrategy = {
-    isCompleted: new IsCompletedConstraintStrategy()
+    isCompleted: new IsCompletedConstraintStrategy(),
+    branchPathTaken: new BranchPathTakenConstraintStrategy()
   };
 
   criteriaFunctionNameToFunction = {
-    branchPathTaken: (criteria) => {
-      return this.evaluateBranchPathTakenCriteria(criteria);
-    },
     isVisible: (criteria) => {
       return this.evaluateIsVisibleCriteria(criteria);
     },
@@ -144,7 +143,7 @@ export class ConstraintService {
   }
 
   private evaluateCriteria(criteria: any): boolean {
-    if (criteria.name === 'isCompleted') {
+    if (['isCompleted', 'branchPathTaken'].includes(criteria.name)) {
       this.evaluateConstraintContext.setStrategy(
         this.criteriaFunctionNameToStrategy[criteria.name]
       );
@@ -162,21 +161,6 @@ export class ConstraintService {
       }
     }
     return true;
-  }
-
-  evaluateBranchPathTakenCriteria(criteria: any): boolean {
-    const expectedFromNodeId = criteria.params.fromNodeId;
-    const expectedToNodeId = criteria.params.toNodeId;
-    const branchPathTakenEvents = this.dataService.getBranchPathTakenEventsByNodeId(
-      expectedFromNodeId
-    );
-    for (const branchPathTakenEvent of branchPathTakenEvents) {
-      const data = branchPathTakenEvent.data;
-      if (criteria.params.fromNodeId === data.fromNodeId && expectedToNodeId === data.toNodeId) {
-        return true;
-      }
-    }
-    return false;
   }
 
   evaluateIsVisibleCriteria(criteria: any): boolean {


### PR DESCRIPTION
## Changes
Extract various criteria constraint evaluation logic in ConstraintService using Strategy pattern and put them into their own file. To keep the work&review scopes manageable, only these logic are extracted in this PR:
- BranchPathTakenConstraintStrategy
- IsCorrectConstraintStrategy
- UsedXSubmitsConstraintStrategy
- WroteXNumberOfWordsConstraintStrategy

## Test
- Above criteria constraint evaluation work as before
- Other criteria constraint evaluation work as before

Closes #1088