### PR TITLE
fix(Authoring): Jigsaw incorrect constraints

### DIFF
--- a/src/assets/wise5/authoringTool/structure/jigsaw/nodes-3.json
+++ b/src/assets/wise5/authoringTool/structure/jigsaw/nodes-3.json
@@ -628,9 +628,9 @@
     "constraints": [
       {
         "removalConditional": "all",
-        "targetId": "node6",
+        "targetId": "node7",
         "action": "makeThisNodeNotVisible",
-        "id": "node6Constraint1",
+        "id": "node7Constraint1",
         "removalCriteria": [
           {
             "name": "branchPathTaken",
@@ -643,9 +643,9 @@
       },
       {
         "removalConditional": "all",
-        "targetId": "node6",
+        "targetId": "node7",
         "action": "makeThisNodeNotVisitable",
-        "id": "node6Constraint2",
+        "id": "node7Constraint2",
         "removalCriteria": [
           {
             "name": "branchPathTaken",

--- a/src/assets/wise5/authoringTool/structure/jigsaw/nodes-4.json
+++ b/src/assets/wise5/authoringTool/structure/jigsaw/nodes-4.json
@@ -647,9 +647,9 @@
     "constraints": [
       {
         "removalConditional": "all",
-        "targetId": "node6",
+        "targetId": "node7",
         "action": "makeThisNodeNotVisible",
-        "id": "node6Constraint1",
+        "id": "node7Constraint1",
         "removalCriteria": [
           {
             "name": "branchPathTaken",
@@ -662,9 +662,9 @@
       },
       {
         "removalConditional": "all",
-        "targetId": "node6",
+        "targetId": "node7",
         "action": "makeThisNodeNotVisitable",
-        "id": "node6Constraint2",
+        "id": "node7Constraint2",
         "removalCriteria": [
           {
             "name": "branchPathTaken",
@@ -832,9 +832,9 @@
     "constraints": [
       {
         "removalConditional": "all",
-        "targetId": "node8",
+        "targetId": "node9",
         "action": "makeThisNodeNotVisible",
-        "id": "node8Constraint1",
+        "id": "node9Constraint1",
         "removalCriteria": [
           {
             "name": "branchPathTaken",
@@ -847,9 +847,9 @@
       },
       {
         "removalConditional": "all",
-        "targetId": "node8",
+        "targetId": "node9",
         "action": "makeThisNodeNotVisitable",
-        "id": "node8Constraint2",
+        "id": "node9Constraint2",
         "removalCriteria": [
           {
             "name": "branchPathTaken",


### PR DESCRIPTION
## Changes

Fixed constraints in jigsaw three group and four group content.

## Test

1. In the Authoring Tool, add a Jigsaw with three groups
2. Preview the project and look at the step drop down
3. You should not see the step "C: Discuss what you learned about Topic C". You should only see this step if you choose branch 3.


1. In the Authoring Tool, add a Jigsaw with four groups
2. Preview the project and look at the step drop down
3. You should not see the step "C: Discuss what you learned about Topic C". You should only see this step if you choose branch 3.
4. You should not see the step "D: Discuss what you learned about Topic D". You should only see this step if you choose branch 4.

Closes #1090