### PR TITLE
fix(WISE Link): Link stops working when component is authored again

### DIFF
--- a/src/assets/wise5/common/wise-link/wise-link.spec.ts
+++ b/src/assets/wise5/common/wise-link/wise-link.spec.ts
@@ -148,5 +148,5 @@ function createWiseLinkReplacedByElement(
   componentId: string,
   linkText: string
 ): string {
-  return `<${tag} wiselink="true" onclick="document.getElementById('replace-with-unique-id').dispatchEvent(new CustomEvent('wiselinkclicked', { detail: { nodeId: '${nodeId}', componentId: '${componentId}' } })); return false;">${linkText}</${tag}>`;
+  return `<${tag} wiselink="true" node-id="${nodeId}" component-id="${componentId}" onclick="document.getElementById('replace-with-unique-id').dispatchEvent(new CustomEvent('wiselinkclicked', { detail: { nodeId: '${nodeId}', componentId: '${componentId}' } })); return false;">${linkText}</${tag}>`;
 }

--- a/src/assets/wise5/common/wise-link/wise-link.ts
+++ b/src/assets/wise5/common/wise-link/wise-link.ts
@@ -102,10 +102,11 @@ function replaceWiseLinksHelper(html: string, regex: string): string {
     const linkText = getWiseLinkLinkText(wiseLinkHTML);
     let newElement = '';
     const onclickString = `document.getElementById('replace-with-unique-id').dispatchEvent(new CustomEvent('wiselinkclicked', { detail: { nodeId: '${nodeId}', componentId: '${componentId}' } })); return false;`;
+    const params = `wiselink="true" node-id="${nodeId}" component-id="${componentId}" onclick="${onclickString}"`;
     if (type === 'button') {
-      newElement = `<button wiselink="true" onclick="${onclickString}">${linkText}</button>`;
+      newElement = `<button ${params}>${linkText}</button>`;
     } else {
-      newElement = `<a wiselink="true" onclick="${onclickString}">${linkText}</a>`;
+      newElement = `<a ${params}>${linkText}</a>`;
     }
     html = html.replace(wiseLinkHTML, newElement);
     wiseLinkRegExMatchResult = wiseLinkRegEx.exec(html);


### PR DESCRIPTION
## Changes

Added node-id and component-id params to the elements that are generated to display to the student.

## Test

1. Open a project in the Authoring Tool
2. Create an HTML component (or use an existing one)
3. Add a WISE Link that points to another step
4. Preview the project and click the link to test it. It should properly bring you to the other step.
5. Go back to the Authoring Tool and leave the step and come back to it
6. Edit the HTML component by adding some text
7. Preview the project and click the link to test it. The link used to no longer work but now it should.

Closes #1094