### PR TITLE
refactor(ConstraintService): Extract criteria constraint evaluation logic part 3

### DIFF
--- a/src/app/services/constraintService.spec.ts
+++ b/src/app/services/constraintService.spec.ts
@@ -17,8 +17,6 @@ let criteria1: any;
 let criteria2: any;
 let nodeConstraintTwoRemovalCriteria: any;
 let scoreCriteria: any;
-let addXNumberOfNotesOnThisStepCriteria: any;
-let addXNumberOfNotesOnThisStepNotebook: any;
 
 describe('ConstraintService', () => {
   beforeEach(() => {
@@ -56,32 +54,10 @@ describe('ConstraintService', () => {
         scores: [1, 2, 3]
       }
     };
-    addXNumberOfNotesOnThisStepCriteria = {
-      params: {
-        nodeId: 'node1',
-        requiredNumberOfNotes: 10
-      }
-    };
-    addXNumberOfNotesOnThisStepNotebook = {
-      allItems: [
-        { nodeId: 'node1' },
-        { nodeId: 'node1' },
-        { nodeId: 'node1' },
-        { nodeId: 'node1' },
-        { nodeId: 'node1' },
-        { nodeId: 'node2' },
-        { nodeId: 'node2' },
-        { nodeId: 'node2' },
-        { nodeId: 'node2' },
-        { nodeId: 'node2' }
-      ]
-    };
   });
-
   evaluateNodeConstraintWithOneRemovalCriteria();
   evaluateNodeConstraintWithTwoRemovalCriteria();
   evaluateScoreCriteria();
-  evaluateAddXNumberOfNotesOnThisStepCriteria();
   evaluateCriterias();
 });
 
@@ -132,28 +108,6 @@ function evaluateScoreCriteria() {
   it('should evaluate score criteria true', () => {
     scoreCriteriaSpies(3);
     expect(service.evaluateScoreCriteria(scoreCriteria)).toEqual(true);
-  });
-}
-
-function evaluateAddXNumberOfNotesOnThisStepCriteria() {
-  it('should evaluate add x number of notes on this step criteria false', () => {
-    spyOn(notebookService, 'getNotebookByWorkgroup').and.returnValue(
-      addXNumberOfNotesOnThisStepNotebook
-    );
-    expect(
-      service.evaluateAddXNumberOfNotesOnThisStepCriteria(addXNumberOfNotesOnThisStepCriteria)
-    ).toEqual(false);
-  });
-  it('should evaluate add x number of notes on this step criteria true', () => {
-    addXNumberOfNotesOnThisStepNotebook.allItems.forEach((item) => {
-      item.nodeId = 'node1';
-    });
-    spyOn(notebookService, 'getNotebookByWorkgroup').and.returnValue(
-      addXNumberOfNotesOnThisStepNotebook
-    );
-    expect(
-      service.evaluateAddXNumberOfNotesOnThisStepCriteria(addXNumberOfNotesOnThisStepCriteria)
-    ).toEqual(true);
   });
 }
 

--- a/src/assets/wise5/common/constraint/EvaluateConstraintContext.ts
+++ b/src/assets/wise5/common/constraint/EvaluateConstraintContext.ts
@@ -1,4 +1,5 @@
 import { ComponentServiceLookupService } from '../../services/componentServiceLookupService';
+import { NotebookService } from '../../services/notebookService';
 import { StudentDataService } from '../../services/studentDataService';
 import { ConstraintStrategy } from './strategies/ConstraintStrategy';
 
@@ -7,7 +8,8 @@ export class EvaluateConstraintContext {
 
   constructor(
     private componentServiceLookupService: ComponentServiceLookupService,
-    private dataService: StudentDataService
+    private dataService: StudentDataService,
+    private notebookService: NotebookService
   ) {}
 
   getComponentServiceLookupService(): ComponentServiceLookupService {
@@ -16,6 +18,10 @@ export class EvaluateConstraintContext {
 
   getDataService(): StudentDataService {
     return this.dataService;
+  }
+
+  getNotebookService(): NotebookService {
+    return this.notebookService;
   }
 
   setStrategy(strategy: ConstraintStrategy): void {

--- a/src/assets/wise5/common/constraint/EvaluateConstraintContext.ts
+++ b/src/assets/wise5/common/constraint/EvaluateConstraintContext.ts
@@ -1,10 +1,18 @@
+import { ComponentServiceLookupService } from '../../services/componentServiceLookupService';
 import { StudentDataService } from '../../services/studentDataService';
 import { ConstraintStrategy } from './strategies/ConstraintStrategy';
 
 export class EvaluateConstraintContext {
   private strategy: ConstraintStrategy;
 
-  constructor(private dataService: StudentDataService) {}
+  constructor(
+    private componentServiceLookupService: ComponentServiceLookupService,
+    private dataService: StudentDataService
+  ) {}
+
+  getComponentServiceLookupService(): ComponentServiceLookupService {
+    return this.componentServiceLookupService;
+  }
 
   getDataService(): StudentDataService {
     return this.dataService;

--- a/src/assets/wise5/common/constraint/strategies/AbstractConstraintStrategy.ts
+++ b/src/assets/wise5/common/constraint/strategies/AbstractConstraintStrategy.ts
@@ -1,14 +1,17 @@
+import { ComponentServiceLookupService } from '../../../services/componentServiceLookupService';
 import { StudentDataService } from '../../../services/studentDataService';
 import { EvaluateConstraintContext } from '../EvaluateConstraintContext';
 import { ConstraintStrategy } from './ConstraintStrategy';
 
 export abstract class AbstractConstraintStrategy implements ConstraintStrategy {
+  componentServiceLookupService: ComponentServiceLookupService;
   context: EvaluateConstraintContext;
   dataService: StudentDataService;
 
   setContext(context: EvaluateConstraintContext): void {
     this.context = context;
     this.dataService = this.context.getDataService();
+    this.componentServiceLookupService = this.context.getComponentServiceLookupService();
   }
 
   abstract evaluate(criteria: any): boolean;

--- a/src/assets/wise5/common/constraint/strategies/AbstractConstraintStrategy.ts
+++ b/src/assets/wise5/common/constraint/strategies/AbstractConstraintStrategy.ts
@@ -1,4 +1,5 @@
 import { ComponentServiceLookupService } from '../../../services/componentServiceLookupService';
+import { NotebookService } from '../../../services/notebookService';
 import { StudentDataService } from '../../../services/studentDataService';
 import { EvaluateConstraintContext } from '../EvaluateConstraintContext';
 import { ConstraintStrategy } from './ConstraintStrategy';
@@ -7,11 +8,13 @@ export abstract class AbstractConstraintStrategy implements ConstraintStrategy {
   componentServiceLookupService: ComponentServiceLookupService;
   context: EvaluateConstraintContext;
   dataService: StudentDataService;
+  notebookService: NotebookService;
 
   setContext(context: EvaluateConstraintContext): void {
     this.context = context;
     this.dataService = this.context.getDataService();
     this.componentServiceLookupService = this.context.getComponentServiceLookupService();
+    this.notebookService = this.context.getNotebookService();
   }
 
   abstract evaluate(criteria: any): boolean;

--- a/src/assets/wise5/common/constraint/strategies/AddXNumberOfNotesOnThisStepConstraintStrategy.spec.ts
+++ b/src/assets/wise5/common/constraint/strategies/AddXNumberOfNotesOnThisStepConstraintStrategy.spec.ts
@@ -1,0 +1,56 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { MatDialogModule } from '@angular/material/dialog';
+import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { NotebookService } from '../../../services/notebookService';
+import { StudentDataService } from '../../../services/studentDataService';
+import { AddXNumberOfNotesOnThisStepConstraintStrategy } from './AddXNumberOfNotesOnThisStepConstraintStrategy';
+
+let dataService: StudentDataService;
+let notebookService: NotebookService;
+let strategy: AddXNumberOfNotesOnThisStepConstraintStrategy;
+
+describe('AddXNumberOfNotesOnThisStepConstraintStrategy', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, MatDialogModule, StudentTeacherCommonServicesModule]
+    });
+    dataService = TestBed.inject(StudentDataService);
+    notebookService = TestBed.inject(NotebookService);
+    strategy = new AddXNumberOfNotesOnThisStepConstraintStrategy();
+    strategy.dataService = dataService;
+    strategy.notebookService = notebookService;
+  });
+  evaluate();
+});
+
+function evaluate() {
+  describe('evaluate()', () => {
+    const criteria = {
+      params: {
+        nodeId: 'node1',
+        requiredNumberOfNotes: 2
+      }
+    };
+    let notebook;
+    beforeEach(() => {
+      notebook = {
+        allItems: [{ nodeId: 'node1' }, { nodeId: 'node2' }]
+      };
+    });
+    it('should return false when there are not enough required number of notes', () => {
+      expectEvaluate(criteria, notebook, false);
+    });
+    it('should return true when there are enough required number of notes', () => {
+      notebook.allItems.forEach((item) => {
+        item.nodeId = 'node1';
+      });
+      expectEvaluate(criteria, notebook, true);
+    });
+  });
+}
+
+function expectEvaluate(criteria: any, notebook: any, expectedValue: boolean): void {
+  spyOn(notebookService, 'getNotebookByWorkgroup').and.returnValue(notebook);
+  expect(strategy.evaluate(criteria)).toEqual(expectedValue);
+}

--- a/src/assets/wise5/common/constraint/strategies/AddXNumberOfNotesOnThisStepConstraintStrategy.ts
+++ b/src/assets/wise5/common/constraint/strategies/AddXNumberOfNotesOnThisStepConstraintStrategy.ts
@@ -1,0 +1,14 @@
+import { AbstractConstraintStrategy } from './AbstractConstraintStrategy';
+
+export class AddXNumberOfNotesOnThisStepConstraintStrategy extends AbstractConstraintStrategy {
+  evaluate(criteria: any): boolean {
+    try {
+      const notebookItemsByNodeId = this.dataService.getNotebookItemsByNodeId(
+        this.notebookService.getNotebookByWorkgroup(),
+        criteria.params.nodeId
+      );
+      return notebookItemsByNodeId.length >= criteria.params.requiredNumberOfNotes;
+    } catch (e) {}
+    return false;
+  }
+}

--- a/src/assets/wise5/common/constraint/strategies/ChoiceChosenConstraintStrategy.ts
+++ b/src/assets/wise5/common/constraint/strategies/ChoiceChosenConstraintStrategy.ts
@@ -1,0 +1,12 @@
+import { AbstractConstraintStrategy } from './AbstractConstraintStrategy';
+
+export class ChoiceChosenConstraintStrategy extends AbstractConstraintStrategy {
+  evaluate(criteria: any): boolean {
+    const service = this.componentServiceLookupService.getService('MultipleChoice');
+    const latestComponentState = this.dataService.getLatestComponentStateByNodeIdAndComponentId(
+      criteria.params.nodeId,
+      criteria.params.componentId
+    );
+    return latestComponentState != null && service.choiceChosen(criteria, latestComponentState);
+  }
+}

--- a/src/assets/wise5/common/constraint/strategies/FillXNumberOfRowsConstraintStrategy.ts
+++ b/src/assets/wise5/common/constraint/strategies/FillXNumberOfRowsConstraintStrategy.ts
@@ -1,0 +1,20 @@
+import { AbstractConstraintStrategy } from './AbstractConstraintStrategy';
+
+export class FillXNumberOfRowsConstraintStrategy extends AbstractConstraintStrategy {
+  evaluate(criteria: any): boolean {
+    const componentState = this.dataService.getLatestComponentStateByNodeIdAndComponentId(
+      criteria.params.nodeId,
+      criteria.params.componentId
+    );
+    const tableService = this.componentServiceLookupService.getService('Table');
+    return (
+      componentState != null &&
+      tableService.hasRequiredNumberOfFilledRows(
+        componentState,
+        criteria.params.requiredNumberOfFilledRows,
+        criteria.params.tableHasHeaderRow,
+        criteria.params.requireAllCellsInARowToBeFilled
+      )
+    );
+  }
+}

--- a/src/assets/wise5/services/constraintService.ts
+++ b/src/assets/wise5/services/constraintService.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { EvaluateConstraintContext } from '../common/constraint/EvaluateConstraintContext';
 import { BranchPathTakenConstraintStrategy } from '../common/constraint/strategies/BranchPathTakenConstraintStrategy';
 import { ChoiceChosenConstraintStrategy } from '../common/constraint/strategies/ChoiceChosenConstraintStrategy';
+import { FillXNumberOfRowsConstraintStrategy } from '../common/constraint/strategies/FillXNumberOfRowsConstraintStrategy';
 import { IsCompletedConstraintStrategy } from '../common/constraint/strategies/IsCompletedConstraintStrategy';
 import { IsCorrectConstraintStrategy } from '../common/constraint/strategies/IsCorrectConstraintStrategy';
 import { IsRevisedAfterConstraintStrategy } from '../common/constraint/strategies/IsRevisedAfterConstraintStrategy';
@@ -24,6 +25,7 @@ export class ConstraintService {
   criteriaFunctionNameToStrategy = {
     branchPathTaken: new BranchPathTakenConstraintStrategy(),
     choiceChosen: new ChoiceChosenConstraintStrategy(),
+    fillXNumberOfRows: new FillXNumberOfRowsConstraintStrategy(),
     isCompleted: new IsCompletedConstraintStrategy(),
     isCorrect: new IsCorrectConstraintStrategy(),
     isRevisedAfter: new IsRevisedAfterConstraintStrategy(),
@@ -46,9 +48,6 @@ export class ConstraintService {
     addXNumberOfNotesOnThisStep: (criteria) => {
       return this.evaluateAddXNumberOfNotesOnThisStepCriteria(criteria);
     },
-    fillXNumberOfRows: (criteria) => {
-      return this.evaluateFillXNumberOfRowsCriteria(criteria);
-    },
     hasTag: (criteria) => {
       return this.evaluateHasTagCriteria(criteria);
     }
@@ -58,7 +57,7 @@ export class ConstraintService {
 
   constructor(
     private annotationService: AnnotationService,
-    private componentServiceLookupService: ComponentServiceLookupService,
+    componentServiceLookupService: ComponentServiceLookupService,
     private configService: ConfigService,
     private dataService: StudentDataService,
     private notebookService: NotebookService,
@@ -140,6 +139,7 @@ export class ConstraintService {
       [
         'branchPathTaken',
         'choiceChosen',
+        'fillXNumberOfRows',
         'isCompleted',
         'isCorrect',
         'isRevisedAfter',
@@ -170,6 +170,7 @@ export class ConstraintService {
     }
     return true;
   }
+
   evaluateScoreCriteria(criteria: any): boolean {
     const params = criteria.params;
     const scoreType = 'any';
@@ -203,29 +204,6 @@ export class ConstraintService {
       return notebookItemsByNodeId.length >= requiredNumberOfNotes;
     } catch (e) {}
     return false;
-  }
-
-  evaluateFillXNumberOfRowsCriteria(criteria: any): boolean {
-    const params = criteria.params;
-    const nodeId = params.nodeId;
-    const componentId = params.componentId;
-    const requiredNumberOfFilledRows = params.requiredNumberOfFilledRows;
-    const tableHasHeaderRow = params.tableHasHeaderRow;
-    const requireAllCellsInARowToBeFilled = params.requireAllCellsInARowToBeFilled;
-    const tableService = this.componentServiceLookupService.getService('Table');
-    const componentState = this.dataService.getLatestComponentStateByNodeIdAndComponentId(
-      nodeId,
-      componentId
-    );
-    return (
-      componentState != null &&
-      tableService.hasRequiredNumberOfFilledRows(
-        componentState,
-        requiredNumberOfFilledRows,
-        tableHasHeaderRow,
-        requireAllCellsInARowToBeFilled
-      )
-    );
   }
 
   evaluateHasTagCriteria(criteria: any): boolean {

--- a/src/assets/wise5/services/constraintService.ts
+++ b/src/assets/wise5/services/constraintService.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { EvaluateConstraintContext } from '../common/constraint/EvaluateConstraintContext';
+import { AddXNumberOfNotesOnThisStepConstraintStrategy } from '../common/constraint/strategies/AddXNumberOfNotesOnThisStepConstraintStrategy';
 import { BranchPathTakenConstraintStrategy } from '../common/constraint/strategies/BranchPathTakenConstraintStrategy';
 import { ChoiceChosenConstraintStrategy } from '../common/constraint/strategies/ChoiceChosenConstraintStrategy';
 import { FillXNumberOfRowsConstraintStrategy } from '../common/constraint/strategies/FillXNumberOfRowsConstraintStrategy';
@@ -23,6 +24,7 @@ import { TagService } from './tagService';
 @Injectable()
 export class ConstraintService {
   criteriaFunctionNameToStrategy = {
+    addXNumberOfNotesOnThisStep: new AddXNumberOfNotesOnThisStepConstraintStrategy(),
     branchPathTaken: new BranchPathTakenConstraintStrategy(),
     choiceChosen: new ChoiceChosenConstraintStrategy(),
     fillXNumberOfRows: new FillXNumberOfRowsConstraintStrategy(),
@@ -45,9 +47,6 @@ export class ConstraintService {
     teacherRemoval: (criteria) => {
       return this.evaluateTeacherRemovalCriteria(criteria);
     },
-    addXNumberOfNotesOnThisStep: (criteria) => {
-      return this.evaluateAddXNumberOfNotesOnThisStepCriteria(criteria);
-    },
     hasTag: (criteria) => {
       return this.evaluateHasTagCriteria(criteria);
     }
@@ -60,12 +59,13 @@ export class ConstraintService {
     componentServiceLookupService: ComponentServiceLookupService,
     private configService: ConfigService,
     private dataService: StudentDataService,
-    private notebookService: NotebookService,
+    notebookService: NotebookService,
     private tagService: TagService
   ) {
     this.evaluateConstraintContext = new EvaluateConstraintContext(
       componentServiceLookupService,
-      dataService
+      dataService,
+      notebookService
     );
   }
 
@@ -137,6 +137,7 @@ export class ConstraintService {
   private evaluateCriteria(criteria: any): boolean {
     if (
       [
+        'addXNumberOfNotesOnThisStep',
         'branchPathTaken',
         'choiceChosen',
         'fillXNumberOfRows',
@@ -192,18 +193,6 @@ export class ConstraintService {
 
   evaluateTeacherRemovalCriteria(criteria: any): boolean {
     return criteria.params.periodId !== this.configService.getPeriodId();
-  }
-
-  evaluateAddXNumberOfNotesOnThisStepCriteria(criteria: any): boolean {
-    const params = criteria.params;
-    const nodeId = params.nodeId;
-    const requiredNumberOfNotes = params.requiredNumberOfNotes;
-    try {
-      const notebook = this.notebookService.getNotebookByWorkgroup();
-      const notebookItemsByNodeId = this.dataService.getNotebookItemsByNodeId(notebook, nodeId);
-      return notebookItemsByNodeId.length >= requiredNumberOfNotes;
-    } catch (e) {}
-    return false;
   }
 
   evaluateHasTagCriteria(criteria: any): boolean {

--- a/src/assets/wise5/services/constraintService.ts
+++ b/src/assets/wise5/services/constraintService.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { EvaluateConstraintContext } from '../common/constraint/EvaluateConstraintContext';
 import { BranchPathTakenConstraintStrategy } from '../common/constraint/strategies/BranchPathTakenConstraintStrategy';
+import { ChoiceChosenConstraintStrategy } from '../common/constraint/strategies/ChoiceChosenConstraintStrategy';
 import { IsCompletedConstraintStrategy } from '../common/constraint/strategies/IsCompletedConstraintStrategy';
 import { IsCorrectConstraintStrategy } from '../common/constraint/strategies/IsCorrectConstraintStrategy';
 import { IsRevisedAfterConstraintStrategy } from '../common/constraint/strategies/IsRevisedAfterConstraintStrategy';
@@ -22,6 +23,7 @@ import { TagService } from './tagService';
 export class ConstraintService {
   criteriaFunctionNameToStrategy = {
     branchPathTaken: new BranchPathTakenConstraintStrategy(),
+    choiceChosen: new ChoiceChosenConstraintStrategy(),
     isCompleted: new IsCompletedConstraintStrategy(),
     isCorrect: new IsCorrectConstraintStrategy(),
     isRevisedAfter: new IsRevisedAfterConstraintStrategy(),
@@ -35,9 +37,6 @@ export class ConstraintService {
   };
 
   criteriaFunctionNameToFunction = {
-    choiceChosen: (criteria) => {
-      return this.evaluateChoiceChosenCriteria(criteria);
-    },
     score: (criteria) => {
       return this.evaluateScoreCriteria(criteria);
     },
@@ -65,7 +64,10 @@ export class ConstraintService {
     private notebookService: NotebookService,
     private tagService: TagService
   ) {
-    this.evaluateConstraintContext = new EvaluateConstraintContext(dataService);
+    this.evaluateConstraintContext = new EvaluateConstraintContext(
+      componentServiceLookupService,
+      dataService
+    );
   }
 
   evaluate(constraints: any[]): any {
@@ -137,6 +139,7 @@ export class ConstraintService {
     if (
       [
         'branchPathTaken',
+        'choiceChosen',
         'isCompleted',
         'isCorrect',
         'isRevisedAfter',
@@ -167,16 +170,6 @@ export class ConstraintService {
     }
     return true;
   }
-
-  evaluateChoiceChosenCriteria(criteria: any): boolean {
-    const service = this.componentServiceLookupService.getService('MultipleChoice');
-    const latestComponentState = this.dataService.getLatestComponentStateByNodeIdAndComponentId(
-      criteria.params.nodeId,
-      criteria.params.componentId
-    );
-    return latestComponentState != null && service.choiceChosen(criteria, latestComponentState);
-  }
-
   evaluateScoreCriteria(criteria: any): boolean {
     const params = criteria.params;
     const scoreType = 'any';


### PR DESCRIPTION
## Changes
Extract various criteria constraint evaluation logic in ConstraintService using Strategy pattern and put them into their own file. To keep the work&review scopes manageable, only these logic are extracted in this PR:
- AddXNumberOfNotesOnThisStepConstraintStrategy
- FillXNumberOfRowsConstraintStrategy
- ChoiceChosenConstraintStrategy

## Test
- Above criteria constraint evaluation work as before
- Other criteria constraint evaluation work as before

Closes #1096