### PR TITLE
refactor(ConstraintService): Extract criteria constraint evaluation logic part 4

### DIFF
--- a/src/app/services/constraintService.spec.ts
+++ b/src/app/services/constraintService.spec.ts
@@ -4,29 +4,19 @@ import { ConstraintService } from '../../assets/wise5/services/constraintService
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { StudentDataService } from '../../assets/wise5/services/studentDataService';
-import { ConfigService } from '../../assets/wise5/services/configService';
-import { AnnotationService } from '../../assets/wise5/services/annotationService';
-import { NotebookService } from '../../assets/wise5/services/notebookService';
 
-let annotationService: AnnotationService;
-let configService: ConfigService;
 let dataService: StudentDataService;
-let notebookService: NotebookService;
 let service: ConstraintService;
 let criteria1: any;
 let criteria2: any;
 let nodeConstraintTwoRemovalCriteria: any;
-let scoreCriteria: any;
 
 describe('ConstraintService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, MatDialogModule, StudentTeacherCommonServicesModule]
     });
-    annotationService = TestBed.inject(AnnotationService);
-    configService = TestBed.inject(ConfigService);
     dataService = TestBed.inject(StudentDataService);
-    notebookService = TestBed.inject(NotebookService);
     service = TestBed.inject(ConstraintService);
     criteria1 = {
       name: 'isCompleted',
@@ -47,17 +37,9 @@ describe('ConstraintService', () => {
       removalCriteria: [criteria1, criteria2],
       removalConditional: 'all'
     };
-    scoreCriteria = {
-      params: {
-        nodeId: 'node1',
-        componentId: 'component1',
-        scores: [1, 2, 3]
-      }
-    };
   });
   evaluateNodeConstraintWithOneRemovalCriteria();
   evaluateNodeConstraintWithTwoRemovalCriteria();
-  evaluateScoreCriteria();
   evaluateCriterias();
 });
 
@@ -91,23 +73,6 @@ function evaluateNodeConstraintWithTwoRemovalCriteria() {
     isCompletedSpy();
     nodeConstraintTwoRemovalCriteria.removalConditional = 'any';
     expect(service.evaluateNodeConstraint(nodeConstraintTwoRemovalCriteria)).toEqual(true);
-  });
-}
-
-function evaluateScoreCriteria() {
-  const annotation = {};
-  function scoreCriteriaSpies(returnScore: number): void {
-    spyOn(configService, 'getWorkgroupId').and.returnValue(1);
-    spyOn(annotationService, 'getLatestScoreAnnotation').and.returnValue(annotation);
-    spyOn(annotationService, 'getScoreValueFromScoreAnnotation').and.returnValue(returnScore);
-  }
-  it('should evaluate score criteria false', () => {
-    scoreCriteriaSpies(4);
-    expect(service.evaluateScoreCriteria(scoreCriteria)).toEqual(false);
-  });
-  it('should evaluate score criteria true', () => {
-    scoreCriteriaSpies(3);
-    expect(service.evaluateScoreCriteria(scoreCriteria)).toEqual(true);
   });
 }
 

--- a/src/assets/wise5/common/constraint/EvaluateConstraintContext.ts
+++ b/src/assets/wise5/common/constraint/EvaluateConstraintContext.ts
@@ -1,4 +1,6 @@
+import { AnnotationService } from '../../services/annotationService';
 import { ComponentServiceLookupService } from '../../services/componentServiceLookupService';
+import { ConfigService } from '../../services/configService';
 import { NotebookService } from '../../services/notebookService';
 import { StudentDataService } from '../../services/studentDataService';
 import { ConstraintStrategy } from './strategies/ConstraintStrategy';
@@ -7,13 +9,23 @@ export class EvaluateConstraintContext {
   private strategy: ConstraintStrategy;
 
   constructor(
+    private annotationService: AnnotationService,
     private componentServiceLookupService: ComponentServiceLookupService,
+    private configService: ConfigService,
     private dataService: StudentDataService,
     private notebookService: NotebookService
   ) {}
 
+  getAnnotationService(): AnnotationService {
+    return this.annotationService;
+  }
+
   getComponentServiceLookupService(): ComponentServiceLookupService {
     return this.componentServiceLookupService;
+  }
+
+  getConfigService(): ConfigService {
+    return this.configService;
   }
 
   getDataService(): StudentDataService {

--- a/src/assets/wise5/common/constraint/EvaluateConstraintContext.ts
+++ b/src/assets/wise5/common/constraint/EvaluateConstraintContext.ts
@@ -3,6 +3,7 @@ import { ComponentServiceLookupService } from '../../services/componentServiceLo
 import { ConfigService } from '../../services/configService';
 import { NotebookService } from '../../services/notebookService';
 import { StudentDataService } from '../../services/studentDataService';
+import { TagService } from '../../services/tagService';
 import { ConstraintStrategy } from './strategies/ConstraintStrategy';
 
 export class EvaluateConstraintContext {
@@ -13,7 +14,8 @@ export class EvaluateConstraintContext {
     private componentServiceLookupService: ComponentServiceLookupService,
     private configService: ConfigService,
     private dataService: StudentDataService,
-    private notebookService: NotebookService
+    private notebookService: NotebookService,
+    private tagService: TagService
   ) {}
 
   getAnnotationService(): AnnotationService {
@@ -34,6 +36,10 @@ export class EvaluateConstraintContext {
 
   getNotebookService(): NotebookService {
     return this.notebookService;
+  }
+
+  getTagService(): TagService {
+    return this.tagService;
   }
 
   setStrategy(strategy: ConstraintStrategy): void {

--- a/src/assets/wise5/common/constraint/strategies/AbstractConstraintStrategy.ts
+++ b/src/assets/wise5/common/constraint/strategies/AbstractConstraintStrategy.ts
@@ -1,20 +1,26 @@
+import { AnnotationService } from '../../../services/annotationService';
 import { ComponentServiceLookupService } from '../../../services/componentServiceLookupService';
+import { ConfigService } from '../../../services/configService';
 import { NotebookService } from '../../../services/notebookService';
 import { StudentDataService } from '../../../services/studentDataService';
 import { EvaluateConstraintContext } from '../EvaluateConstraintContext';
 import { ConstraintStrategy } from './ConstraintStrategy';
 
 export abstract class AbstractConstraintStrategy implements ConstraintStrategy {
+  annotationService: AnnotationService;
   componentServiceLookupService: ComponentServiceLookupService;
+  configService: ConfigService;
   context: EvaluateConstraintContext;
   dataService: StudentDataService;
   notebookService: NotebookService;
 
   setContext(context: EvaluateConstraintContext): void {
+    this.annotationService = context.getAnnotationService();
     this.context = context;
-    this.dataService = this.context.getDataService();
-    this.componentServiceLookupService = this.context.getComponentServiceLookupService();
-    this.notebookService = this.context.getNotebookService();
+    this.configService = context.getConfigService();
+    this.dataService = context.getDataService();
+    this.componentServiceLookupService = context.getComponentServiceLookupService();
+    this.notebookService = context.getNotebookService();
   }
 
   abstract evaluate(criteria: any): boolean;

--- a/src/assets/wise5/common/constraint/strategies/AbstractConstraintStrategy.ts
+++ b/src/assets/wise5/common/constraint/strategies/AbstractConstraintStrategy.ts
@@ -3,6 +3,7 @@ import { ComponentServiceLookupService } from '../../../services/componentServic
 import { ConfigService } from '../../../services/configService';
 import { NotebookService } from '../../../services/notebookService';
 import { StudentDataService } from '../../../services/studentDataService';
+import { TagService } from '../../../services/tagService';
 import { EvaluateConstraintContext } from '../EvaluateConstraintContext';
 import { ConstraintStrategy } from './ConstraintStrategy';
 
@@ -13,6 +14,7 @@ export abstract class AbstractConstraintStrategy implements ConstraintStrategy {
   context: EvaluateConstraintContext;
   dataService: StudentDataService;
   notebookService: NotebookService;
+  tagService: TagService;
 
   setContext(context: EvaluateConstraintContext): void {
     this.annotationService = context.getAnnotationService();
@@ -21,6 +23,7 @@ export abstract class AbstractConstraintStrategy implements ConstraintStrategy {
     this.dataService = context.getDataService();
     this.componentServiceLookupService = context.getComponentServiceLookupService();
     this.notebookService = context.getNotebookService();
+    this.tagService = context.getTagService();
   }
 
   abstract evaluate(criteria: any): boolean;

--- a/src/assets/wise5/common/constraint/strategies/HasTagConstraintStrategy.ts
+++ b/src/assets/wise5/common/constraint/strategies/HasTagConstraintStrategy.ts
@@ -1,0 +1,7 @@
+import { AbstractConstraintStrategy } from './AbstractConstraintStrategy';
+
+export class HasTagConstraintStrategy extends AbstractConstraintStrategy {
+  evaluate(criteria: any): boolean {
+    return this.tagService.hasTagName(criteria.params.tag);
+  }
+}

--- a/src/assets/wise5/common/constraint/strategies/ScoreConstraintStrategy.spec.ts
+++ b/src/assets/wise5/common/constraint/strategies/ScoreConstraintStrategy.spec.ts
@@ -1,0 +1,54 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { AnnotationService } from '../../../services/annotationService';
+import { ConfigService } from '../../../services/configService';
+import { StudentDataService } from '../../../services/studentDataService';
+import { ScoreConstraintStrategy } from './ScoreConstraintStrategy';
+
+let annotationService: AnnotationService;
+let configService: ConfigService;
+let dataService: StudentDataService;
+let strategy: ScoreConstraintStrategy;
+
+describe('ScoreConstraintStrategy', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, StudentTeacherCommonServicesModule]
+    });
+    annotationService = TestBed.inject(AnnotationService);
+    configService = TestBed.inject(ConfigService);
+    dataService = TestBed.inject(StudentDataService);
+    strategy = new ScoreConstraintStrategy();
+    strategy.annotationService = annotationService;
+    strategy.configService = configService;
+    strategy.dataService = dataService;
+  });
+  evaluate();
+});
+
+function evaluate() {
+  describe('evaluate()', () => {
+    const criteria = {
+      params: {
+        nodeId: 'node1',
+        componentId: 'component1',
+        scores: [1, 2, 3]
+      }
+    };
+    it('should evaluate score criteria false', () => {
+      scoreCriteriaSpies({}, 4);
+      expect(strategy.evaluate(criteria)).toEqual(false);
+    });
+    it('should evaluate score criteria true', () => {
+      scoreCriteriaSpies({}, 3);
+      expect(strategy.evaluate(criteria)).toEqual(true);
+    });
+  });
+}
+
+function scoreCriteriaSpies(annotation: any, score: number): void {
+  spyOn(configService, 'getWorkgroupId').and.returnValue(1);
+  spyOn(annotationService, 'getLatestScoreAnnotation').and.returnValue(annotation);
+  spyOn(annotationService, 'getScoreValueFromScoreAnnotation').and.returnValue(score);
+}

--- a/src/assets/wise5/common/constraint/strategies/ScoreConstraintStrategy.spec.ts
+++ b/src/assets/wise5/common/constraint/strategies/ScoreConstraintStrategy.spec.ts
@@ -36,19 +36,18 @@ function evaluate() {
         scores: [1, 2, 3]
       }
     };
-    it('should evaluate score criteria false', () => {
-      scoreCriteriaSpies({}, 4);
-      expect(strategy.evaluate(criteria)).toEqual(false);
+    it('should return false when score is not found in the criteria', () => {
+      expectEvaluate(criteria, 4, false);
     });
-    it('should evaluate score criteria true', () => {
-      scoreCriteriaSpies({}, 3);
-      expect(strategy.evaluate(criteria)).toEqual(true);
+    it('should return true when score is found in the criteria', () => {
+      expectEvaluate(criteria, 3, true);
     });
   });
 }
 
-function scoreCriteriaSpies(annotation: any, score: number): void {
+function expectEvaluate(criteria: any, score: number, expected: boolean): void {
   spyOn(configService, 'getWorkgroupId').and.returnValue(1);
-  spyOn(annotationService, 'getLatestScoreAnnotation').and.returnValue(annotation);
+  spyOn(annotationService, 'getLatestScoreAnnotation').and.returnValue({});
   spyOn(annotationService, 'getScoreValueFromScoreAnnotation').and.returnValue(score);
+  expect(strategy.evaluate(criteria)).toEqual(expected);
 }

--- a/src/assets/wise5/common/constraint/strategies/ScoreConstraintStrategy.ts
+++ b/src/assets/wise5/common/constraint/strategies/ScoreConstraintStrategy.ts
@@ -1,0 +1,23 @@
+import { AbstractConstraintStrategy } from './AbstractConstraintStrategy';
+
+export class ScoreConstraintStrategy extends AbstractConstraintStrategy {
+  evaluate(criteria: any): boolean {
+    const latestScoreAnnotation = this.annotationService.getLatestScoreAnnotation(
+      criteria.params.nodeId,
+      criteria.params.componentId,
+      this.configService.getWorkgroupId(),
+      'any'
+    );
+    return (
+      latestScoreAnnotation != null && this.isScoreInExpectedScores(criteria, latestScoreAnnotation)
+    );
+  }
+
+  isScoreInExpectedScores(criteria: any, scoreAnnotation: any): boolean {
+    const scoreValue = this.dataService.getScoreValueFromScoreAnnotation(
+      scoreAnnotation,
+      criteria.params.scoreId
+    );
+    return this.dataService.isScoreInExpectedScores(criteria.params.scores, scoreValue);
+  }
+}

--- a/src/assets/wise5/common/constraint/strategies/TeacherRemovalConstraintStrategy.ts
+++ b/src/assets/wise5/common/constraint/strategies/TeacherRemovalConstraintStrategy.ts
@@ -1,0 +1,7 @@
+import { AbstractConstraintStrategy } from './AbstractConstraintStrategy';
+
+export class TeacherRemovalConstraintStrategy extends AbstractConstraintStrategy {
+  evaluate(criteria: any): boolean {
+    return this.configService.getPeriodId() !== criteria.params.periodId;
+  }
+}

--- a/src/assets/wise5/services/constraintService.ts
+++ b/src/assets/wise5/services/constraintService.ts
@@ -13,6 +13,7 @@ import { IsVisitedAfterConstraintStrategy } from '../common/constraint/strategie
 import { IsVisitedAndRevisedAfterConstraintStrategy } from '../common/constraint/strategies/IsVisitedAndRevisedAfterConstraintStrategy';
 import { IsVisitedConstraintStrategy } from '../common/constraint/strategies/IsVisitedConstraintStrategy';
 import { ScoreConstraintStrategy } from '../common/constraint/strategies/ScoreConstraintStrategy';
+import { TeacherRemovalConstraintStrategy } from '../common/constraint/strategies/TeacherRemovalConstraintStrategy';
 import { UsedXSubmitsConstraintStrategy } from '../common/constraint/strategies/UsedXSubmitsConstraintStrategy';
 import { WroteXNumberOfWordsConstraintStrategy } from '../common/constraint/strategies/WroteXNumberOfWordsConstraintStrategy';
 import { AnnotationService } from './annotationService';
@@ -38,14 +39,12 @@ export class ConstraintService {
     isVisitedAfter: new IsVisitedAfterConstraintStrategy(),
     isVisitedAndRevisedAfter: new IsVisitedAndRevisedAfterConstraintStrategy(),
     score: new ScoreConstraintStrategy(),
+    teacherRemoval: new TeacherRemovalConstraintStrategy(),
     usedXSubmits: new UsedXSubmitsConstraintStrategy(),
     wroteXNumberOfWords: new WroteXNumberOfWordsConstraintStrategy()
   };
 
   criteriaFunctionNameToFunction = {
-    teacherRemoval: (criteria) => {
-      return this.evaluateTeacherRemovalCriteria(criteria);
-    },
     hasTag: (criteria) => {
       return this.evaluateHasTagCriteria(criteria);
     }
@@ -56,7 +55,7 @@ export class ConstraintService {
   constructor(
     annotationService: AnnotationService,
     componentServiceLookupService: ComponentServiceLookupService,
-    private configService: ConfigService,
+    configService: ConfigService,
     dataService: StudentDataService,
     notebookService: NotebookService,
     private tagService: TagService
@@ -151,6 +150,7 @@ export class ConstraintService {
         'isVisitedAfter',
         'isVisitedAndRevisedAfter',
         'score',
+        'teacherRemoval',
         'usedXSubmits',
         'wroteXNumberOfWords'
       ].includes(criteria.name)
@@ -172,10 +172,6 @@ export class ConstraintService {
       }
     }
     return true;
-  }
-
-  evaluateTeacherRemovalCriteria(criteria: any): boolean {
-    return criteria.params.periodId !== this.configService.getPeriodId();
   }
 
   evaluateHasTagCriteria(criteria: any): boolean {

--- a/src/assets/wise5/services/constraintService.ts
+++ b/src/assets/wise5/services/constraintService.ts
@@ -12,6 +12,7 @@ import { IsVisitableConstraintStrategy } from '../common/constraint/strategies/I
 import { IsVisitedAfterConstraintStrategy } from '../common/constraint/strategies/IsVisitedAfterConstraintStrategy';
 import { IsVisitedAndRevisedAfterConstraintStrategy } from '../common/constraint/strategies/IsVisitedAndRevisedAfterConstraintStrategy';
 import { IsVisitedConstraintStrategy } from '../common/constraint/strategies/IsVisitedConstraintStrategy';
+import { ScoreConstraintStrategy } from '../common/constraint/strategies/ScoreConstraintStrategy';
 import { UsedXSubmitsConstraintStrategy } from '../common/constraint/strategies/UsedXSubmitsConstraintStrategy';
 import { WroteXNumberOfWordsConstraintStrategy } from '../common/constraint/strategies/WroteXNumberOfWordsConstraintStrategy';
 import { AnnotationService } from './annotationService';
@@ -36,14 +37,12 @@ export class ConstraintService {
     isVisited: new IsVisitedConstraintStrategy(),
     isVisitedAfter: new IsVisitedAfterConstraintStrategy(),
     isVisitedAndRevisedAfter: new IsVisitedAndRevisedAfterConstraintStrategy(),
+    score: new ScoreConstraintStrategy(),
     usedXSubmits: new UsedXSubmitsConstraintStrategy(),
     wroteXNumberOfWords: new WroteXNumberOfWordsConstraintStrategy()
   };
 
   criteriaFunctionNameToFunction = {
-    score: (criteria) => {
-      return this.evaluateScoreCriteria(criteria);
-    },
     teacherRemoval: (criteria) => {
       return this.evaluateTeacherRemovalCriteria(criteria);
     },
@@ -55,15 +54,17 @@ export class ConstraintService {
   evaluateConstraintContext: EvaluateConstraintContext;
 
   constructor(
-    private annotationService: AnnotationService,
+    annotationService: AnnotationService,
     componentServiceLookupService: ComponentServiceLookupService,
     private configService: ConfigService,
-    private dataService: StudentDataService,
+    dataService: StudentDataService,
     notebookService: NotebookService,
     private tagService: TagService
   ) {
     this.evaluateConstraintContext = new EvaluateConstraintContext(
+      annotationService,
       componentServiceLookupService,
+      configService,
       dataService,
       notebookService
     );
@@ -149,6 +150,7 @@ export class ConstraintService {
         'isVisited',
         'isVisitedAfter',
         'isVisitedAndRevisedAfter',
+        'score',
         'usedXSubmits',
         'wroteXNumberOfWords'
       ].includes(criteria.name)
@@ -170,25 +172,6 @@ export class ConstraintService {
       }
     }
     return true;
-  }
-
-  evaluateScoreCriteria(criteria: any): boolean {
-    const params = criteria.params;
-    const scoreType = 'any';
-    const latestScoreAnnotation = this.annotationService.getLatestScoreAnnotation(
-      params.nodeId,
-      params.componentId,
-      this.configService.getWorkgroupId(),
-      scoreType
-    );
-    if (latestScoreAnnotation != null) {
-      const scoreValue = this.dataService.getScoreValueFromScoreAnnotation(
-        latestScoreAnnotation,
-        params.scoreId
-      );
-      return this.dataService.isScoreInExpectedScores(params.scores, scoreValue);
-    }
-    return false;
   }
 
   evaluateTeacherRemovalCriteria(criteria: any): boolean {


### PR DESCRIPTION
## Changes
- Extract various criteria constraint evaluation logic in ConstraintService using Strategy pattern and put them into their own file. To keep the work&review scopes manageable, only these logic are extracted in this PR:
   - ScoreConstraintStrategy
   - TeacherRemovalConstraintStrategy
   - HasTagConstraintStrategy
- Clean up ConstraintService
   - remove criteriaFunctionNameToFunction now that all the logic has been converted to strategies
   - update evaluateCriteria()

## Test
- Above criteria constraint evaluation work as before
   - TeacherRemoval requires manually adding periodId to removalCriteria in JSON
   ```
     ...
     "removalCriteria": [
        {
          "name": "teacherRemoval",
          "params": {
            "periodId": 461
          }
        }
      ]
      ...
   ``` 
   - We currently don't fetch tags, and HasTagConstraintStrategy doesn't seem to be used. We can include this Strategy in the PR, and decide later what we want to do with it
- Other criteria constraint evaluation work as before

Closes #1098