### PR TITLE
feat(AT): Directly add component to step if step is empty

### DIFF
--- a/src/app/authoring-tool/add-component/choose-new-component-location/choose-new-component-location.component.ts
+++ b/src/app/authoring-tool/add-component/choose-new-component-location/choose-new-component-location.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { goToNodeAuthoring } from '../../../../assets/wise5/common/ui-router/ui-router';
 import { ComponentTypeService } from '../../../../assets/wise5/services/componentTypeService';
 import { ConfigService } from '../../../../assets/wise5/services/configService';
 import { TeacherDataService } from '../../../../assets/wise5/services/teacherDataService';
@@ -34,7 +35,7 @@ export class ChooseNewComponentLocation {
     this.insertComponentAfter(null);
   }
 
-  insertComponentAfter(insertAfterComponentId = null) {
+  insertComponentAfter(insertAfterComponentId = null): void {
     const newComponent = this.TeacherProjectService.createComponent(
       this.nodeId,
       this.upgrade.$injector.get('$stateParams').componentType,
@@ -42,11 +43,12 @@ export class ChooseNewComponentLocation {
     );
     this.TeacherProjectService.saveProject().then(() => {
       this.saveAddComponentEvent(newComponent);
-      this.upgrade.$injector.get('$state').go('root.at.project.node', {
-        projectId: this.ConfigService.getProjectId(),
-        nodeId: this.nodeId,
-        newComponents: [newComponent]
-      });
+      goToNodeAuthoring(
+        this.upgrade.$injector.get('$state'),
+        this.ConfigService.getProjectId(),
+        this.nodeId,
+        [newComponent]
+      );
     });
   }
 

--- a/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html
+++ b/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html
@@ -20,13 +20,7 @@
 <hr />
 <div fxLayout="row" fxLayoutAlign="end center">
   <button mat-button class="mat-primary" (click)="cancel()" aria-label="cancel" i18n>Cancel</button>
-  <button
-    mat-button
-    class="mat-raised-button mat-primary"
-    (click)="chooseLocation()"
-    aria-label="next"
-    i18n
-  >
+  <button mat-button class="mat-raised-button mat-primary" (click)="next()" aria-label="next" i18n>
     Next
   </button>
 </div>

--- a/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.ts
+++ b/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.ts
@@ -1,6 +1,10 @@
 import { Component } from '@angular/core';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { goToNodeAuthoring } from '../../../../assets/wise5/common/ui-router/ui-router';
 import { ComponentTypeService } from '../../../../assets/wise5/services/componentTypeService';
+import { ConfigService } from '../../../../assets/wise5/services/configService';
+import { TeacherDataService } from '../../../../assets/wise5/services/teacherDataService';
+import { TeacherProjectService } from '../../../../assets/wise5/services/teacherProjectService';
 
 @Component({
   selector: 'choose-new-component',
@@ -11,7 +15,13 @@ export class ChooseNewComponent {
   componentTypes: any[];
   selectedComponentType: string;
 
-  constructor(private upgrade: UpgradeModule, private componentTypeService: ComponentTypeService) {}
+  constructor(
+    private componentTypeService: ComponentTypeService,
+    private configService: ConfigService,
+    private dataService: TeacherDataService,
+    private projectService: TeacherProjectService,
+    private upgrade: UpgradeModule
+  ) {}
 
   ngOnInit() {
     this.componentTypes = this.componentTypeService.getComponentTypes();
@@ -22,9 +32,30 @@ export class ChooseNewComponent {
     this.selectedComponentType = componentType;
   }
 
-  chooseLocation() {
-    this.upgrade.$injector.get('$state').go('root.at.project.node.add-component.choose-location', {
-      componentType: this.selectedComponentType
+  next(): void {
+    const nodeId = this.dataService.getCurrentNodeId();
+    const components = this.projectService.getComponents(nodeId);
+    if (components.length === 0) {
+      this.insertComponentAsFirst(nodeId, this.selectedComponentType);
+    } else {
+      this.upgrade.$injector
+        .get('$state')
+        .go('root.at.project.node.add-component.choose-location', {
+          componentType: this.selectedComponentType
+        });
+    }
+  }
+
+  private insertComponentAsFirst(nodeId: string, componentType: string): void {
+    const newComponent = this.projectService.createComponent(nodeId, componentType, null);
+    this.projectService.saveProject().then(() => {
+      this.dataService.saveAddComponentEvent(nodeId, newComponent);
+      goToNodeAuthoring(
+        this.upgrade.$injector.get('$state'),
+        this.configService.getProjectId(),
+        nodeId,
+        [newComponent]
+      );
     });
   }
 

--- a/src/assets/wise5/common/ui-router/ui-router.ts
+++ b/src/assets/wise5/common/ui-router/ui-router.ts
@@ -1,0 +1,12 @@
+export function goToNodeAuthoring(
+  state: any,
+  projectId: number,
+  nodeId: string,
+  newComponents: any[]
+): void {
+  state.go('root.at.project.node', {
+    projectId: projectId,
+    nodeId: nodeId,
+    newComponents: newComponents
+  });
+}

--- a/src/assets/wise5/services/teacherDataService.ts
+++ b/src/assets/wise5/services/teacherDataService.ts
@@ -112,6 +112,13 @@ export class TeacherDataService extends DataService {
       });
   }
 
+  saveAddComponentEvent(nodeId: string, newComponent: any): void {
+    this.saveEvent('AuthoringTool', nodeId, null, null, 'Authoring', 'componentCreated', {
+      componentId: newComponent.id,
+      componentType: newComponent.type
+    });
+  }
+
   addCommonParams(params) {
     params = this.addProjectIdToHttpParams(params);
     params = this.addRunIdToHttpParams(params);

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -526,7 +526,7 @@
         <source> Next </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html</context>
-          <context context-type="linenumber">29,31</context>
+          <context context-type="linenumber">23,25</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
@@ -8395,7 +8395,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherDataService.ts</context>
-          <context context-type="linenumber">630</context>
+          <context context-type="linenumber">637</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d9b2ffb3e1ce1ca42a3db04d00ea072777898eb3" datatype="html">
@@ -18695,21 +18695,21 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">180</context>
+          <context context-type="linenumber">156</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5275881069346355759" datatype="html">
         <source>Auto Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">185</context>
+          <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2692433425768915750" datatype="html">
         <source>Submitted <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">166</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846fecebb7756c6127955bc2c08d2111dce64c3c" datatype="html">


### PR DESCRIPTION
## Changes
- In add component to step view, if the step has no components, add the chosen component to the step directly. Previously, we were showing a view where they select "insert as first component" instead.
 
## Test
- Adding a component to an empty step directly adds the component
- Adding a component to a non-empty step asks the author to choose where to put the new component

Closes #1100