### PR TITLE
refactor(Project Service): Move getConstraintsThatAffectNode()

### DIFF
--- a/src/app/domain/constraint.ts
+++ b/src/app/domain/constraint.ts
@@ -1,0 +1,13 @@
+export class Constraint {
+  action: string;
+  id: string;
+  removalConditional: string;
+  removalCriteria: any[];
+  targetId: string;
+
+  constructor(jsonObject: any = {}) {
+    for (const key of Object.keys(jsonObject)) {
+      this[key] = jsonObject[key];
+    }
+  }
+}

--- a/src/app/services/constraintService.spec.ts
+++ b/src/app/services/constraintService.spec.ts
@@ -129,17 +129,17 @@ function evaluateNodeConstraintWithTwoRemovalCriteria() {
 
 function evaluateCriterias() {
   describe('evaluateCriterias()', () => {
-    it('should evaluate criterias when it is passed one criteria that is false', () => {
+    it(`should return false when it is passed one criteria that is false`, () => {
       const criterias = [criteria1];
       spyOn(dataService, 'isCompleted').and.returnValue(false);
       expect(service.evaluateCriterias(criterias)).toEqual(false);
     });
-    it('should evaluate criterias when it is passed one criteria that is true', () => {
+    it(`should return true when it is passed one criteria that is true`, () => {
       const criterias = [criteria1];
       spyOn(dataService, 'isCompleted').and.returnValue(true);
       expect(service.evaluateCriterias(criterias)).toEqual(true);
     });
-    it('should evaluate criterias when it is passed multiple criterias and one is false', () => {
+    it(`should return false when it is passed multiple criterias and one is false`, () => {
       const criterias = [criteria1, criteria2];
       spyOn(dataService, 'isCompleted')
         .withArgs(nodeId1)
@@ -172,19 +172,18 @@ function getConstraintsThatAffectNode() {
       spyOn(configService, 'getConfigParam').and.returnValue(true);
       service.activeConstraints = [constraint1, constraint2, constraint3];
     });
-    it(`should get the constraints that affect the node when there are no constraints that affect
-        the node`, () => {
+    it(`should return empty array when there are no constraints that affect the node`, () => {
       getConstraintsThatAffectNodeAndExpect(nodeId1, []);
     });
-    it(`should get the constraints that affect the node when there is a node after constraint that
-        affects the node`, () => {
+    it(`should return one constraint when there is a node after constraint that affects the
+        node`, () => {
       getConstraintsThatAffectNodeAndExpect(nodeId6, [constraint1]);
     });
-    it(`should get the constraints that affect the node when the node is the target`, () => {
+    it(`should return one constraint when the node is the target of a constraint`, () => {
       getConstraintsThatAffectNodeAndExpect(nodeId2, [constraint2]);
     });
-    it(`should get the constraints that affect the node when the node is a child of the
-        target`, () => {
+    it(`should return one constraint when the node is a child of the target in a
+        constraint`, () => {
       getConstraintsThatAffectNodeAndExpect(nodeId4, [constraint3]);
     });
   });
@@ -196,7 +195,7 @@ function getConstraintsThatAffectNodeAndExpect(nodeId: string, expectedConstrain
 
 function orderConstraints() {
   describe('orderConstraints()', () => {
-    it('should order constraints', () => {
+    it('should order constraints in the order that they are in the unit', () => {
       spyOn(projectService, 'getFlattenedProjectAsNodeIds').and.returnValue([
         nodeId1,
         nodeId2,

--- a/src/app/services/constraintService.spec.ts
+++ b/src/app/services/constraintService.spec.ts
@@ -13,21 +13,43 @@ class MockProjectService {
   private projectParsedSource: Subject<void> = new Subject<void>();
   public projectParsed$: Observable<void> = this.projectParsedSource.asObservable();
   getFlattenedProjectAsNodeIds() {}
-  isNodeIdAfter(nodeId1: string, nodeId2: string) {
+  getNodeById(nodeId: string) {
+    if (nodeId.startsWith('node')) {
+      return { id: nodeId, type: 'node' };
+    } else if (nodeId.startsWith('group')) {
+      return { id: nodeId, type: 'group' };
+    } else {
+      return null;
+    }
+  }
+  isNodeDescendentOfGroup(node: any, targetNode: any): boolean {
+    return (
+      ((node.id === nodeId1 || node.id === nodeId2) && targetNode.id === groupId1) ||
+      ((node.id === nodeId3 || node.id === nodeId4) && targetNode.id === groupId2) ||
+      ((node.id === nodeId5 || node.id === nodeId6) && targetNode.id === groupId3)
+    );
+  }
+  isNodeIdAfter(nodeId1: string, nodeId2: string): boolean {
     return nodeId1 < nodeId2;
   }
 }
 
 let configService: ConfigService;
-let dataService: StudentDataService;
-let projectService: ProjectService;
-let service: ConstraintService;
 let criteria1: any;
 let criteria2: any;
+let dataService: StudentDataService;
+const groupId1 = 'group1';
+const groupId2 = 'group2';
+const groupId3 = 'group3';
 let nodeConstraintTwoRemovalCriteria: any;
 const nodeId1 = 'node1';
 const nodeId2 = 'node2';
 const nodeId3 = 'node3';
+const nodeId4 = 'node4';
+const nodeId5 = 'node5';
+const nodeId6 = 'node6';
+let projectService: ProjectService;
+let service: ConstraintService;
 
 describe('ConstraintService', () => {
   beforeEach(() => {
@@ -42,29 +64,35 @@ describe('ConstraintService', () => {
     criteria1 = {
       name: 'isCompleted',
       params: {
-        nodeId: 'node1'
+        nodeId: nodeId1
       }
     };
     criteria2 = {
       name: 'isCompleted',
       params: {
-        nodeId: 'node2'
+        nodeId: nodeId2
       }
     };
     nodeConstraintTwoRemovalCriteria = {
       id: 'node3Constraint1',
       action: '',
-      targetId: 'node3',
+      targetId: nodeId3,
       removalCriteria: [criteria1, criteria2],
       removalConditional: 'all'
     };
   });
-  evaluateNodeConstraintWithOneRemovalCriteria();
-  evaluateNodeConstraintWithTwoRemovalCriteria();
+  evaluateNodeConstraint();
   evaluateCriterias();
   getConstraintsThatAffectNode();
   orderConstraints();
 });
+
+function evaluateNodeConstraint() {
+  describe('evaluateNodeConstraint()', () => {
+    evaluateNodeConstraintWithOneRemovalCriteria();
+    evaluateNodeConstraintWithTwoRemovalCriteria();
+  });
+}
 
 function evaluateNodeConstraintWithOneRemovalCriteria() {
   it('should evaluate node constraint with one removal criteria', () => {
@@ -72,7 +100,7 @@ function evaluateNodeConstraintWithOneRemovalCriteria() {
     const constraint = {
       id: 'node1Constraint1',
       action: '',
-      targetId: 'node1',
+      targetId: nodeId1,
       removalCriteria: [criteria1],
       removalConditional: 'all'
     };
@@ -83,9 +111,9 @@ function evaluateNodeConstraintWithOneRemovalCriteria() {
 function evaluateNodeConstraintWithTwoRemovalCriteria() {
   function isCompletedSpy(): void {
     spyOn(dataService, 'isCompleted')
-      .withArgs('node1')
+      .withArgs(nodeId1)
       .and.returnValue(true)
-      .withArgs('node2')
+      .withArgs(nodeId2)
       .and.returnValue(false);
   }
   it('should evaluate node constraint with two removal criteria requiring all', () => {
@@ -100,49 +128,67 @@ function evaluateNodeConstraintWithTwoRemovalCriteria() {
 }
 
 function evaluateCriterias() {
-  it('should evaluate criterias when it is passed one criteria that is false', () => {
-    const criterias = [criteria1];
-    spyOn(dataService, 'isCompleted').and.returnValue(false);
-    expect(service.evaluateCriterias(criterias)).toEqual(false);
-  });
-  it('should evaluate criterias when it is passed one criteria that is true', () => {
-    const criterias = [criteria1];
-    spyOn(dataService, 'isCompleted').and.returnValue(true);
-    expect(service.evaluateCriterias(criterias)).toEqual(true);
-  });
-  it('should evaluate criterias when it is passed multiple criterias and one is false', () => {
-    const criterias = [criteria1, criteria2];
-    spyOn(dataService, 'isCompleted')
-      .withArgs('node1')
-      .and.returnValue(true)
-      .withArgs('node2')
-      .and.returnValue(false);
-    expect(service.evaluateCriterias(criterias)).toEqual(false);
+  describe('evaluateCriterias()', () => {
+    it('should evaluate criterias when it is passed one criteria that is false', () => {
+      const criterias = [criteria1];
+      spyOn(dataService, 'isCompleted').and.returnValue(false);
+      expect(service.evaluateCriterias(criterias)).toEqual(false);
+    });
+    it('should evaluate criterias when it is passed one criteria that is true', () => {
+      const criterias = [criteria1];
+      spyOn(dataService, 'isCompleted').and.returnValue(true);
+      expect(service.evaluateCriterias(criterias)).toEqual(true);
+    });
+    it('should evaluate criterias when it is passed multiple criterias and one is false', () => {
+      const criterias = [criteria1, criteria2];
+      spyOn(dataService, 'isCompleted')
+        .withArgs(nodeId1)
+        .and.returnValue(true)
+        .withArgs(nodeId2)
+        .and.returnValue(false);
+      expect(service.evaluateCriterias(criterias)).toEqual(false);
+    });
   });
 }
 
 function getConstraintsThatAffectNode() {
   let constraint1: Constraint;
+  let constraint2: Constraint;
+  let constraint3: Constraint;
   describe('getConstraintsThatAffectNode()', () => {
     beforeEach(() => {
       spyOn(configService, 'getConfigParam').and.returnValue(true);
       constraint1 = new Constraint({
         id: 'constraint1',
         action: 'makeAllNodesAfterThisNotVisible',
-        targetId: nodeId1
+        targetId: nodeId5
       });
-      service.activeConstraints = [constraint1];
+      constraint2 = new Constraint({
+        id: 'constraint2',
+        action: 'makeThisNodeNotVisitable',
+        targetId: nodeId2
+      });
+      constraint3 = new Constraint({
+        id: 'constraint3',
+        action: 'makeThisNodeNotVisitable',
+        targetId: groupId2
+      });
+      service.activeConstraints = [constraint1, constraint2, constraint3];
     });
     it(`should get the constraints that affect the node when there are no constraints that affect
-      the node`, () => {
-      const constraints = service.getConstraintsThatAffectNode({ id: nodeId1 });
-      expect(constraints.length).toEqual(0);
+        the node`, () => {
+      expect(service.getConstraintsThatAffectNode({ id: nodeId1 })).toEqual([]);
     });
-    it(`should get the constraints that affect the node when there are constraints that affect the
-      node`, () => {
-      const constraints = service.getConstraintsThatAffectNode({ id: nodeId2 });
-      expect(constraints.length).toEqual(1);
-      expect(constraints[0]).toEqual(constraint1);
+    it(`should get the constraints that affect the node when there is a node after constraint that
+        affects the node`, () => {
+      expect(service.getConstraintsThatAffectNode({ id: nodeId6 })).toEqual([constraint1]);
+    });
+    it(`should get the constraints that affect the node when the node is the target`, () => {
+      expect(service.getConstraintsThatAffectNode({ id: nodeId2 })).toEqual([constraint2]);
+    });
+    it(`should get the constraints that affect the node when the node is a child of the
+        target`, () => {
+      expect(service.getConstraintsThatAffectNode({ id: nodeId4 })).toEqual([constraint3]);
     });
   });
 }

--- a/src/app/services/constraintService.spec.ts
+++ b/src/app/services/constraintService.spec.ts
@@ -152,45 +152,46 @@ function evaluateCriterias() {
 }
 
 function getConstraintsThatAffectNode() {
-  let constraint1: Constraint;
-  let constraint2: Constraint;
-  let constraint3: Constraint;
+  const constraint1: Constraint = new Constraint({
+    id: 'constraint1',
+    action: 'makeAllNodesAfterThisNotVisible',
+    targetId: nodeId5
+  });
+  const constraint2: Constraint = new Constraint({
+    id: 'constraint2',
+    action: 'makeThisNodeNotVisitable',
+    targetId: nodeId2
+  });
+  const constraint3: Constraint = new Constraint({
+    id: 'constraint3',
+    action: 'makeThisNodeNotVisitable',
+    targetId: groupId2
+  });
   describe('getConstraintsThatAffectNode()', () => {
     beforeEach(() => {
       spyOn(configService, 'getConfigParam').and.returnValue(true);
-      constraint1 = new Constraint({
-        id: 'constraint1',
-        action: 'makeAllNodesAfterThisNotVisible',
-        targetId: nodeId5
-      });
-      constraint2 = new Constraint({
-        id: 'constraint2',
-        action: 'makeThisNodeNotVisitable',
-        targetId: nodeId2
-      });
-      constraint3 = new Constraint({
-        id: 'constraint3',
-        action: 'makeThisNodeNotVisitable',
-        targetId: groupId2
-      });
       service.activeConstraints = [constraint1, constraint2, constraint3];
     });
     it(`should get the constraints that affect the node when there are no constraints that affect
         the node`, () => {
-      expect(service.getConstraintsThatAffectNode({ id: nodeId1 })).toEqual([]);
+      getConstraintsThatAffectNodeAndExpect(nodeId1, []);
     });
     it(`should get the constraints that affect the node when there is a node after constraint that
         affects the node`, () => {
-      expect(service.getConstraintsThatAffectNode({ id: nodeId6 })).toEqual([constraint1]);
+      getConstraintsThatAffectNodeAndExpect(nodeId6, [constraint1]);
     });
     it(`should get the constraints that affect the node when the node is the target`, () => {
-      expect(service.getConstraintsThatAffectNode({ id: nodeId2 })).toEqual([constraint2]);
+      getConstraintsThatAffectNodeAndExpect(nodeId2, [constraint2]);
     });
     it(`should get the constraints that affect the node when the node is a child of the
         target`, () => {
-      expect(service.getConstraintsThatAffectNode({ id: nodeId4 })).toEqual([constraint3]);
+      getConstraintsThatAffectNodeAndExpect(nodeId4, [constraint3]);
     });
   });
+}
+
+function getConstraintsThatAffectNodeAndExpect(nodeId: string, expectedConstraints: Constraint[]) {
+  expect(service.getConstraintsThatAffectNode({ id: nodeId })).toEqual(expectedConstraints);
 }
 
 function orderConstraints() {

--- a/src/app/student/top-bar/top-bar.component.ts
+++ b/src/app/student/top-bar/top-bar.component.ts
@@ -2,6 +2,7 @@ import { Component, ViewChild } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Subscription } from 'rxjs';
 import { ConfigService } from '../../../assets/wise5/services/configService';
+import { ConstraintService } from '../../../assets/wise5/services/constraintService';
 import { NodeStatusService } from '../../../assets/wise5/services/nodeStatusService';
 import { NotificationService } from '../../../assets/wise5/services/notificationService';
 import { ProjectService } from '../../../assets/wise5/services/projectService';
@@ -32,6 +33,7 @@ export class TopBarComponent {
   constructor(
     private dialog: MatDialog,
     private configService: ConfigService,
+    private constraintService: ConstraintService,
     private nodeStatusService: NodeStatusService,
     private notificationService: NotificationService,
     private projectService: ProjectService,
@@ -78,12 +80,12 @@ export class TopBarComponent {
 
   disableConstraints($event: any): void {
     this.isConstraintsDisabled = true;
-    this.projectService.activeConstraints = [];
+    this.constraintService.activeConstraints = [];
     this.studentDataService.updateNodeStatuses();
   }
 
   hasConstraints(): boolean {
-    const activeConstraints = this.projectService.activeConstraints;
+    const activeConstraints = this.constraintService.activeConstraints;
     return activeConstraints != null && activeConstraints.length > 0;
   }
 

--- a/src/assets/wise5/common/stepTools/step-tools.component.ts
+++ b/src/assets/wise5/common/stepTools/step-tools.component.ts
@@ -45,7 +45,7 @@ export class StepToolsComponent {
       })
     );
     this.subscriptions.add(
-      this.ProjectService.projectChanged$.subscribe(() => {
+      this.ProjectService.projectParsed$.subscribe(() => {
         this.calculateNodeIds();
       })
     );

--- a/src/assets/wise5/services/constraintService.ts
+++ b/src/assets/wise5/services/constraintService.ts
@@ -161,7 +161,7 @@ export class ConstraintService {
     }
     const constraints = [];
     const allConstraints = this.activeConstraints;
-    for (let constraint of allConstraints) {
+    for (const constraint of allConstraints) {
       if (this.isNodeAffectedByConstraint(node, constraint)) {
         constraints.push(constraint);
       }
@@ -181,36 +181,33 @@ export class ConstraintService {
       return cachedResult;
     } else {
       let result = false;
-      const nodeId = node.id;
-      const targetId = constraint.targetId;
-      const action = constraint.action;
-
-      if (action === 'makeAllNodesAfterThisNotVisible') {
-        if (this.projectService.isNodeIdAfter(targetId, node.id)) {
-          result = true;
-        }
-      } else if (action === 'makeAllNodesAfterThisNotVisitable') {
-        if (this.projectService.isNodeIdAfter(targetId, node.id)) {
-          result = true;
-        }
+      if (
+        this.isNodeAfterConstraintAction(constraint.action) &&
+        this.projectService.isNodeIdAfter(constraint.targetId, node.id)
+      ) {
+        result = true;
       } else {
-        const targetNode = this.projectService.getNodeById(targetId);
-        if (targetNode != null) {
-          const nodeType = targetNode.type;
-          if (nodeType === 'node' && nodeId === targetId) {
-            result = true;
-          } else if (
-            nodeType === 'group' &&
-            (nodeId === targetId || this.projectService.isNodeDescendentOfGroup(node, targetNode))
-          ) {
-            result = true;
-          }
-        }
+        result = this.isNodeTargetOfConstraint(node, constraint.targetId);
       }
-
       this.cacheIsNodeAffectedByConstraintResult(node.id, constraint.id, result);
       return result;
     }
+  }
+
+  private isNodeAfterConstraintAction(action: string): boolean {
+    return (
+      action === 'makeAllNodesAfterThisNotVisible' || action === 'makeAllNodesAfterThisNotVisitable'
+    );
+  }
+
+  private isNodeTargetOfConstraint(node: any, targetId: string) {
+    const targetNode = this.projectService.getNodeById(targetId);
+    return (
+      targetNode != null &&
+      ((targetNode.type === 'node' && node.id === targetId) ||
+        (targetNode.type === 'group' &&
+          (node.id === targetId || this.projectService.isNodeDescendentOfGroup(node, targetNode))))
+    );
   }
 
   /**

--- a/src/assets/wise5/services/constraintService.ts
+++ b/src/assets/wise5/services/constraintService.ts
@@ -23,11 +23,13 @@ import { AnnotationService } from './annotationService';
 import { ComponentServiceLookupService } from './componentServiceLookupService';
 import { ConfigService } from './configService';
 import { NotebookService } from './notebookService';
+import { ProjectService } from './projectService';
 import { StudentDataService } from './studentDataService';
 import { TagService } from './tagService';
 
 @Injectable()
 export class ConstraintService {
+  activeConstraints: any[] = [];
   criteriaFunctionNameToStrategy = {
     addXNumberOfNotesOnThisStep: new AddXNumberOfNotesOnThisStepConstraintStrategy(),
     branchPathTaken: new BranchPathTakenConstraintStrategy(),
@@ -48,13 +50,15 @@ export class ConstraintService {
     wroteXNumberOfWords: new WroteXNumberOfWordsConstraintStrategy()
   };
   evaluateConstraintContext: EvaluateConstraintContext;
+  isNodeAffectedByConstraintResult: any = {};
 
   constructor(
     annotationService: AnnotationService,
     componentServiceLookupService: ComponentServiceLookupService,
-    configService: ConfigService,
+    private configService: ConfigService,
     dataService: StudentDataService,
     notebookService: NotebookService,
+    private projectService: ProjectService,
     tagService: TagService
   ) {
     this.evaluateConstraintContext = new EvaluateConstraintContext(
@@ -65,6 +69,24 @@ export class ConstraintService {
       notebookService,
       tagService
     );
+    this.subscribeToProjectParsed();
+  }
+
+  private subscribeToProjectParsed(): void {
+    this.projectService.projectParsed$.subscribe(() => {
+      this.activeConstraints = [];
+      this.isNodeAffectedByConstraintResult = {};
+      for (const node of this.projectService.project.nodes) {
+        const constraints = node.constraints;
+        if (constraints != null) {
+          if (this.configService.getConfigParam('constraints')) {
+            for (const constraint of constraints) {
+              this.activeConstraints.push(constraint);
+            }
+          }
+        }
+      }
+    });
   }
 
   evaluate(constraints: any[]): ConstraintEvaluationResult {
@@ -131,5 +153,113 @@ export class ConstraintService {
 
   evaluateCriterias(criterias: any[]): boolean {
     return criterias.every((criteria) => this.evaluateCriteria(criteria));
+  }
+
+  getConstraintsThatAffectNode(node: any): any[] {
+    if (!this.configService.getConfigParam('constraints')) {
+      return [];
+    }
+    const constraints = [];
+    const allConstraints = this.activeConstraints;
+    for (let constraint of allConstraints) {
+      if (this.isNodeAffectedByConstraint(node, constraint)) {
+        constraints.push(constraint);
+      }
+    }
+    return constraints;
+  }
+
+  /**
+   * Check if a node is affected by the constraint
+   * @param node check if the node is affected
+   * @param constraint the constraint that might affect the node
+   * @returns whether the node is affected by the constraint
+   */
+  private isNodeAffectedByConstraint(node: any, constraint: any): boolean {
+    const cachedResult = this.getCachedIsNodeAffectedByConstraintResult(node.id, constraint.id);
+    if (cachedResult != null) {
+      return cachedResult;
+    } else {
+      let result = false;
+      const nodeId = node.id;
+      const targetId = constraint.targetId;
+      const action = constraint.action;
+
+      if (action === 'makeAllNodesAfterThisNotVisible') {
+        if (this.projectService.isNodeIdAfter(targetId, node.id)) {
+          result = true;
+        }
+      } else if (action === 'makeAllNodesAfterThisNotVisitable') {
+        if (this.projectService.isNodeIdAfter(targetId, node.id)) {
+          result = true;
+        }
+      } else {
+        const targetNode = this.projectService.getNodeById(targetId);
+        if (targetNode != null) {
+          const nodeType = targetNode.type;
+          if (nodeType === 'node' && nodeId === targetId) {
+            result = true;
+          } else if (
+            nodeType === 'group' &&
+            (nodeId === targetId || this.projectService.isNodeDescendentOfGroup(node, targetNode))
+          ) {
+            result = true;
+          }
+        }
+      }
+
+      this.cacheIsNodeAffectedByConstraintResult(node.id, constraint.id, result);
+      return result;
+    }
+  }
+
+  /**
+   * Check if we have calculated the result for whether the node is affected by the constraint
+   * @param nodeId the node id
+   * @param constraintId the constraint id
+   * @return Return the result if we have calculated the result before. If we have not calculated
+   * the result before, we will return null.
+   */
+  private getCachedIsNodeAffectedByConstraintResult(nodeId: string, constraintId: string): boolean {
+    return this.isNodeAffectedByConstraintResult[nodeId + '-' + constraintId];
+  }
+
+  /**
+   * Remember the result for whether the node is affected by the constraint
+   * @param nodeId the node id
+   * @param constraintId the constraint id
+   * @param whether the node is affected by the constraint
+   */
+  private cacheIsNodeAffectedByConstraintResult(
+    nodeId: string,
+    constraintId: string,
+    result: boolean
+  ): void {
+    this.isNodeAffectedByConstraintResult[nodeId + '-' + constraintId] = result;
+  }
+
+  /**
+   * Order the constraints so that they show up in the same order as in the project.
+   * @param constraints An array of constraint objects
+   * @return An array of ordered constraints
+   */
+  orderConstraints(constraints: any[]): any[] {
+    const orderedNodeIds = this.projectService.getFlattenedProjectAsNodeIds();
+    return constraints.sort(this.constraintsComparatorGenerator(orderedNodeIds));
+  }
+
+  /**
+   * Create the constraints comparator function that is used for sorting an array of constraint
+   * objects.
+   * @param orderedNodeIds An array of node ids in the order in which they show up in the project.
+   * @return A comparator that orders constraint objects in the order in which the target ids show
+   * up in the project.
+   */
+  private constraintsComparatorGenerator(orderedNodeIds: string[]): any {
+    return function (constraintA: any, constraintB: any) {
+      const constraintAIndex = orderedNodeIds.indexOf(constraintA.targetId);
+      const constraintBIndex = orderedNodeIds.indexOf(constraintB.targetId);
+      return constraintAIndex - constraintBIndex;
+    };
   }
 }

--- a/src/assets/wise5/services/nodeClickLockedService.ts
+++ b/src/assets/wise5/services/nodeClickLockedService.ts
@@ -18,11 +18,11 @@ export class NodeClickLockedService {
     this.studentDataService.nodeClickLocked$.subscribe(({ nodeId }) => {
       let message = $localize`Sorry, you cannot view this item yet.`;
       const node = this.projectService.getNodeById(nodeId);
-      const constraints = this.projectService.getConstraintsThatAffectNode(node);
+      const constraints = this.constraintService.getConstraintsThatAffectNode(node);
       if (constraints.length > 0) {
         const nodeTitle = this.projectService.getNodePositionAndTitle(nodeId);
         message = $localize`<p>To visit <b>${nodeTitle}</b> you need to:</p><ul>`;
-        this.projectService.orderConstraints(constraints);
+        this.constraintService.orderConstraints(constraints);
         for (const constraint of constraints) {
           if (!this.constraintService.evaluateConstraint(constraint)) {
             message += `<li>${this.getConstraintMessage(constraint)}</li>`;

--- a/src/assets/wise5/services/nodeStatusService.ts
+++ b/src/assets/wise5/services/nodeStatusService.ts
@@ -74,7 +74,7 @@ export class NodeStatusService {
   private calculateNodeStatus(node: any): NodeStatus {
     const nodeId = node.id;
     const nodeStatus = new NodeStatus(nodeId);
-    const constraintsForNode = this.projectService.getConstraintsThatAffectNode(node);
+    const constraintsForNode = this.constraintService.getConstraintsThatAffectNode(node);
     const constraintResults = this.constraintService.evaluate(constraintsForNode);
     nodeStatus.isVisible = constraintResults.isVisible;
     nodeStatus.isVisitable = constraintResults.isVisitable;

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -18429,112 +18429,112 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Complete &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1277</context>
+          <context context-type="linenumber">1158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4750375498606149231" datatype="html">
         <source>Visit &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1283</context>
+          <context context-type="linenumber">1164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6126058561630526429" datatype="html">
         <source>Correctly answer &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1289</context>
+          <context context-type="linenumber">1170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7085241847460263487" datatype="html">
         <source>Obtain a score of &lt;b&gt;<x id="PH" equiv-text="scoresString"/>&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1304</context>
+          <context context-type="linenumber">1185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5469027549306748048" datatype="html">
         <source>You must choose &quot;<x id="PH" equiv-text="choiceText"/>&quot; on &quot;<x id="PH_1" equiv-text="nodeTitle"/>&quot;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1312</context>
+          <context context-type="linenumber">1193</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6293177000168372990" datatype="html">
         <source>Submit &lt;b&gt;<x id="PH" equiv-text="requiredSubmitCount"/>&lt;/b&gt; time on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1324</context>
+          <context context-type="linenumber">1205</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4693324974790890133" datatype="html">
         <source>Submit &lt;b&gt;<x id="PH" equiv-text="requiredSubmitCount"/>&lt;/b&gt; times on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1326</context>
+          <context context-type="linenumber">1207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8416169412912074869" datatype="html">
         <source>Take the branch path from &lt;b&gt;<x id="PH" equiv-text="fromNodeTitle"/>&lt;/b&gt; to &lt;b&gt;<x id="PH_1" equiv-text="toNodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1333</context>
+          <context context-type="linenumber">1214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8087029188038414167" datatype="html">
         <source>Write &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfWords"/>&lt;/b&gt; words on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1339</context>
+          <context context-type="linenumber">1220</context>
         </context-group>
       </trans-unit>
       <trans-unit id="22049568725715518" datatype="html">
         <source>&quot;<x id="PH" equiv-text="nodeTitle"/>&quot; is visible</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1345</context>
+          <context context-type="linenumber">1226</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5023130174506669799" datatype="html">
         <source>&quot;<x id="PH" equiv-text="nodeTitle"/>&quot; is visitable</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1351</context>
+          <context context-type="linenumber">1232</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1185133360670447094" datatype="html">
         <source>Add &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfNotes"/>&lt;/b&gt; note on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1358</context>
+          <context context-type="linenumber">1239</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5985921753090789216" datatype="html">
         <source>Add &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfNotes"/>&lt;/b&gt; notes on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1360</context>
+          <context context-type="linenumber">1241</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4560070803879446782" datatype="html">
         <source>You must fill in &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfFilledRows"/>&lt;/b&gt; row in the &lt;b&gt;Table&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1367</context>
+          <context context-type="linenumber">1248</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2804292280751903227" datatype="html">
         <source>You must fill in &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfFilledRows"/>&lt;/b&gt; rows in the &lt;b&gt;Table&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1369</context>
+          <context context-type="linenumber">1250</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4171523921205906508" datatype="html">
         <source>Wait for your teacher to unlock the item</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1372</context>
+          <context context-type="linenumber">1253</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8770055323459972095" datatype="html">


### PR DESCRIPTION
## Changes

- Moved getConstraintsThatAffectNode() from ProjectService to ConstraintService
- Changed name of observable projectChanged to projectParsed
- Removed loading of project.constraints because I couldn't find anywhere that used or set project.constraints. Our constraints are usually at the node level and not the project level.

## Test

Make sure constraints still work.

Closes #1069