### PR TITLE
refactor(ProjectAuthoring): Move Create Lesson to route

### DIFF
--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -22,9 +22,13 @@ import { ComponentStudentModule } from '../../assets/wise5/components/component/
 import { PreviewComponentModule } from '../../assets/wise5/authoringTool/components/preview-component/preview-component.module';
 import { StudentTeacherCommonModule } from '../student-teacher-common.module';
 import { RecoveryAuthoringComponent } from '../../assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component';
+import { AddLessonConfigureComponent } from '../../assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component';
+import { AddLessonChooseLocationComponent } from '../../assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component';
 
 @NgModule({
   declarations: [
+    AddLessonChooseLocationComponent,
+    AddLessonConfigureComponent,
     AddYourOwnNode,
     AdvancedProjectAuthoringComponent,
     CardSelectorComponent,

--- a/src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.html
+++ b/src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.html
@@ -1,4 +1,4 @@
-<h5 i18n>Choose a location for the new lesson: {{ name }}</h5>
+<h5 i18n>Choose a location for the new lesson: {{ title }}</h5>
 <div style="margin-top: 20px; margin-left: 20px">
   <div fxLayout="row">
     <h5 i18n>Active Lessons</h5>

--- a/src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.html
+++ b/src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.html
@@ -1,0 +1,54 @@
+<h5 i18n>Choose a location for the new lesson: {{ name }}</h5>
+<div style="margin-top: 20px; margin-left: 20px">
+  <div fxLayout="row">
+    <h5 i18n>Active Lessons</h5>
+    <ng-container *ngTemplateOutlet="insertInsideButton; context: { active: true }"></ng-container>
+  </div>
+  <div *ngFor="let groupId of groupIds">
+    <ng-container *ngTemplateOutlet="group; context: { groupId: groupId }"></ng-container>
+  </div>
+  <div fxLayout="row">
+    <h5 i18n>Unused Lessons</h5>
+    <ng-container *ngTemplateOutlet="insertInsideButton; context: { active: false }"></ng-container>
+  </div>
+  <div *ngFor="let groupId of unusedGroupIds">
+    <ng-container *ngTemplateOutlet="group; context: { groupId: groupId }"></ng-container>
+  </div>
+</div>
+<hr />
+<button mat-button class="mat-primary" (click)="cancel()" aria-label="Cancel" i18n>Cancel</button>
+
+<ng-template #group let-groupId="groupId">
+  <div fxLayout="row" fxLayoutGap="16px" style="margin: 4px 0px">
+    <div fxLayout="row" fxLayoutAlign="start center">
+      <node-icon [nodeId]="groupId" size="18"></node-icon>&nbsp;
+      <p style="display: inline; cursor: pointer">
+        {{ getNodePositionAndTitle(groupId) }}
+      </p>
+    </div>
+    <button
+      mat-button
+      class="mat-raised-button mat-primary"
+      matTooltip="Insert After"
+      i18n-matTooltip
+      matTooltipPosition="above"
+      (click)="addLessonAfter(groupId); $event.stopPropagation()"
+    >
+      <mat-icon>subdirectory_arrow_left</mat-icon>
+    </button>
+  </div>
+</ng-template>
+
+<ng-template #insertInsideButton let-active="active">
+  <button
+    mat-button
+    class="mat-raised-button mat-primary"
+    style="margin: 8px 8px"
+    matTooltip="Insert at the Beginning"
+    i18n-matTooltip
+    matTooltipPosition="above"
+    (click)="addLessonAtBeginning(active); $event.stopPropagation()"
+  >
+    <mat-icon>call_received</mat-icon>
+  </button>
+</ng-template>

--- a/src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.ts
+++ b/src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.ts
@@ -7,7 +7,7 @@ import { TeacherProjectService } from '../../../services/teacherProjectService';
   templateUrl: './add-lesson-choose-location.component.html'
 })
 export class AddLessonChooseLocationComponent implements OnInit {
-  name: string;
+  title: string;
   groupIds: string[];
   unusedGroupIds: string[] = [];
 
@@ -16,7 +16,7 @@ export class AddLessonChooseLocationComponent implements OnInit {
     private projectService: TeacherProjectService,
     private upgrade: UpgradeModule
   ) {
-    this.name = this.upgrade.$injector.get('$stateParams').name;
+    this.title = this.upgrade.$injector.get('$stateParams').title;
   }
 
   ngOnInit(): void {
@@ -27,13 +27,13 @@ export class AddLessonChooseLocationComponent implements OnInit {
   }
 
   protected addLessonAfter(nodeId: string): void {
-    const newLesson = this.projectService.createGroup(this.name);
+    const newLesson = this.projectService.createGroup(this.title);
     this.projectService.createNodeAfter(newLesson, nodeId);
     this.save(newLesson);
   }
 
   protected addLessonAtBeginning(active: boolean): void {
-    const newLesson = this.projectService.createGroup(this.name);
+    const newLesson = this.projectService.createGroup(this.title);
     const insertInsideNodeId = active ? 'group0' : 'inactiveGroups';
     this.projectService.createNodeInside(newLesson, insertInsideNodeId);
     this.save(newLesson);

--- a/src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.ts
+++ b/src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.ts
@@ -1,0 +1,88 @@
+import { Component, OnInit } from '@angular/core';
+import { UpgradeModule } from '@angular/upgrade/static';
+import { TeacherDataService } from '../../../services/teacherDataService';
+import { TeacherProjectService } from '../../../services/teacherProjectService';
+
+@Component({
+  templateUrl: './add-lesson-choose-location.component.html'
+})
+export class AddLessonChooseLocationComponent implements OnInit {
+  name: string;
+  groupIds: string[];
+  unusedGroupIds: string[] = [];
+
+  constructor(
+    private dataService: TeacherDataService,
+    private projectService: TeacherProjectService,
+    private upgrade: UpgradeModule
+  ) {
+    this.name = this.upgrade.$injector.get('$stateParams').name;
+  }
+
+  ngOnInit(): void {
+    const nodeIds = Object.keys(this.projectService.idToOrder);
+    nodeIds.shift(); // remove the 'group0' master root node from consideration
+    this.groupIds = nodeIds.filter((nodeId) => this.isGroupNode(nodeId));
+    this.unusedGroupIds = this.projectService.getInactiveGroupNodes().map((node) => node.id);
+  }
+
+  protected addLessonAfter(nodeId: string): void {
+    const newLesson = this.projectService.createGroup(this.name);
+    this.projectService.createNodeAfter(newLesson, nodeId);
+    this.save(newLesson);
+  }
+
+  protected addLessonAtBeginning(active: boolean): void {
+    const newLesson = this.projectService.createGroup(this.name);
+    const insertInsideNodeId = active ? 'group0' : 'inactiveGroups';
+    this.projectService.createNodeInside(newLesson, insertInsideNodeId);
+    this.save(newLesson);
+  }
+
+  protected cancel(): void {
+    this.goToProjectView();
+  }
+
+  protected getNodePositionAndTitle(nodeId: string) {
+    const title = this.projectService.getNodeTitle(nodeId);
+    return this.projectService.isActive(nodeId)
+      ? `${this.projectService.getNodePositionById(nodeId)} : ${title}`
+      : title;
+  }
+
+  private goToProjectView(): void {
+    this.upgrade.$injector.get('$state').go('root.at.project');
+  }
+
+  private isGroupNode(nodeId: string) {
+    return this.projectService.isGroupNode(nodeId);
+  }
+
+  private save(newLesson: any): void {
+    this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
+      this.projectService.refreshProject();
+      this.saveEvent('activityCreated', {
+        nodeId: newLesson.id,
+        title: this.projectService.getNodePositionAndTitle(newLesson.id)
+      });
+      this.goToProjectView();
+    });
+  }
+
+  private saveEvent(eventName: string, data = {}): void {
+    const category = 'Authoring';
+    const context = 'AuthoringTool';
+    const nodeId = null;
+    const componentId = null;
+    const componentType = null;
+    this.dataService.saveEvent(
+      context,
+      nodeId,
+      componentId,
+      componentType,
+      category,
+      eventName,
+      data
+    );
+  }
+}

--- a/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html
+++ b/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html
@@ -1,16 +1,42 @@
-<h5 i18n>Enter a name for the new lesson</h5>
-<div fxLayout="row" style="height: 50">
+<h5 i18n>Enter a title for the new lesson</h5>
+<form role="form" [formGroup]="addLessonFormGroup" (keydown.enter)="next(); $event.prventDefault()">
+  <mat-form-field appearance="fill" class="title-field">
+    <mat-label i18n>Lesson Title</mat-label>
+    <input
+      #titleField
+      autofocus
+      matInput
+      type="text"
+      id="title"
+      name="title"
+      formControlName="title"
+      (keyup)="$event.keyCode == 13 && next()"
+      required
+    />
+    <mat-error *ngIf="addLessonFormGroup.controls['title'].hasError('required')" i18n>
+      Lesson Title is required
+    </mat-error>
+  </mat-form-field>
+  <mat-divider></mat-divider>
   <div fxLayout="row">
-    <mat-form-field>
-      <mat-label i18n>Lesson name</mat-label>
-      <input matInput [(ngModel)]="name" (keyup)="$event.keyCode == 13 && next()" #nameField />
-    </mat-form-field>
+    <button
+      mat-button
+      class="mat-primary"
+      (click)="cancel(); $event.preventDefault()"
+      aria-label="cancel"
+      i18n
+    >
+      Cancel
+    </button>
+    <button
+      mat-button
+      class="mat-raised-button mat-primary"
+      (click)="next()"
+      aria-label="next"
+      [disabled]="!addLessonFormGroup.valid"
+      i18n
+    >
+      Next
+    </button>
   </div>
-</div>
-<hr />
-<div fxLayout="row">
-  <button mat-button class="mat-primary" (click)="cancel()" aria-label="cancel" i18n>Cancel</button>
-  <button mat-button class="mat-raised-button mat-primary" (click)="next()" aria-label="next" i18n>
-    Next
-  </button>
-</div>
+</form>

--- a/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html
+++ b/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html
@@ -1,0 +1,16 @@
+<h5 i18n>Enter a name for the new lesson</h5>
+<div fxLayout="row" style="height: 50">
+  <div fxLayout="row">
+    <mat-form-field>
+      <mat-label i18n>Lesson name</mat-label>
+      <input matInput [(ngModel)]="name" (keyup)="$event.keyCode == 13 && next()" #nameField />
+    </mat-form-field>
+  </div>
+</div>
+<hr />
+<div fxLayout="row">
+  <button mat-button class="mat-primary" (click)="cancel()" aria-label="cancel" i18n>Cancel</button>
+  <button mat-button class="mat-raised-button mat-primary" (click)="next()" aria-label="next" i18n>
+    Next
+  </button>
+</div>

--- a/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html
+++ b/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html
@@ -1,5 +1,9 @@
 <h5 i18n>Enter a title for the new lesson</h5>
-<form role="form" [formGroup]="addLessonFormGroup" (keydown.enter)="next(); $event.prventDefault()">
+<form
+  role="form"
+  [formGroup]="addLessonFormGroup"
+  (keydown.enter)="next(); $event.preventDefault()"
+>
   <mat-form-field appearance="fill" class="title-field">
     <mat-label i18n>Lesson Title</mat-label>
     <input

--- a/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.scss
+++ b/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.scss
@@ -1,0 +1,4 @@
+.title-field {
+  width: 360px;
+  max-width: 100%;
+}

--- a/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.ts
+++ b/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.ts
@@ -1,17 +1,20 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { UpgradeModule } from '@angular/upgrade/static';
 
 @Component({
   templateUrl: './add-lesson-configure.component.html'
 })
 export class AddLessonConfigureComponent {
-  name: string;
-  @ViewChild('nameField') nameField: ElementRef;
+  addLessonFormGroup: FormGroup = this.fb.group({
+    title: new FormControl('', [Validators.required])
+  });
+  @ViewChild('titleField') titleField: ElementRef;
 
-  constructor(private upgrade: UpgradeModule) {}
+  constructor(private fb: FormBuilder, private upgrade: UpgradeModule) {}
 
   ngAfterViewInit() {
-    this.nameField.nativeElement.focus();
+    this.titleField.nativeElement.focus();
   }
 
   protected cancel(): void {
@@ -20,7 +23,7 @@ export class AddLessonConfigureComponent {
 
   protected next(): void {
     this.upgrade.$injector.get('$state').go('root.at.project.add-lesson.choose-location', {
-      name: this.name
+      title: this.addLessonFormGroup.controls['title'].value
     });
   }
 }

--- a/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.ts
+++ b/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.ts
@@ -1,0 +1,26 @@
+import { Component, ElementRef, ViewChild } from '@angular/core';
+import { UpgradeModule } from '@angular/upgrade/static';
+
+@Component({
+  templateUrl: './add-lesson-configure.component.html'
+})
+export class AddLessonConfigureComponent {
+  name: string;
+  @ViewChild('nameField') nameField: ElementRef;
+
+  constructor(private upgrade: UpgradeModule) {}
+
+  ngAfterViewInit() {
+    this.nameField.nativeElement.focus();
+  }
+
+  protected cancel(): void {
+    this.upgrade.$injector.get('$state').go('root.at.project');
+  }
+
+  protected next(): void {
+    this.upgrade.$injector.get('$state').go('root.at.project.add-lesson.choose-location', {
+      name: this.name
+    });
+  }
+}

--- a/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.ts
+++ b/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms'
 import { UpgradeModule } from '@angular/upgrade/static';
 
 @Component({
+  styleUrls: ['./add-lesson-configure.component.scss'],
   templateUrl: './add-lesson-configure.component.html'
 })
 export class AddLessonConfigureComponent {

--- a/src/assets/wise5/authoringTool/addLesson/addLessonModule.ts
+++ b/src/assets/wise5/authoringTool/addLesson/addLessonModule.ts
@@ -1,0 +1,36 @@
+import * as angular from 'angular';
+import { downgradeComponent } from '@angular/upgrade/static';
+import { AddLessonConfigureComponent } from './add-lesson-configure/add-lesson-configure.component';
+import { AddLessonChooseLocationComponent } from './add-lesson-choose-location/add-lesson-choose-location.component';
+
+export default angular
+  .module('addLessonModule', ['ui.router'])
+  .directive(
+    'addLessonConfigure',
+    downgradeComponent({ component: AddLessonConfigureComponent }) as angular.IDirectiveFactory
+  )
+  .directive(
+    'addLessonChooseLocation',
+    downgradeComponent({ component: AddLessonChooseLocationComponent }) as angular.IDirectiveFactory
+  )
+  .config([
+    '$stateProvider',
+    ($stateProvider) => {
+      $stateProvider
+        .state('root.at.project.add-lesson', {
+          url: '/add-lesson',
+          abstract: true,
+          params: {
+            name: ''
+          }
+        })
+        .state('root.at.project.add-lesson.configure', {
+          url: '/configure',
+          component: 'addLessonConfigure'
+        })
+        .state('root.at.project.add-lesson.choose-location', {
+          url: '/choose-location',
+          component: 'addLessonChooseLocation'
+        });
+    }
+  ]);

--- a/src/assets/wise5/authoringTool/addLesson/addLessonModule.ts
+++ b/src/assets/wise5/authoringTool/addLesson/addLessonModule.ts
@@ -21,7 +21,7 @@ export default angular
           url: '/add-lesson',
           abstract: true,
           params: {
-            name: ''
+            title: ''
           }
         })
         .state('root.at.project.add-lesson.configure', {

--- a/src/assets/wise5/authoringTool/authoring-tool.module.ts
+++ b/src/assets/wise5/authoringTool/authoring-tool.module.ts
@@ -3,6 +3,7 @@
 import * as angular from 'angular';
 import { downgradeComponent, downgradeInjectable } from '@angular/upgrade/static';
 import './addComponent/addComponentModule';
+import './addLesson/addLessonModule';
 import './addNode/addNodeModule';
 import '../components/component-authoring.module';
 import './components/shared/shared';
@@ -21,6 +22,7 @@ import { StepToolsComponent } from '../common/stepTools/step-tools.component';
 export default angular
   .module('authoringTool', [
     'addComponentModule',
+    'addLessonModule',
     'addNodeModule',
     'atShared',
     'componentAuthoringModule',

--- a/src/assets/wise5/authoringTool/project/projectAuthoring.html
+++ b/src/assets/wise5/authoringTool/project/projectAuthoring.html
@@ -114,7 +114,7 @@
               <md-button
                 id="createNewActivityButton"
                 class="topButton md-raised md-primary"
-                ng-click="$ctrl.creatNewActivityClicked()"
+                ng-click="$ctrl.createNewLesson()"
                 ng-disabled="$ctrl.insertGroupMode || $ctrl.insertNodeMode || $ctrl.stepNodeSelected || $ctrl.activityNodeSelected"
               >
                 <md-icon>queue</md-icon>
@@ -234,40 +234,6 @@
                 >
               </md-button>
             </div>
-            <div ng-if="$ctrl.showCreateGroup" layout="row" style="height: 50">
-              <div layout="row">
-                <md-input-container style="width: 500">
-                  <label translate="activityTitle"></label>
-                  <input
-                    id="createGroupTitle"
-                    ng-model="$ctrl.createGroupTitle"
-                    ng-keyup="$event.keyCode == 13 && $ctrl.createGroup()"
-                  />
-                </md-input-container>
-              </div>
-              <div layout="row" style="margin-top: 8px">
-                <md-button
-                  id="createGroupCreateButton"
-                  class="createButton md-raised md-primary"
-                  ng-click="$ctrl.createGroup()"
-                >
-                  <md-icon>check</md-icon>
-                  <md-tooltip md-direction="top" class="projectButtonTooltip"
-                    >{{ ::"create" | translate }}</md-tooltip
-                  >
-                </md-button>
-                <md-button
-                  id="createGroupCancelButton"
-                  class="createButton md-raised md-primary"
-                  ng-click="$ctrl.showProjectView()"
-                >
-                  <md-icon>close</md-icon>
-                  <md-tooltip md-direction="top" class="projectButtonTooltip"
-                    >{{ ::"CANCEL" | translate }}</md-tooltip
-                  >
-                </md-button>
-              </div>
-            </div>
             <div
               ng-if="$ctrl.insertGroupMode || $ctrl.insertNodeMode"
               layout="row"
@@ -305,7 +271,7 @@
                     ng-model="item.checked"
                     ng-change="$ctrl.projectItemClicked(item.$key)"
                     class="check"
-                    ng-disabled="$ctrl.showCreateGroup || $ctrl.insertNodeMode || $ctrl.insertGroupMode || ($ctrl.isGroupNode(item.$key) && $ctrl.stepNodeSelected) || (!$ctrl.isGroupNode(item.$key) && $ctrl.activityNodeSelected)"
+                    ng-disabled="$ctrl.insertNodeMode || $ctrl.insertGroupMode || ($ctrl.isGroupNode(item.$key) && $ctrl.stepNodeSelected) || (!$ctrl.isGroupNode(item.$key) && $ctrl.activityNodeSelected)"
                     aria-label="{{::$ctrl.getNodePositionById(item.$key)}} {{::$ctrl.getNodeTitle(item.$key)}}"
                   >
                   </md-checkbox>
@@ -439,7 +405,7 @@
                       ng-model="inactiveNode.checked"
                       ng-change="$ctrl.projectItemClicked(inactiveNode.id)"
                       class="check"
-                      ng-disabled="$ctrl.showCreateGroup || $ctrl.insertNodeMode || $ctrl.insertGroupMode || $ctrl.stepNodeSelected"
+                      ng-disabled="$ctrl.insertNodeMode || $ctrl.insertGroupMode || $ctrl.stepNodeSelected"
                       aria-label="{{::$ctrl.getNodeTitle(inactiveNode.id)}}"
                     >
                     </md-checkbox>
@@ -494,7 +460,7 @@
                         ng-model="$ctrl.idToNode[inactiveChildId].checked"
                         ng-change="$ctrl.projectItemClicked(inactiveChildId)"
                         class="check"
-                        ng-disabled="$ctrl.showCreateGroup || $ctrl.insertNodeMode || $ctrl.insertGroupMode || $ctrl.activityNodeSelected"
+                        ng-disabled="$ctrl.insertNodeMode || $ctrl.insertGroupMode || $ctrl.activityNodeSelected"
                         aria-label="{{::$ctrl.getNodeTitle(inactiveChildId.id)}}"
                       >
                       </md-checkbox>
@@ -564,7 +530,7 @@
                         ng-model="inactiveNode.checked"
                         ng-change="$ctrl.projectItemClicked(inactiveNode.id)"
                         class="check"
-                        ng-disabled="$ctrl.showCreateGroup || $ctrl.insertNodeMode || $ctrl.insertGroupMode || $ctrl.activityNodeSelected"
+                        ng-disabled="$ctrl.insertNodeMode || $ctrl.insertGroupMode || $ctrl.activityNodeSelected"
                         aria-label="{{::$ctrl.getNodeTitle(inactiveNode.id)}}"
                       >
                       </md-checkbox>

--- a/src/assets/wise5/authoringTool/project/projectAuthoringComponent.ts
+++ b/src/assets/wise5/authoringTool/project/projectAuthoringComponent.ts
@@ -15,13 +15,11 @@ import { temporarilyHighlightElement } from '../../common/dom/dom';
 
 class ProjectAuthoringController {
   $translate: any;
-  createGroupTitle: string;
   projectId: number;
   items: any;
   nodeIds: [];
   nodeId: string;
   projectTitle: string;
-  showCreateGroup: boolean = false;
   inactiveGroupNodes: any[];
   inactiveStepNodes: any[];
   inactiveNodes: any[];
@@ -29,7 +27,6 @@ class ProjectAuthoringController {
   insertNodeMode: boolean;
   idToNode: any;
   copyMode: boolean;
-  createMode: boolean;
   nodeToAdd: any;
   projectScriptFilename: string;
   currentAuthorsMessage: string = '';
@@ -219,19 +216,9 @@ class ProjectAuthoringController {
     this.$state.go('root.at.project.node.advanced.path', { nodeId: nodeId });
   }
 
-  createGroup() {
-    this.nodeToAdd = this.ProjectService.createGroup(this.createGroupTitle);
-    this.showCreateGroup = false;
-    this.createGroupTitle = '';
-    this.insertGroupMode = true;
-    this.createMode = true;
-  }
-
   insertInside(nodeId) {
     // TODO check that we are inserting into a group
-    if (this.createMode) {
-      this.handleCreateModeInsert(nodeId, 'inside');
-    } else if (this.moveMode) {
+    if (this.moveMode) {
       this.handleMoveModeInsert(nodeId, 'inside');
     } else if (this.copyMode) {
       this.handleCopyModeInsert(nodeId, 'inside');
@@ -239,52 +226,11 @@ class ProjectAuthoringController {
   }
 
   insertAfter(nodeId) {
-    if (this.createMode) {
-      this.handleCreateModeInsert(nodeId, 'after');
-    } else if (this.moveMode) {
+    if (this.moveMode) {
       this.handleMoveModeInsert(nodeId, 'after');
     } else if (this.copyMode) {
       this.handleCopyModeInsert(nodeId, 'after');
     }
-  }
-
-  /**
-   * Create a node and then insert it in the specified location
-   * @param nodeId insert the new node inside or after this node id
-   * @param moveTo whether to insert 'inside' or 'after' the nodeId parameter
-   */
-  handleCreateModeInsert(nodeId, moveTo) {
-    if (moveTo === 'inside') {
-      this.ProjectService.createNodeInside(this.nodeToAdd, nodeId);
-    } else if (moveTo === 'after') {
-      this.ProjectService.createNodeAfter(this.nodeToAdd, nodeId);
-    } else {
-      // an unspecified moveTo was provided
-      return;
-    }
-
-    let newNodes = [this.nodeToAdd];
-    let newNode = this.nodeToAdd;
-    this.nodeToAdd = null;
-    this.createMode = false;
-    this.insertGroupMode = false;
-    this.insertNodeMode = false;
-    this.temporarilyHighlightNewNodes(newNodes);
-
-    this.ProjectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
-      this.refreshProject();
-      if (newNode != null) {
-        let nodeCreatedEventData = {
-          nodeId: newNode.id,
-          title: this.ProjectService.getNodePositionAndTitle(newNode.id)
-        };
-        if (this.ProjectService.isGroupNode(newNode.id)) {
-          this.saveEvent('activityCreated', 'Authoring', nodeCreatedEventData);
-        } else {
-          this.saveEvent('stepCreated', 'Authoring', nodeCreatedEventData);
-        }
-      }
-    });
   }
 
   /**
@@ -573,14 +519,8 @@ class ProjectAuthoringController {
     this.activityNodeSelected = false;
   }
 
-  creatNewActivityClicked() {
-    this.clearGroupTitle();
-    this.toggleGroupView();
-    if (this.showCreateGroup) {
-      this.$timeout(() => {
-        $('#createGroupTitle').focus();
-      });
-    }
+  protected createNewLesson(): void {
+    this.$state.go('root.at.project.add-lesson.configure');
   }
 
   createNewStep() {
@@ -595,7 +535,6 @@ class ProjectAuthoringController {
     this.insertGroupMode = false;
     this.insertNodeMode = false;
     this.nodeToAdd = null;
-    this.createMode = false;
     this.moveMode = false;
     this.copyMode = false;
     this.unselectAllItems();
@@ -654,19 +593,6 @@ class ProjectAuthoringController {
 
   isNodeInAnyBranchPath(nodeId) {
     return this.ProjectService.isNodeInAnyBranchPath(nodeId);
-  }
-
-  showProjectView() {
-    this.clearGroupTitle();
-    this.showCreateGroup = false;
-  }
-
-  toggleGroupView() {
-    this.showCreateGroup = !this.showCreateGroup;
-  }
-
-  clearGroupTitle() {
-    this.createGroupTitle = '';
   }
 
   goBackToProjectList() {

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -257,7 +257,7 @@ export class TeacherProjectService extends ProjectService {
    * @param title the title of the group
    * @returns the group object
    */
-  createGroup(title) {
+  createGroup(title: string): any {
     return {
       id: this.getNextAvailableGroupId(),
       type: 'group',

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -463,10 +463,6 @@
           <context context-type="linenumber">19</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
-          <context context-type="linenumber">12</context>
-        </context-group>
-        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component.html</context>
           <context context-type="linenumber">53</context>
         </context-group>
@@ -543,10 +539,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
           <context context-type="linenumber">93,95</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
-          <context context-type="linenumber">13,15</context>
         </context-group>
       </trans-unit>
       <trans-unit id="894bea82695eeeb7710668fdfc4a51fb524a58d0" datatype="html">
@@ -8475,8 +8467,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="ce56419283b30d1fd871f9e38c929a9166f536d2" datatype="html">
-        <source>Choose a location for the new lesson: <x id="INTERPOLATION" equiv-text="{{ name }}"/></source>
+      <trans-unit id="fe6e2f065cc702b14273855c483508aedc35a279" datatype="html">
+        <source>Choose a location for the new lesson: <x id="INTERPOLATION" equiv-text="{{ title }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.html</context>
           <context context-type="linenumber">1</context>
@@ -8503,18 +8495,51 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">47</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="69eb09896fb2567d8699926b58944436edf4d483" datatype="html">
-        <source>Enter a name for the new lesson</source>
+      <trans-unit id="1c3c38ba6a1160fe7ff5ba8cf663262d3968c999" datatype="html">
+        <source>Enter a title for the new lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7239333d32abe0a614e50cf45b623ae7c5ba1770" datatype="html">
-        <source>Lesson name</source>
+      <trans-unit id="8038f3a869fb34dc1ec87e558cf6f97515bd3cf6" datatype="html">
+        <source>Lesson Title</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
-          <context context-type="linenumber">5</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6e865bed9e5566eb4a24f5b09e0518e7bbf8f5f9" datatype="html">
+        <source> Lesson Title is required </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
+          <context context-type="linenumber">16,18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="da44efc7b658c318651866454d258bbbe57ff21c" datatype="html">
+        <source> Cancel </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
+          <context context-type="linenumber">28,30</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
+          <context context-type="linenumber">67,69</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.html</context>
+          <context context-type="linenumber">28,30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="c9702419b173fe7ab2aeee4ec1f5857fca1135a1" datatype="html">
+        <source> Next </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
+          <context context-type="linenumber">38,40</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
+          <context context-type="linenumber">76,78</context>
         </context-group>
       </trans-unit>
       <trans-unit id="891f639ffcf9d31aea80ea7e8e428a6597b059b3" datatype="html">
@@ -8580,24 +8605,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-step-visits/export-step-visits.component.html</context>
           <context context-type="linenumber">8</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="da44efc7b658c318651866454d258bbbe57ff21c" datatype="html">
-        <source> Cancel </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">67,69</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.html</context>
-          <context context-type="linenumber">28,30</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="c9702419b173fe7ab2aeee4ec1f5857fca1135a1" datatype="html">
-        <source> Next </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">76,78</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fe47acba6a2b6d343c4568432b800629bb8dd638" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -389,6 +389,10 @@
           <context context-type="linenumber">41</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component.html</context>
           <context context-type="linenumber">41</context>
         </context-group>
@@ -453,6 +457,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/use-with-class-warning-dialog/use-with-class-warning-dialog.component.html</context>
           <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
+          <context context-type="linenumber">12</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component.html</context>
@@ -531,6 +543,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
           <context context-type="linenumber">93,95</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
+          <context context-type="linenumber">13,15</context>
         </context-group>
       </trans-unit>
       <trans-unit id="894bea82695eeeb7710668fdfc4a51fb524a58d0" datatype="html">
@@ -8457,6 +8473,48 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/use-with-class-warning-dialog/use-with-class-warning-dialog.component.html</context>
           <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ce56419283b30d1fd871f9e38c929a9166f536d2" datatype="html">
+        <source>Choose a location for the new lesson: <x id="INTERPOLATION" equiv-text="{{ name }}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="aacae3c725e0f8a8dd08d2d686a4d0f3f1dcd507" datatype="html">
+        <source>Active Lessons</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="a899296e423748c91e4d987550b8797e115b82c8" datatype="html">
+        <source>Unused Lessons</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="24b2aed16c8aef6c967fb04c48adde152cf40193" datatype="html">
+        <source>Insert at the Beginning</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="69eb09896fb2567d8699926b58944436edf4d483" datatype="html">
+        <source>Enter a name for the new lesson</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7239333d32abe0a614e50cf45b623ae7c5ba1770" datatype="html">
+        <source>Lesson name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
+          <context context-type="linenumber">5</context>
         </context-group>
       </trans-unit>
       <trans-unit id="891f639ffcf9d31aea80ea7e8e428a6597b059b3" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -8506,21 +8506,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Lesson Title</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
-          <context context-type="linenumber">4</context>
+          <context context-type="linenumber">8</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6e865bed9e5566eb4a24f5b09e0518e7bbf8f5f9" datatype="html">
         <source> Lesson Title is required </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
-          <context context-type="linenumber">16,18</context>
+          <context context-type="linenumber">20,22</context>
         </context-group>
       </trans-unit>
       <trans-unit id="da44efc7b658c318651866454d258bbbe57ff21c" datatype="html">
         <source> Cancel </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
-          <context context-type="linenumber">28,30</context>
+          <context context-type="linenumber">32,34</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
@@ -8535,7 +8535,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source> Next </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
-          <context context-type="linenumber">38,40</context>
+          <context context-type="linenumber">42,44</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>


### PR DESCRIPTION
## Changes
- Move Create Lesson functionality out from ProjectAuthoringController/template and into its own routes:
   - /add-lesson/configure: choose lesson name
   - /add-lesson/choose-location: choose lesson location

## Test
- Create Lesson
   - Can create lesson and place it 
      - At the top (beginning) of active/inactive lessons
      - After existing active/inactive lessons
   - Can cancel any time and go back to project view
- Does not break other existing AT functionality in the ProjectAuthoring view
   - Create/move/delete step
   - Move/delete lesson

Closes #1112