### PR TITLE
refactor(UtilService): Move comparison functions

### DIFF
--- a/src/app/services/milestoneService.spec.ts
+++ b/src/app/services/milestoneService.spec.ts
@@ -114,11 +114,8 @@ describe('MilestoneService', () => {
   chooseTemplate();
   isTemplateMatch();
   isTemplateCriterionSatisfied();
-  isPercentOfScoresSatisfiesComparator();
-  getComparatorSum();
   getAggregateData();
   getPossibleScores();
-  isPercentThresholdSatisfied();
   getSatisfyCriteriaReferencedComponents();
   adjustKIScore();
   getKIScoreBounds();
@@ -658,7 +655,7 @@ function isTemplateMatch() {
 }
 
 function isTemplateCriterionSatisfied() {
-  it('should check is template criterion satisfied false', () => {
+  it('should check is percent of scores greater than', () => {
     const satisfyCriterion = {
       function: 'percentOfScoresGreaterThan',
       componentId: 'component1',
@@ -669,200 +666,70 @@ function isTemplateCriterionSatisfied() {
     expect(service.isTemplateCriterionSatisfied(satisfyCriterion, aggregateAutoScores50)).toEqual(
       false
     );
-  });
-  it('should check is template criterion satisfied true', () => {
-    const satisfyCriterion = createSatisfyCriteria(
-      'node1',
-      'component1',
-      'ki',
-      'percentOfScoresGreaterThan',
-      2,
-      50
-    );
+    satisfyCriterion.value = 2;
     expect(service.isTemplateCriterionSatisfied(satisfyCriterion, aggregateAutoScores50)).toEqual(
       true
     );
   });
-}
-
-function isPercentOfScoresSatisfiesComparator() {
-  describe('isPercentOfScoresSatisfiesComparator()', () => {
-    isPercentOfScoresGreaterThan();
-    isPercentOfScoresGreaterThanOrEqualTo();
-    isPercentOfScoresLessThan();
-    isPercentOfScoresLessThanOrEqualTo();
-    isPercentOfScoresEqualTo();
-    isPercentOfScoresNotEqualTo();
-  });
-}
-
-function isPercentOfScoresGreaterThan() {
-  it('should check is percent of scores greater than false', () => {
-    const satisfyCriterion = createSatisfyCriteria(
-      'node1',
-      'component1',
-      'ki',
-      'percentOfScoresGreaterThan',
-      3,
-      50
+  it('should check is percent of scores greater than or equal to', () => {
+    const satisfyCriterion = {
+      function: 'percentOfScoresGreaterThanOrEqualTo',
+      componentId: 'component1',
+      targetVariable: 'ki',
+      value: 4,
+      percentThreshold: 50
+    };
+    expect(service.isTemplateCriterionSatisfied(satisfyCriterion, aggregateAutoScores50)).toEqual(
+      false
     );
-    expect(
-      service.isPercentOfScoresSatisfiesComparator(
-        satisfyCriterion,
-        aggregateAutoScores50,
-        utilService.greaterThan
-      )
-    ).toEqual(false);
-  });
-  it('should check is percent of scores greater than true', () => {
-    const satisfyCriterion = createSatisfyCriteria(
-      'node1',
-      'component1',
-      'ki',
-      'percentOfScoresGreaterThan',
-      2,
-      50
+    satisfyCriterion.value = 3;
+    expect(service.isTemplateCriterionSatisfied(satisfyCriterion, aggregateAutoScores50)).toEqual(
+      true
     );
-    expect(
-      service.isPercentOfScoresSatisfiesComparator(
-        satisfyCriterion,
-        aggregateAutoScores50,
-        utilService.greaterThan
-      )
-    ).toEqual(true);
   });
-}
-
-function isPercentOfScoresGreaterThanOrEqualTo() {
-  it('should check is percent of scores greater than or equal to false', () => {
-    const satisfyCriterion = createSatisfyCriteria(
-      'node1',
-      'component1',
-      'ki',
-      'percentOfScoresGreaterThanOrEqualTo',
-      4,
-      50
+  it('should check is percent of scores less than', () => {
+    const satisfyCriterion = {
+      function: 'percentOfScoresLessThan',
+      componentId: 'component1',
+      targetVariable: 'ki',
+      value: 3,
+      percentThreshold: 50
+    };
+    expect(service.isTemplateCriterionSatisfied(satisfyCriterion, aggregateAutoScores50)).toEqual(
+      false
     );
-    expect(
-      service.isPercentOfScoresSatisfiesComparator(
-        satisfyCriterion,
-        aggregateAutoScores50,
-        utilService.greaterThanEqualTo
-      )
-    ).toEqual(false);
-  });
-  it('should check is percent of scores greater than or equal to true', () => {
-    const satisfyCriterion = createSatisfyCriteria(
-      'node1',
-      'component1',
-      'ki',
-      'percentOfScoresGreaterThanOrEqualTo',
-      3,
-      50
+    satisfyCriterion.value = 4;
+    expect(service.isTemplateCriterionSatisfied(satisfyCriterion, aggregateAutoScores50)).toEqual(
+      true
     );
-    expect(
-      service.isPercentOfScoresSatisfiesComparator(
-        satisfyCriterion,
-        aggregateAutoScores50,
-        utilService.greaterThanEqualTo
-      )
-    ).toEqual(true);
   });
-}
-
-function isPercentOfScoresLessThan() {
-  it('should check is percent of scores less than false', () => {
-    const satisfyCriterion = createSatisfyCriteria(
-      'node1',
-      'component1',
-      'ki',
-      'percentOfScoresLessThan',
-      3,
-      50
+  it('should check is percent of scores less than or equal to', () => {
+    const satisfyCriterion = {
+      function: 'percentOfScoresLessThanOrEqualTo',
+      componentId: 'component1',
+      targetVariable: 'ki',
+      value: 2,
+      percentThreshold: 50
+    };
+    expect(service.isTemplateCriterionSatisfied(satisfyCriterion, aggregateAutoScores50)).toEqual(
+      false
     );
-    expect(
-      service.isPercentOfScoresSatisfiesComparator(
-        satisfyCriterion,
-        aggregateAutoScores50,
-        utilService.lessThan
-      )
-    ).toEqual(false);
-  });
-  it('should check is percent of scores less than true', () => {
-    const satisfyCriterion = createSatisfyCriteria(
-      'node1',
-      'component1',
-      'ki',
-      'percentOfScoresLessThan',
-      4,
-      50
+    satisfyCriterion.value = 3;
+    expect(service.isTemplateCriterionSatisfied(satisfyCriterion, aggregateAutoScores50)).toEqual(
+      true
     );
-    expect(
-      service.isPercentOfScoresSatisfiesComparator(
-        satisfyCriterion,
-        aggregateAutoScores50,
-        utilService.lessThan
-      )
-    ).toEqual(true);
   });
-}
-
-function isPercentOfScoresLessThanOrEqualTo() {
-  it('should check is percent of scores less than or equal to false', () => {
-    const satisfyCriterion = createSatisfyCriteria(
-      'node1',
-      'component1',
-      'ki',
-      'percentOfScoresLessThanOrEqualTo',
-      2,
-      50
+  it('should check is percent of scores equal to', () => {
+    const satisfyCriterion = {
+      function: 'percentOfScoresEqualTo',
+      componentId: 'component1',
+      targetVariable: 'ki',
+      value: 3,
+      percentThreshold: 50
+    };
+    expect(service.isTemplateCriterionSatisfied(satisfyCriterion, aggregateAutoScores50)).toEqual(
+      false
     );
-    expect(
-      service.isPercentOfScoresSatisfiesComparator(
-        satisfyCriterion,
-        aggregateAutoScores50,
-        utilService.lessThanEqualTo
-      )
-    ).toEqual(false);
-  });
-  it('should check is percent of scores less than or equal to true', () => {
-    const satisfyCriterion = createSatisfyCriteria(
-      'node1',
-      'component1',
-      'ki',
-      'percentOfScoresLessThanOrEqualTo',
-      3,
-      50
-    );
-    expect(
-      service.isPercentOfScoresSatisfiesComparator(
-        satisfyCriterion,
-        aggregateAutoScores50,
-        utilService.lessThanEqualTo
-      )
-    ).toEqual(true);
-  });
-}
-
-function isPercentOfScoresEqualTo() {
-  const satisfyCriterion = createSatisfyCriteria(
-    'node1',
-    'component1',
-    'ki',
-    'percentOfScoresEqualTo',
-    3,
-    50
-  );
-  it('should check is percent of scores equal to false', () => {
-    expect(
-      service.isPercentOfScoresSatisfiesComparator(
-        satisfyCriterion,
-        aggregateAutoScores50,
-        utilService.equalTo
-      )
-    ).toEqual(false);
-  });
-  it('should check is percent of scores equal to true', () => {
     const aggregateAutoScores = [
       {
         nodeId: 'node1',
@@ -876,74 +743,19 @@ function isPercentOfScoresEqualTo() {
         }
       }
     ];
-    expect(
-      service.isPercentOfScoresSatisfiesComparator(
-        satisfyCriterion,
-        aggregateAutoScores,
-        utilService.equalTo
-      )
-    ).toEqual(true);
+    expect(service.isTemplateCriterionSatisfied(satisfyCriterion, aggregateAutoScores)).toEqual(
+      true
+    );
   });
-}
-
-function isPercentOfScoresNotEqualTo() {
-  it('should return true when percent of scores equal to value are less than threshold', () => {
+  it('should check is percent of scores not equal to', () => {
     expect(
-      service.isPercentOfScoresSatisfiesComparator(
-        satisfyCriterionSample,
-        aggregateAutoScoresSample,
-        utilService.notEqualTo
-      )
+      service.isTemplateCriterionSatisfied(satisfyCriterionSample, aggregateAutoScoresSample)
     ).toEqual(true);
-  });
-  it('should return true when percent of scores equal to value meet threshold', () => {
     const aggregateAutoScores = angular.copy(aggregateAutoScoresSample);
     aggregateAutoScores[0].aggregateAutoScore.ki.counts = { 1: 1, 2: 0, 3: 2, 4: 0, 5: 0 };
     expect(
-      service.isPercentOfScoresSatisfiesComparator(
-        satisfyCriterionSample,
-        aggregateAutoScores,
-        utilService.notEqualTo
-      )
+      service.isTemplateCriterionSatisfied(satisfyCriterionSample, aggregateAutoScores)
     ).toEqual(false);
-  });
-}
-
-function getComparatorSum() {
-  describe('getComparatorSum()', () => {
-    getComparatorSum_greaterThan0_ReturnSumAll();
-    getComparatorSum_greaterThan3_ReturnSumPartial();
-    getComparatorSum_greaterThan5_Return0();
-  });
-}
-
-function expectComparatorResult(satisfyCriterionValue: number, expectedResult: number) {
-  const satisfyCriterion = { value: satisfyCriterionValue };
-  expect(
-    service.getComparatorSum(
-      satisfyCriterion,
-      sampleAggregateData,
-      possibleScoresKi,
-      utilService.greaterThan
-    )
-  ).toEqual(expectedResult);
-}
-
-function getComparatorSum_greaterThan0_ReturnSumAll() {
-  it('should get greater than sum with score 0', () => {
-    expectComparatorResult(0, 150);
-  });
-}
-
-function getComparatorSum_greaterThan3_ReturnSumPartial() {
-  it('should get greater than sum with score 3', () => {
-    expectComparatorResult(3, 90);
-  });
-}
-
-function getComparatorSum_greaterThan5_Return0() {
-  it('should get greater than sum with score 5', () => {
-    expectComparatorResult(5, 0);
   });
 }
 
@@ -968,53 +780,6 @@ function getPossibleScores() {
     };
     it('should return the possible scores', () => {
       expect(service.getPossibleScores(aggregateData)).toEqual([1, 2, 3, 4, 5]);
-    });
-  });
-}
-
-function isPercentThresholdSatisfied() {
-  describe('isPercentThresholdSatisfied()', () => {
-    it('should return true when percent threshold is satisfied', () => {
-      const aggregateAutoScores = [
-        {
-          nodeId: 'node1',
-          componentId: 'xfns1g7pga',
-          aggregateAutoScore: {
-            ki: { counts: { 1: 1, 2: 0, 3: 2, 4: 0, 5: 0 }, scoreCount: 3 }
-          }
-        }
-      ];
-      const aggregateData = service.getAggregateData(satisfyCriterionSample, aggregateAutoScores);
-      const sum = service.getComparatorSum(
-        satisfyCriterionSample,
-        aggregateData,
-        possibleScoresKi,
-        utilService.equalTo
-      );
-      const result = service.isPercentThresholdSatisfied(
-        satisfyCriterionSample,
-        aggregateData,
-        sum
-      );
-      expect(result).toBeTruthy();
-    });
-    it('should return false when percent threshold is not satisfied', () => {
-      const aggregateData = service.getAggregateData(
-        satisfyCriterionSample,
-        aggregateAutoScoresSample
-      );
-      const sum = service.getComparatorSum(
-        satisfyCriterionSample,
-        aggregateData,
-        possibleScoresKi,
-        utilService.equalTo
-      );
-      const result = service.isPercentThresholdSatisfied(
-        satisfyCriterionSample,
-        aggregateData,
-        sum
-      );
-      expect(result).toBeFalsy();
     });
   });
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-details-dialog/milestone-details-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-details-dialog/milestone-details-dialog.component.html
@@ -1,5 +1,5 @@
 <h1 mat-dialog-title i18n>Milestone: {{ milestone.name }}</h1>
-<div mat-dialog-content>
+<div mat-dialog-content class="dialog-content-scroll">
   <milestone-details [milestone]="milestone" (onVisitNodeGrading)="onVisitNodeGrading($event)">
   </milestone-details>
 </div>

--- a/src/assets/wise5/services/milestoneService.ts
+++ b/src/assets/wise5/services/milestoneService.ts
@@ -5,7 +5,6 @@ import { AnnotationService } from './annotationService';
 import { ConfigService } from './configService';
 import { ProjectService } from './projectService';
 import { TeacherDataService } from './teacherDataService';
-import { UtilService } from './utilService';
 import { Injectable } from '@angular/core';
 import { copy } from '../common/object/object';
 
@@ -23,57 +22,80 @@ export class MilestoneService {
       return this.isPercentOfScoresSatisfiesComparator(
         satisfyCriterion,
         aggregateAutoScores,
-        this.UtilService.greaterThan
+        this.greaterThan
       );
     },
     percentOfScoresGreaterThanOrEqualTo: (satisfyCriterion: any, aggregateAutoScores: any[]) => {
       return this.isPercentOfScoresSatisfiesComparator(
         satisfyCriterion,
         aggregateAutoScores,
-        this.UtilService.greaterThanEqualTo
+        this.greaterThanEqualTo
       );
     },
     percentOfScoresLessThan: (satisfyCriterion: any, aggregateAutoScores: any[]) => {
       return this.isPercentOfScoresSatisfiesComparator(
         satisfyCriterion,
         aggregateAutoScores,
-        this.UtilService.lessThan
+        this.lessThan
       );
     },
     percentOfScoresLessThanOrEqualTo: (satisfyCriterion: any, aggregateAutoScores: any[]) => {
       return this.isPercentOfScoresSatisfiesComparator(
         satisfyCriterion,
         aggregateAutoScores,
-        this.UtilService.lessThanEqualTo
+        this.lessThanEqualTo
       );
     },
     percentOfScoresEqualTo: (satisfyCriterion: any, aggregateAutoScores: any[]) => {
       return this.isPercentOfScoresSatisfiesComparator(
         satisfyCriterion,
         aggregateAutoScores,
-        this.UtilService.equalTo
+        this.equalTo
       );
     },
     percentOfScoresNotEqualTo: (satisfyCriterion: any, aggregateAutoScores: any[]) => {
       return this.isPercentOfScoresSatisfiesComparator(
         satisfyCriterion,
         aggregateAutoScores,
-        this.UtilService.notEqualTo
+        this.notEqualTo
       );
     }
   };
 
   constructor(
-    private AchievementService: AchievementService,
-    private AnnotationService: AnnotationService,
-    private ConfigService: ConfigService,
-    private ProjectService: ProjectService,
-    private TeacherDataService: TeacherDataService,
-    private UtilService: UtilService
+    private achievementService: AchievementService,
+    private annotationService: AnnotationService,
+    private configService: ConfigService,
+    private projectService: ProjectService,
+    private teacherDataService: TeacherDataService
   ) {}
 
+  private greaterThanEqualTo(a: number, b: number): boolean {
+    return a >= b;
+  }
+
+  private greaterThan(a: number, b: number): boolean {
+    return a > b;
+  }
+
+  private lessThanEqualTo(a: number, b: number): boolean {
+    return a <= b;
+  }
+
+  private lessThan(a: number, b: number): boolean {
+    return a < b;
+  }
+
+  private equalTo(a: number, b: number): boolean {
+    return a === b;
+  }
+
+  private notEqualTo(a: number, b: number): boolean {
+    return a !== b;
+  }
+
   getProjectMilestones() {
-    const achievements = this.ProjectService.getAchievements();
+    const achievements = this.projectService.getAchievements();
     if (achievements.isEnabled) {
       return achievements.items.filter((achievement) => {
         return ['milestone', 'milestoneReport'].includes(achievement.type);
@@ -100,9 +122,9 @@ export class MilestoneService {
   }
 
   getProjectMilestoneStatus(milestoneId: string) {
-    this.periodId = this.TeacherDataService.getCurrentPeriod().periodId;
+    this.periodId = this.teacherDataService.getCurrentPeriod().periodId;
     this.setWorkgroupsInCurrentPeriod();
-    let milestone = this.ProjectService.getAchievementByAchievementId(milestoneId);
+    let milestone = this.projectService.getAchievementByAchievementId(milestoneId);
     milestone = this.insertMilestoneItems(milestone);
     milestone = this.insertMilestoneCompletion(milestone);
     if (milestone.type === 'milestoneReport') {
@@ -112,7 +134,7 @@ export class MilestoneService {
   }
 
   insertMilestoneItems(milestone: any) {
-    milestone.items = copy(this.ProjectService.idToOrder);
+    milestone.items = copy(this.projectService.idToOrder);
     if (milestone.params != null && milestone.params.nodeIds != null) {
       for (const nodeId of milestone.params.nodeIds) {
         if (milestone.items[nodeId] != null) {
@@ -124,7 +146,7 @@ export class MilestoneService {
   }
 
   insertMilestoneCompletion(milestone: any) {
-    const achievementIdToStudentAchievements = this.AchievementService.getAchievementIdToStudentAchievementsMappings();
+    const achievementIdToStudentAchievements = this.achievementService.getAchievementIdToStudentAchievementsMappings();
     const studentAchievements = achievementIdToStudentAchievements[milestone.id];
     const workgroupIdsCompleted = [];
     const achievementTimes = [];
@@ -151,7 +173,7 @@ export class MilestoneService {
       const achievementTime = achievementTimes[c];
       const workgroupObject = {
         workgroupId: workgroupId,
-        displayNames: this.getDisplayUsernamesByWorkgroupId(workgroupId),
+        displayNames: this.configService.getDisplayUsernamesByWorkgroupId(workgroupId),
         achievementTime: achievementTime,
         completed: true
       };
@@ -161,7 +183,7 @@ export class MilestoneService {
     for (const workgroupId of workgroupIdsNotCompleted) {
       const workgroupObject = {
         workgroupId: workgroupId,
-        displayNames: this.getDisplayUsernamesByWorkgroupId(workgroupId),
+        displayNames: this.configService.getDisplayUsernamesByWorkgroupId(workgroupId),
         achievementTime: null,
         completed: false
       };
@@ -178,8 +200,8 @@ export class MilestoneService {
 
   setWorkgroupsInCurrentPeriod() {
     this.workgroupIds = [];
-    for (const workgroupId of this.ConfigService.getClassmateWorkgroupIds()) {
-      const currentPeriodId = this.ConfigService.getPeriodIdByWorkgroupId(workgroupId);
+    for (const workgroupId of this.configService.getClassmateWorkgroupIds()) {
+      const currentPeriodId = this.configService.getPeriodIdByWorkgroupId(workgroupId);
       if (this.periodId === -1 || currentPeriodId === this.periodId) {
         this.workgroupIds.push(workgroupId);
       }
@@ -208,10 +230,6 @@ export class MilestoneService {
     return referencedComponentValues[referencedComponentValues.length - 1];
   }
 
-  getDisplayUsernamesByWorkgroupId(workgroupId: number) {
-    return this.ConfigService.getDisplayUsernamesByWorkgroupId(workgroupId);
-  }
-
   isCompletionReached(projectAchievement: any) {
     return (
       projectAchievement.percentageCompleted >= projectAchievement.satisfyMinPercentage &&
@@ -235,7 +253,7 @@ export class MilestoneService {
     };
   }
 
-  getComponentAggregateAutoScores(projectAchievement: any): any[] {
+  private getComponentAggregateAutoScores(projectAchievement: any): any[] {
     const componentAggregateAutoScores = [];
     for (const referencedComponent of projectAchievement.report.locations) {
       const componentAggregateAutoScore = this.getComponentAggregateAutoScore(
@@ -249,7 +267,7 @@ export class MilestoneService {
     return componentAggregateAutoScores;
   }
 
-  getComponentAggregateAutoScore(
+  private getComponentAggregateAutoScore(
     nodeId: string,
     componentId: string,
     periodId: number,
@@ -264,7 +282,7 @@ export class MilestoneService {
     return {
       nodeId: nodeId,
       componentId: componentId,
-      stepTitle: this.ProjectService.getNodePositionAndTitle(nodeId),
+      stepTitle: this.projectService.getNodePositionAndTitle(nodeId),
       aggregateAutoScore: aggregateAutoScore
     };
   }
@@ -304,7 +322,7 @@ export class MilestoneService {
     );
   }
 
-  getComparatorSum(
+  private getComparatorSum(
     satisfyCriterion: any,
     aggregateData: any,
     possibleScores: number[],
@@ -319,7 +337,7 @@ export class MilestoneService {
     return sum;
   }
 
-  isPercentOfScoresSatisfiesComparator(
+  private isPercentOfScoresSatisfiesComparator(
     satisfyCriterion: any,
     aggregateAutoScores: any[],
     comparator: any
@@ -343,7 +361,11 @@ export class MilestoneService {
     return Object.keys(aggregateData.counts).map(Number).sort();
   }
 
-  isPercentThresholdSatisfied(satisfyCriterion: any, aggregateData: any, sum: number): boolean {
+  private isPercentThresholdSatisfied(
+    satisfyCriterion: any,
+    aggregateData: any,
+    sum: number
+  ): boolean {
     const percentOfScores = (100 * sum) / aggregateData.scoreCount;
     return percentOfScores >= satisfyCriterion.percentThreshold;
   }
@@ -372,7 +394,7 @@ export class MilestoneService {
     reportSettings: any
   ) {
     const aggregate = {};
-    const scoreAnnotations = this.AnnotationService.getAllLatestScoreAnnotations(
+    const scoreAnnotations = this.annotationService.getAllLatestScoreAnnotations(
       nodeId,
       componentId,
       periodId
@@ -381,7 +403,7 @@ export class MilestoneService {
       if (scoreAnnotation.type === 'autoScore') {
         this.addDataToAggregate(aggregate, scoreAnnotation, reportSettings);
       } else {
-        const autoScoreAnnotation = this.AnnotationService.getLatestScoreAnnotation(
+        const autoScoreAnnotation = this.annotationService.getLatestScoreAnnotation(
           nodeId,
           componentId,
           scoreAnnotation.toWorkgroupId,
@@ -400,7 +422,7 @@ export class MilestoneService {
     return aggregate;
   }
 
-  mergeAutoScoreAndTeacherScore(
+  private mergeAutoScoreAndTeacherScore(
     autoScoreAnnotation: any,
     teacherScoreAnnotation: any,
     reportSettings: any
@@ -512,7 +534,7 @@ export class MilestoneService {
     return content;
   }
 
-  getAggregateDataBySubScoreId(componentAggregateAutoScores: any[]): any {
+  private getAggregateDataBySubScoreId(componentAggregateAutoScores: any[]): any {
     const aggregateDataBySubScoreId = {};
     for (const componentAggregateAutoScore of componentAggregateAutoScores) {
       const aggregateAutoScore = componentAggregateAutoScore.aggregateAutoScore;
@@ -531,7 +553,7 @@ export class MilestoneService {
     return aggregateDataBySubScoreId;
   }
 
-  addAggregateDataBySubScoreId(
+  private addAggregateDataBySubScoreId(
     aggregateDataBySubScoreId: any,
     subScoreId: string,
     aggregateData: any,
@@ -546,7 +568,7 @@ export class MilestoneService {
     aggregateDataBySubScoreId[subScoreId].push(aggregateData);
   }
 
-  injectAdditionalFieldsIntoAggregateData(
+  private injectAdditionalFieldsIntoAggregateData(
     aggregateData: any,
     nodeId: string,
     componentId: string,

--- a/src/assets/wise5/services/utilService.ts
+++ b/src/assets/wise5/services/utilService.ts
@@ -127,30 +127,6 @@ export class UtilService {
     return values.reduce((a, b) => a + b) / values.length;
   }
 
-  greaterThanEqualTo(a: number, b: number): boolean {
-    return a >= b;
-  }
-
-  greaterThan(a: number, b: number): boolean {
-    return a > b;
-  }
-
-  lessThanEqualTo(a: number, b: number): boolean {
-    return a <= b;
-  }
-
-  lessThan(a: number, b: number): boolean {
-    return a < b;
-  }
-
-  equalTo(a: number, b: number): boolean {
-    return a === b;
-  }
-
-  notEqualTo(a: number, b: number): boolean {
-    return a !== b;
-  }
-
   getSavedMessage(clientSaveTime: number, showFullDate: boolean = false): string {
     let saveTimeText = this.getSaveTimeText(clientSaveTime, showFullDate);
     return $localize`Saved ${saveTimeText}:saveTime:`;

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -18728,21 +18728,21 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">156</context>
+          <context context-type="linenumber">132</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5275881069346355759" datatype="html">
         <source>Auto Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">161</context>
+          <context context-type="linenumber">137</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2692433425768915750" datatype="html">
         <source>Submitted <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/utilService.ts</context>
-          <context context-type="linenumber">166</context>
+          <context context-type="linenumber">142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846fecebb7756c6127955bc2c08d2111dce64c3c" datatype="html">


### PR DESCRIPTION
## Changes
- Move number comparison functions from UtilService to MilestoneService
- Remove UtilService dependency from MilestoneService
- Make functions not used by other files (or MilestoneService tests) private
- Refactor related tests

Note: MilestoneService could use some more refactoring and many additional functions can be made private. Will need to refactor corresponding tests. This should probably be done in a separate issue.

## Test
- Make sure Milestone Reports work as before, specifically that correct templates are matched and displayed.

Closes #967.