### PR TITLE
refactor(NodeConstraintAuthoring): Clean up code 

### DIFF
--- a/src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.spec.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
@@ -43,6 +44,7 @@ describe('NodeAdvancedConstraintAuthoringComponent', () => {
       []
     );
     spyOn(TestBed.inject(TeacherProjectService), 'getNodeById').and.returnValue({
+      id: 'node1',
       constraints: []
     });
     spyOn(TestBed.inject(TeacherDataService), 'getCurrentNodeId').and.returnValue(nodeId1);
@@ -58,7 +60,7 @@ describe('NodeAdvancedConstraintAuthoringComponent', () => {
   }
 
   function deleteConstraint() {
-    it('should add a constraint', () => {
+    it('should delete a constraint', () => {
       spyOn(window, 'confirm').and.returnValue(true);
       component.addConstraint();
       expect(component.node.constraints.length).toEqual(1);

--- a/src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts
@@ -10,273 +10,270 @@ import { temporarilyHighlightElement } from '../../../../common/dom/dom';
   styleUrls: ['node-advanced-constraint-authoring.component.scss']
 })
 export class NodeAdvancedConstraintAuthoringComponent implements OnInit {
-  constraintActions: any[];
+  constraintActions = [
+    {
+      value: '',
+      text: $localize`Please Choose an Action`
+    },
+    {
+      value: 'makeAllNodesAfterThisNotVisitable',
+      text: $localize`Make all nodes after this not visitable`
+    },
+    {
+      value: 'makeAllNodesAfterThisNotVisible',
+      text: $localize`Make all nodes after this not visible`
+    },
+    {
+      value: 'makeAllOtherNodesNotVisitable',
+      text: $localize`Make all other nodes not visitable`
+    },
+    {
+      value: 'makeAllOtherNodesNotVisible',
+      text: $localize`Make all other nodes not visible`
+    },
+    {
+      value: 'makeThisNodeNotVisitable',
+      text: $localize`Make this node not visitable`
+    },
+    {
+      value: 'makeThisNodeNotVisible',
+      text: $localize`Make this node not visible`
+    }
+  ];
   node: any;
-  nodeId: string;
   nodeIds: string[];
-  removalConditionals: any[];
-  removalCriteria: any;
+  removalConditionals = [
+    {
+      value: 'all',
+      text: $localize`All`
+    },
+    {
+      value: 'any',
+      text: $localize`Any`
+    }
+  ];
+  removalCriteria = [
+    {
+      value: '',
+      text: $localize`Please Choose a Removal Criteria`
+    },
+    {
+      value: 'isCompleted',
+      text: $localize`Is Completed`,
+      params: [
+        {
+          value: 'nodeId',
+          text: $localize`Step`
+        }
+      ]
+    },
+    {
+      value: 'score',
+      text: $localize`Score`,
+      params: [
+        {
+          value: 'nodeId',
+          text: $localize`Step`
+        },
+        {
+          value: 'componentId',
+          text: $localize`Component`
+        },
+        {
+          value: 'scores',
+          text: $localize`Score(s)`
+        }
+      ]
+    },
+    {
+      value: 'branchPathTaken',
+      text: $localize`Branch Path Taken`,
+      params: [
+        {
+          value: 'fromNodeId',
+          text: $localize`From Step`
+        },
+        {
+          value: 'toNodeId',
+          text: $localize`To Step`
+        }
+      ]
+    },
+    {
+      value: 'choiceChosen',
+      text: $localize`Choice Chosen`,
+      params: [
+        {
+          value: 'nodeId',
+          text: $localize`Step`
+        },
+        {
+          value: 'componentId',
+          text: $localize`Component`
+        },
+        {
+          value: 'choiceIds',
+          text: $localize`Choices`
+        }
+      ]
+    },
+    {
+      value: 'isCorrect',
+      text: $localize`Is Correct`,
+      params: [
+        {
+          value: 'nodeId',
+          text: $localize`Step`
+        },
+        {
+          value: 'componentId',
+          text: $localize`Component`
+        }
+      ]
+    },
+    {
+      value: 'usedXSubmits',
+      text: $localize`Used X Submits`,
+      params: [
+        {
+          value: 'nodeId',
+          text: $localize`Step`
+        },
+        {
+          value: 'componentId',
+          text: $localize`Component`
+        },
+        {
+          value: 'requiredSubmitCount',
+          text: $localize`Required Submit Count`
+        }
+      ]
+    },
+    {
+      value: 'isVisible',
+      text: $localize`Is Visible`,
+      params: [
+        {
+          value: 'nodeId',
+          text: $localize`Step`
+        }
+      ]
+    },
+    {
+      value: 'isVisitable',
+      text: $localize`Is Visitable`,
+      params: [
+        {
+          value: 'nodeId',
+          text: $localize`Step`
+        }
+      ]
+    },
+    {
+      value: 'isVisited',
+      text: $localize`Is Visited`,
+      params: [
+        {
+          value: 'nodeId',
+          text: $localize`Step`
+        }
+      ]
+    },
+    {
+      value: 'wroteXNumberOfWords',
+      text: $localize`Wrote X Number of Words`,
+      params: [
+        {
+          value: 'nodeId',
+          text: $localize`Step`
+        },
+        {
+          value: 'componentId',
+          text: $localize`Component`
+        },
+        {
+          value: 'requiredNumberOfWords',
+          text: $localize`Required Number of Words`
+        }
+      ]
+    },
+    {
+      value: 'addXNumberOfNotesOnThisStep',
+      text: $localize`Add X Number of Notes On This Step`,
+      params: [
+        {
+          value: 'nodeId',
+          text: $localize`Step`
+        },
+        {
+          value: 'requiredNumberOfNotes',
+          text: $localize`Required Number of Notes`
+        }
+      ]
+    },
+    {
+      value: 'fillXNumberOfRows',
+      text: $localize`Fill X Number of Rows`,
+      params: [
+        {
+          value: 'nodeId',
+          text: $localize`Step`
+        },
+        {
+          value: 'componentId',
+          text: $localize`Component`
+        },
+        {
+          value: 'requiredNumberOfFilledRows',
+          defaultValue: null,
+          text: $localize`Required Number of Filled Rows (Not Including Header Row)`
+        },
+        {
+          value: 'tableHasHeaderRow',
+          defaultValue: true,
+          text: $localize`Table Has Header Row`
+        },
+        {
+          value: 'requireAllCellsInARowToBeFilled',
+          defaultValue: true,
+          text: $localize`Require All Cells In a Row To Be Filled`
+        }
+      ]
+    },
+    {
+      value: 'teacherRemoval',
+      text: $localize`Teacher Removes Constraint`,
+      params: []
+    }
+  ];
 
   constructor(
-    private ProjectService: TeacherProjectService,
-    private TeacherDataService: TeacherDataService
-  ) {
-    this.constraintActions = [
-      {
-        value: '',
-        text: $localize`Please Choose an Action`
-      },
-      {
-        value: 'makeAllNodesAfterThisNotVisitable',
-        text: $localize`Make all nodes after this not visitable`
-      },
-      {
-        value: 'makeAllNodesAfterThisNotVisible',
-        text: $localize`Make all nodes after this not visible`
-      },
-      {
-        value: 'makeAllOtherNodesNotVisitable',
-        text: $localize`Make all other nodes not visitable`
-      },
-      {
-        value: 'makeAllOtherNodesNotVisible',
-        text: $localize`Make all other nodes not visible`
-      },
-      {
-        value: 'makeThisNodeNotVisitable',
-        text: $localize`Make this node not visitable`
-      },
-      {
-        value: 'makeThisNodeNotVisible',
-        text: $localize`Make this node not visible`
-      }
-    ];
-    this.removalConditionals = [
-      {
-        value: 'all',
-        text: $localize`All`
-      },
-      {
-        value: 'any',
-        text: $localize`Any`
-      }
-    ];
-    this.removalCriteria = [
-      {
-        value: '',
-        text: $localize`Please Choose a Removal Criteria`
-      },
-      {
-        value: 'isCompleted',
-        text: $localize`Is Completed`,
-        params: [
-          {
-            value: 'nodeId',
-            text: $localize`Step`
-          }
-        ]
-      },
-      {
-        value: 'score',
-        text: $localize`Score`,
-        params: [
-          {
-            value: 'nodeId',
-            text: $localize`Step`
-          },
-          {
-            value: 'componentId',
-            text: $localize`Component`
-          },
-          {
-            value: 'scores',
-            text: $localize`Score(s)`
-          }
-        ]
-      },
-      {
-        value: 'branchPathTaken',
-        text: $localize`Branch Path Taken`,
-        params: [
-          {
-            value: 'fromNodeId',
-            text: $localize`From Step`
-          },
-          {
-            value: 'toNodeId',
-            text: $localize`To Step`
-          }
-        ]
-      },
-      {
-        value: 'choiceChosen',
-        text: $localize`Choice Chosen`,
-        params: [
-          {
-            value: 'nodeId',
-            text: $localize`Step`
-          },
-          {
-            value: 'componentId',
-            text: $localize`Component`
-          },
-          {
-            value: 'choiceIds',
-            text: $localize`Choices`
-          }
-        ]
-      },
-      {
-        value: 'isCorrect',
-        text: $localize`Is Correct`,
-        params: [
-          {
-            value: 'nodeId',
-            text: $localize`Step`
-          },
-          {
-            value: 'componentId',
-            text: $localize`Component`
-          }
-        ]
-      },
-      {
-        value: 'usedXSubmits',
-        text: $localize`Used X Submits`,
-        params: [
-          {
-            value: 'nodeId',
-            text: $localize`Step`
-          },
-          {
-            value: 'componentId',
-            text: $localize`Component`
-          },
-          {
-            value: 'requiredSubmitCount',
-            text: $localize`Required Submit Count`
-          }
-        ]
-      },
-      {
-        value: 'isVisible',
-        text: $localize`Is Visible`,
-        params: [
-          {
-            value: 'nodeId',
-            text: $localize`Step`
-          }
-        ]
-      },
-      {
-        value: 'isVisitable',
-        text: $localize`Is Visitable`,
-        params: [
-          {
-            value: 'nodeId',
-            text: $localize`Step`
-          }
-        ]
-      },
-      {
-        value: 'isVisited',
-        text: $localize`Is Visited`,
-        params: [
-          {
-            value: 'nodeId',
-            text: $localize`Step`
-          }
-        ]
-      },
-      {
-        value: 'wroteXNumberOfWords',
-        text: $localize`Wrote X Number of Words`,
-        params: [
-          {
-            value: 'nodeId',
-            text: $localize`Step`
-          },
-          {
-            value: 'componentId',
-            text: $localize`Component`
-          },
-          {
-            value: 'requiredNumberOfWords',
-            text: $localize`Required Number of Words`
-          }
-        ]
-      },
-      {
-        value: 'addXNumberOfNotesOnThisStep',
-        text: $localize`Add X Number of Notes On This Step`,
-        params: [
-          {
-            value: 'nodeId',
-            text: $localize`Step`
-          },
-          {
-            value: 'requiredNumberOfNotes',
-            text: $localize`Required Number of Notes`
-          }
-        ]
-      },
-      {
-        value: 'fillXNumberOfRows',
-        text: $localize`Fill X Number of Rows`,
-        params: [
-          {
-            value: 'nodeId',
-            text: $localize`Step`
-          },
-          {
-            value: 'componentId',
-            text: $localize`Component`
-          },
-          {
-            value: 'requiredNumberOfFilledRows',
-            defaultValue: null,
-            text: $localize`Required Number of Filled Rows (Not Including Header Row)`
-          },
-          {
-            value: 'tableHasHeaderRow',
-            defaultValue: true,
-            text: $localize`Table Has Header Row`
-          },
-          {
-            value: 'requireAllCellsInARowToBeFilled',
-            defaultValue: true,
-            text: $localize`Require All Cells In a Row To Be Filled`
-          }
-        ]
-      },
-      {
-        value: 'teacherRemoval',
-        text: $localize`Teacher Removes Constraint`,
-        params: []
-      }
-    ];
-  }
+    private dataService: TeacherDataService,
+    private projectService: TeacherProjectService
+  ) {}
 
   ngOnInit() {
-    this.nodeIds = this.ProjectService.getFlattenedProjectAsNodeIds(true);
-    this.nodeId = this.TeacherDataService.getCurrentNodeId();
-    this.node = this.ProjectService.getNodeById(this.nodeId);
+    this.nodeIds = this.projectService.getFlattenedProjectAsNodeIds(true);
+    this.node = this.projectService.getNodeById(this.dataService.getCurrentNodeId());
+    if (this.node.constraints == null) {
+      this.node.constraints = [];
+    }
   }
 
-  addConstraintAndScrollToBottom(): void {
+  protected addConstraintAndScrollToBottom(): void {
     const newNodeConstraintId = this.addConstraint();
     setTimeout(() => {
-      this.ProjectService.scrollToBottomOfPage();
+      this.projectService.scrollToBottomOfPage();
       temporarilyHighlightElement(newNodeConstraintId);
     });
   }
 
-  addConstraint(): string {
-    const newNodeConstraintId = this.getNewNodeConstraintId(this.nodeId);
+  private addConstraint(): string {
+    const newNodeConstraintId = this.getNewNodeConstraintId();
     const constraint = {
       id: newNodeConstraintId,
       action: '',
-      targetId: this.nodeId,
+      targetId: this.node.id,
       removalConditional: 'any',
       removalCriteria: [
         {
@@ -285,58 +282,41 @@ export class NodeAdvancedConstraintAuthoringComponent implements OnInit {
         }
       ]
     };
-    if (this.node.constraints == null) {
-      this.node.constraints = [];
-    }
     this.node.constraints.push(constraint);
-    this.ProjectService.saveProject();
+    this.projectService.saveProject();
     return newNodeConstraintId;
   }
 
-  getNewNodeConstraintId(nodeId: string): string {
-    let newNodeConstraintId = null;
-    const usedConstraintIds = [];
-    const node = this.ProjectService.getNodeById(nodeId);
-    if (node != null && node.constraints != null) {
-      for (const constraint of node.constraints) {
-        if (constraint != null) {
-          usedConstraintIds.push(constraint.id);
-        }
-      }
-    }
+  private getNewNodeConstraintId(): string {
+    const usedConstraintIds = this.node.constraints.map((constraint) => constraint.id);
     let constraintCounter = 1;
-    while (newNodeConstraintId == null) {
-      let potentialNewNodeConstraintId = nodeId + 'Constraint' + constraintCounter;
-      if (usedConstraintIds.indexOf(potentialNewNodeConstraintId) == -1) {
-        newNodeConstraintId = potentialNewNodeConstraintId;
+    while (true) {
+      const newConstraintId = this.node.id + 'Constraint' + constraintCounter;
+      if (!usedConstraintIds.includes(newConstraintId)) {
+        return newConstraintId;
       } else {
         constraintCounter++;
       }
     }
-    return newNodeConstraintId;
   }
 
-  deleteConstraint(constraintIndex): void {
+  protected deleteConstraint(constraintIndex: number): void {
     if (confirm($localize`Are you sure you want to delete this constraint?`)) {
-      const node = this.ProjectService.getNodeById(this.nodeId);
-      const constraints = node.constraints;
-      if (constraints != null) {
-        constraints.splice(constraintIndex, 1);
-      }
-      this.ProjectService.saveProject();
+      this.node.constraints.splice(constraintIndex, 1);
+      this.projectService.saveProject();
     }
   }
 
-  addRemovalCriteria(constraint: any): void {
+  protected addRemovalCriteria(constraint: any): void {
     const removalCriteria = {
       name: '',
       params: {}
     };
     constraint.removalCriteria.push(removalCriteria);
-    this.ProjectService.saveProject();
+    this.projectService.saveProject();
   }
 
-  removalCriteriaNameChanged(criteria: any): void {
+  protected removalCriteriaNameChanged(criteria: any): void {
     criteria.params = {};
     const params = this.getRemovalCriteriaParamsByName(criteria.name);
     if (params != null) {
@@ -348,14 +328,14 @@ export class NodeAdvancedConstraintAuthoringComponent implements OnInit {
           criteria.params[value] = '';
         }
         if (value === 'nodeId') {
-          criteria.params[value] = this.nodeId;
+          criteria.params[value] = this.node.id;
         }
       }
     }
-    this.ProjectService.saveProject();
+    this.projectService.saveProject();
   }
 
-  getRemovalCriteriaParamsByName(name: string): any[] {
+  private getRemovalCriteriaParamsByName(name: string): any[] {
     for (const singleRemovalCriteria of this.removalCriteria) {
       if (singleRemovalCriteria.value === name) {
         return singleRemovalCriteria.params;
@@ -364,56 +344,53 @@ export class NodeAdvancedConstraintAuthoringComponent implements OnInit {
     return [];
   }
 
-  constraintRemovalCriteriaNodeIdChanged(criteria: any): void {
+  protected constraintRemovalCriteriaNodeIdChanged(criteria: any): void {
     criteria.params.componentId = '';
-    this.ProjectService.saveProject();
+    this.projectService.saveProject();
   }
 
-  constraintRemovalCriteriaComponentIdChanged() {
-    this.ProjectService.saveProject();
+  protected constraintRemovalCriteriaComponentIdChanged(): void {
+    this.projectService.saveProject();
   }
 
-  deleteRemovalCriteria(constraint: any, removalCriteriaIndex: number): void {
+  protected deleteRemovalCriteria(constraint: any, removalCriteriaIndex: number): void {
     if (confirm($localize`Are you sure you want to delete this removal criteria?`)) {
-      const removalCriteria = constraint.removalCriteria;
-      if (removalCriteria != null) {
-        removalCriteria.splice(removalCriteriaIndex, 1);
-      }
-      this.ProjectService.saveProject();
+      constraint.removalCriteria.splice(removalCriteriaIndex, 1);
+      this.projectService.saveProject();
     }
   }
 
-  getChoices(nodeId: string, componentId: string): any[] {
-    return this.ProjectService.getChoices(nodeId, componentId);
+  protected getChoices(nodeId: string, componentId: string): any[] {
+    return this.projectService.getChoices(nodeId, componentId);
   }
 
-  getChoiceTypeByNodeIdAndComponentId(nodeId: string, componentId: string): string {
+  protected getChoiceTypeByNodeIdAndComponentId(nodeId: string, componentId: string): string {
     let choiceType = null;
-    let component = this.ProjectService.getComponent(nodeId, componentId) as MultipleChoiceContent;
+    let component = this.projectService.getComponent(nodeId, componentId) as MultipleChoiceContent;
     if (component != null && component.choiceType != null) {
       choiceType = component.choiceType;
     }
     return choiceType;
   }
 
-  getComponents(nodeId: string): any[] {
-    return this.ProjectService.getComponents(nodeId);
+  protected getComponents(nodeId: string): any[] {
+    return this.projectService.getComponents(nodeId);
   }
 
-  getNodeTitle(nodeId: string): string {
-    return this.ProjectService.getNodeTitle(nodeId);
+  protected getNodeTitle(nodeId: string): string {
+    return this.projectService.getNodeTitle(nodeId);
   }
 
-  getNodePositionById(nodeId: string): string {
-    return this.ProjectService.getNodePositionById(nodeId);
+  protected getNodePositionById(nodeId: string): string {
+    return this.projectService.getNodePositionById(nodeId);
   }
 
-  scoresChanged(value: any, params: any): void {
+  protected scoresChanged(value: any, params: any): void {
     params.scores = value.split(',');
-    this.ProjectService.saveProject();
+    this.projectService.saveProject();
   }
 
-  saveProject(): void {
-    this.ProjectService.saveProject();
+  protected saveProject(): void {
+    this.projectService.saveProject();
   }
 }

--- a/src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts
@@ -291,7 +291,7 @@ export class NodeAdvancedConstraintAuthoringComponent implements OnInit {
     const usedConstraintIds = this.node.constraints.map((constraint) => constraint.id);
     let constraintCounter = 1;
     while (true) {
-      const newConstraintId = this.node.id + 'Constraint' + constraintCounter;
+      const newConstraintId = `${this.node.id}Constraint${constraintCounter}`;
       if (!usedConstraintIds.includes(newConstraintId)) {
         return newConstraintId;
       } else {
@@ -365,12 +365,11 @@ export class NodeAdvancedConstraintAuthoringComponent implements OnInit {
   }
 
   protected getChoiceTypeByNodeIdAndComponentId(nodeId: string, componentId: string): string {
-    let choiceType = null;
-    let component = this.projectService.getComponent(nodeId, componentId) as MultipleChoiceContent;
-    if (component != null && component.choiceType != null) {
-      choiceType = component.choiceType;
-    }
-    return choiceType;
+    const component = this.projectService.getComponent(
+      nodeId,
+      componentId
+    ) as MultipleChoiceContent;
+    return component != null && component.choiceType != null ? component.choiceType : null;
   }
 
   protected getComponents(nodeId: string): any[] {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -8983,7 +8983,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">72</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
@@ -8998,7 +8998,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">113</context>
+          <context context-type="linenumber">104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1102665189929883417" datatype="html">
@@ -9209,63 +9209,63 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Please Choose an Action</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">16</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8564983557318479146" datatype="html">
         <source>Make all nodes after this not visitable</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">20</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7251598407563761816" datatype="html">
         <source>Make all nodes after this not visible</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">24</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6911980762729094571" datatype="html">
         <source>Make all other nodes not visitable</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9001525595437976518" datatype="html">
         <source>Make all other nodes not visible</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">43</context>
+          <context context-type="linenumber">32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8764818364930909549" datatype="html">
         <source>Make this node not visitable</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">47</context>
+          <context context-type="linenumber">36</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6344618803354581997" datatype="html">
         <source>Make this node not visible</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">40</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1616102757855967475" datatype="html">
         <source>All</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">48</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3184700926171002527" datatype="html">
         <source>Any</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">52</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/PeerGroupingLogic.ts</context>
@@ -9276,123 +9276,123 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Please Choose a Removal Criteria</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6460463610153137840" datatype="html">
         <source>Is Completed</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">71</context>
+          <context context-type="linenumber">62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8980375993935541237" datatype="html">
         <source>Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">75</context>
+          <context context-type="linenumber">66</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">85</context>
+          <context context-type="linenumber">76</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">117</context>
+          <context context-type="linenumber">108</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">135</context>
+          <context context-type="linenumber">126</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">149</context>
+          <context context-type="linenumber">140</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">167</context>
+          <context context-type="linenumber">158</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">177</context>
+          <context context-type="linenumber">168</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">187</context>
+          <context context-type="linenumber">178</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">188</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">215</context>
+          <context context-type="linenumber">206</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">229</context>
+          <context context-type="linenumber">220</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5847302460276630595" datatype="html">
         <source>Component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">89</context>
+          <context context-type="linenumber">80</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">112</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">139</context>
+          <context context-type="linenumber">130</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">153</context>
+          <context context-type="linenumber">144</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">192</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">233</context>
+          <context context-type="linenumber">224</context>
         </context-group>
       </trans-unit>
       <trans-unit id="185559960832537937" datatype="html">
         <source>Score(s)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">93</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="16986194959433746" datatype="html">
         <source>Branch Path Taken</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">99</context>
+          <context context-type="linenumber">90</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6380325907263903883" datatype="html">
         <source>From Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">103</context>
+          <context context-type="linenumber">94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="455666817590621118" datatype="html">
         <source>To Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">107</context>
+          <context context-type="linenumber">98</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6910078656226990536" datatype="html">
         <source>Choices</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">125</context>
+          <context context-type="linenumber">116</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
@@ -9411,119 +9411,119 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Is Correct</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">131</context>
+          <context context-type="linenumber">122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4268291134905709874" datatype="html">
         <source>Used X Submits</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">145</context>
+          <context context-type="linenumber">136</context>
         </context-group>
       </trans-unit>
       <trans-unit id="767433972334291022" datatype="html">
         <source>Required Submit Count</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">157</context>
+          <context context-type="linenumber">148</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2997822456018079719" datatype="html">
         <source>Is Visible</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">163</context>
+          <context context-type="linenumber">154</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2226381985639556979" datatype="html">
         <source>Is Visitable</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">173</context>
+          <context context-type="linenumber">164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3284330787067886212" datatype="html">
         <source>Is Visited</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3120562623622017132" datatype="html">
         <source>Wrote X Number of Words</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">193</context>
+          <context context-type="linenumber">184</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3793469420585389570" datatype="html">
         <source>Required Number of Words</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">205</context>
+          <context context-type="linenumber">196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2346474241177154844" datatype="html">
         <source>Add X Number of Notes On This Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">211</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2215706295447985195" datatype="html">
         <source>Required Number of Notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">219</context>
+          <context context-type="linenumber">210</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3753898460381641212" datatype="html">
         <source>Fill X Number of Rows</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">225</context>
+          <context context-type="linenumber">216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8868642264052368211" datatype="html">
         <source>Required Number of Filled Rows (Not Including Header Row)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">238</context>
+          <context context-type="linenumber">229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3373179210544883044" datatype="html">
         <source>Table Has Header Row</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">243</context>
+          <context context-type="linenumber">234</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3682483624336387760" datatype="html">
         <source>Require All Cells In a Row To Be Filled</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">248</context>
+          <context context-type="linenumber">239</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6549053190457916462" datatype="html">
         <source>Teacher Removes Constraint</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">254</context>
+          <context context-type="linenumber">245</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7765979807116943270" datatype="html">
         <source>Are you sure you want to delete this constraint?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">320</context>
+          <context context-type="linenumber">304</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8870343237719695349" datatype="html">
         <source>Are you sure you want to delete this removal criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component.ts</context>
-          <context context-type="linenumber">377</context>
+          <context context-type="linenumber">357</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bfab7f41cfc32a926c55987d6a9c3349ae417131" datatype="html">


### PR DESCRIPTION
## Changes
- Move variable declarations/instantiations (constraintActions, removalConditionals, removalCriteria...) to top of class instead of in the constructor
- Use this.node.id instead of this.nodeId
- Reduce complexity of getNewNodeConstraintId()
- Add private/protected to functions
- Add types to params and function return types

## Test
- Node constraint authoring works as before

Closes #1117