### PR TITLE
fix(Grade By Step): Duplicate student work request

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading-view/node-grading-view.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading-view/node-grading-view.component.ts
@@ -77,7 +77,7 @@ export class NodeGradingViewComponent implements OnInit {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.nodeId) {
+    if (changes.nodeId && !changes.nodeId.firstChange) {
       this.nodeId = changes.nodeId.currentValue;
       this.setupNode();
     }


### PR DESCRIPTION
## Changes

Do not retrieve student work on the first ngOnChanges() of the nodeId in NodeGradingViewComponent.

## Test

1. Log in as a teacher
2. Open the Classroom Monitor for a run
3. Go to the "Grade By Step" view
4. Open the browser developer tools
5. Go to the "Network" tab
6. Click on a step to load the student work for that step
7. In the "Network" tab make sure there is only one request made to `https://wise.berkeley.edu/api/teacher/data`. Previously there would be two identical requests.

Closes #1124