### PR TITLE
feat(Table): Hide reset button when there are no editable cells

### DIFF
--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -83,9 +83,6 @@ export class TableStudent extends ComponentStudent {
     // holds the the table data
     this.tableData = null;
 
-    // whether the reset table button is shown or not
-    this.isResetTableButtonVisible = true;
-
     // the label for the notebook in thos project
     this.notebookConfig = this.NotebookService.getNotebookConfig();
 
@@ -101,7 +98,6 @@ export class TableStudent extends ComponentStudent {
 
     this.isSaveButtonVisible = this.componentContent.showSaveButton;
     this.isSubmitButtonVisible = this.componentContent.showSubmitButton;
-    this.isResetTableButtonVisible = true;
 
     if (this.UtilService.hasShowWorkConnectedComponent(this.componentContent)) {
       // we will show work from another component
@@ -147,6 +143,9 @@ export class TableStudent extends ComponentStudent {
       this.isDisabled = true;
     }
 
+    this.isResetTableButtonVisible = this.TableService.componentHasEditableCells(
+      this.componentContent
+    );
     this.disableComponentIfNecessary();
 
     if (this.isDataExplorerEnabled && this.componentContent.dataExplorerDataToColumn != null) {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12564,11 +12564,25 @@ Are you sure you want to proceed?</source>
           <context context-type="linenumber">105</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1728967729900769266" datatype="html">
-        <source><x id="PH" equiv-text="prefix"/> <x id="saveTime" equiv-text="saveTimeText"/></source>
+      <trans-unit id="2692433425768915750" datatype="html">
+        <source>Submitted <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/save-time-message/save-time-message.component.ts</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5275881069346355759" datatype="html">
+        <source>Auto Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/common/save-time-message/save-time-message.component.ts</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3124371804165766752" datatype="html">
+        <source>Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/common/save-time-message/save-time-message.component.ts</context>
+          <context context-type="linenumber">32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9ba24bf3c65fed6e59c2d2264be8d104f370a69c" datatype="html">


### PR DESCRIPTION
## Changes
Reset button on Table components only appears for students when the table contains editable cells.

## Test
- Make sure reset button does not appear no cells in Table component are editable.
- Make sure reset button appears and works as before when there are editable cells in component.

Closes #1122.