### PR TITLE
refactor(StudentDataService): Extract NodeProgressService

### DIFF
--- a/src/app/services/nodeProgressService.spec.ts
+++ b/src/app/services/nodeProgressService.spec.ts
@@ -1,0 +1,83 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { NodeProgressService } from '../../assets/wise5/services/nodeProgressService';
+import { ProjectService } from '../../assets/wise5/services/projectService';
+import { StudentTeacherCommonServicesModule } from '../student-teacher-common-services.module';
+
+let projectService: ProjectService;
+let service: NodeProgressService;
+describe('NodeProgressService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, StudentTeacherCommonServicesModule]
+    });
+    projectService = TestBed.inject(ProjectService);
+    service = TestBed.inject(NodeProgressService);
+  });
+  getNodeProgress();
+});
+
+function getNodeProgress() {
+  describe('getNodeProgress()', () => {
+    beforeEach(() => {
+      spyOn(projectService, 'isGroupNode').and.callFake((nodeId) => {
+        return nodeId.startsWith('group');
+      });
+      spyOn(projectService, 'nodeHasWork').and.returnValue(true);
+    });
+    getNodeProgress_childStepNodes_returnProgress();
+    getNodeProgress_childGroupNodes_returnProgress();
+  });
+}
+
+function getNodeProgress_childStepNodes_returnProgress() {
+  it('should return progress with child step nodes', () => {
+    const nodeStatuses = {
+      node1: { nodeId: 'node1', isVisible: true, isCompleted: true },
+      node2: { nodeId: 'node2', isVisible: true, isCompleted: false }
+    };
+    spyOn(projectService, 'getChildNodeIdsById').and.returnValue(['node1', 'node2']);
+    expect(service.getNodeProgress('group1', nodeStatuses)).toEqual({
+      completedItems: 1,
+      completedItemsWithWork: 1,
+      completionPct: 50,
+      completionPctWithWork: 50,
+      totalItems: 2,
+      totalItemsWithWork: 2
+    });
+  });
+}
+
+function getNodeProgress_childGroupNodes_returnProgress() {
+  it('should return progress with child group nodes', () => {
+    const nodeStatuses = {
+      group1: {
+        nodeId: 'group1',
+        progress: {
+          completedItems: 1,
+          totalItems: 1,
+          completedItemsWithWork: 1,
+          totalItemsWithWork: 1
+        }
+      },
+      group2: {
+        nodeId: 'group2',
+        progress: {
+          completedItems: 2,
+          totalItems: 2,
+          completedItemsWithWork: 2,
+          totalItemsWithWork: 2
+        }
+      }
+    };
+    spyOn(projectService, 'getChildNodeIdsById').and.returnValue(['group1', 'group2']);
+    expect(service.getNodeProgress('group0', nodeStatuses)).toEqual({
+      completedItems: 3,
+      completedItemsWithWork: 3,
+      completionPct: 100,
+      completionPctWithWork: 100,
+      totalItems: 3,
+      totalItemsWithWork: 3
+    });
+  });
+}

--- a/src/app/services/studentDataService.spec.ts
+++ b/src/app/services/studentDataService.spec.ts
@@ -48,7 +48,6 @@ describe('StudentDataService', () => {
   shouldGetLatestNodeEnteredEventNodeIdWithExistingNode();
   shouldCalculateCanVisitNode();
   shouldGetNodeStatusByNodeId();
-  shouldGetProgressById();
   shouldCheckIsCompleted();
   shouldGetLatestComponentStatesByNodeId();
   shouldGetLatestComponentStateByNodeId();
@@ -565,64 +564,6 @@ function shouldGetNodeStatusByNodeId() {
     };
     const nodeStatus = service.getNodeStatusByNodeId('node1');
     expect(nodeStatus.nodeId).toEqual('node1');
-  });
-}
-
-function shouldGetProgressById() {
-  it('should get progress by id with child step nodes', () => {
-    const nodeStatuses = {
-      node1: { nodeId: 'node1', isVisible: true, isCompleted: true },
-      node2: { nodeId: 'node2', isVisible: true, isCompleted: false }
-    };
-    service.nodeStatuses = nodeStatuses;
-    spyOn(projectService, 'isGroupNode').and.callFake((nodeId) => {
-      return nodeId.startsWith('group');
-    });
-    const childNodeIds = ['node1', 'node2'];
-    spyOn(projectService, 'getChildNodeIdsById').and.returnValue(childNodeIds);
-    spyOn(projectService, 'nodeHasWork').and.returnValue(true);
-    const progress: any = service.getNodeProgressById('group1', nodeStatuses);
-    expect(progress.completedItems).toEqual(1);
-    expect(progress.completedItemsWithWork).toEqual(1);
-    expect(progress.totalItems).toEqual(2);
-    expect(progress.totalItemsWithWork).toEqual(2);
-    expect(progress.completionPct).toEqual(50);
-    expect(progress.completionPctWithWork).toEqual(50);
-  });
-  it('should get progress by id with child group nodes', () => {
-    const nodeStatuses = {
-      group1: {
-        nodeId: 'group1',
-        progress: {
-          completedItems: 1,
-          totalItems: 1,
-          completedItemsWithWork: 1,
-          totalItemsWithWork: 1
-        }
-      },
-      group2: {
-        nodeId: 'group2',
-        progress: {
-          completedItems: 2,
-          totalItems: 2,
-          completedItemsWithWork: 2,
-          totalItemsWithWork: 2
-        }
-      }
-    };
-    service.nodeStatuses = nodeStatuses;
-    spyOn(projectService, 'isGroupNode').and.callFake((nodeId) => {
-      return nodeId.startsWith('group');
-    });
-    const childNodeIds = ['group1', 'group2'];
-    spyOn(projectService, 'getChildNodeIdsById').and.returnValue(childNodeIds);
-    const progress: any = service.getNodeProgressById('group0', nodeStatuses);
-    expect(progress.completedItems).toEqual(3);
-    expect(progress.completedItemsWithWork).toEqual(3);
-    expect(progress.totalItems).toEqual(3);
-    expect(progress.totalItemsWithWork).toEqual(3);
-    expect(progress.completionPct).toEqual(100);
-    expect(progress.completionPctWithWork).toEqual(100);
   });
 }
 

--- a/src/app/services/studentDataService.spec.ts
+++ b/src/app/services/studentDataService.spec.ts
@@ -570,17 +570,18 @@ function shouldGetNodeStatusByNodeId() {
 
 function shouldGetProgressById() {
   it('should get progress by id with child step nodes', () => {
-    service.nodeStatuses = {
+    const nodeStatuses = {
       node1: { nodeId: 'node1', isVisible: true, isCompleted: true },
       node2: { nodeId: 'node2', isVisible: true, isCompleted: false }
     };
+    service.nodeStatuses = nodeStatuses;
     spyOn(projectService, 'isGroupNode').and.callFake((nodeId) => {
       return nodeId.startsWith('group');
     });
     const childNodeIds = ['node1', 'node2'];
     spyOn(projectService, 'getChildNodeIdsById').and.returnValue(childNodeIds);
     spyOn(projectService, 'nodeHasWork').and.returnValue(true);
-    const progress: any = service.getNodeProgressById('group1');
+    const progress: any = service.getNodeProgressById('group1', nodeStatuses);
     expect(progress.completedItems).toEqual(1);
     expect(progress.completedItemsWithWork).toEqual(1);
     expect(progress.totalItems).toEqual(2);
@@ -589,7 +590,7 @@ function shouldGetProgressById() {
     expect(progress.completionPctWithWork).toEqual(50);
   });
   it('should get progress by id with child group nodes', () => {
-    service.nodeStatuses = {
+    const nodeStatuses = {
       group1: {
         nodeId: 'group1',
         progress: {
@@ -609,12 +610,13 @@ function shouldGetProgressById() {
         }
       }
     };
+    service.nodeStatuses = nodeStatuses;
     spyOn(projectService, 'isGroupNode').and.callFake((nodeId) => {
       return nodeId.startsWith('group');
     });
     const childNodeIds = ['group1', 'group2'];
     spyOn(projectService, 'getChildNodeIdsById').and.returnValue(childNodeIds);
-    const progress: any = service.getNodeProgressById('group0');
+    const progress: any = service.getNodeProgressById('group0', nodeStatuses);
     expect(progress.completedItems).toEqual(3);
     expect(progress.completedItemsWithWork).toEqual(3);
     expect(progress.totalItems).toEqual(3);

--- a/src/app/student-teacher-common-services.module.ts
+++ b/src/app/student-teacher-common-services.module.ts
@@ -51,6 +51,7 @@ import { StudentPeerGroupService } from '../assets/wise5/services/studentPeerGro
 import { ConstraintService } from '../assets/wise5/services/constraintService';
 import { NodeStatusService } from '../assets/wise5/services/nodeStatusService';
 import { PeerGroupService } from '../assets/wise5/services/peerGroupService';
+import { NodeProgressService } from '../assets/wise5/services/nodeProgressService';
 
 @NgModule({
   providers: [
@@ -78,6 +79,7 @@ import { PeerGroupService } from '../assets/wise5/services/peerGroupService';
     LabelService,
     MatchService,
     MultipleChoiceService,
+    NodeProgressService,
     NodeService,
     NodeStatusService,
     NotebookService,

--- a/src/assets/wise5/common/NodeProgress.ts
+++ b/src/assets/wise5/common/NodeProgress.ts
@@ -1,0 +1,8 @@
+export interface NodeProgress {
+  completedItems: number;
+  completedItemsWithWork: number;
+  completionPct?: number;
+  completionPctWithWork?: number;
+  totalItems: number;
+  totalItemsWithWork: number;
+}

--- a/src/assets/wise5/common/StudentStatus.ts
+++ b/src/assets/wise5/common/StudentStatus.ts
@@ -1,9 +1,11 @@
+import { NodeProgress } from './NodeProgress';
+
 export class StudentStatus {
   computerAvatarId?: string;
   currentNodeId: string;
   nodeStatuses: any;
   periodId: number;
-  projectCompletion: any;
+  projectCompletion: NodeProgress;
   runId: number;
   workgroupId: number;
 

--- a/src/assets/wise5/services/nodeProgressService.ts
+++ b/src/assets/wise5/services/nodeProgressService.ts
@@ -1,0 +1,96 @@
+import { Injectable } from '@angular/core';
+import { NodeProgress } from '../common/NodeProgress';
+import { ProjectService } from './projectService';
+
+@Injectable()
+export class NodeProgressService {
+  constructor(protected projectService: ProjectService) {}
+
+  /**
+   * Get progress information for a given node
+   * @param nodeId the node id
+   * @param nodeStatuses all the NodeStatuses for the student
+   * @returns object with number of completed items (both all and for items that capture student
+   * work), number of visible items (all/with work), completion % (for all items, items with student
+   * work)
+   */
+  getNodeProgress(nodeId: string, nodeStatuses: any): NodeProgress {
+    const progress: NodeProgress = {
+      totalItems: 0,
+      totalItemsWithWork: 0,
+      completedItems: 0,
+      completedItemsWithWork: 0
+    };
+    if (this.projectService.isGroupNode(nodeId)) {
+      for (const childNodeId of this.projectService.getChildNodeIdsById(nodeId)) {
+        if (this.projectService.isGroupNode(childNodeId)) {
+          this.updateGroupNodeProgress(childNodeId, progress, nodeStatuses);
+        } else {
+          this.updateStepNodeProgress(childNodeId, progress, nodeStatuses);
+        }
+      }
+      this.calculateAndInjectCompletionPercentage(progress);
+      this.calculateAndInjectCompletionPercentageWithWork(progress);
+    }
+    // TODO: implement for steps (using components instead of child nodes)?
+    return progress;
+  }
+
+  private updateGroupNodeProgress(
+    nodeId: string,
+    progress: NodeProgress,
+    nodeStatuses: any
+  ): NodeProgress {
+    const nodeStatus = nodeStatuses[nodeId];
+    if (nodeStatus.progress.totalItemsWithWork > -1) {
+      progress.completedItems += nodeStatus.progress.completedItems;
+      progress.totalItems += nodeStatus.progress.totalItems;
+      progress.completedItemsWithWork += nodeStatus.progress.completedItemsWithWork;
+      progress.totalItemsWithWork += nodeStatus.progress.totalItemsWithWork;
+    } else {
+      // we have a legacy node status so we'll need to calculate manually
+      const groupProgress = this.getNodeProgress(nodeId, nodeStatuses);
+      progress.completedItems += groupProgress.completedItems;
+      progress.totalItems += groupProgress.totalItems;
+      progress.completedItemsWithWork += groupProgress.completedItemsWithWork;
+      progress.totalItemsWithWork += groupProgress.totalItemsWithWork;
+    }
+    return progress;
+  }
+
+  private updateStepNodeProgress(
+    nodeId: string,
+    progress: NodeProgress,
+    nodeStatuses: any
+  ): NodeProgress {
+    const nodeStatus = nodeStatuses[nodeId];
+    if (nodeStatus.isVisible) {
+      progress.totalItems++;
+      const hasWork = this.projectService.nodeHasWork(nodeId);
+      if (hasWork) {
+        progress.totalItemsWithWork++;
+      }
+      if (nodeStatus.isCompleted) {
+        progress.completedItems++;
+        if (hasWork) {
+          progress.completedItemsWithWork++;
+        }
+      }
+    }
+    return progress;
+  }
+
+  private calculateAndInjectCompletionPercentage(progress: NodeProgress): void {
+    const totalItems = progress.totalItems;
+    const completedItems = progress.completedItems;
+    progress.completionPct = totalItems ? Math.round((completedItems / totalItems) * 100) : 0;
+  }
+
+  private calculateAndInjectCompletionPercentageWithWork(progress: NodeProgress): void {
+    const totalItemsWithWork = progress.totalItemsWithWork;
+    const completedItemsWithWork = progress.completedItemsWithWork;
+    progress.completionPctWithWork = totalItemsWithWork
+      ? Math.round((completedItemsWithWork / totalItemsWithWork) * 100)
+      : 0;
+  }
+}

--- a/src/assets/wise5/services/nodeStatusService.ts
+++ b/src/assets/wise5/services/nodeStatusService.ts
@@ -115,7 +115,10 @@ export class NodeStatusService {
   }
 
   private updateNodeStatusProgress(nodeId: string): void {
-    this.dataService.nodeStatuses[nodeId].progress = this.dataService.getNodeProgressById(nodeId);
+    this.dataService.nodeStatuses[nodeId].progress = this.dataService.getNodeProgressById(
+      nodeId,
+      this.getNodeStatuses()
+    );
   }
 
   private updateNodeStatusIcon(nodeId: string): void {

--- a/src/assets/wise5/services/nodeStatusService.ts
+++ b/src/assets/wise5/services/nodeStatusService.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { NodeStatus } from '../common/NodeStatus';
 import { ConstraintService } from './constraintService';
+import { NodeProgressService } from './nodeProgressService';
 import { NotebookService } from './notebookService';
 import { ProjectService } from './projectService';
 import { StudentDataService } from './studentDataService';
@@ -9,9 +10,10 @@ import { StudentDataService } from './studentDataService';
 export class NodeStatusService {
   constructor(
     private constraintService: ConstraintService,
+    private dataService: StudentDataService,
+    private nodeProgressService: NodeProgressService,
     private notebookService: NotebookService,
-    private projectService: ProjectService,
-    private dataService: StudentDataService
+    private projectService: ProjectService
   ) {
     this.dataService.updateNodeStatuses$.subscribe(() => {
       this.updateNodeStatuses();
@@ -115,7 +117,7 @@ export class NodeStatusService {
   }
 
   private updateNodeStatusProgress(nodeId: string): void {
-    this.dataService.nodeStatuses[nodeId].progress = this.dataService.getNodeProgressById(
+    this.dataService.nodeStatuses[nodeId].progress = this.nodeProgressService.getNodeProgress(
       nodeId,
       this.getNodeStatuses()
     );

--- a/src/assets/wise5/services/studentDataService.ts
+++ b/src/assets/wise5/services/studentDataService.ts
@@ -666,7 +666,7 @@ export class StudentDataService extends DataService {
    * work), number of visible items (all/with work), completion % (for all items, items with student
    * work)
    */
-  getNodeProgressById(nodeId) {
+  getNodeProgressById(nodeId: string, nodeStatuses: any): any {
     const progress = {
       totalItems: 0,
       totalItemsWithWork: 0,
@@ -675,11 +675,10 @@ export class StudentDataService extends DataService {
     };
     if (this.ProjectService.isGroupNode(nodeId)) {
       for (const childNodeId of this.ProjectService.getChildNodeIdsById(nodeId)) {
-        const nodeStatus = this.nodeStatuses[childNodeId];
         if (this.ProjectService.isGroupNode(childNodeId)) {
-          this.updateGroupNodeProgress(childNodeId, progress, nodeStatus);
+          this.updateGroupNodeProgress(childNodeId, progress, nodeStatuses);
         } else {
-          this.updateStepNodeProgress(childNodeId, progress, nodeStatus);
+          this.updateStepNodeProgress(childNodeId, progress, nodeStatuses);
         }
       }
       this.calculateAndInjectCompletionPercentage(progress);
@@ -689,7 +688,8 @@ export class StudentDataService extends DataService {
     return progress;
   }
 
-  updateGroupNodeProgress(nodeId, progress, nodeStatus) {
+  private updateGroupNodeProgress(nodeId: string, progress: any, nodeStatuses: any): any {
+    const nodeStatus = nodeStatuses[nodeId];
     if (nodeStatus.progress.totalItemsWithWork > -1) {
       progress.completedItems += nodeStatus.progress.completedItems;
       progress.totalItems += nodeStatus.progress.totalItems;
@@ -697,7 +697,7 @@ export class StudentDataService extends DataService {
       progress.totalItemsWithWork += nodeStatus.progress.totalItemsWithWork;
     } else {
       // we have a legacy node status so we'll need to calculate manually
-      const groupProgress = this.getNodeProgressById(nodeId);
+      const groupProgress = this.getNodeProgressById(nodeId, nodeStatuses);
       progress.completedItems += groupProgress.completedItems;
       progress.totalItems += groupProgress.totalItems;
       progress.completedItemsWithWork += groupProgress.completedItemsWithWork;
@@ -706,7 +706,8 @@ export class StudentDataService extends DataService {
     return progress;
   }
 
-  updateStepNodeProgress(nodeId, progress, nodeStatus) {
+  private updateStepNodeProgress(nodeId: string, progress: any, nodeStatuses: any): any {
+    const nodeStatus = nodeStatuses[nodeId];
     if (nodeStatus.isVisible) {
       progress.totalItems++;
       const hasWork = this.ProjectService.nodeHasWork(nodeId);
@@ -820,7 +821,7 @@ export class StudentDataService extends DataService {
 
   getProjectCompletion() {
     const nodeId = 'group0';
-    return this.getNodeProgressById(nodeId);
+    return this.getNodeProgressById(nodeId, this.nodeStatuses);
   }
 
   getRunStatus() {

--- a/src/assets/wise5/services/studentStatusService.ts
+++ b/src/assets/wise5/services/studentStatusService.ts
@@ -57,16 +57,13 @@ export class StudentStatusService {
       const runId = this.configService.getRunId();
       const periodId = this.configService.getPeriodId();
       const workgroupId = this.configService.getWorkgroupId();
-      const currentNodeId = this.studentDataService.getCurrentNodeId();
-      const nodeStatuses = this.nodeStatusService.getNodeStatuses();
-      const projectCompletion = this.studentDataService.getProjectCompletion();
       const studentStatusJSON: StudentStatus = {
         runId: runId,
         periodId: periodId,
         workgroupId: workgroupId,
-        currentNodeId: currentNodeId,
-        nodeStatuses: nodeStatuses,
-        projectCompletion: projectCompletion
+        currentNodeId: this.studentDataService.getCurrentNodeId(),
+        nodeStatuses: this.nodeStatusService.getNodeStatuses(),
+        projectCompletion: this.studentDataService.getProjectCompletion()
       };
       const computerAvatarId = this.getComputerAvatarId();
       if (computerAvatarId != null) {

--- a/src/assets/wise5/vle/node/node.component.ts
+++ b/src/assets/wise5/vle/node/node.component.ts
@@ -7,6 +7,7 @@ import { ComponentService } from '../../components/componentService';
 import { ComponentStateWrapper } from '../../components/ComponentStateWrapper';
 import { ConfigService } from '../../services/configService';
 import { NodeService } from '../../services/nodeService';
+import { NodeStatusService } from '../../services/nodeStatusService';
 import { SessionService } from '../../services/sessionService';
 import { StudentDataService } from '../../services/studentDataService';
 import { VLEProjectService } from '../vleProjectService';
@@ -57,6 +58,7 @@ export class NodeComponent implements OnInit {
     private componentService: ComponentService,
     private configService: ConfigService,
     private nodeService: NodeService,
+    private nodeStatusService: NodeStatusService,
     private projectService: VLEProjectService,
     private sessionService: SessionService,
     private studentDataService: StudentDataService
@@ -140,7 +142,7 @@ export class NodeComponent implements OnInit {
     this.nodeId = this.studentDataService.getCurrentNodeId();
     this.node = this.projectService.getNode(this.nodeId);
     this.nodeContent = this.projectService.getNodeById(this.nodeId);
-    this.nodeStatus = this.studentDataService.getNodeStatusByNodeId(this.nodeId);
+    this.nodeStatus = this.nodeStatusService.getNodeStatusByNodeId(this.nodeId);
     this.components = this.getComponents();
 
     if (

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -18660,28 +18660,28 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Preview Student</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">78</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1967824796880640028" datatype="html">
         <source>StudentDataService.saveComponentEvent: component, category, event args must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">276</context>
+          <context context-type="linenumber">279</context>
         </context-group>
       </trans-unit>
       <trans-unit id="944638387659785956" datatype="html">
         <source>StudentDataService.saveComponentEvent: nodeId, componentId, componentType must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">286</context>
+          <context context-type="linenumber">289</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4924640921903672943" datatype="html">
         <source>StudentDataService.saveVLEEvent: category and event args must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">295</context>
+          <context context-type="linenumber">298</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8725215606116054825" datatype="html">


### PR DESCRIPTION
## Changes
- Extract StudentDataService.getNodeProgressById() to new NodeProgressService.getNodeProgress()
- Define NodeProgress interface for representing node progress and update references (e.g. change any -> NodeProgress)
- Pass in NodeStatus to NodeProgressService.getNodeProgress(). This is part of the refactoring work to move NodeStatus out of StudentDataService

## Test
- Node Progress (e.g. completion percentage) updates and appears correctly as before in:
   - student VLE, account menu and project plan view 
   - grading tool 

Closes #1139