### PR TITLE
refactor(UtilService): Move removeHTMLTags

### DIFF
--- a/src/app/services/utilService.spec.ts
+++ b/src/app/services/utilService.spec.ts
@@ -10,8 +10,6 @@ describe('UtilService', () => {
     service = TestBed.inject(UtilService);
   });
   calculateMeanTests();
-  removeHTMLTags();
-  replaceImgTagWithFileName();
 });
 
 function calculateMeanTests() {
@@ -24,36 +22,6 @@ function calculateMeanTests() {
     it('should calculate the mean when there are multiple values', () => {
       const values = [1, 2, 3, 4, 10];
       expect(service.calculateMean(values)).toEqual(4);
-    });
-  });
-}
-
-function removeHTMLTags() {
-  describe('removeHTMLTags()', () => {
-    it('should remove html tags', () => {
-      expect(service.removeHTMLTags('<p><img src="computer.png"/></p>')).toEqual(' computer.png ');
-    });
-  });
-}
-
-function replaceImgTagWithFileName() {
-  describe('replaceImgTagWithFileName()', () => {
-    it('should replace image tag with file name when it uses double quotes', () => {
-      expect(service.replaceImgTagWithFileName('<img src="computer.png"/>')).toEqual(
-        'computer.png'
-      );
-    });
-    it('should replace image tag with file name when it uses single quotes', () => {
-      expect(service.replaceImgTagWithFileName("<img src='computer.png'/>")).toEqual(
-        'computer.png'
-      );
-    });
-    it('should replace image tag with file name when there are other attributes', () => {
-      expect(
-        service.replaceImgTagWithFileName(
-          "<img alt='Computer' src='computer.png' aria-label='Computer'/>"
-        )
-      ).toEqual('computer.png');
     });
   });
 }

--- a/src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts
@@ -22,6 +22,7 @@ import { DialogWithSpinnerComponent } from '../../../directives/dialog-with-spin
 import { DiscussionComponentDataExportStrategy } from '../strategies/DiscussionComponentDataExportStrategy';
 import { LabelComponentDataExportStrategy } from '../strategies/LabelComponentDataExportStrategy';
 import { Component as WISEComponent } from '../../../common/Component';
+import { removeHTMLTags } from '../../../common/string/string';
 
 @Component({
   selector: 'data-export',
@@ -311,7 +312,7 @@ export class DataExportComponent implements OnInit {
     if (component != null) {
       row[columnNameToNumber['Component Type']] = component.type;
       if (component.prompt != null) {
-        var prompt = this.utilService.removeHTMLTags(component.prompt);
+        var prompt = removeHTMLTags(component.prompt);
         prompt = prompt.replace(/"/g, '""');
         row[columnNameToNumber['Component Prompt']] = prompt;
       }
@@ -464,7 +465,7 @@ export class DataExportComponent implements OnInit {
       if (data != null) {
         var autoComment = data.value;
         if (autoComment != null) {
-          row[columnNameToNumber['Auto Comment']] = this.utilService.removeHTMLTags(autoComment);
+          row[columnNameToNumber['Auto Comment']] = removeHTMLTags(autoComment);
         }
       }
     }
@@ -571,7 +572,7 @@ export class DataExportComponent implements OnInit {
     let componentService = this.componentServiceLookupService.getService(componentType);
     if (componentService != null && componentService.getStudentDataString != null) {
       studentDataString = componentService.getStudentDataString(componentState);
-      studentDataString = this.utilService.removeHTMLTags(studentDataString);
+      studentDataString = removeHTMLTags(studentDataString);
       studentDataString = studentDataString.replace(/"/g, '""');
     } else {
       studentDataString = componentState.studentData;

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/AbstractComponentDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/AbstractComponentDataExportStrategy.ts
@@ -1,4 +1,5 @@
 import { Component } from '../../../common/Component';
+import { removeHTMLTags } from '../../../common/string/string';
 import { ComponentDataExportParams } from '../ComponentDataExportParams';
 import { ComponentRevisionCounter } from '../ComponentRevisionCounter';
 import { UserIdsAndStudentNames } from '../UserIdsAndStudentNames';
@@ -184,7 +185,7 @@ export abstract class AbstractComponentDataExportStrategy extends AbstractDataEx
     row[this.columnNameToNumber.get('Component Part Number')] = componentPartNumber;
     row[this.columnNameToNumber.get('Component Type')] = this.component.content.type;
     if (this.component.content.prompt != null) {
-      let prompt = this.utilService.removeHTMLTags(this.component.content.prompt);
+      let prompt = removeHTMLTags(this.component.content.prompt);
       prompt = prompt.replace(/"/g, '""');
       row[this.columnNameToNumber.get('Component Prompt')] = prompt;
     }

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/DiscussionComponentDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/DiscussionComponentDataExportStrategy.ts
@@ -1,3 +1,4 @@
+import { removeHTMLTags } from '../../../common/string/string';
 import { AbstractDataExportStrategy } from './AbstractDataExportStrategy';
 
 export class DiscussionComponentDataExportStrategy extends AbstractDataExportStrategy {
@@ -144,15 +145,13 @@ export class DiscussionComponentDataExportStrategy extends AbstractDataExportStr
       this.projectService.getComponentPosition(nodeId, componentId) + 1;
     row[columnNameToNumber['Component ID']] = component.id;
     row[columnNameToNumber['Component Type']] = component.type;
-    row[columnNameToNumber['Component Prompt']] = this.utilService.removeHTMLTags(component.prompt);
+    row[columnNameToNumber['Component Prompt']] = removeHTMLTags(component.prompt);
     row[columnNameToNumber['Student Data']] = componentState.studentData;
     row[columnNameToNumber['Student Work ID']] = componentState.id;
     row[columnNameToNumber['Thread ID']] = threadId;
     row[columnNameToNumber['Workgroup ID']] = workgroupId;
     row[columnNameToNumber['Post Level']] = this.getPostLevel(componentState);
-    row[columnNameToNumber['Post Text']] = this.utilService.removeHTMLTags(
-      componentState.studentData.response
-    );
+    row[columnNameToNumber['Post Text']] = removeHTMLTags(componentState.studentData.response);
     return row;
   }
 

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/EventDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/EventDataExportStrategy.ts
@@ -1,3 +1,4 @@
+import { removeHTMLTags } from '../../../common/string/string';
 import { AbstractDataExportStrategy } from './AbstractDataExportStrategy';
 
 export class EventDataExportStrategy extends AbstractDataExportStrategy {
@@ -455,7 +456,7 @@ export class EventDataExportStrategy extends AbstractDataExportStrategy {
 
   private setComponentPrompt(row, columnNameToNumber, component) {
     if (component != null) {
-      let prompt = this.utilService.removeHTMLTags(component.prompt);
+      let prompt = removeHTMLTags(component.prompt);
       prompt = prompt.replace(/"/g, '""');
       row[columnNameToNumber['Component Prompt']] = prompt;
     }

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/NotebookDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/NotebookDataExportStrategy.ts
@@ -1,3 +1,4 @@
+import { removeHTMLTags } from '../../../common/string/string';
 import { AbstractDataExportStrategy } from './AbstractDataExportStrategy';
 
 export class NotebookDataExportStrategy extends AbstractDataExportStrategy {
@@ -122,7 +123,7 @@ export class NotebookDataExportStrategy extends AbstractDataExportStrategy {
     }
     const responseJSON = JSON.parse(notebookItem.content);
     if (notebookItem.type === 'report') {
-      row[columnNameToNumber['Response']] = this.utilService.removeHTMLTags(responseJSON.content);
+      row[columnNameToNumber['Response']] = removeHTMLTags(responseJSON.content);
     } else {
       row[columnNameToNumber['Response']] = responseJSON.text;
     }

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/OneWorkgroupPerRowDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/OneWorkgroupPerRowDataExportStrategy.ts
@@ -1,3 +1,4 @@
+import { removeHTMLTags } from '../../../common/string/string';
 import { AbstractDataExportStrategy } from './AbstractDataExportStrategy';
 
 export class OneWorkgroupPerRowDataExportStrategy extends AbstractDataExportStrategy {
@@ -385,7 +386,7 @@ export class OneWorkgroupPerRowDataExportStrategy extends AbstractDataExportStra
             if (component != null) {
               var componentId = component.id;
               var columnIdPrefix = nodeId + '-' + componentId;
-              var prompt = this.utilService.removeHTMLTags(component.prompt);
+              var prompt = removeHTMLTags(component.prompt);
               prompt = prompt.replace(/"/g, '""');
               if (prompt == '') {
                 prompt = ' ';

--- a/src/assets/wise5/common/string/string.spec.ts
+++ b/src/assets/wise5/common/string/string.spec.ts
@@ -1,4 +1,4 @@
-import { isValidJSONString, trimToLength, wordWrap } from './string';
+import { isValidJSONString, removeHTMLTags, trimToLength, wordWrap } from './string';
 
 describe('isValidJSONString()', () => {
   it('should return true if json string is valid', () => {
@@ -33,5 +33,23 @@ describe('trimToLength()', () => {
   });
   it('should trim string and add ellipses if length is longer than max length', () => {
     expect(trimToLength('123456789', 7)).toEqual('1234...');
+  });
+});
+
+describe('removeHTMLTags()', () => {
+  it('should remove html tags', () => {
+    expect(removeHTMLTags('<p><img src="computer.png"/></p>')).toEqual(' computer.png ');
+  });
+
+  it('should replace image tag with file name when it uses double quotes', () => {
+    expect(removeHTMLTags('<img src="computer.png"/>')).toEqual('computer.png');
+  });
+  it('should replace image tag with file name when it uses single quotes', () => {
+    expect(removeHTMLTags("<img src='computer.png'/>")).toEqual('computer.png');
+  });
+  it('should replace image tag with file name when there are other attributes', () => {
+    expect(
+      removeHTMLTags("<img alt='Computer' src='computer.png' aria-label='Computer'/>")
+    ).toEqual('computer.png');
   });
 });

--- a/src/assets/wise5/common/string/string.ts
+++ b/src/assets/wise5/common/string/string.ts
@@ -59,3 +59,23 @@ function testWhite(x) {
 export function trimToLength(str: string, maxLength: number): string {
   return str.length > maxLength ? `${str.substring(0, maxLength - 3)}...` : str;
 }
+
+/**
+ * Remove html tags and newlines from the string.
+ * @param html an html string
+ * @return text without html tags and new lines
+ */
+export function removeHTMLTags(html: string = '') {
+  let text = replaceImgTagWithFileName(html);
+  text = text.replace(/<\/?[^>]+(>|$)/g, ' ');
+  return removeNewLines(text);
+}
+
+function removeNewLines(html: string = '') {
+  let text = html.replace(/\n/g, ' ');
+  return text.replace(/\r/g, ' ');
+}
+
+function replaceImgTagWithFileName(html: string = '') {
+  return html.replace(/<img.*?src=["'](.*?)["'].*?>/g, '$1');
+}

--- a/src/assets/wise5/services/utilService.ts
+++ b/src/assets/wise5/services/utilService.ts
@@ -8,30 +8,6 @@ export class UtilService {
   constructor() {}
 
   /**
-   * Remove html tags and newlines from the string.
-   * @param html an html string
-   * @return text without html tags and new lines
-   */
-  removeHTMLTags(html = '') {
-    let text = this.replaceImgTagWithFileName(html);
-    text = text.replace(/<\/?[^>]+(>|$)/g, ' ');
-    return this.removeNewLines(text);
-  }
-
-  removeNewLines(html = '') {
-    let text = html.replace(/\n/g, ' ');
-    return text.replace(/\r/g, ' ');
-  }
-
-  /**
-   * Replace img tags with the src value.
-   * Example: <img src="computer.png"/> will be replaced with computer.png.
-   */
-  replaceImgTagWithFileName(html = '') {
-    return html.replace(/<img.*?src=["'](.*?)["'].*?>/g, '$1');
-  }
-
-  /**
    * Check if a string ends with a specific string
    * @param subjectString the main string
    * @param searchString the potential end of the string

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -11975,49 +11975,49 @@ Are you sure you want to proceed?</source>
         <source>Correctness column key: 0 = Incorrect, 1 = Correct, 2 = Correct bucket but wrong position</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">133</context>
+          <context context-type="linenumber">134</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7865202073915909645" datatype="html">
         <source>One Workgroup Per Row</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">172</context>
+          <context context-type="linenumber">173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="789970879723970594" datatype="html">
         <source>Latest Student Work</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">174</context>
+          <context context-type="linenumber">175</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6593306077428507515" datatype="html">
         <source>All Student Work</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">176</context>
+          <context context-type="linenumber">177</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5729418620241283277" datatype="html">
         <source>Events</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">178</context>
+          <context context-type="linenumber">179</context>
         </context-group>
       </trans-unit>
       <trans-unit id="347166173746466674" datatype="html">
         <source>Raw Data</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">180</context>
+          <context context-type="linenumber">181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="456492495567778711" datatype="html">
         <source>Downloading Export</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">2121</context>
+          <context context-type="linenumber">2122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="18a393cd6211a7e1f51159db6b49637ee7c61490" datatype="html">


### PR DESCRIPTION
## Changes
Moved removeHTMLTags() function to `string.ts`.

## Test
Make sure data exports for runs still work properly when export data (student work and/or annotations) include HTML content and HTML tags are stripped out of prompt and student response cells.

Closes #1085.