### PR TITLE
feat(Data Explorer): Tooltip header column

### DIFF
--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
@@ -244,9 +244,9 @@ function convertRowDataToSeriesData() {
       };
       const seriesData = component.convertRowDataToSeriesData(rows, params);
       expect(seriesData).toEqual([
-        [0, 0],
-        [10, 5],
-        [20, 10]
+        { x: 0, y: 0 },
+        { x: 10, y: 5 },
+        { x: 20, y: 10 }
       ]);
     });
   });
@@ -422,7 +422,10 @@ function handleTableConnectedComponentStudentDataChanged() {
         }
       };
       component.handleTableConnectedComponentStudentDataChanged(connectedComponent, componentState);
-      expect(component.activeTrial.series[0].data).toEqual(dataRows);
+      expect(component.activeTrial.series[0].data).toEqual([
+        { x: 0, y: 0 },
+        { x: 10, y: 20 }
+      ]);
     });
     it('should handle table connected component student data changed with selected rows', () => {
       const connectedComponent = createTableConnectedComponent();
@@ -441,8 +444,8 @@ function handleTableConnectedComponentStudentDataChanged() {
       };
       component.handleTableConnectedComponentStudentDataChanged(connectedComponent, componentState);
       expect(component.activeTrial.series[0].data).toEqual([
-        [0, 0],
-        [20, 40]
+        { x: 0, y: 0 },
+        { x: 20, y: 40 }
       ]);
     });
     it('should handle table connected component student data changed with sorted rows', () => {
@@ -462,10 +465,10 @@ function handleTableConnectedComponentStudentDataChanged() {
       };
       component.handleTableConnectedComponentStudentDataChanged(connectedComponent, componentState);
       expect(component.activeTrial.series[0].data).toEqual([
-        [20, 40],
-        [10, 20],
-        [0, 0],
-        [30, 80]
+        { x: 20, y: 40 },
+        { x: 10, y: 20 },
+        { x: 0, y: 0 },
+        { x: 30, y: 80 }
       ]);
     });
     it('should handle table connected component student data changed with selected and sorted rows', () => {
@@ -486,8 +489,8 @@ function handleTableConnectedComponentStudentDataChanged() {
       };
       component.handleTableConnectedComponentStudentDataChanged(connectedComponent, componentState);
       expect(component.activeTrial.series[0].data).toEqual([
-        [20, 40],
-        [0, 0]
+        { x: 20, y: 40 },
+        { x: 0, y: 0 }
       ]);
     });
     it('should handle connected data explorer student data changed', () => {
@@ -505,8 +508,11 @@ function handleTableConnectedComponentStudentDataChanged() {
       expect(series.type).toEqual('scatter');
       expect(series.name).toEqual('The series name');
       expect(series.color).toEqual('blue');
-      expect(series.data[0][0]).toEqual(1);
-      expect(series.data[1][1]).toEqual(20);
+      expect(series.data).toEqual([
+        { x: 1, y: 10 },
+        { x: 2, y: 20 },
+        { x: 3, y: 30 }
+      ]);
     });
     it('should handle connected data explorer student data changed with selected rows', () => {
       const connectedComponent = createTableConnectedComponent();
@@ -524,8 +530,10 @@ function handleTableConnectedComponentStudentDataChanged() {
       expect(series.type).toEqual('scatter');
       expect(series.name).toEqual('The series name');
       expect(series.color).toEqual('blue');
-      expect(series.data[0][0]).toEqual(1);
-      expect(series.data[1][1]).toEqual(30);
+      expect(series.data).toEqual([
+        { x: 1, y: 10 },
+        { x: 3, y: 30 }
+      ]);
     });
   });
 }
@@ -1679,18 +1687,18 @@ function generateDataExplorerSeries() {
       graphType,
       name,
       color,
-      yAxis
+      yAxis,
+      null
     );
     expect(series.name).toEqual('Age');
     expect(series.type).toEqual('scatter');
     expect(series.color).toEqual('blue');
     expect(series.data.length).toEqual(3);
-    expect(series.data[0][0]).toEqual(1);
-    expect(series.data[0][1]).toEqual(10);
-    expect(series.data[1][0]).toEqual(2);
-    expect(series.data[1][1]).toEqual(20);
-    expect(series.data[2][0]).toEqual(3);
-    expect(series.data[2][1]).toEqual(30);
+    expect(series.data).toEqual([
+      { x: 1, y: 10 },
+      { x: 2, y: 20 },
+      { x: 3, y: 30 }
+    ]);
   });
 }
 
@@ -1758,14 +1766,13 @@ function convertDataExplorerDataToSeriesData() {
     ];
     const xColumn = 0;
     const yColumn = 1;
-    const data = component.convertDataExplorerDataToSeriesData(rows, xColumn, yColumn);
+    const data = component.convertDataExplorerDataToSeriesData(rows, xColumn, yColumn, null);
     expect(data.length).toEqual(3);
-    expect(data[0][0]).toEqual(1);
-    expect(data[0][1]).toEqual(10);
-    expect(data[1][0]).toEqual(2);
-    expect(data[1][1]).toEqual(20);
-    expect(data[2][0]).toEqual(3);
-    expect(data[2][1]).toEqual(30);
+    expect(data).toEqual([
+      { x: 1, y: 10 },
+      { x: 2, y: 20 },
+      { x: 3, y: 30 }
+    ]);
   });
 }
 

--- a/src/assets/wise5/components/graph/graphService.ts
+++ b/src/assets/wise5/components/graph/graphService.ts
@@ -370,14 +370,31 @@ export class GraphService extends ComponentService {
     yAxis: any,
     roundValuesTo: string
   ): string {
-    const seriesName = this.getSeriesText(series);
+    const tooltipHeader = this.getTooltipHeader(point, series, yAxis);
     const xText = this.getAxisTextForLimitGraph(series, point.x, 'xAxis', xAxis, roundValuesTo);
     const yText = this.getAxisTextForLimitGraph(series, point.y, 'yAxis', yAxis, roundValuesTo);
-    return this.combineSeriesNameXTextYText(seriesName, xText, yText);
+    return this.combineSeriesNameXTextYText(tooltipHeader, xText, yText);
   }
 
-  getSeriesText(series: any): string {
-    return series.name === '' ? '' : `<b>${series.name}</b>`;
+  getTooltipHeader(point: any, series: any, yAxis: any): string {
+    let tooltipHeader = '';
+    if (point.point.tooltipHeader) {
+      tooltipHeader = point.point.tooltipHeader;
+    } else {
+      const yAxisLabel = this.getAxisTitle(series, yAxis);
+      const seriesName = series.name;
+      if (yAxisLabel !== seriesName) {
+        tooltipHeader = seriesName;
+      }
+    }
+    if (tooltipHeader !== '') {
+      tooltipHeader = this.getBoldText(tooltipHeader);
+    }
+    return tooltipHeader;
+  }
+
+  getBoldText(text: string): string {
+    return `<b>${text}</b>`;
   }
 
   getAxisTextForLimitGraph(
@@ -444,7 +461,7 @@ export class GraphService extends ComponentService {
     yAxis: any,
     roundValuesTo: string
   ): string {
-    const seriesName = this.getSeriesText(series);
+    const tooltipHeader = this.getTooltipHeader(point, series, yAxis);
     const xText = this.getXTextForCategoriesGraph(
       series,
       point.point,
@@ -453,7 +470,7 @@ export class GraphService extends ComponentService {
       roundValuesTo
     );
     const yText = this.getYTextForCategoriesGraph(series, point.y, yAxis, roundValuesTo);
-    return this.combineSeriesNameXTextYText(seriesName, xText, yText);
+    return this.combineSeriesNameXTextYText(tooltipHeader, xText, yText);
   }
 
   getXTextForCategoriesGraph(

--- a/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html
+++ b/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html
@@ -195,7 +195,7 @@
         </mat-select>
       </mat-form-field>
       <mat-icon
-        matTooltip="When the student hovers their mouse over a data point, the tooltip will display the value from this column along with the x and y values. This can be left blank and the tooltip will still show the x and y values like normal."
+        matTooltip="When the student hovers their mouse over a data point on a scatter plot or line graph, the tooltip will display the value from this column along with the x and y values. This can be left blank and the tooltip will still show the x and y values like normal."
         matTooltipPosition="right"
         i18n-matTooltip
       >

--- a/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html
+++ b/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html
@@ -175,6 +175,33 @@
         </mat-select>
       </mat-form-field>
     </div>
+    <div fxLayoutGap="10px">
+      <mat-form-field>
+        <mat-label i18n>Tooltip Header Column</mat-label>
+        <mat-select
+          [(ngModel)]="componentContent.dataExplorerTooltipHeaderColumn"
+          (ngModelChange)="componentChanged()"
+        >
+          <mat-option [value]="" i18n>(Default)</mat-option>
+          <mat-option
+            *ngFor="let columnName of columnNames; index as columnIndex"
+            [value]="columnIndex"
+          >
+            <ng-container *ngIf="columnName === ''">
+              (<span i18n>Table Column</span> {{ columnIndex + 1 }})
+            </ng-container>
+            <ng-container *ngIf="columnName !== ''">{{ columnName }}</ng-container>
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-icon
+        matTooltip="When the student hovers their mouse over a data point, the tooltip will display the value from this column along with the x and y values. This can be left blank and the tooltip will still show the x and y values like normal."
+        matTooltipPosition="right"
+        i18n-matTooltip
+      >
+        help
+      </mat-icon>
+    </div>
   </div>
 </div>
 <div fxLayout fxLayoutAlign="start center">

--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -32,6 +32,7 @@ export class TableStudent extends ComponentStudent {
   dataExplorerGraphType: string;
   dataExplorerSeries: any[];
   dataExplorerSeriesParams: any[];
+  dataExplorerTooltipHeaderColumn: number;
   dataExplorerXAxisLabel: string;
   dataExplorerXColumn: number;
   dataExplorerYAxisLabel: string;
@@ -168,6 +169,7 @@ export class TableStudent extends ComponentStudent {
     this.isDataExplorerScatterPlotRegressionLineEnabled = this.componentContent.isDataExplorerScatterPlotRegressionLineEnabled;
     this.dataExplorerYAxisLabels = Array(this.componentContent.numDataExplorerYAxis).fill('');
     this.dataExplorerSeriesParams = this.componentContent.dataExplorerSeriesParams;
+    this.dataExplorerTooltipHeaderColumn = this.componentContent.dataExplorerTooltipHeaderColumn;
   }
 
   setDataExplorerDataToColumn(): void {
@@ -404,6 +406,7 @@ export class TableStudent extends ComponentStudent {
     studentData.isDataExplorerEnabled = this.isDataExplorerEnabled;
     studentData.dataExplorerGraphType = this.dataExplorerGraphType;
     studentData.dataExplorerXAxisLabel = this.dataExplorerXAxisLabel;
+    studentData.dataExplorerTooltipHeaderColumn = this.dataExplorerTooltipHeaderColumn;
     if (this.dataExplorerYAxisLabel != null) {
       studentData.dataExplorerYAxisLabel = this.dataExplorerYAxisLabel;
     }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15862,39 +15862,39 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>The series you are trying to add a point to is currently hidden. Please show the series by clicking the series name in the legend and try adding the point again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1091</context>
+          <context context-type="linenumber">1113</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2852989551014711458" datatype="html">
         <source>You can not edit this series. Please choose a series that can be edited.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1105</context>
+          <context context-type="linenumber">1127</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7053114367342967943" datatype="html">
         <source>Are you sure you want to reset the series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1383</context>
+          <context context-type="linenumber">1405</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7889560203726829643" datatype="html">
         <source>Are you sure you want to reset the &quot;<x id="PH" equiv-text="seriesName"/>&quot; series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1385</context>
+          <context context-type="linenumber">1407</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6999515396807067782" datatype="html">
         <source>Trial</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1906</context>
+          <context context-type="linenumber">1943</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">2740</context>
+          <context context-type="linenumber">2777</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9070768663485888935" datatype="html">
@@ -17787,6 +17787,10 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="sourcefile">src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html</context>
           <context context-type="linenumber">171</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html</context>
+          <context context-type="linenumber">191</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="dba97f2b34e2e417cf30f6a74a19f5ee1f91dc12" datatype="html">
         <source>Y Data <x id="INTERPOLATION" equiv-text="{{
@@ -17797,25 +17801,46 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">152,155</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="b76eb2713d56d6355cbff9020f380e5fec2680c8" datatype="html">
+        <source>Tooltip Header Column</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html</context>
+          <context context-type="linenumber">180</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ad76c6445b04ac709c20ed50fc35db2767c99434" datatype="html">
+        <source>(Default)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html</context>
+          <context context-type="linenumber">185</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="308b2c34885c4f962f8d2c64bd172d99da2ef34a" datatype="html">
+        <source>When the student hovers their mouse over a data point, the tooltip will display the value from this column along with the x and y values. This can be left blank and the tooltip will still show the x and y values like normal.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html</context>
+          <context context-type="linenumber">198</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="b652160adbee3bf218c97721e5b26a3bccf7b0c9" datatype="html">
         <source>Import Table</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html</context>
-          <context context-type="linenumber">187</context>
+          <context context-type="linenumber">214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f691a121c479261a164621480b345efc8f65326c" datatype="html">
         <source>Only .csv (comma separated values) files are allowed</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html</context>
-          <context context-type="linenumber">196</context>
+          <context context-type="linenumber">223</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3d7f8dac570a1d36a691e532f23a1f61297f4858" datatype="html">
         <source> Enable Row Selection </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html</context>
-          <context context-type="linenumber">225,227</context>
+          <context context-type="linenumber">252,254</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3802284852279199102" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -17815,8 +17815,8 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">185</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="308b2c34885c4f962f8d2c64bd172d99da2ef34a" datatype="html">
-        <source>When the student hovers their mouse over a data point, the tooltip will display the value from this column along with the x and y values. This can be left blank and the tooltip will still show the x and y values like normal.</source>
+      <trans-unit id="5157093c5cf05f98b4e4e0178bfdaa09a4d1b17b" datatype="html">
+        <source>When the student hovers their mouse over a data point on a scatter plot or line graph, the tooltip will display the value from this column along with the x and y values. This can be left blank and the tooltip will still show the x and y values like normal.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html</context>
           <context context-type="linenumber">198</context>


### PR DESCRIPTION
## Changes

- Allow the author to specify dataExplorerTooltipHeaderColumn. When the student hovers over a data point, the value from this column will be displayed along with the x and y values.
- Data point tooltips no longer display the tooltip header if the header is the same as the y axis title. It will just display the x and y labels and data so that the y label is no longer duplicated like it used to be.

## Test

- Make sure Data Explorer Graph tooltips work with the Tooltip Header Column specified
- Make sure Data Explorer Graph tooltips work with the Tooltip Header Column not specified
- Make sure regular Graph data point tooltips work, particularly with multiple series in a trial

Closes #1142