### PR TITLE
fix(Match): Images appear broken in grading view

### DIFF
--- a/src/assets/wise5/components/component-show-work.directive.ts
+++ b/src/assets/wise5/components/component-show-work.directive.ts
@@ -14,7 +14,10 @@ export abstract class ComponentShowWorkDirective {
   constructor(protected nodeService: NodeService, protected projectService: ProjectService) {}
 
   ngOnInit() {
-    this.componentContent = this.projectService.getComponent(this.nodeId, this.componentId);
+    this.componentContent = this.projectService.injectAssetPaths(
+      this.projectService.getComponent(this.nodeId, this.componentId)
+    );
+    this.componentState = this.projectService.injectAssetPaths(this.componentState);
   }
 
   ngAfterViewInit(): void {

--- a/src/assets/wise5/components/conceptMap/concept-map-show-work/concept-map-show-work.component.ts
+++ b/src/assets/wise5/components/conceptMap/concept-map-show-work/concept-map-show-work.component.ts
@@ -32,7 +32,6 @@ export class ConceptMapShowWorkComponent extends ComponentShowWorkDirective {
   ngOnInit(): void {
     super.ngOnInit();
     this.svgId = this.getConceptMapId();
-    this.componentState = this.ProjectService.injectAssetPaths(this.componentState);
 
     /*
      * Call initializeSVG() after a timeout so that angular has a chance to set the svg element id

--- a/src/assets/wise5/components/embedded/embedded-show-work/embedded-show-work.component.ts
+++ b/src/assets/wise5/components/embedded/embedded-show-work/embedded-show-work.component.ts
@@ -33,7 +33,6 @@ export class EmbeddedShowWorkComponent extends ComponentShowWorkDirective {
 
   ngOnInit(): void {
     super.ngOnInit();
-    this.componentContent = this.ProjectService.injectAssetPaths(this.componentContent);
     this.embeddedApplicationIFrameId = this.getIframeId();
     this.setHeight(this.componentContent);
     this.url = this.sanitizer.bypassSecurityTrustResourceUrl(this.componentContent.url);

--- a/src/assets/wise5/components/graph/graph-show-work/graph-show-work.component.ts
+++ b/src/assets/wise5/components/graph/graph-show-work/graph-show-work.component.ts
@@ -34,8 +34,6 @@ export class GraphShowWorkComponent extends ComponentShowWorkDirective {
 
   ngOnInit(): void {
     super.ngOnInit();
-    this.componentContent = this.ProjectService.injectAssetPaths(this.componentContent);
-    this.componentState = this.ProjectService.injectAssetPaths(this.componentState);
     this.graphType = this.componentContent.graphType;
     if (this.graphType == null) {
       this.graphType = 'line';

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-show-work/multiple-choice-show-work.component.ts
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-show-work/multiple-choice-show-work.component.ts
@@ -24,7 +24,6 @@ export class MultipleChoiceShowWorkComponent extends ComponentShowWorkDirective 
 
   ngOnInit(): void {
     super.ngOnInit();
-    this.componentContent = this.projectService.injectAssetPaths(this.componentContent);
     this.component = new MultipleChoiceComponent(this.componentContent, this.nodeId);
     if (this.component.isRadio()) {
       const studentChoiceIds = this.getChoiceIds(this.componentState.studentData.studentChoices);


### PR DESCRIPTION
## Changes
- Pushed injectAssetPath() call on componentState and componentContent to parent ComponentShowWorkDirective and updated references

## Test
- Images appear correctly in grading view
   - Image choices in Match component (this was NOT working before this PR)
   - Image choices in MC component (this was working before this PR)
- Show Student Work with ConceptMap component that has images appear correctly

Closes #1145