### PR TITLE
feat(Component): Add ComponentStatus class to determine Node completion

### DIFF
--- a/src/assets/wise5/common/ComponentStatus.ts
+++ b/src/assets/wise5/common/ComponentStatus.ts
@@ -1,0 +1,13 @@
+export class ComponentStatus {
+  isCompleted: boolean;
+  isVisible: boolean;
+
+  constructor(isCompleted: boolean, isVisible: boolean) {
+    this.isCompleted = isCompleted;
+    this.isVisible = isVisible;
+  }
+
+  isVisibleAndNotCompleted(): boolean {
+    return this.isVisible && !this.isCompleted;
+  }
+}

--- a/src/assets/wise5/common/NodeStatus.ts
+++ b/src/assets/wise5/common/NodeStatus.ts
@@ -1,4 +1,7 @@
+import { ComponentStatus } from './ComponentStatus';
+
 export class NodeStatus {
+  componentStatuses: { [componentId: string]: ComponentStatus };
   isCompleted: boolean;
   isVisible: boolean;
   isVisitable: boolean;

--- a/src/assets/wise5/services/nodeStatusService.ts
+++ b/src/assets/wise5/services/nodeStatusService.ts
@@ -129,6 +129,7 @@ export class NodeStatusService {
   }
 
   private updateNodeStatus(nodeId: string, nodeStatus: NodeStatus): void {
+    // TODO: figure out why we need this if-else check. Why not just over-write the NodeStatus?
     const oldNodeStatus = this.getNodeStatusByNodeId(nodeId);
     if (oldNodeStatus == null) {
       this.setNodeStatusByNodeId(nodeId, nodeStatus);
@@ -137,6 +138,9 @@ export class NodeStatusService {
       this.dataService.nodeStatuses[nodeId].isVisible = nodeStatus.isVisible;
       this.dataService.nodeStatuses[nodeId].isVisitable = nodeStatus.isVisitable;
       this.dataService.nodeStatuses[nodeId].isCompleted = nodeStatus.isCompleted;
+      if (this.projectService.isApplicationNode(nodeId)) {
+        this.dataService.nodeStatuses[nodeId].componentStatuses = nodeStatus.componentStatuses;
+      }
     }
   }
 


### PR DESCRIPTION
## Note
- This is a working branch PR

## Changes
- Add ComponentStatus class for storing isVisible and isCompleted fields, and store it in NodeStatus, as ```componentId: ComponentStatus``` key/value field.
- Update NodeStatusService.calculateNodeStatus() to calculate all the components' ComponentStatuses, and use that to determine the node's completion

## Test
- In VLE and Grading Tool, verify that node completion (nodeStatus.isCompleted) is calculated and displays correctly for
   - Node with no hidden components
   - Node with hidden components (using constraint)
      - A node is considered complete iff ALL of its visible components are completed. 
   - Groups
- StudentStatus saves and loads correctly, and includes component statuses for all the components in the unit. It should be in the "status" field

Closes #1148