### PR TITLE
refactor(UtilService): Move endsWith() 

### DIFF
--- a/src/app/services/projectAssetService.spec.ts
+++ b/src/app/services/projectAssetService.spec.ts
@@ -15,9 +15,9 @@ describe('ProjectAssetService', () => {
       imports: [HttpClientTestingModule, UpgradeModule, StudentTeacherCommonServicesModule],
       providers: [ProjectAssetService]
     });
-    http = TestBed.get(HttpTestingController);
-    configService = TestBed.get(ConfigService);
-    service = TestBed.get(ProjectAssetService);
+    http = TestBed.inject(HttpTestingController);
+    configService = TestBed.inject(ConfigService);
+    service = TestBed.inject(ProjectAssetService);
     spyOn(configService, 'getConfigParam').and.callFake((param) => {
       if (param === 'projectAssetURL') {
         return '/author/project/asset/1';
@@ -43,8 +43,6 @@ describe('ProjectAssetService', () => {
   retrieveTextFilesAndCalculateUsedFiles();
   getAllUsedTextContent();
   isFileAlreadyAdded();
-  getAllTextFiles();
-  isTextFile();
   calculateUsedFiles();
   getFileNameFromURL();
   getTextFiles();
@@ -132,39 +130,6 @@ function calculateAssetUsage() {
       spongeBobAndPatrickAssets,
       usedTextContent
     );
-  });
-}
-
-function getAllTextFiles() {
-  it('should get all text files when there are no files', () => {
-    const assets = {
-      files: []
-    };
-    const allTextFiles = service.getAllTextFiles(assets);
-    expect(allTextFiles.length).toEqual(0);
-  });
-  it('should get all text files when there are no text files', () => {
-    const assets = {
-      files: [{ fileName: 'spongebob.png' }]
-    };
-    const allTextFiles = service.getAllTextFiles(assets);
-    expect(allTextFiles.length).toEqual(0);
-  });
-  it('should get all text files when there are text files', () => {
-    const assets = {
-      files: [{ fileName: 'spongebob.png' }, { fileName: 'model.html' }]
-    };
-    const allTextFiles = service.getAllTextFiles(assets);
-    expect(allTextFiles.length).toEqual(1);
-  });
-}
-
-function isTextFile() {
-  it('should check if a file is a text file when it is not', () => {
-    expect(service.isTextFile('spongebob.png')).toEqual(false);
-  });
-  it('should check if a file is a text file when it is', () => {
-    expect(service.isTextFile('model.html')).toEqual(true);
   });
 }
 

--- a/src/app/services/projectAssetService.ts
+++ b/src/app/services/projectAssetService.ts
@@ -7,7 +7,6 @@ import { forkJoin, BehaviorSubject } from 'rxjs';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
-import { UtilService } from '../../assets/wise5/services/utilService';
 import { isAudio, isImage, isVideo } from '../../assets/wise5/common/file/file';
 
 @Injectable()
@@ -19,11 +18,10 @@ export class ProjectAssetService {
   projectThumbnailFileName = 'project_thumb.png';
 
   constructor(
-    protected upgrade: UpgradeModule,
+    protected configService: ConfigService,
     protected http: HttpClient,
-    protected ConfigService: ConfigService,
-    protected ProjectService: ProjectService,
-    protected UtilService: UtilService
+    protected projectService: ProjectService,
+    protected upgrade: UpgradeModule
   ) {
     this.getProjectAssets().subscribe((projectAssets) => {
       if (projectAssets != null) {
@@ -65,9 +63,9 @@ export class ProjectAssetService {
   }
 
   retrieveProjectAssets(): any {
-    const url = this.ConfigService.getConfigParam('projectAssetURL');
+    const url = this.configService.getConfigParam('projectAssetURL');
     return this.http.get(url).subscribe((projectAssets: any) => {
-      this.totalSizeMax = this.ConfigService.getConfigParam('projectAssetTotalSizeMax');
+      this.totalSizeMax = this.configService.getConfigParam('projectAssetTotalSizeMax');
       this.injectFileTypeValues(projectAssets.files);
       this.setProjectAssets(projectAssets);
     });
@@ -88,7 +86,7 @@ export class ProjectAssetService {
   }
 
   uploadAssets(files: any[]) {
-    const url = this.ConfigService.getConfigParam('projectAssetURL');
+    const url = this.configService.getConfigParam('projectAssetURL');
     const formData = new FormData();
     files.forEach((file: any) => formData.append('files', file, file.name));
     return this.http.post(url, formData).pipe(
@@ -102,13 +100,13 @@ export class ProjectAssetService {
 
   downloadAssetItem(assetItem: any) {
     window.open(
-      `${this.ConfigService.getConfigParam('projectAssetURL')}` +
+      `${this.configService.getConfigParam('projectAssetURL')}` +
         `/download?assetFileName=${assetItem.fileName}`
     );
   }
 
   deleteAssetItem(assetItem: any): any {
-    const url = `${this.ConfigService.getConfigParam('projectAssetURL')}/delete`;
+    const url = `${this.configService.getConfigParam('projectAssetURL')}/delete`;
     const params = new HttpParams().set('assetFileName', assetItem.fileName);
     return this.http.post(url, params).subscribe((projectAssets: any) => {
       this.injectFileTypeValues(projectAssets.files);
@@ -116,9 +114,9 @@ export class ProjectAssetService {
     });
   }
 
-  calculateAssetUsage(assets: any = this.getProjectAssets().getValue()) {
-    let usedTextContent = JSON.stringify(this.ProjectService.project);
-    usedTextContent += this.projectThumbnailFileName;
+  calculateAssetUsage(assets: any = this.getProjectAssets().getValue()): void {
+    const usedTextContent =
+      JSON.stringify(this.projectService.project) + this.projectThumbnailFileName;
     const allTextFiles = this.getAllTextFiles(assets);
     if (allTextFiles.length == 0) {
       this.calculateUsedFiles(assets, usedTextContent);
@@ -127,7 +125,7 @@ export class ProjectAssetService {
     }
   }
 
-  getAllTextFiles(assets: any) {
+  private getAllTextFiles(assets: any): any[] {
     const allTextFiles = [];
     for (const asset of assets.files) {
       const fileName = asset.fileName;
@@ -138,12 +136,16 @@ export class ProjectAssetService {
     return allTextFiles;
   }
 
-  isTextFile(fileName: string) {
+  private isTextFile(fileName: string): boolean {
     return (
-      this.UtilService.endsWith(fileName, '.html') ||
-      this.UtilService.endsWith(fileName, '.htm') ||
-      this.UtilService.endsWith(fileName, '.js')
+      this.endsWith(fileName, '.html') ||
+      this.endsWith(fileName, '.htm') ||
+      this.endsWith(fileName, '.js')
     );
+  }
+
+  private endsWith(str: string, suffix: string): boolean {
+    return str.substring(str.length - suffix.length) === suffix;
   }
 
   calculateUsedFiles(assets: any, usedTextContent: string) {
@@ -219,7 +221,7 @@ export class ProjectAssetService {
 
   getTextFiles(textFileNames: string[]): any {
     const requests = [];
-    const projectAssetsDirectoryPath = this.ConfigService.getProjectAssetsDirectoryPath();
+    const projectAssetsDirectoryPath = this.configService.getProjectAssetsDirectoryPath();
     for (const textFileName of textFileNames) {
       const request = this.http.get(`${projectAssetsDirectoryPath}/${textFileName}`, {
         observe: 'response',

--- a/src/assets/wise5/services/utilService.ts
+++ b/src/assets/wise5/services/utilService.ts
@@ -8,27 +8,6 @@ export class UtilService {
   constructor() {}
 
   /**
-   * Check if a string ends with a specific string
-   * @param subjectString the main string
-   * @param searchString the potential end of the string
-   * @param position (optional) the position to start searching
-   * @return whether the subjectString ends with the searchString
-   */
-  endsWith(subjectString: string, searchString: string, position?: number) {
-    if (
-      typeof position !== 'number' ||
-      !isFinite(position) ||
-      Math.floor(position) !== position ||
-      position > subjectString.length
-    ) {
-      position = subjectString.length;
-    }
-    position -= searchString.length;
-    const lastIndex = subjectString.lastIndexOf(searchString, position);
-    return lastIndex !== -1 && lastIndex === position;
-  }
-
-  /**
    * Sort the objects by server save time
    * @param object1 an object
    * @param object2 an object


### PR DESCRIPTION
## Changes
- Move UtilService.endsWith() to ProjectAssetService.endsWith(), made function private
- Made related functions private if appropriate and added types
- Remove tests for private functions in ProjectAssetService
- Lowercase service variable names in ProjectAssetService

## Test
- In AT's project asset view, asset size is calculated and displays correctly

Closes #1076