### PR TITLE
feat(Grading): Look at component statuses to show components

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading-view/node-grading-view.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading-view/node-grading-view.component.ts
@@ -271,6 +271,8 @@ export class NodeGradingViewComponent implements OnInit {
       workgroupId,
       this.nodeId
     );
+    const studentStatus = this.classroomStatusService.getStudentStatusForWorkgroupId(workgroupId);
+    workgroup.nodeStatus = studentStatus.nodeStatuses[this.nodeId];
   }
 
   private workgroupHasNewAlert(alertNotifications: Notification[]): boolean {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.html
@@ -35,27 +35,29 @@
   </button>
   <mat-list-item *ngIf="expanded && !disabled" class="grading__item-container">
     <div class="grading__item" style="width: 100%">
-      <div
-        id="component_{{ component.id }}_{{ workgroupId }}"
-        class="component component--grading"
-        *ngFor="let component of components; let i = index"
-      >
-        <div [hidden]="!isComponentVisible(component.id)">
-          <h3 class="accent-1 mat-body-2 gray-lightest-bg component__header">
-            {{ i + 1 + '. ' + getComponentTypeLabel(component.type) }}&nbsp;
-            <component-new-work-badge
+      <ng-container *ngFor="let component of components; let i = index">
+        <div
+          *ngIf="componentIdToIsVisible[component.id]"
+          id="component_{{ component.id }}_{{ workgroupId }}"
+          class="component component--grading"
+        >
+          <div [hidden]="!isComponentVisible(component.id)">
+            <h3 class="accent-1 mat-body-2 gray-lightest-bg component__header">
+              {{ i + 1 + '. ' + getComponentTypeLabel(component.type) }}&nbsp;
+              <component-new-work-badge
+                [componentId]="component.id"
+                [workgroupId]="workgroupId"
+                [nodeId]="nodeId"
+              ></component-new-work-badge>
+            </h3>
+            <workgroup-component-grading
               [componentId]="component.id"
               [workgroupId]="workgroupId"
               [nodeId]="nodeId"
-            ></component-new-work-badge>
-          </h3>
-          <workgroup-component-grading
-            [componentId]="component.id"
-            [workgroupId]="workgroupId"
-            [nodeId]="nodeId"
-          ></workgroup-component-grading>
+            ></workgroup-component-grading>
+          </div>
         </div>
-      </div>
+      </ng-container>
     </div>
   </mat-list-item>
 </div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.spec.ts
@@ -26,7 +26,9 @@ describe('WorkgroupItemComponent', () => {
     getComponentsSpy.and.returnValue([]);
     fixture = TestBed.createComponent(WorkgroupItemComponent);
     component = fixture.componentInstance;
-    component.workgroupData = {};
+    component.workgroupData = {
+      nodeStatus: {}
+    };
     fixture.detectChanges();
   });
 
@@ -52,7 +54,8 @@ function ngOnInit() {
         }
       };
       component.ngOnInit();
-      expect(component.components).toEqual([component1]);
+      expect(component.componentIdToIsVisible[component1.id]).toEqual(true);
+      expect(component.componentIdToIsVisible[component2.id]).toEqual(false);
     });
   });
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.spec.ts
@@ -32,30 +32,7 @@ describe('WorkgroupItemComponent', () => {
     fixture.detectChanges();
   });
 
-  ngOnInit();
-});
-
-function ngOnInit() {
-  describe('ngOnInit', () => {
-    it('should set the components that are visible to the student', () => {
-      const component1 = { id: 'component1', type: 'OpenResponse' };
-      const component2 = { id: 'component2', type: 'OpenResponse' };
-      getComponentsSpy.and.returnValue([component1, component2]);
-      component.workgroupData = {
-        nodeStatus: {
-          componentStatuses: {
-            component1: {
-              isVisible: true
-            },
-            component2: {
-              isVisible: false
-            }
-          }
-        }
-      };
-      component.ngOnInit();
-      expect(component.componentIdToIsVisible[component1.id]).toEqual(true);
-      expect(component.componentIdToIsVisible[component2.id]).toEqual(false);
-    });
+  it('should create', () => {
+    expect(component).toBeTruthy();
   });
-}
+});

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.spec.ts
@@ -1,17 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ClassroomMonitorTestingModule } from '../../../classroom-monitor-testing.module';
-import { StepItemComponent } from './step-item.component';
+import { WorkgroupItemComponent } from './workgroup-item.component';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 
-let component: StepItemComponent;
-let fixture: ComponentFixture<StepItemComponent>;
+let component: WorkgroupItemComponent;
+let fixture: ComponentFixture<WorkgroupItemComponent>;
+let getComponentsSpy: jasmine.Spy;
 let teacherProjectService: TeacherProjectService;
 
-describe('StepItemComponent', () => {
+describe('WorkgroupItemComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [StepItemComponent],
+      declarations: [WorkgroupItemComponent],
       imports: [ClassroomMonitorTestingModule],
       providers: [TeacherProjectService],
       schemas: [NO_ERRORS_SCHEMA]
@@ -20,8 +21,12 @@ describe('StepItemComponent', () => {
 
   beforeEach(() => {
     teacherProjectService = TestBed.inject(TeacherProjectService);
-    fixture = TestBed.createComponent(StepItemComponent);
+    spyOn(teacherProjectService, 'nodeHasWork').and.returnValue(true);
+    getComponentsSpy = spyOn(teacherProjectService, 'getComponents');
+    getComponentsSpy.and.returnValue([]);
+    fixture = TestBed.createComponent(WorkgroupItemComponent);
     component = fixture.componentInstance;
+    component.workgroupData = {};
     fixture.detectChanges();
   });
 
@@ -33,8 +38,8 @@ function ngOnInit() {
     it('should set the components that are visible to the student', () => {
       const component1 = { id: 'component1', type: 'OpenResponse' };
       const component2 = { id: 'component2', type: 'OpenResponse' };
-      spyOn(teacherProjectService, 'getComponents').and.returnValue([component1, component2]);
-      component.stepData = {
+      getComponentsSpy.and.returnValue([component1, component2]);
+      component.workgroupData = {
         nodeStatus: {
           componentStatuses: {
             component1: {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, Output, SimpleChanges } from '@angular/core';
 import { ComponentTypeService } from '../../../../services/componentTypeService';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
+import { isComponentVisibleToStudent } from '../../shared/grading-helpers/grading-helpers';
 
 @Component({
   selector: 'workgroup-item',
@@ -39,7 +40,10 @@ export class WorkgroupItemComponent {
   updateNode(): void {
     this.nodeHasWork = this.projectService.nodeHasWork(this.nodeId);
     this.components = this.projectService.getComponents(this.nodeId).filter((component) => {
-      return this.projectService.componentHasWork(component);
+      return (
+        this.projectService.componentHasWork(component) &&
+        isComponentVisibleToStudent(this.workgroupData.nodeStatus, component)
+      );
     });
   }
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts
@@ -9,6 +9,7 @@ import { calculateComponentVisibility } from '../../shared/grading-helpers/gradi
   styleUrls: ['workgroup-item.component.scss']
 })
 export class WorkgroupItemComponent {
+  componentIdToHasWork: { [componentId: string]: boolean } = {};
   componentIdToIsVisible: { [componentId: string]: boolean } = {};
   components: any[] = [];
   disabled: boolean;
@@ -41,10 +42,11 @@ export class WorkgroupItemComponent {
   updateNode(): void {
     this.nodeHasWork = this.projectService.nodeHasWork(this.nodeId);
     this.components = this.projectService.getComponents(this.nodeId);
+    this.componentIdToHasWork = this.projectService.calculateComponentIdToHasWork(this.components);
     this.componentIdToIsVisible = calculateComponentVisibility(
-      this.nodeId,
-      this.workgroupData.nodeStatus.componentStatuses,
-      this.projectService
+      this.components,
+      this.componentIdToHasWork,
+      this.workgroupData.nodeStatus.componentStatuses
     );
   }
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts
@@ -44,7 +44,6 @@ export class WorkgroupItemComponent {
     this.components = this.projectService.getComponents(this.nodeId);
     this.componentIdToHasWork = this.projectService.calculateComponentIdToHasWork(this.components);
     this.componentIdToIsVisible = calculateComponentVisibility(
-      this.components,
       this.componentIdToHasWork,
       this.workgroupData.nodeStatus.componentStatuses
     );

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/grading-helpers/grading-helpers.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/grading-helpers/grading-helpers.spec.ts
@@ -1,0 +1,33 @@
+import { ComponentStatus } from '../../../../common/ComponentStatus';
+import { calculateComponentVisibility } from './grading-helpers';
+
+const component1 = { id: 'component1', type: 'OpenResponse' };
+const component2 = { id: 'component2', type: 'HTML' };
+const component3 = { id: 'component3', type: 'OpenResponse' };
+
+describe('calculateComponentVisibility()', () => {
+  describe(`when there is a visible component, a component with no work, and a component that is not
+    visible`, () => {
+    it('should calculate component visibility correctly', () => {
+      const components = [component1, component2, component3];
+      const componentIdToHasWork = {
+        component1: true,
+        component2: false,
+        component3: true
+      };
+      const componentStatuses = {
+        component1: new ComponentStatus(true, true),
+        component2: new ComponentStatus(true, true),
+        component3: new ComponentStatus(false, false)
+      };
+      const componentVisibility = calculateComponentVisibility(
+        components,
+        componentIdToHasWork,
+        componentStatuses
+      );
+      expect(componentVisibility[component1.id]).toEqual(true);
+      expect(componentVisibility[component2.id]).toEqual(false);
+      expect(componentVisibility[component3.id]).toEqual(false);
+    });
+  });
+});

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/grading-helpers/grading-helpers.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/grading-helpers/grading-helpers.spec.ts
@@ -1,33 +1,29 @@
 import { ComponentStatus } from '../../../../common/ComponentStatus';
 import { calculateComponentVisibility } from './grading-helpers';
 
-const component1 = { id: 'component1', type: 'OpenResponse' };
-const component2 = { id: 'component2', type: 'HTML' };
-const component3 = { id: 'component3', type: 'OpenResponse' };
+const componentId1 = 'component1';
+const componentId2 = 'component2';
+const componentId3 = 'component3';
 
 describe('calculateComponentVisibility()', () => {
   describe(`when there is a visible component, a component with no work, and a component that is not
     visible`, () => {
     it('should calculate component visibility correctly', () => {
-      const components = [component1, component2, component3];
-      const componentIdToHasWork = {
-        component1: true,
-        component2: false,
-        component3: true
-      };
-      const componentStatuses = {
-        component1: new ComponentStatus(true, true),
-        component2: new ComponentStatus(true, true),
-        component3: new ComponentStatus(false, false)
-      };
+      const componentIdToHasWork = {};
+      componentIdToHasWork[componentId1] = true;
+      componentIdToHasWork[componentId2] = false;
+      componentIdToHasWork[componentId3] = true;
+      const componentStatuses = {};
+      componentStatuses[componentId1] = new ComponentStatus(true, true);
+      componentStatuses[componentId2] = new ComponentStatus(true, true);
+      componentStatuses[componentId3] = new ComponentStatus(false, false);
       const componentVisibility = calculateComponentVisibility(
-        components,
         componentIdToHasWork,
         componentStatuses
       );
-      expect(componentVisibility[component1.id]).toEqual(true);
-      expect(componentVisibility[component2.id]).toEqual(false);
-      expect(componentVisibility[component3.id]).toEqual(false);
+      expect(componentVisibility[componentId1]).toEqual(true);
+      expect(componentVisibility[componentId2]).toEqual(false);
+      expect(componentVisibility[componentId3]).toEqual(false);
     });
   });
 });

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/grading-helpers/grading-helpers.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/grading-helpers/grading-helpers.ts
@@ -1,16 +1,14 @@
-import { ComponentContent } from '../../../../common/ComponentContent';
 import { ComponentStatus } from '../../../../common/ComponentStatus';
 
 export function calculateComponentVisibility(
-  components: ComponentContent[],
   componentIdToHasWork: { [componentId: string]: boolean },
   componentStatuses: { [componentId: string]: ComponentStatus }
 ): { [componentId: string]: boolean } {
   const componentIdToIsVisible = {};
-  for (const component of components) {
-    componentIdToIsVisible[component.id] =
-      componentIdToHasWork[component.id] &&
-      isComponentVisibleToStudent(componentStatuses, component.id);
+  for (const componentId in componentIdToHasWork) {
+    componentIdToIsVisible[componentId] =
+      componentIdToHasWork[componentId] &&
+      isComponentVisibleToStudent(componentStatuses, componentId);
   }
   return componentIdToIsVisible;
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/grading-helpers/grading-helpers.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/grading-helpers/grading-helpers.ts
@@ -1,15 +1,15 @@
+import { ComponentContent } from '../../../../common/ComponentContent';
 import { ComponentStatus } from '../../../../common/ComponentStatus';
-import { TeacherProjectService } from '../../../../services/teacherProjectService';
 
 export function calculateComponentVisibility(
-  nodeId: string,
-  componentStatuses: { [componentId: string]: ComponentStatus },
-  projectService: TeacherProjectService
+  components: ComponentContent[],
+  componentIdToHasWork: { [componentId: string]: boolean },
+  componentStatuses: { [componentId: string]: ComponentStatus }
 ): { [componentId: string]: boolean } {
   const componentIdToIsVisible = {};
-  for (const component of projectService.getComponents(nodeId)) {
+  for (const component of components) {
     componentIdToIsVisible[component.id] =
-      projectService.componentHasWork(component) &&
+      componentIdToHasWork[component.id] &&
       isComponentVisibleToStudent(componentStatuses, component.id);
   }
   return componentIdToIsVisible;

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/grading-helpers/grading-helpers.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/grading-helpers/grading-helpers.ts
@@ -1,0 +1,10 @@
+export function isComponentVisibleToStudent(nodeStatus: any, component: any): boolean {
+  let result = true;
+  if (nodeStatus.componentStatuses != null) {
+    const componentStatus = nodeStatus.componentStatuses[component.id];
+    if (componentStatus != null) {
+      result = componentStatus.isVisible;
+    }
+  }
+  return result;
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/grading-helpers/grading-helpers.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/grading-helpers/grading-helpers.ts
@@ -1,10 +1,24 @@
-export function isComponentVisibleToStudent(nodeStatus: any, component: any): boolean {
-  let result = true;
-  if (nodeStatus.componentStatuses != null) {
-    const componentStatus = nodeStatus.componentStatuses[component.id];
-    if (componentStatus != null) {
-      result = componentStatus.isVisible;
-    }
+import { ComponentStatus } from '../../../../common/ComponentStatus';
+import { TeacherProjectService } from '../../../../services/teacherProjectService';
+
+export function calculateComponentVisibility(
+  nodeId: string,
+  componentStatuses: { [componentId: string]: ComponentStatus },
+  projectService: TeacherProjectService
+): { [componentId: string]: boolean } {
+  const componentIdToIsVisible = {};
+  for (const component of projectService.getComponents(nodeId)) {
+    componentIdToIsVisible[component.id] =
+      projectService.componentHasWork(component) &&
+      isComponentVisibleToStudent(componentStatuses, component.id);
   }
-  return result;
+  return componentIdToIsVisible;
+}
+
+function isComponentVisibleToStudent(
+  componentStatuses: { [componentId: string]: ComponentStatus } = {},
+  componentId: string
+): boolean {
+  const componentStatus = componentStatuses[componentId];
+  return componentStatus == null || componentStatus.isVisible;
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.html
@@ -37,27 +37,29 @@
   </div>
   <mat-list-item *ngIf="expand && !disabled" class="grading__item-container">
     <div class="grading__item">
-      <div
-        id="component_{{ component.id }}_{{ workgroupId }}"
-        class="component component--grading"
-        *ngFor="let component of components; let index = index"
-      >
-        <h3 class="accent-1 mat-body-2 gray-lightest-bg component__header">
-          {{ index + 1 + '. ' + getComponentTypeLabel(component.type) }}&nbsp;
-          <component-new-work-badge
+      <ng-container *ngFor="let component of components; let index = index">
+        <div
+          *ngIf="componentIdToIsVisible[component.id]"
+          id="component_{{ component.id }}_{{ workgroupId }}"
+          class="component component--grading"
+        >
+          <h3 class="accent-1 mat-body-2 gray-lightest-bg component__header">
+            {{ index + 1 + '. ' + getComponentTypeLabel(component.type) }}&nbsp;
+            <component-new-work-badge
+              [componentId]="component.id"
+              [workgroupId]="workgroupId"
+              [nodeId]="nodeId"
+            >
+            </component-new-work-badge>
+          </h3>
+          <workgroup-component-grading
             [componentId]="component.id"
             [workgroupId]="workgroupId"
             [nodeId]="nodeId"
           >
-          </component-new-work-badge>
-        </h3>
-        <workgroup-component-grading
-          [componentId]="component.id"
-          [workgroupId]="workgroupId"
-          [nodeId]="nodeId"
-        >
-        </workgroup-component-grading>
-      </div>
+          </workgroup-component-grading>
+        </div>
+      </ng-container>
     </div>
   </mat-list-item>
 </div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.spec.ts
@@ -22,6 +22,9 @@ describe('StepItemComponent', () => {
     teacherProjectService = TestBed.inject(TeacherProjectService);
     fixture = TestBed.createComponent(StepItemComponent);
     component = fixture.componentInstance;
+    component.stepData = {
+      nodeStatus: {}
+    };
     fixture.detectChanges();
   });
 
@@ -47,7 +50,8 @@ function ngOnInit() {
         }
       };
       component.ngOnInit();
-      expect(component.components).toEqual([component1]);
+      expect(component.componentIdToIsVisible[component1.id]).toEqual(true);
+      expect(component.componentIdToIsVisible[component2.id]).toEqual(false);
     });
   });
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.spec.ts
@@ -28,30 +28,7 @@ describe('StepItemComponent', () => {
     fixture.detectChanges();
   });
 
-  ngOnInit();
-});
-
-function ngOnInit() {
-  describe('ngOnInit', () => {
-    it('should set the components that are visible to the student', () => {
-      const component1 = { id: 'component1', type: 'OpenResponse' };
-      const component2 = { id: 'component2', type: 'OpenResponse' };
-      spyOn(teacherProjectService, 'getComponents').and.returnValue([component1, component2]);
-      component.stepData = {
-        nodeStatus: {
-          componentStatuses: {
-            component1: {
-              isVisible: true
-            },
-            component2: {
-              isVisible: false
-            }
-          }
-        }
-      };
-      component.ngOnInit();
-      expect(component.componentIdToIsVisible[component1.id]).toEqual(true);
-      expect(component.componentIdToIsVisible[component2.id]).toEqual(false);
-    });
+  it('should create', () => {
+    expect(component).toBeTruthy();
   });
-}
+});

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts
@@ -10,7 +10,7 @@ import {
 import { copy } from '../../../../common/object/object';
 import { ComponentServiceLookupService } from '../../../../services/componentServiceLookupService';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
-import { isComponentVisibleToStudent } from '../../shared/grading-helpers/grading-helpers';
+import { calculateComponentVisibility } from '../../shared/grading-helpers/grading-helpers';
 
 @Component({
   selector: 'step-item',
@@ -19,6 +19,7 @@ import { isComponentVisibleToStudent } from '../../shared/grading-helpers/gradin
   encapsulation: ViewEncapsulation.None
 })
 export class StepItemComponent implements OnInit {
+  componentIdToIsVisible: { [componentId: string]: boolean } = {};
   components: any[];
   disabled: boolean;
   @Input() expand: boolean;
@@ -44,12 +45,12 @@ export class StepItemComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.components = this.projectService.getComponents(this.nodeId).filter((component) => {
-      return (
-        this.projectService.componentHasWork(component) &&
-        isComponentVisibleToStudent(this.stepData.nodeStatus, component)
-      );
-    });
+    this.components = this.projectService.getComponents(this.nodeId);
+    this.componentIdToIsVisible = calculateComponentVisibility(
+      this.nodeId,
+      this.stepData.nodeStatus.componentStatuses,
+      this.projectService
+    );
   }
 
   ngOnChanges(changesObj: SimpleChanges): void {
@@ -64,6 +65,11 @@ export class StepItemComponent implements OnInit {
       this.hasNewAlert = stepData.hasNewAlert;
       this.status = stepData.completionStatus;
       this.score = stepData.score >= 0 ? stepData.score : '-';
+      this.componentIdToIsVisible = calculateComponentVisibility(
+        this.nodeId,
+        stepData.nodeStatus.componentStatuses,
+        this.projectService
+      );
     }
     this.update();
   }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts
@@ -64,7 +64,6 @@ export class StepItemComponent implements OnInit {
         this.components
       );
       this.componentIdToIsVisible = calculateComponentVisibility(
-        this.components,
         this.componentIdToHasWork,
         stepData.nodeStatus.componentStatuses
       );

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts
@@ -19,6 +19,7 @@ import { calculateComponentVisibility } from '../../shared/grading-helpers/gradi
   encapsulation: ViewEncapsulation.None
 })
 export class StepItemComponent implements OnInit {
+  componentIdToHasWork: { [componentId: string]: boolean } = {};
   componentIdToIsVisible: { [componentId: string]: boolean } = {};
   components: any[];
   disabled: boolean;
@@ -44,14 +45,7 @@ export class StepItemComponent implements OnInit {
     private projectService: TeacherProjectService
   ) {}
 
-  ngOnInit(): void {
-    this.components = this.projectService.getComponents(this.nodeId);
-    this.componentIdToIsVisible = calculateComponentVisibility(
-      this.nodeId,
-      this.stepData.nodeStatus.componentStatuses,
-      this.projectService
-    );
-  }
+  ngOnInit(): void {}
 
   ngOnChanges(changesObj: SimpleChanges): void {
     if (changesObj.maxScore) {
@@ -65,10 +59,14 @@ export class StepItemComponent implements OnInit {
       this.hasNewAlert = stepData.hasNewAlert;
       this.status = stepData.completionStatus;
       this.score = stepData.score >= 0 ? stepData.score : '-';
+      this.components = this.projectService.getComponents(this.nodeId);
+      this.componentIdToHasWork = this.projectService.calculateComponentIdToHasWork(
+        this.components
+      );
       this.componentIdToIsVisible = calculateComponentVisibility(
-        this.nodeId,
-        stepData.nodeStatus.componentStatuses,
-        this.projectService
+        this.components,
+        this.componentIdToHasWork,
+        stepData.nodeStatus.componentStatuses
       );
     }
     this.update();

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts
@@ -10,6 +10,7 @@ import {
 import { copy } from '../../../../common/object/object';
 import { ComponentServiceLookupService } from '../../../../services/componentServiceLookupService';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
+import { isComponentVisibleToStudent } from '../../shared/grading-helpers/grading-helpers';
 
 @Component({
   selector: 'step-item',
@@ -44,7 +45,10 @@ export class StepItemComponent implements OnInit {
 
   ngOnInit(): void {
     this.components = this.projectService.getComponents(this.nodeId).filter((component) => {
-      return this.projectService.componentHasWork(component);
+      return (
+        this.projectService.componentHasWork(component) &&
+        isComponentVisibleToStudent(this.stepData.nodeStatus, component)
+      );
     });
   }
 

--- a/src/assets/wise5/classroomMonitor/student-grading/student-grading.component.ts
+++ b/src/assets/wise5/classroomMonitor/student-grading/student-grading.component.ts
@@ -229,6 +229,9 @@ export class StudentGradingComponent implements OnInit {
       }
       node.order = this.projectService.getOrderById(nodeId);
       node.show = this.isNodeShown(nodeId);
+      node.nodeStatus = this.classroomStatusService.getStudentStatusForWorkgroupId(
+        this.workgroupId
+      ).nodeStatuses[nodeId];
     }
   }
 

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -1363,6 +1363,16 @@ export class ProjectService {
     return componentService.componentHasWork(component);
   }
 
+  calculateComponentIdToHasWork(
+    components: ComponentContent[]
+  ): { [componentId: string]: boolean } {
+    const componentIdToHasWork: { [componentId: string]: boolean } = {};
+    for (const component of components) {
+      componentIdToHasWork[component.id] = this.componentHasWork(component);
+    }
+    return componentIdToHasWork;
+  }
+
   getComponentType(nodeId: string, componentId: string): string {
     const component = this.getComponent(nodeId, componentId);
     return component.type;


### PR DESCRIPTION
## Changes

Grade by Step and Grade by Team now look at component statuses for a workgroup to determine which components to show in the grading view.

## Test

1. Author a project that has component visibility constraints

For example a step that contains 3 components
  - A Multiple Choice component that has choices A and B
  - A component that is only visible when the student chooses A
  - A component that is only visible when the student chooses B
3. Have students work on the project
4. Go to the Grade by Step view and make sure the correct components are visible or hidden
5. Go to the Grade by Team view and make sure the correct components are visible or hidden

Closes #1157