### PR TITLE
refactor(StudentDataService): Move endCurrentNodeAndSetCurrentNodeByNodeId() to NodeService

### DIFF
--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -15,8 +15,6 @@ export class DataService {
 
   constructor(protected ProjectService: ProjectService) {}
 
-  endCurrentNodeAndSetCurrentNodeByNodeId(nextNodeId) {}
-
   getCurrentNode() {
     return this.currentNode;
   }
@@ -65,4 +63,6 @@ export class DataService {
   broadcastStudentWorkReceived(studentWork: any) {
     this.studentWorkReceivedSource.next(studentWork);
   }
+
+  nodeClickLocked(nodeId: string): void {}
 }

--- a/src/app/services/studentNodeService.spec.ts
+++ b/src/app/services/studentNodeService.spec.ts
@@ -1,0 +1,55 @@
+import { TestBed } from '@angular/core/testing';
+import { StudentNodeService } from '../../assets/wise5/services/studentNodeService';
+import { StudentTeacherCommonServicesModule } from '../student-teacher-common-services.module';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { MatDialogModule } from '@angular/material/dialog';
+import { NodeStatusService } from '../../assets/wise5/services/nodeStatusService';
+import { DataService } from './data.service';
+
+let dataService: DataService;
+let nodeStatusService: NodeStatusService;
+let service: StudentNodeService;
+describe('StudentNodeService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, MatDialogModule, StudentTeacherCommonServicesModule]
+    });
+    dataService = TestBed.inject(DataService);
+    service = TestBed.inject(StudentNodeService);
+    nodeStatusService = TestBed.inject(NodeStatusService);
+  });
+  setCurrentNode();
+});
+
+function setCurrentNode() {
+  describe('setCurrentNode()', () => {
+    setCurrentNode_isVisitable_setCurrentNode();
+    setCurrentNode_isNotVisitable_nodeClickLocked();
+  });
+}
+
+function setCurrentNode_isVisitable_setCurrentNode() {
+  describe('is visible', () => {
+    it('should call StudentDataService to set current node', () => {
+      expectFunctionCall(true, 'setCurrentNodeByNodeId');
+    });
+  });
+}
+
+function setCurrentNode_isNotVisitable_nodeClickLocked() {
+  describe('is not visible', () => {
+    it('should call StudentDataService to lock node', () => {
+      expectFunctionCall(false, 'nodeClickLocked');
+    });
+  });
+}
+
+function expectFunctionCall(
+  isVisitable: boolean,
+  expectedFunction: 'setCurrentNodeByNodeId' | 'nodeClickLocked'
+) {
+  spyOn(nodeStatusService, 'getNodeStatusByNodeId').and.returnValue({ isVisitable: isVisitable });
+  const spy = spyOn(dataService, expectedFunction);
+  service.setCurrentNode('node1');
+  expect(spy).toHaveBeenCalledWith('node1');
+}

--- a/src/app/services/wiseLinkService.ts
+++ b/src/app/services/wiseLinkService.ts
@@ -53,7 +53,7 @@ export class WiseLinkService {
     if (componentId !== '') {
       this.nodeService.registerScrollToComponent(componentId);
     }
-    this.studentDataService.endCurrentNodeAndSetCurrentNodeByNodeId(nodeId);
+    this.nodeService.setCurrentNode(nodeId);
   }
 
   generateHtmlWithWiseLink(html: string): SafeHtml {

--- a/src/app/student-teacher-common-services.module.ts
+++ b/src/app/student-teacher-common-services.module.ts
@@ -53,6 +53,7 @@ import { NodeStatusService } from '../assets/wise5/services/nodeStatusService';
 import { PeerGroupService } from '../assets/wise5/services/peerGroupService';
 import { NodeProgressService } from '../assets/wise5/services/nodeProgressService';
 import { CompletionService } from '../assets/wise5/services/completionService';
+import { StudentNodeService } from '../assets/wise5/services/studentNodeService';
 
 @NgModule({
   providers: [
@@ -82,7 +83,7 @@ import { CompletionService } from '../assets/wise5/services/completionService';
     MatchService,
     MultipleChoiceService,
     NodeProgressService,
-    NodeService,
+    { provide: NodeService, useExisting: StudentNodeService },
     NodeStatusService,
     NotebookService,
     NotificationService,
@@ -100,6 +101,7 @@ import { CompletionService } from '../assets/wise5/services/completionService';
     StompService,
     StudentAssetService,
     StudentDataService,
+    StudentNodeService,
     StudentPeerGroupService,
     StudentStatusService,
     StudentWebSocketService,

--- a/src/app/teacher-hybrid-angular.module.ts
+++ b/src/app/teacher-hybrid-angular.module.ts
@@ -33,6 +33,8 @@ import { TeacherPeerGroupService } from '../assets/wise5/services/teacherPeerGro
 import { DataExportService } from '../assets/wise5/services/dataExportService';
 import { TeacherNodeIconComponent } from '../assets/wise5/authoringTool/teacher-node-icon/teacher-node-icon.component';
 import { PeerGroupService } from '../assets/wise5/services/peerGroupService';
+import { NodeService } from '../assets/wise5/services/nodeService';
+import { TeacherNodeService } from '../assets/wise5/services/teacherNodeService';
 
 @Component({ template: `` })
 export class EmptyComponent {}
@@ -59,12 +61,14 @@ export class EmptyComponent {}
     InsertNodesService,
     MilestoneService,
     MoveNodesService,
+    { provide: NodeService, useExisting: TeacherNodeService },
     ProjectAssetService,
     SpaceService,
     { provide: PeerGroupService, useExisting: TeacherPeerGroupService },
     { provide: ProjectService, useExisting: TeacherProjectService },
     TeacherDataService,
     TeacherDiscussionService,
+    TeacherNodeService,
     TeacherPeerGroupService,
     TeacherProjectService,
     TeacherWebSocketService,

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.spec.ts
@@ -6,11 +6,16 @@ import { TeacherDataService } from '../../../../services/teacherDataService';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
 import { ClassroomMonitorTestingModule } from '../../../classroom-monitor-testing.module';
 import { NavItemComponent } from './nav-item.component';
+import { NodeService } from '../../../../services/nodeService';
 
 class MockNotificationService {
   getAlertNotifications() {
     return [];
   }
+}
+
+class MockNodeService {
+  setCurrentNode(): void {}
 }
 
 class MockTeacherDataService {
@@ -20,7 +25,6 @@ class MockTeacherDataService {
   private currentPeriodChangedSource: Subject<any> = new Subject<any>();
   public currentPeriodChanged$: Observable<any> = this.currentPeriodChangedSource.asObservable();
 
-  endCurrentNodeAndSetCurrentNodeByNodeId() {}
   getCurrentPeriod() {
     return { periodId: periodId };
   }
@@ -52,6 +56,7 @@ describe('NavItemComponent', () => {
       declarations: [NavItemComponent],
       imports: [ClassroomMonitorTestingModule, MatSnackBarModule],
       providers: [
+        { provide: NodeService, useClass: MockNodeService },
         { provide: NotificationService, useClass: MockNotificationService },
         { provide: TeacherDataService, useClass: MockTeacherDataService },
         { provide: TeacherProjectService, useClass: MockTeacherProjectService }
@@ -86,13 +91,10 @@ function itemClicked() {
     });
 
     it('should set current node when a step is clicked', () => {
-      const endCurrentNodeAndSetCurrentNodeByNodeIdSpy = spyOn(
-        TestBed.inject(TeacherDataService),
-        'endCurrentNodeAndSetCurrentNodeByNodeId'
-      );
+      const spy = spyOn(TestBed.inject(NodeService), 'setCurrentNode');
       component.isGroup = false;
       component.itemClicked();
-      expect(endCurrentNodeAndSetCurrentNodeByNodeIdSpy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalled();
     });
   });
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts
@@ -7,6 +7,7 @@ import { NotificationService } from '../../../../services/notificationService';
 import { TeacherDataService } from '../../../../services/teacherDataService';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
 import { TeacherWebSocketService } from '../../../../services/teacherWebSocketService';
+import { NodeService } from '../../../../services/nodeService';
 
 @Component({
   selector: 'nav-item',
@@ -45,6 +46,7 @@ export class NavItemComponent implements OnInit {
   constructor(
     private annotationService: AnnotationService,
     private classroomStatusService: ClassroomStatusService,
+    private nodeService: NodeService,
     private notificationService: NotificationService,
     private projectService: TeacherProjectService,
     private snackBar: MatSnackBar,
@@ -167,7 +169,7 @@ export class NavItemComponent implements OnInit {
       this.groupItemClicked();
       this.onExpandedEvent.emit({ nodeId: this.nodeId, expanded: this.expanded });
     } else {
-      this.teacherDataService.endCurrentNodeAndSetCurrentNodeByNodeId(this.nodeId);
+      this.nodeService.setCurrentNode(this.nodeId);
     }
   }
 
@@ -177,7 +179,7 @@ export class NavItemComponent implements OnInit {
       if (this.isCurrentNode) {
         this.zoomToElement();
       } else {
-        this.teacherDataService.endCurrentNodeAndSetCurrentNodeByNodeId(this.nodeId);
+        this.nodeService.setCurrentNode(this.nodeId);
       }
     }
   }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/node-progress-view/node-progress-view.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/node-progress-view/node-progress-view.component.ts
@@ -5,6 +5,7 @@ import { Subscription } from 'rxjs';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { MatDialog } from '@angular/material/dialog';
 import { DialogWithOpenInNewWindowComponent } from '../../../../directives/dialog-with-open-in-new-window/dialog-with-open-in-new-window.component';
+import { NodeService } from '../../../../services/nodeService';
 
 @Component({
   selector: 'node-progress-view',
@@ -25,6 +26,7 @@ export class NodeProgressViewComponent implements OnInit {
 
   constructor(
     private dialog: MatDialog,
+    private nodeService: NodeService,
     private projectService: TeacherProjectService,
     private teacherDataService: TeacherDataService,
     private upgrade: UpgradeModule
@@ -96,7 +98,7 @@ export class NodeProgressViewComponent implements OnInit {
       const fromNodeId = $transition.params('from').nodeId;
       if (toNodeId && fromNodeId && toNodeId !== fromNodeId) {
         this.nodeId = toNodeId;
-        this.teacherDataService.endCurrentNodeAndSetCurrentNodeByNodeId(toNodeId);
+        this.nodeService.setCurrentNode(toNodeId);
       }
 
       if (toNodeId === 'group0') {

--- a/src/assets/wise5/directives/group-tabs/group-tabs.component.spec.ts
+++ b/src/assets/wise5/directives/group-tabs/group-tabs.component.spec.ts
@@ -4,6 +4,7 @@ import { NodeStatusService } from '../../services/nodeStatusService';
 import { StudentDataService } from '../../services/studentDataService';
 import { VLEProjectService } from '../../vle/vleProjectService';
 import { GroupTabsComponent } from './group-tabs.component';
+import { NodeService } from '../../services/nodeService';
 
 const group1 = { id: 'group1' };
 const group2 = { id: 'group2' };
@@ -13,6 +14,10 @@ class MockNodeStatusService {
   canVisitNode(): boolean {
     return true;
   }
+}
+
+class MockNodeService {
+  setCurrentNode(): void {}
 }
 
 class MockVLEProjectService {
@@ -39,17 +44,16 @@ class MockStudentDataService {
   canVisitNode(): boolean {
     return true;
   }
-  endCurrentNodeAndSetCurrentNodeByNodeId(): void {}
 }
 
 let component: GroupTabsComponent;
 let projectService: VLEProjectService;
-let studentDataService: StudentDataService;
 describe('GroupTabsComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         GroupTabsComponent,
+        { provide: NodeService, useClass: MockNodeService },
         { provide: NodeStatusService, useClass: MockNodeStatusService },
         { provide: VLEProjectService, useClass: MockVLEProjectService },
         { provide: StudentDataService, useClass: MockStudentDataService }
@@ -57,7 +61,6 @@ describe('GroupTabsComponent', () => {
     });
     component = TestBed.inject(GroupTabsComponent);
     projectService = TestBed.inject(VLEProjectService);
-    studentDataService = TestBed.inject(StudentDataService);
   });
   ngOnInit();
   goToGroupTab();
@@ -79,7 +82,7 @@ function goToGroupTab() {
       component.groupNodes = [
         { id: 'group1', disabled: false, startId: 'node1', title: 'Lesson 1' }
       ];
-      const spy = spyOn(studentDataService, 'endCurrentNodeAndSetCurrentNodeByNodeId');
+      const spy = spyOn(TestBed.inject(NodeService), 'setCurrentNode');
       component.goToGroupTab(0);
       expect(spy).toHaveBeenCalledWith('node1');
     });

--- a/src/assets/wise5/directives/group-tabs/group-tabs.component.ts
+++ b/src/assets/wise5/directives/group-tabs/group-tabs.component.ts
@@ -3,6 +3,7 @@ import { Subscription } from 'rxjs';
 import { NodeStatusService } from '../../services/nodeStatusService';
 import { StudentDataService } from '../../services/studentDataService';
 import { VLEProjectService } from '../../vle/vleProjectService';
+import { NodeService } from '../../services/nodeService';
 
 class GroupNode {
   id: string;
@@ -21,6 +22,7 @@ export class GroupTabsComponent implements OnInit {
   private subscriptions: Subscription = new Subscription();
 
   constructor(
+    private nodeService: NodeService,
     private nodeStatusService: NodeStatusService,
     private projectService: VLEProjectService,
     private studentDataService: StudentDataService
@@ -62,6 +64,6 @@ export class GroupTabsComponent implements OnInit {
 
   goToGroupTab(groupTabIndex: number): void {
     const groupStartNodeId = this.groupNodes[groupTabIndex].startId;
-    this.studentDataService.endCurrentNodeAndSetCurrentNodeByNodeId(groupStartNodeId);
+    this.nodeService.setCurrentNode(groupStartNodeId);
   }
 }

--- a/src/assets/wise5/services/nodeService.ts
+++ b/src/assets/wise5/services/nodeService.ts
@@ -25,18 +25,22 @@ export class NodeService {
   public deleteStarterState$: Observable<any> = this.deleteStarterStateSource.asObservable();
 
   constructor(
-    private dialog: MatDialog,
-    private ConfigService: ConfigService,
-    private constraintService: ConstraintService,
-    private ProjectService: ProjectService,
-    private DataService: DataService
+    protected dialog: MatDialog,
+    protected ConfigService: ConfigService,
+    protected constraintService: ConstraintService,
+    protected ProjectService: ProjectService,
+    protected DataService: DataService
   ) {}
+
+  setCurrentNode(nodeId: string): void {
+    this.DataService.setCurrentNodeByNodeId(nodeId);
+  }
 
   goToNextNode() {
     return this.getNextNodeId().then((nextNodeId) => {
       if (nextNodeId != null) {
         const mode = this.ConfigService.getMode();
-        this.DataService.endCurrentNodeAndSetCurrentNodeByNodeId(nextNodeId);
+        this.setCurrentNode(nextNodeId);
       }
       return nextNodeId;
     });
@@ -159,7 +163,7 @@ export class NodeService {
   goToNextNodeWithWork(): Promise<string> {
     return this.getNextNodeIdWithWork().then((nextNodeId: string) => {
       if (nextNodeId) {
-        this.DataService.endCurrentNodeAndSetCurrentNodeByNodeId(nextNodeId);
+        this.setCurrentNode(nextNodeId);
       }
       return nextNodeId;
     });
@@ -186,7 +190,7 @@ export class NodeService {
 
   goToPrevNode() {
     const prevNodeId = this.getPrevNodeId();
-    this.DataService.endCurrentNodeAndSetCurrentNodeByNodeId(prevNodeId);
+    this.setCurrentNode(prevNodeId);
   }
 
   /**
@@ -254,7 +258,7 @@ export class NodeService {
    */
   goToPrevNodeWithWork() {
     const prevNodeId = this.getPrevNodeIdWithWork();
-    this.DataService.endCurrentNodeAndSetCurrentNodeByNodeId(prevNodeId);
+    this.setCurrentNode(prevNodeId);
   }
 
   /**
@@ -285,7 +289,7 @@ export class NodeService {
       let currentNodeId = currentNode.id;
       let parentNode = this.ProjectService.getParentGroup(currentNodeId);
       let parentNodeId = parentNode.id;
-      this.DataService.endCurrentNodeAndSetCurrentNodeByNodeId(parentNodeId);
+      this.setCurrentNode(parentNodeId);
     }
   }
 

--- a/src/assets/wise5/services/studentDataService.ts
+++ b/src/assets/wise5/services/studentDataService.ts
@@ -655,15 +655,7 @@ export class StudentDataService extends DataService {
     return this.ProjectService.getNodeById(nodeId) != null && this.ProjectService.isActive(nodeId);
   }
 
-  endCurrentNodeAndSetCurrentNodeByNodeId(nodeId) {
-    if (this.nodeStatuses[nodeId].isVisitable) {
-      this.setCurrentNodeByNodeId(nodeId);
-    } else {
-      this.nodeClickLocked(nodeId);
-    }
-  }
-
-  nodeClickLocked(nodeId) {
+  nodeClickLocked(nodeId: string): void {
     this.broadcastNodeClickLocked({ nodeId: nodeId });
   }
 

--- a/src/assets/wise5/services/studentNodeService.ts
+++ b/src/assets/wise5/services/studentNodeService.ts
@@ -10,21 +10,21 @@ import { NodeStatusService } from './nodeStatusService';
 @Injectable()
 export class StudentNodeService extends NodeService {
   constructor(
-    dialog: MatDialog,
-    configService: ConfigService,
-    constraintService: ConstraintService,
+    protected dialog: MatDialog,
+    protected configService: ConfigService,
+    protected constraintService: ConstraintService,
     private nodeStatusService: NodeStatusService,
-    projectService: ProjectService,
-    dataService: DataService
+    protected projectService: ProjectService,
+    protected dataService: DataService
   ) {
     super(dialog, configService, constraintService, projectService, dataService);
   }
 
   setCurrentNode(nodeId: string): void {
     if (this.nodeStatusService.getNodeStatusByNodeId(nodeId).isVisitable) {
-      this.DataService.setCurrentNodeByNodeId(nodeId);
+      this.dataService.setCurrentNodeByNodeId(nodeId);
     } else {
-      this.DataService.nodeClickLocked(nodeId);
+      this.dataService.nodeClickLocked(nodeId);
     }
   }
 }

--- a/src/assets/wise5/services/studentNodeService.ts
+++ b/src/assets/wise5/services/studentNodeService.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { NodeService } from './nodeService';
+import { MatDialog } from '@angular/material/dialog';
+import { DataService } from '../../../app/services/data.service';
+import { ConfigService } from './configService';
+import { ConstraintService } from './constraintService';
+import { ProjectService } from './projectService';
+import { NodeStatusService } from './nodeStatusService';
+
+@Injectable()
+export class StudentNodeService extends NodeService {
+  constructor(
+    dialog: MatDialog,
+    configService: ConfigService,
+    constraintService: ConstraintService,
+    private nodeStatusService: NodeStatusService,
+    projectService: ProjectService,
+    dataService: DataService
+  ) {
+    super(dialog, configService, constraintService, projectService, dataService);
+  }
+
+  setCurrentNode(nodeId: string): void {
+    if (this.nodeStatusService.getNodeStatusByNodeId(nodeId).isVisitable) {
+      this.DataService.setCurrentNodeByNodeId(nodeId);
+    } else {
+      this.DataService.nodeClickLocked(nodeId);
+    }
+  }
+}

--- a/src/assets/wise5/services/studentWebSocketService.ts
+++ b/src/assets/wise5/services/studentWebSocketService.ts
@@ -16,7 +16,7 @@ export class StudentWebSocketService {
   constructor(
     private AnnotationService: AnnotationService,
     private configService: ConfigService,
-    private NodeService: NodeService,
+    private nodeService: NodeService,
     private notebookService: NotebookService,
     private ProjectService: ProjectService,
     private stompService: StompService,
@@ -61,7 +61,7 @@ export class StudentWebSocketService {
         const tags = JSON.parse(body.content);
         this.TagService.setTags(tags);
         this.StudentDataService.updateNodeStatuses();
-        this.NodeService.evaluateTransitionLogic();
+        this.nodeService.evaluateTransitionLogic();
       } else if (body.type === 'goToNode') {
         this.goToStep(body.content);
       } else if (body.type === 'goToNextNode') {
@@ -82,12 +82,12 @@ export class StudentWebSocketService {
   }
 
   goToStep(nodeId: string): void {
-    this.StudentDataService.endCurrentNodeAndSetCurrentNodeByNodeId(nodeId);
+    this.nodeService.setCurrentNode(nodeId);
   }
 
   goToNextStep(): void {
-    this.NodeService.getNextNodeId().then((nextNodeId) => {
-      this.StudentDataService.endCurrentNodeAndSetCurrentNodeByNodeId(nextNodeId);
+    this.nodeService.getNextNodeId().then((nextNodeId) => {
+      this.nodeService.setCurrentNode(nextNodeId);
     });
   }
 

--- a/src/assets/wise5/services/teacherDataService.ts
+++ b/src/assets/wise5/services/teacherDataService.ts
@@ -730,10 +730,6 @@ export class TeacherDataService extends DataService {
     return this.currentStep;
   }
 
-  endCurrentNodeAndSetCurrentNodeByNodeId(nodeId) {
-    this.setCurrentNodeByNodeId(nodeId);
-  }
-
   getTotalScoreByWorkgroupId(workgroupId: number) {
     return this.AnnotationService.getTotalScore(
       this.studentData.annotationsToWorkgroupId[workgroupId]

--- a/src/assets/wise5/services/teacherNodeService.ts
+++ b/src/assets/wise5/services/teacherNodeService.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@angular/core';
+import { NodeService } from './nodeService';
+
+@Injectable()
+export class TeacherNodeService extends NodeService {}

--- a/src/assets/wise5/themes/default/themeComponents/stepTools/step-tools.component.ts
+++ b/src/assets/wise5/themes/default/themeComponents/stepTools/step-tools.component.ts
@@ -66,7 +66,7 @@ export class StepToolsComponent implements OnInit {
   }
 
   toNodeIdChanged(): void {
-    this.studentDataService.endCurrentNodeAndSetCurrentNodeByNodeId(this.toNodeId);
+    this.nodeService.setCurrentNode(this.toNodeId);
   }
 
   updateModel(): void {

--- a/src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.spec.ts
+++ b/src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.spec.ts
@@ -8,6 +8,7 @@ import { MatInputModule } from '@angular/material/input';
 import { StudentDataService } from '../../services/studentDataService';
 import { DismissAmbientNotificationDialogComponent } from './dismiss-ambient-notification-dialog.component';
 import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
+import { NodeService } from '../../services/nodeService';
 
 let component: DismissAmbientNotificationDialogComponent;
 const DISMISS_CODE: string = 'computer';
@@ -80,14 +81,14 @@ function dismissCodeShouldShowInvalidDismissCodeMessage(
 function visitNode(): void {
   describe('visitNode', () => {
     it('should visit node', () => {
-      const endCurrentNodeSpy = spyOn(
-        TestBed.inject(StudentDataService),
-        'endCurrentNodeAndSetCurrentNodeByNodeId'
+      const setCurrentNodeSpy = spyOn(
+        TestBed.inject(NodeService),
+        'setCurrentNode'
       ).and.callFake(() => {});
       component.notification.nodeId = nodeId;
       component.visitNode();
       expect(saveVLEEventSpy).toHaveBeenCalled();
-      expect(endCurrentNodeSpy).toHaveBeenCalledWith(nodeId);
+      expect(setCurrentNodeSpy).toHaveBeenCalledWith(nodeId);
     });
   });
 }

--- a/src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.ts
+++ b/src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.ts
@@ -11,6 +11,7 @@ import { Observable, Subject } from 'rxjs';
 import { Notification } from '../../../../app/domain/notification';
 import { ProjectService } from '../../services/projectService';
 import { StudentDataService } from '../../services/studentDataService';
+import { NodeService } from '../../services/nodeService';
 
 @Component({
   selector: 'dismiss-ambient-notification-dialog',
@@ -31,6 +32,7 @@ export class DismissAmbientNotificationDialogComponent implements OnInit {
     @Inject(MAT_DIALOG_DATA) public notification: Notification,
     public dialogRef: MatDialogRef<DismissAmbientNotificationDialogComponent>,
     private formBuilder: FormBuilder,
+    private nodeService: NodeService,
     private projectService: ProjectService,
     private studentDataService: StudentDataService
   ) {}
@@ -122,7 +124,7 @@ export class DismissAmbientNotificationDialogComponent implements OnInit {
 
     const goToNodeId = this.notification.nodeId;
     if (goToNodeId != null) {
-      this.studentDataService.endCurrentNodeAndSetCurrentNodeByNodeId(goToNodeId);
+      this.nodeService.setCurrentNode(goToNodeId);
     }
   }
 

--- a/src/assets/wise5/vle/nav-item/nav-item.component.ts
+++ b/src/assets/wise5/vle/nav-item/nav-item.component.ts
@@ -4,6 +4,7 @@ import { Component, Input } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { ProjectService } from '../../services/projectService';
 import { StudentDataService } from '../../services/studentDataService';
+import { NodeService } from '../../services/nodeService';
 
 @Component({
   selector: 'nav-item',
@@ -31,6 +32,7 @@ export class NavItemComponent {
   type: string;
 
   constructor(
+    private nodeService: NodeService,
     private ProjectService: ProjectService,
     private StudentDataService: StudentDataService
   ) {}
@@ -119,12 +121,12 @@ export class NavItemComponent {
         if (this.isCurrentNode) {
           this.zoomToElement();
         } else {
-          this.StudentDataService.endCurrentNodeAndSetCurrentNodeByNodeId(this.nodeId);
+          this.nodeService.setCurrentNode(this.nodeId);
         }
       }
       this.StudentDataService.setNavItemExpanded(this.nodeId, this.expanded);
     } else {
-      this.StudentDataService.endCurrentNodeAndSetCurrentNodeByNodeId(this.nodeId);
+      this.nodeService.setCurrentNode(this.nodeId);
     }
   }
 }

--- a/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.spec.ts
+++ b/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.spec.ts
@@ -4,10 +4,10 @@ import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { NotificationService } from '../../services/notificationService';
-import { StudentDataService } from '../../services/studentDataService';
 import { NotificationsDialogComponent } from './notifications-dialog.component';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
+import { NodeService } from '../../services/nodeService';
 
 describe('NotificationsMenuComponent', () => {
   let component: NotificationsDialogComponent;
@@ -84,13 +84,13 @@ describe('NotificationsMenuComponent', () => {
   }
 
   it('should dismiss notification aggregate and visit node', () => {
-    const endCurrentNodeAndSetCurrentNodeByNodeIdSpy = spyOn(
-      TestBed.inject(StudentDataService),
-      'endCurrentNodeAndSetCurrentNodeByNodeId'
+    const setCurrentNodeSpy = spyOn(
+      TestBed.inject(NodeService),
+      'setCurrentNode'
     ).and.callFake(() => {});
     component.dismissNotificationAggregateAndVisitNode(notificationAggregate1);
     expect(dismissNotificationSpy).toHaveBeenCalledTimes(2);
-    expect(endCurrentNodeAndSetCurrentNodeByNodeIdSpy).toHaveBeenCalledWith(nodeId1);
+    expect(setCurrentNodeSpy).toHaveBeenCalledWith(nodeId1);
   });
 
   it('should dismiss notification aggregate that does not require dismiss code', () => {

--- a/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.ts
+++ b/src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.ts
@@ -5,7 +5,7 @@ import { Notification } from '../../../../app/domain/notification';
 import { NotebookService } from '../../services/notebookService';
 import { NotificationService } from '../../services/notificationService';
 import { ProjectService } from '../../services/projectService';
-import { StudentDataService } from '../../services/studentDataService';
+import { NodeService } from '../../services/nodeService';
 
 @Component({
   selector: 'notifications-dialog',
@@ -20,10 +20,10 @@ export class NotificationsDialogComponent implements OnInit {
   constructor(
     public dialog: MatDialog,
     public dialogRef: MatDialogRef<NotificationsDialogComponent>,
+    private nodeService: NodeService,
     private notebookService: NotebookService,
     private notificationService: NotificationService,
-    private projectService: ProjectService,
-    private studentDataService: StudentDataService
+    private projectService: ProjectService
   ) {}
 
   ngOnInit(): void {
@@ -54,7 +54,7 @@ export class NotificationsDialogComponent implements OnInit {
     let goToNodeId = notificationAggregate.nodeId;
     let notebookItemId = notificationAggregate.notebookItemId;
     if (goToNodeId != null) {
-      this.studentDataService.endCurrentNodeAndSetCurrentNodeByNodeId(goToNodeId);
+      this.nodeService.setCurrentNode(goToNodeId);
       this.dialogRef.close();
     } else if (notebookItemId != null) {
       // assume notification with notebookItemId is for the report for now,

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1518,7 +1518,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts</context>
-          <context context-type="linenumber">78</context>
+          <context context-type="linenumber">80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1217086124949795770" datatype="html">
@@ -1540,7 +1540,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">83</context>
         </context-group>
       </trans-unit>
       <trans-unit id="88936072a55699e997d6cc9e47305cdbb26ad42a" datatype="html">
@@ -8447,7 +8447,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts</context>
-          <context context-type="linenumber">355</context>
+          <context context-type="linenumber">357</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component.ts</context>
@@ -11118,21 +11118,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source><x id="PH" equiv-text="this.nodeTitle"/> has been locked for <x id="PH_1" equiv-text="this.getPeriodLabel()"/>.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts</context>
-          <context context-type="linenumber">237</context>
+          <context context-type="linenumber">239</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7788246130452063015" datatype="html">
         <source><x id="PH" equiv-text="this.nodeTitle"/> has been unlocked for <x id="PH_1" equiv-text="this.getPeriodLabel()"/>.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts</context>
-          <context context-type="linenumber">239</context>
+          <context context-type="linenumber">241</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6933068701447776492" datatype="html">
         <source>Period: <x id="PH" equiv-text="this.currentPeriod.periodName"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts</context>
-          <context context-type="linenumber">356</context>
+          <context context-type="linenumber">358</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component.ts</context>
@@ -11143,14 +11143,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Unlock for <x id="PH" equiv-text="this.getPeriodLabel()"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts</context>
-          <context context-type="linenumber">361</context>
+          <context context-type="linenumber">363</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2330813372531032088" datatype="html">
         <source>Lock for <x id="PH" equiv-text="this.getPeriodLabel()"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts</context>
-          <context context-type="linenumber">363</context>
+          <context context-type="linenumber">365</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5411ee1bc7179f254f2db73cf448e995fca45f43" datatype="html">
@@ -19053,7 +19053,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Invalid dismiss code. Please try again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.ts</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f3bb0234ead15a9bf90c2cb2ed7b48570d6011c5" datatype="html">


### PR DESCRIPTION
## Changes
- Move StudentDataService.endCurrentNodeAndSetCurrentNodeByNodeId() to NodeService.setCurrentNode()
- Create StudentNodeService and TeacherNodeService classes that extend NodeService (TeacherNodeService simply extends NodeService and doesn't overwrite any functions atm, but we still need this class for the compiler to work)
- Update references
- Add test for StudentNodeService.setCurrentNode()

## Test
- In Student VLE/preview unit
   - navigation between steps works as before, esp. using 
      - next/prev buttons and select step drop down
      - project plan
      - wiselink
   - Node locked message appears as before, i.e., due to active constraints
- In CM and AT, navigation between steps works as before, esp. using
   - next/prev buttons and select step drop down

Closes #1166