### PR TITLE
refactor(StudentDataService): Move visitedNodesHistory to NodeStatusService

### DIFF
--- a/src/assets/wise5/services/nodeStatusService.ts
+++ b/src/assets/wise5/services/nodeStatusService.ts
@@ -9,6 +9,8 @@ import { CompletionService } from './completionService';
 
 @Injectable()
 export class NodeStatusService {
+  private nodeIdToIsVisited: { [nodeId: string]: boolean } = {};
+
   constructor(
     private completionService: CompletionService,
     private constraintService: ConstraintService,
@@ -17,12 +19,26 @@ export class NodeStatusService {
     private notebookService: NotebookService,
     private projectService: ProjectService
   ) {
+    this.dataService.dataRetrieved$.subscribe((studentData) => {
+      this.populateNodeIdToIsVisited(studentData.events);
+      this.updateNodeStatuses();
+    });
     this.dataService.updateNodeStatuses$.subscribe(() => {
       this.updateNodeStatuses();
     });
     this.notebookService.notebookUpdated$.subscribe(() => {
       this.updateNodeStatuses();
     });
+  }
+
+  private populateNodeIdToIsVisited(events: any[]): void {
+    events
+      .filter((event) => event.event === 'nodeEntered')
+      .forEach((event) => this.setNodeIsVisited(event.nodeId));
+  }
+
+  setNodeIsVisited(nodeId: string): void {
+    this.nodeIdToIsVisited[nodeId] = true;
   }
 
   canVisitNode(nodeId: string): boolean {
@@ -84,7 +100,7 @@ export class NodeStatusService {
     nodeStatus.isVisitable = constraintResults.isVisitable;
     this.setNotVisibleIfRequired(nodeId, constraintsForNode, nodeStatus);
     nodeStatus.isCompleted = this.completionService.isCompleted(nodeId);
-    nodeStatus.isVisited = this.dataService.isNodeVisited(nodeId);
+    nodeStatus.isVisited = this.nodeIdToIsVisited[nodeId] == true;
     return nodeStatus;
   }
 

--- a/src/assets/wise5/services/studentDataService.ts
+++ b/src/assets/wise5/services/studentDataService.ts
@@ -22,7 +22,6 @@ export class StudentDataService extends DataService {
     events: [],
     annotations: []
   };
-  visitedNodesHistory = [];
 
   private nodeClickLockedSource: Subject<any> = new Subject<any>();
   public nodeClickLocked$: Observable<any> = this.nodeClickLockedSource.asObservable();
@@ -36,6 +35,8 @@ export class StudentDataService extends DataService {
   public componentSubmitTriggered$: Observable<any> = this.componentSubmitTriggeredSource.asObservable();
   private componentStudentDataSource: Subject<any> = new Subject<any>();
   public componentStudentData$: Observable<any> = this.componentStudentDataSource.asObservable();
+  private dataRetrievedSource: Subject<any> = new Subject<any>();
+  public dataRetrieved$: Observable<any> = this.dataRetrievedSource.asObservable();
   private studentWorkSavedToServerSource: Subject<any> = new Subject<any>();
   public studentWorkSavedToServer$: Observable<any> = this.studentWorkSavedToServerSource.asObservable();
   private navItemIsExpandedSource: Subject<any> = new Subject<any>();
@@ -76,8 +77,7 @@ export class StudentDataService extends DataService {
       userId: '0'
     };
     this.AnnotationService.setAnnotations(this.studentData.annotations);
-    this.populateHistories(this.studentData.events);
-    this.updateNodeStatuses();
+    this.dataRetrievedSource.next(this.studentData);
   }
 
   updateNodeStatuses(): void {
@@ -121,7 +121,7 @@ export class StudentDataService extends DataService {
     this.studentData.annotations = resultData.annotations;
     this.AnnotationService.setAnnotations(this.studentData.annotations);
     this.populateHistories(this.studentData.events);
-    this.updateNodeStatuses();
+    this.dataRetrievedSource.next(this.studentData);
     return this.studentData;
   }
 
@@ -199,11 +199,9 @@ export class StudentDataService extends DataService {
 
   populateHistories(events) {
     this.stackHistory = [];
-    this.visitedNodesHistory = [];
     for (const event of events) {
       if (event.event === 'nodeEntered') {
         this.updateStackHistory(event.nodeId);
-        this.updateVisitedNodesHistory(event.nodeId);
       }
     }
   }
@@ -229,23 +227,6 @@ export class StudentDataService extends DataService {
     } else {
       this.stackHistory.splice(indexOfNodeId + 1, this.stackHistory.length);
     }
-  }
-
-  updateVisitedNodesHistory(nodeId) {
-    const indexOfNodeId = this.visitedNodesHistory.indexOf(nodeId);
-    if (indexOfNodeId === -1) {
-      this.visitedNodesHistory.push(nodeId);
-    }
-  }
-
-  getVisitedNodesHistory() {
-    return this.visitedNodesHistory;
-  }
-
-  isNodeVisited(nodeId) {
-    const visitedNodesHistory = this.visitedNodesHistory;
-    const indexOfNodeId = visitedNodesHistory.indexOf(nodeId);
-    return indexOfNodeId !== -1;
   }
 
   createComponentState() {

--- a/src/assets/wise5/vle/vle.component.ts
+++ b/src/assets/wise5/vle/vle.component.ts
@@ -13,6 +13,7 @@ import { AnnotationService } from '../services/annotationService';
 import { ActivatedRoute, Router } from '@angular/router';
 import { WiseLinkService } from '../../../app/services/wiseLinkService';
 import { convertToPNGFile } from '../common/canvas/canvas';
+import { NodeStatusService } from '../services/nodeStatusService';
 
 @Component({
   selector: 'vle',
@@ -42,6 +43,7 @@ export class VLEComponent implements AfterViewInit {
     private configService: ConfigService,
     private dialog: MatDialog,
     private initializeVLEService: InitializeVLEService,
+    private nodeStatusService: NodeStatusService,
     private notebookService: NotebookService,
     private notificationService: NotificationService,
     private projectService: VLEProjectService,
@@ -164,7 +166,7 @@ export class VLEComponent implements AfterViewInit {
         let currentNodeId = this.currentNode.id;
 
         this.studentDataService.updateStackHistory(currentNodeId);
-        this.studentDataService.updateVisitedNodesHistory(currentNodeId);
+        this.nodeStatusService.setNodeIsVisited(currentNodeId);
 
         let componentId, componentType, category, eventName, eventData, eventNodeId;
         if (previousNode != null && this.projectService.isGroupNode(previousNode.id)) {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10181,7 +10181,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">144</context>
+          <context context-type="linenumber">146</context>
         </context-group>
       </trans-unit>
       <trans-unit id="537022937435161177" datatype="html">
@@ -10192,7 +10192,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">145</context>
+          <context context-type="linenumber">147</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3023661788238273336" datatype="html">
@@ -18685,28 +18685,28 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Preview Student</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">75</context>
+          <context context-type="linenumber">76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1967824796880640028" datatype="html">
         <source>StudentDataService.saveComponentEvent: component, category, event args must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">272</context>
+          <context context-type="linenumber">253</context>
         </context-group>
       </trans-unit>
       <trans-unit id="944638387659785956" datatype="html">
         <source>StudentDataService.saveComponentEvent: nodeId, componentId, componentType must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">282</context>
+          <context context-type="linenumber">263</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4924640921903672943" datatype="html">
         <source>StudentDataService.saveVLEEvent: category and event args must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">291</context>
+          <context context-type="linenumber">272</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8725215606116054825" datatype="html">


### PR DESCRIPTION
## Changes
- Move StudentDataService.visitedNodesHistory to NodeStatusService.nodeIdToIsVisited and convert it from an array into a map of [nodeId, isVisited] values, which is populated/updated when
   - The student data is retrieved (for student and preview) when the VLE launches
   - Student visits a node

## Test
- IsVisited values in NodeStatuses are calculated and saved as before. Check the StudentStatus that is saved each time you visit a step and verify that on the steps that you've visited has isVisited set to true.

Closes #1169