### PR TITLE
fix(Graph): Multiple regression lines

### DIFF
--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.spec.ts
@@ -1887,7 +1887,8 @@ function setYAxisLabelsWhenMultipleYAxes() {
       }
     ];
     const studentData = {
-      dataExplorerYAxisLabels: ['Count', 'Price']
+      dataExplorerYAxisLabels: ['Count', 'Price'],
+      dataExplorerSeries: [{ yAxis: 0 }, { yAxis: 1 }]
     };
     component.setYAxisLabels(studentData);
     expect(component.yAxis[0].title.text).toEqual('Count');

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -417,8 +417,9 @@ export class GraphStudent extends ComponentStudent {
     } else if (studentData.dataExplorerYAxisLabels != null) {
       for (let [index, yAxis] of Object.entries(this.yAxis)) {
         (yAxis as any).title.text = studentData.dataExplorerYAxisLabels[index];
-        (yAxis as any).title.style.color = this.dataExplorerColors[index];
-        (yAxis as any).labels.style.color = this.dataExplorerColors[index];
+        const yAxisIndex = studentData.dataExplorerSeries[index].yAxis;
+        (yAxis as any).title.style.color = this.dataExplorerColors[yAxisIndex];
+        (yAxis as any).labels.style.color = this.dataExplorerColors[yAxisIndex];
       }
     }
   }

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -337,6 +337,7 @@ export class GraphStudent extends ComponentStudent {
     this.setYAxisLabels(studentData);
     this.setXAxisLabels(studentData);
 
+    const allRegressionSeries = [];
     for (let seriesIndex = 0; seriesIndex < dataExplorerSeries.length; seriesIndex++) {
       const xColumn = dataExplorerSeries[seriesIndex].xColumn;
       const yColumn = dataExplorerSeries[seriesIndex].yColumn;
@@ -359,15 +360,23 @@ export class GraphStudent extends ComponentStudent {
         }
         this.activeTrial.series.push(series);
         if (graphType === 'scatter' && studentData.isDataExplorerScatterPlotRegressionLineEnabled) {
-          const regressionSeries = this.generateDataExplorerRegressionSeries(
+          const singleRegressionSeries = this.generateDataExplorerRegressionSeries(
             studentData.tableData,
             xColumn,
             yColumn,
-            color
+            color,
+            yAxis
           );
-          this.activeTrial.series.push(regressionSeries);
+          allRegressionSeries.push(singleRegressionSeries);
         }
       }
+    }
+
+    // Add all the regression series after all the data series so that all the data series are
+    // located at the expected index within the active trial. We need to do this because we expect
+    // the series index to match up with the axis index like in GraphService.getAxisTitle().
+    for (const singleRegressionSeries of allRegressionSeries) {
+      this.activeTrial.series.push(singleRegressionSeries);
     }
   }
 
@@ -494,13 +503,21 @@ export class GraphStudent extends ComponentStudent {
     return series;
   }
 
-  generateDataExplorerRegressionSeries(tableData, xColumn, yColumn, color) {
+  private generateDataExplorerRegressionSeries(
+    tableData: any[],
+    xColumn: number,
+    yColumn: number,
+    color: string,
+    yAxis: number
+  ): any {
     const regressionLineData = this.calculateRegressionLineData(tableData, xColumn, yColumn);
     return {
       type: 'line',
       name: 'Regression Line',
       color: color,
-      data: regressionLineData
+      data: regressionLineData,
+      yAxis: yAxis,
+      enableMouseTracking: false
     };
   }
 

--- a/src/assets/wise5/components/graph/graphService.ts
+++ b/src/assets/wise5/components/graph/graphService.ts
@@ -412,10 +412,13 @@ export class GraphService extends ComponentService {
 
   getAxisTitle(series: any, axisObj: any): string {
     if (Array.isArray(axisObj)) {
-      if (axisObj[series.index].title.text == null || axisObj[series.index].title.text === '') {
-        return series.name;
-      } else {
-        return axisObj[series.index].title.text;
+      const axisIndex = series.options.yAxis == null ? series.index : series.options.yAxis;
+      if (axisObj[axisIndex] != null) {
+        if (axisObj[axisIndex].title.text == null || axisObj[axisIndex].title.text === '') {
+          return series.name;
+        } else {
+          return axisObj[axisIndex].title.text;
+        }
       }
     } else if (axisObj.title.text == null || axisObj.title.text === '') {
       return series.name;


### PR DESCRIPTION
## Changes

- Multiple regression lines now use the correct Y axis
- Fixed data point tooltips not showing up when the number of series is greater than the number of Y axes
- Fixed series color not matching Y axis color when Series 1 is set to be on Y Axis 2 and Series 2 is set to be on Y Axis 1
- You can no longer mouse over the regression lines so they no longer get in the way of mousing over data points

## Test

- Make sure all regression lines work properly when the Data Explorer is set to have multiple series and multiple Y Axes. Make sure to set a matching number of Y Axes in the connected Graph component.
- If you have 3 series and 2 Y axes, make sure the tooltips for the data points in the 3rd series work. They used to not show up on mouse over.
- If you set 2 series and 2 Y Axes and set Series 1 to be on Y Axis 2 and Series 2 to be on Y Axis 1, the series colors should match the Y axis colors and label. They used to not match.
- Make sure that when you mouse over a data point that is very close to a regression line, that you can still see the data point tooltip. Previously the regression line would block mousing over data points.
- Make sure regular graph with trials and multiple series have tooltips and colors that still work like before

Closes #1123