### PR TITLE
fix(Node Completion): Look at NodeStatuses to determine completion

### DIFF
--- a/src/app/services/completionService.spec.ts
+++ b/src/app/services/completionService.spec.ts
@@ -11,18 +11,11 @@ let dataService: StudentDataService;
 let projectService: ProjectService;
 let service: CompletionService;
 const component1 = { id: 'component1', type: 'OpenResponse' } as ComponentContent;
-const component2 = { id: 'component2', type: 'OpenResponse' } as ComponentContent;
-const components = [component1, component2] as ComponentContent[];
 const node1 = { id: 'node1' };
 const stateForComponent1 = {
   nodeId: 'node1',
   componentId: 'component1',
   studentData: { response: 'Hello World 1' }
-};
-const stateForComponent2 = {
-  nodeId: 'node1',
-  componentId: 'component2',
-  studentData: { response: 'Hello World 2' }
 };
 describe('CompletionService', () => {
   beforeEach(() => {
@@ -66,15 +59,15 @@ function isCompleted_Step() {
     beforeEach(() => {
       spyOn(projectService, 'isGroupNode').and.returnValue(false);
       spyOn(projectService, 'getNodeById').and.returnValue(node1);
-      spyOn(projectService, 'getComponents').and.returnValue(components);
     });
-    it('should return false when not all components are completed', () => {
-      dataService.studentData.componentStates = [stateForComponent1];
-      expect(service.isCompleted('node1')).toEqual(false);
-    });
-    it('should return true when all the components in the step are completed', () => {
-      dataService.studentData.componentStates = [stateForComponent1, stateForComponent2];
+    it('should return true when isCompleted is set to true in NodeStatuses', () => {
+      dataService.nodeStatuses = { node1: { isCompleted: true } };
       expect(service.isCompleted('node1')).toEqual(true);
+    });
+    it('should return false when isCompleted is not set or is set to false in NodeStatuses', () => {
+      dataService.nodeStatuses = { node1: { isCompleted: false } };
+      expect(service.isCompleted('node1')).toEqual(false);
+      expect(service.isCompleted('node2')).toBeFalsy();
     });
   });
 }

--- a/src/assets/wise5/services/completionService.ts
+++ b/src/assets/wise5/services/completionService.ts
@@ -24,7 +24,7 @@ export class CompletionService {
     } else if (this.projectService.isGroupNode(nodeId)) {
       result = this.isGroupNodeCompleted(nodeId);
     } else if (this.projectService.isApplicationNode(nodeId)) {
-      result = this.dataService.nodeStatuses[nodeId].isCompleted;
+      result = this.dataService.nodeStatuses[nodeId]?.isCompleted;
     }
     return result;
   }

--- a/src/assets/wise5/services/completionService.ts
+++ b/src/assets/wise5/services/completionService.ts
@@ -24,7 +24,7 @@ export class CompletionService {
     } else if (this.projectService.isGroupNode(nodeId)) {
       result = this.isGroupNodeCompleted(nodeId);
     } else if (this.projectService.isApplicationNode(nodeId)) {
-      result = this.isStepNodeCompleted(nodeId);
+      result = this.dataService.nodeStatuses[nodeId].isCompleted;
     }
     return result;
   }
@@ -47,12 +47,6 @@ export class CompletionService {
       }
     }
     return false;
-  }
-
-  private isStepNodeCompleted(nodeId: string): boolean {
-    return this.projectService
-      .getComponents(nodeId)
-      .every((component) => this.isComponentCompleted(nodeId, component.id));
   }
 
   private isGroupNodeCompleted(nodeId: string): boolean {


### PR DESCRIPTION
## Changes
- Look at NodeStatutes to determine a node's completion, instead of calculating all of its children components' completion.
- This fixes the issue where a node with invisible components were not deemed completed because it was calculating all of its components.

## Test
- Import this unit and verify that the completion constraints unlock properly: [515.zip](https://github.com/WISE-Community/WISE-Client/files/11203578/515.zip). This unit contains two types completion constraints that depend on completion of node with invisible components
- Completion works as before in other cases (unit without invisible components, unit with branches, etc)
- Test existing units in student and teacher modes to make sure that they work as before