### PR TITLE
fix(VLE): Step save and submit buttons not working sometimes

### DIFF
--- a/src/assets/wise5/vle/node/node.component.ts
+++ b/src/assets/wise5/vle/node/node.component.ts
@@ -144,6 +144,8 @@ export class NodeComponent implements OnInit {
     this.nodeContent = this.projectService.getNodeById(this.nodeId);
     this.nodeStatus = this.nodeStatusService.getNodeStatusByNodeId(this.nodeId);
     this.components = this.getComponents();
+    this.dirtyComponentIds = [];
+    this.dirtySubmitComponentIds = [];
 
     if (
       this.nodeService.currentNodeHasTransitionLogic() &&


### PR DESCRIPTION
## Changes

Clear out dirtyComponentIds and dirtySubmitComponentIds when moving to a new step. Note that a new NodeComponent does not get rendered when moving to a new step. The existing one is re-used.

## Test

1. Create two steps that each have one Open Response component
2. For both steps make sure the Open Response save and submit buttons are not enabled and the step save and submit buttons are enabled
3. Preview the first Open Response step
4. Enter some text into the Open Response but do not click the Save button
8. Go to the next Open Response step
9. Enter some text into the Open Response and click the Save button. The Save button used to not grey out and not save the student work but now it should.
10. Try the same process with the submit button and it should work properly now too.

Closes #1177