### PR TITLE
fix(VLE): Step auto save message appears when it shouldn't sometimes

### DIFF
--- a/src/assets/wise5/vle/node/node.component.ts
+++ b/src/assets/wise5/vle/node/node.component.ts
@@ -308,7 +308,10 @@ export class NodeComponent implements OnInit {
             }
             const studentWorkList = savedStudentDataResponse.studentWorkList;
             if (!componentId && studentWorkList && studentWorkList.length) {
-              this.latestComponentState = studentWorkList[studentWorkList.length - 1];
+              const latestComponentState = studentWorkList[studentWorkList.length - 1];
+              if (latestComponentState.nodeId === this.node.id) {
+                this.latestComponentState = latestComponentState;
+              }
             } else {
               this.clearLatestComponentState();
             }


### PR DESCRIPTION
## Changes

Check that the student data in the save to server response is for the step we are currently on in order to determine whether to use the latestComponentState or not which determines whether we show the save message. What was happening was that if you had unsaved work on one step and moved to the next step, that student data would be saved to the server and by the time the saveToServer response was received, you would be on the next step which is different from the one that the student data was from.

## Test

1. Create two steps that each have one Open Response component
2. For both steps make sure the Open Response save and submit buttons are not enabled and the step save button is enabled
3. Preview the first Open Response step
4. Enter some text into the Open Response but do not click the Save button
5. Go to the next Open Response step
6. Next to the step Save button you shouldn't see any message. Previously you would see the "Auto Saved" message.

Closes #1180