### PR TITLE
fix(WISE Link): Author into component rubric does not work

### DIFF
--- a/src/assets/wise5/directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component.ts
+++ b/src/assets/wise5/directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component.ts
@@ -94,7 +94,8 @@ export class WiseAuthoringTinymceEditorComponent extends WiseTinymceEditorCompon
       controllerAs: '$ctrl',
       $stateParams: stateParams,
       clickOutsideToClose: true,
-      escapeToClose: true
+      escapeToClose: true,
+      multiple: true
     });
   }
 


### PR DESCRIPTION
## Changes

WISE Link authoring dialog does not close existing dialogs.

## Test

1. Open a project in the Authoring Tool
2. Go into a step
3. Go into the advanced view for a component
4. Click the "Edit Component Rubric" button to show the rubric editor
5. Click the "Insert WISE Link" button
6. Choose a step for the WISE Link
7. Click "Create"
8. The WISE Link should be added to the rubric. Previously it would not be added to the rubric because the advanced view dialog would have already been closed.
