### PR TITLE
fix(WISE links): Do not work in certain locations

### DIFF
--- a/src/app/authoring-tool/edit-component-rubric/edit-component-rubric.component.ts
+++ b/src/app/authoring-tool/edit-component-rubric/edit-component-rubric.component.ts
@@ -1,6 +1,10 @@
 import { Component, Input } from '@angular/core';
 import { ConfigService } from '../../../assets/wise5/services/configService';
 import { TeacherProjectService } from '../../../assets/wise5/services/teacherProjectService';
+import {
+  insertWiseLinks,
+  replaceWiseLinks
+} from '../../../assets/wise5/common/wise-link/wise-link';
 
 @Component({
   selector: 'edit-component-rubric',
@@ -25,12 +29,14 @@ export class EditComponentRubricComponent {
     if (componentContent.rubric == null) {
       this.rubric = '';
     } else {
-      this.rubric = componentContent.rubric;
+      this.rubric = replaceWiseLinks(componentContent.rubric);
     }
   }
 
   rubricChanged(): void {
-    this.componentContent.rubric = this.ConfigService.removeAbsoluteAssetPaths(this.rubric);
+    this.componentContent.rubric = this.ConfigService.removeAbsoluteAssetPaths(
+      insertWiseLinks(this.rubric)
+    );
     this.ProjectService.componentChanged();
   }
 }

--- a/src/app/notebook/notebook-report/notebook-report.component.ts
+++ b/src/app/notebook/notebook-report/notebook-report.component.ts
@@ -6,6 +6,10 @@ import { ConfigService } from '../../../assets/wise5/services/configService';
 import { NotebookService } from '../../../assets/wise5/services/notebookService';
 import { ProjectService } from '../../../assets/wise5/services/projectService';
 import { NotebookParentComponent } from '../notebook-parent/notebook-parent.component';
+import {
+  insertWiseLinks,
+  replaceWiseLinks
+} from '../../../assets/wise5/common/wise-link/wise-link';
 
 @Component({
   selector: 'notebook-report',
@@ -51,7 +55,9 @@ export class NotebookReportComponent extends NotebookParentComponent {
     if (this.mode !== 'classroomMonitor') {
       this.reportItem.id = null; // set the id to null so it can be inserted as initial version, as opposed to updated. this is true for both new and just-loaded reports.
     }
-    this.reportItemContent = this.ProjectService.injectAssetPaths(this.reportItem.content.content);
+    this.reportItemContent = this.ProjectService.injectAssetPaths(
+      replaceWiseLinks(this.reportItem.content.content)
+    );
     this.latestAnnotations = this.AnnotationService.getLatestNotebookItemAnnotations(
       this.workgroupId,
       this.reportId
@@ -160,7 +166,9 @@ export class NotebookReportComponent extends NotebookParentComponent {
 
   changed(value: string): void {
     this.dirty = true;
-    this.reportItem.content.content = this.ConfigService.removeAbsoluteAssetPaths(value);
+    this.reportItem.content.content = this.ConfigService.removeAbsoluteAssetPaths(
+      insertWiseLinks(value)
+    );
     this.clearSaveTime();
   }
 

--- a/src/assets/wise5/authoringTool/node/editRubric/edit-rubric.component.ts
+++ b/src/assets/wise5/authoringTool/node/editRubric/edit-rubric.component.ts
@@ -1,4 +1,4 @@
-import { insertWiseLinks } from '../../../common/wise-link/wise-link';
+import { insertWiseLinks, replaceWiseLinks } from '../../../common/wise-link/wise-link';
 import { ConfigService } from '../../../services/configService';
 import { TeacherDataService } from '../../../services/teacherDataService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
@@ -26,7 +26,7 @@ class EditRubricComponentController {
   $onInit(): void {
     this.nodeId = this.TeacherDataService.getCurrentNodeId();
     this.node = this.TeacherProjectService.getNodeById(this.nodeId);
-    this.rubric = this.TeacherProjectService.replaceAssetPaths(this.node.rubric);
+    this.rubric = this.TeacherProjectService.replaceAssetPaths(replaceWiseLinks(this.node.rubric));
   }
 
   rubricChanged(): void {

--- a/src/assets/wise5/components/component/component.component.ts
+++ b/src/assets/wise5/components/component/component.component.ts
@@ -42,7 +42,7 @@ export class ComponentComponent {
     }
     this.setComponent();
     if (this.configService.isPreview()) {
-      this.rubric = this.projectService.replaceAssetPaths(this.component.content.rubric);
+      this.rubric = this.component.content.rubric;
       this.showRubric = this.rubric != null && this.rubric != '';
     }
   }

--- a/src/assets/wise5/directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component.ts
+++ b/src/assets/wise5/directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component.ts
@@ -94,7 +94,8 @@ export class WiseAuthoringTinymceEditorComponent extends WiseTinymceEditorCompon
       controllerAs: '$ctrl',
       $stateParams: stateParams,
       clickOutsideToClose: true,
-      escapeToClose: true
+      escapeToClose: true,
+      multiple: true
     });
   }
 

--- a/src/assets/wise5/themes/default/themeComponents/helpIcon/help-icon.component.ts
+++ b/src/assets/wise5/themes/default/themeComponents/helpIcon/help-icon.component.ts
@@ -3,6 +3,8 @@
 import { Component, Input } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { DialogWithCloseComponent } from '../../../../directives/dialog-with-close/dialog-with-close.component';
+import { WiseLinkService } from '../../../../../../app/services/wiseLinkService';
+import { VLEProjectService } from '../../../../vle/vleProjectService';
 
 @Component({
   selector: 'help-icon',
@@ -16,12 +18,18 @@ export class HelpIconComponent {
   @Input() label: string;
   pulse: boolean = true;
 
-  constructor(public dialog: MatDialog) {}
+  constructor(
+    public dialog: MatDialog,
+    private projectService: VLEProjectService,
+    private wiseLinkService: WiseLinkService
+  ) {}
 
   showRubric() {
     this.dialog.open(DialogWithCloseComponent, {
       data: {
-        content: this.content,
+        content: this.wiseLinkService.generateHtmlWithWiseLink(
+          this.projectService.replaceAssetPaths(this.content)
+        ),
         title: $localize`Rubric`,
         scroll: true
       },

--- a/src/assets/wise5/vle/node/node.component.ts
+++ b/src/assets/wise5/vle/node/node.component.ts
@@ -182,7 +182,7 @@ export class NodeComponent implements OnInit {
     );
 
     if (this.configService.isPreview()) {
-      this.rubric = this.projectService.replaceAssetPaths(this.node.rubric);
+      this.rubric = this.node.rubric;
       this.showRubric = this.rubric != null && this.rubric != '';
     }
 


### PR DESCRIPTION
## Changes

- Re-populating WISE Links in the rubric authoring now works. Before if you went back to re-edit rubric content that contained a WISE Link, it would break the WISE Link.
- WISE Links now work in the step rubric
- WISE Links now work in the component rubric
- WISE Links now show up in the student and teacher reports

## Test

- Make sure authoring WISE Links work in the HTML component, step rubric, component rubric, and student and teacher reports. Try adding a WISE Link and then refreshing to make sure the authoring re-populates the WISE Link without breaking it.
- Make sure WISE Links work when you preview the VLE. Particularly in the HTML component, step rubric, and component rubric.
- Make sure WISE Links show up in the student and teacher reports. If you click on them they don't actually do anything but before they wouldn't even show up in the report at all.

Closes #1186
Closes #1007