### PR TITLE
fix(VLE): Error when project script is set to empty string

### DIFF
--- a/src/assets/wise5/vle/vle.component.ts
+++ b/src/assets/wise5/vle/vle.component.ts
@@ -78,7 +78,7 @@ export class VLEComponent implements AfterViewInit {
 
     this.runEndedAndLocked = this.configService.isEndedAndLocked();
     let script = this.projectService.getProjectScript();
-    if (script != null) {
+    if (script != null && script !== '') {
       this.projectService.retrieveScript(script).then((script: string) => {
         new Function(script).call(this);
       });


### PR DESCRIPTION
## Changes

Check if script is empty string before making request for the script.

## Test

1. In the project JSON authoring, add script: "" in the root of the project.json
2. Preview the project and you should not see this error in the console
```
ROR Error: Uncaught (in promise): HttpErrorResponse:
{
	"headers": {
		"normalizedNames": {},
		"lazyUpdate": null
	},
	"status": 404,
	"statusText": "OK",
	"url": "http://localhost:81/curriculum/68/assets/",
	"ok": false,
	"name": "HttpErrorResponse",
	"message": "Http failure response for http://localhost:81/curriculum/68/assets/: 404 OK",
	"error": {
		"timestamp": "2023-04-20T21:25:22.329+00:00",
		"status": 404,
		"error": "Not Found",
		"message": "No message available",
		"path": "/curriculum/68/assets/"
	}
}
```

Closes #1196 