### PR TITLE
fix(Authoring): Allow moving lesson to become the first lesson

### DIFF
--- a/src/assets/wise5/authoringTool/project/projectAuthoring.html
+++ b/src/assets/wise5/authoringTool/project/projectAuthoring.html
@@ -10,7 +10,7 @@
         <concurrent-authors-message
           [authors]="$ctrl.authors"
           class="center app-background"
-          style="position: sticky; top: 1px; padding: 4px 0; display: block; z-index: 3;"
+          style="position: sticky; top: 1px; padding: 4px 0; display: block; z-index: 3"
         ></concurrent-authors-message>
         <style>
           #commitDiv {
@@ -250,6 +250,18 @@
             </div>
           </div>
           <div style="margin-top: 20px; margin-left: 20px">
+            <div ng-if="$ctrl.insertGroupMode">
+              <md-button
+                class="insertButton md-raised md-primary"
+                style="height: 40px"
+                ng-click="$ctrl.insertInside('group0')"
+              >
+                <md-icon>keyboard_backspace</md-icon>
+                <md-tooltip md-direction="top" class="projectButtonTooltip"
+                  >{{ ::'insertAsFirstActivity' | translate }}</md-tooltip
+                >
+              </md-button>
+            </div>
             <div ng-repeat='item in $ctrl.items | toArray | orderBy : "order"'></div>
             <div
               ng-repeat='item in $ctrl.items | toArray | orderBy : "order"'

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -63,6 +63,9 @@ export class TeacherProjectService extends ProjectService {
               fontSet: 'material-icons',
               fontName: 'info'
             }
+          },
+          transitionLogic: {
+            transitions: []
           }
         },
         {


### PR DESCRIPTION
## Changes

When moving a lesson, you can now insert it as the first lesson.

## Test

1. Move all the lessons to the "Unused Lesson" section
2. Move a lesson from the "Unused Lesson" section to the active section
3. Move a lesson in the active section to become the first lesson in the active section

Closes #1109