### PR TITLE
feat(Constraint Removal Authoring): Filter MC components 

### DIFF
--- a/src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.html
+++ b/src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.html
@@ -59,15 +59,15 @@
         <mat-option [value]="''">
           <span class="red" i18n>Please Choose a Component</span>
         </mat-option>
-        <mat-option
-          *ngFor="let component of getComponents(criteria.params.nodeId)"
-          [value]="component.id"
+        <ng-container
+          *ngFor="let component of getComponents(criteria.params.nodeId); index as componentIndex"
         >
-          <span i18n
-            >{{ getComponentIndex(component) + 1 }}. {{ component.type }} (Prompt:
-            {{ component.prompt }})</span
-          >
-        </mat-option>
+          <mat-option *ngIf="componentIdToIsSelectable[component.id]" [value]="component.id">
+            <span i18n
+              >{{ componentIndex + 1 }}. {{ component.type }} (Prompt: {{ component.prompt }})</span
+            >
+          </mat-option>
+        </ng-container>
       </mat-select>
     </mat-form-field>
     <required-error-label *ngIf="criteria.params.componentId === ''"> </required-error-label>

--- a/src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.html
+++ b/src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.html
@@ -60,11 +60,12 @@
           <span class="red" i18n>Please Choose a Component</span>
         </mat-option>
         <mat-option
-          *ngFor="let component of getComponents(criteria.params.nodeId); index as componentIndex"
+          *ngFor="let component of getComponents(criteria.params.nodeId)"
           [value]="component.id"
         >
           <span i18n
-            >{{ componentIndex + 1 }}. {{ component.type }} (Prompt: {{ component.prompt }})</span
+            >{{ getComponentIndex(component) + 1 }}. {{ component.type }} (Prompt:
+            {{ component.prompt }})</span
           >
         </mat-option>
       </mat-select>

--- a/src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.spec.ts
+++ b/src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.spec.ts
@@ -42,18 +42,16 @@ describe('EditConstraintRemovalCriteriaComponent', () => {
   });
 
   beforeEach(() => {
-    removalCriteria = [
-      {
-        name: '',
-        params: {}
-      }
-    ];
+    removalCriteria = {
+      name: '',
+      params: {}
+    };
     component.criteria = removalCriteria;
     component.constraint = new Constraint({
       id: 'node1Constraint1',
       action: '',
       removalConditional: 'any',
-      removalCriteria: removalCriteria
+      removalCriteria: [removalCriteria]
     });
     component.node = { id: 'node1' };
     fixture.detectChanges();

--- a/src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts
+++ b/src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts
@@ -81,7 +81,19 @@ export class EditConstraintRemovalCriteriaComponent implements OnInit {
   constructor(private projectService: TeacherProjectService) {}
 
   ngOnInit(): void {
-    this.nodeIds = this.projectService.getFlattenedProjectAsNodeIds(true);
+    this.setNodeIds();
+  }
+
+  private setNodeIds(): void {
+    const allNodeIds = this.projectService.getFlattenedProjectAsNodeIds(true);
+    this.nodeIds =
+      this.criteria.name === 'choiceChosen'
+        ? allNodeIds.filter((nodeId) =>
+            this.projectService
+              .getNode(nodeId)
+              .components.some((component) => component.type === 'MultipleChoice')
+          )
+        : allNodeIds;
   }
 
   deleteRemovalCriteria(): void {
@@ -102,6 +114,7 @@ export class EditConstraintRemovalCriteriaComponent implements OnInit {
         criteria.params[value] = this.node.id;
       }
     }
+    this.setNodeIds();
     this.saveProject();
   }
 
@@ -128,7 +141,14 @@ export class EditConstraintRemovalCriteriaComponent implements OnInit {
   }
 
   protected getComponents(nodeId: string): ComponentContent[] {
-    return this.projectService.getComponents(nodeId);
+    const components = this.projectService.getComponents(nodeId);
+    return this.criteria.name === 'choiceChosen'
+      ? components.filter((component) => component.type === 'MultipleChoice')
+      : components;
+  }
+
+  protected getComponentIndex(component: ComponentContent): number {
+    return this.projectService.getComponents(this.criteria.params.nodeId).indexOf(component);
   }
 
   protected scoresChanged(value: any, params: any): void {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9002,47 +9002,47 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">60</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="ea0a55a0d4f9d7cf400f299699b5e5f286d69f99" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="{{ componentIndex + 1 }}"/>. <x id="INTERPOLATION_1" equiv-text="{{ component.type }}"/> (Prompt: <x id="INTERPOLATION_2" equiv-text="{{ component.prompt }}"/>)</source>
+      <trans-unit id="e1c728c0a367a6e9a8f7b1c38ce7e38e50c8b192" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="{{ getComponentIndex(component) + 1 }}"/>. <x id="INTERPOLATION_1" equiv-text="{{ component.type }}"/> (Prompt: <x id="INTERPOLATION_2" equiv-text="{{ component.prompt }}"/>)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.html</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">67,68</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2429c94849bccc2d8286fdecef990de25fabb867" datatype="html">
         <source>Please Select a From Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.html</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="20cee39940010d8e8bd5c2bf5871a1e6bf445356" datatype="html">
         <source>Please Select a To Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.html</context>
-          <context context-type="linenumber">106</context>
+          <context context-type="linenumber">107</context>
         </context-group>
       </trans-unit>
       <trans-unit id="337685d80c312b75cbb9b507173f51f559c7f4ae" datatype="html">
         <source>Please Select a Choice</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.html</context>
-          <context context-type="linenumber">177</context>
+          <context context-type="linenumber">178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="331a731f82078e496dfeddc5399c38bd40f7ffaa" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{ param.text }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.html</context>
-          <context context-type="linenumber">222</context>
+          <context context-type="linenumber">223</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.html</context>
-          <context context-type="linenumber">245</context>
+          <context context-type="linenumber">246</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.html</context>
-          <context context-type="linenumber">268</context>
+          <context context-type="linenumber">269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5847302460276630595" datatype="html">
@@ -9255,7 +9255,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete this removal criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">88</context>
+          <context context-type="linenumber">100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8564983557318479146" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9002,11 +9002,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">60</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="e1c728c0a367a6e9a8f7b1c38ce7e38e50c8b192" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="{{ getComponentIndex(component) + 1 }}"/>. <x id="INTERPOLATION_1" equiv-text="{{ component.type }}"/> (Prompt: <x id="INTERPOLATION_2" equiv-text="{{ component.prompt }}"/>)</source>
+      <trans-unit id="ea0a55a0d4f9d7cf400f299699b5e5f286d69f99" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="{{ componentIndex + 1 }}"/>. <x id="INTERPOLATION_1" equiv-text="{{ component.type }}"/> (Prompt: <x id="INTERPOLATION_2" equiv-text="{{ component.prompt }}"/>)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.html</context>
-          <context context-type="linenumber">67,68</context>
+          <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2429c94849bccc2d8286fdecef990de25fabb867" datatype="html">
@@ -9049,7 +9049,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">21</context>
+          <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8980375993935541237" datatype="html">
@@ -9255,7 +9255,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete this removal criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">100</context>
+          <context context-type="linenumber">101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8564983557318479146" datatype="html">


### PR DESCRIPTION
## Changes
- Only show MC steps and components as available options if author choses the "Choice Chosen" removal criteria

## Test
- In constraint removal authoring (for both node and component)
   - if you choose "Choice chosen" for Removal Criteria Name, it should only show steps that contain MC components, and components that are MC.
   - if you choose any other option for Removal Criteria Name, it should show all steps and components like before

Closes #1147