### PR TITLE
refactor(UtilService): Move calculateMean()

### DIFF
--- a/src/app/services/utilService.spec.ts
+++ b/src/app/services/utilService.spec.ts
@@ -9,19 +9,4 @@ describe('UtilService', () => {
     });
     service = TestBed.inject(UtilService);
   });
-  calculateMeanTests();
 });
-
-function calculateMeanTests() {
-  describe('calculateMean()', () => {
-    it('should calculate the mean when there is one value', () => {
-      const values = [1];
-      expect(service.calculateMean(values)).toEqual(1);
-    });
-
-    it('should calculate the mean when there are multiple values', () => {
-      const values = [1, 2, 3, 4, 10];
-      expect(service.calculateMean(values)).toEqual(4);
-    });
-  });
-}

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -22,6 +22,7 @@ import { arraysContainSameValues } from '../../../common/array/array';
 import { generateRandomKey } from '../../../common/string/string';
 import { GraphCustomLegend } from '../GraphCustomLegend';
 import { showXPlotLine, showYPlotLine } from '../graph-plot-line';
+import { calculateMean } from '../util';
 
 const Draggable = require('highcharts/modules/draggable-points.js');
 Draggable(Highcharts);
@@ -529,8 +530,8 @@ export class GraphStudent extends ComponentStudent {
     const covarianceMatrix = covariance(xValues, yValues);
     const covarianceXY = covarianceMatrix[0][1];
     const varianceX = covarianceMatrix[0][0];
-    const meanY = this.calculateMean(yValues);
-    const meanX = this.calculateMean(xValues);
+    const meanY = calculateMean(yValues);
+    const meanX = calculateMean(xValues);
     const slope = covarianceXY / varianceX;
     const intercept = meanY - slope * meanX;
     let firstX = Math.min(...xValues);
@@ -549,10 +550,6 @@ export class GraphStudent extends ComponentStudent {
       [firstX, firstY],
       [secondX, secondY]
     ];
-  }
-
-  private calculateMean(values: number[]): number {
-    return values.reduce((a, b) => a + b) / values.length;
   }
 
   getValuesInColumn(tableData, columnIndex) {

--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -529,8 +529,8 @@ export class GraphStudent extends ComponentStudent {
     const covarianceMatrix = covariance(xValues, yValues);
     const covarianceXY = covarianceMatrix[0][1];
     const varianceX = covarianceMatrix[0][0];
-    const meanY = this.UtilService.calculateMean(yValues);
-    const meanX = this.UtilService.calculateMean(xValues);
+    const meanY = this.calculateMean(yValues);
+    const meanX = this.calculateMean(xValues);
     const slope = covarianceXY / varianceX;
     const intercept = meanY - slope * meanX;
     let firstX = Math.min(...xValues);
@@ -549,6 +549,10 @@ export class GraphStudent extends ComponentStudent {
       [firstX, firstY],
       [secondX, secondY]
     ];
+  }
+
+  private calculateMean(values: number[]): number {
+    return values.reduce((a, b) => a + b) / values.length;
   }
 
   getValuesInColumn(tableData, columnIndex) {

--- a/src/assets/wise5/components/graph/util.spec.ts
+++ b/src/assets/wise5/components/graph/util.spec.ts
@@ -1,0 +1,13 @@
+import { calculateMean } from './util';
+
+describe('calculateMean', () => {
+  it('should calculate the mean when there is one value', () => {
+    const values = [1];
+    expect(calculateMean(values)).toEqual(1);
+  });
+
+  it('should calculate the mean when there are multiple values', () => {
+    const values = [1, 2, 3, 4, 10];
+    expect(calculateMean(values)).toEqual(4);
+  });
+});

--- a/src/assets/wise5/components/graph/util.ts
+++ b/src/assets/wise5/components/graph/util.ts
@@ -1,0 +1,3 @@
+export function calculateMean(values: number[]): number {
+  return values.reduce((a, b) => a + b) / values.length;
+}

--- a/src/assets/wise5/services/utilService.ts
+++ b/src/assets/wise5/services/utilService.ts
@@ -60,10 +60,6 @@ export class UtilService {
     }
     return false;
   }
-
-  calculateMean(values) {
-    return values.reduce((a, b) => a + b) / values.length;
-  }
 }
 
 declare global {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15869,39 +15869,39 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>The series you are trying to add a point to is currently hidden. Please show the series by clicking the series name in the legend and try adding the point again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1085</context>
+          <context context-type="linenumber">1089</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2852989551014711458" datatype="html">
         <source>You can not edit this series. Please choose a series that can be edited.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1099</context>
+          <context context-type="linenumber">1103</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7053114367342967943" datatype="html">
         <source>Are you sure you want to reset the series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1332</context>
+          <context context-type="linenumber">1336</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7889560203726829643" datatype="html">
         <source>Are you sure you want to reset the &quot;<x id="PH" equiv-text="seriesName"/>&quot; series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1334</context>
+          <context context-type="linenumber">1338</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6999515396807067782" datatype="html">
         <source>Trial</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1870</context>
+          <context context-type="linenumber">1874</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">2704</context>
+          <context context-type="linenumber">2708</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9070768663485888935" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15862,46 +15862,46 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Are you sure you want to overwrite the current line data?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">240</context>
+          <context context-type="linenumber">241</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6882380861047606832" datatype="html">
         <source>The series you are trying to add a point to is currently hidden. Please show the series by clicking the series name in the legend and try adding the point again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1089</context>
+          <context context-type="linenumber">1086</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2852989551014711458" datatype="html">
         <source>You can not edit this series. Please choose a series that can be edited.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1103</context>
+          <context context-type="linenumber">1100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7053114367342967943" datatype="html">
         <source>Are you sure you want to reset the series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1336</context>
+          <context context-type="linenumber">1333</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7889560203726829643" datatype="html">
         <source>Are you sure you want to reset the &quot;<x id="PH" equiv-text="seriesName"/>&quot; series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1338</context>
+          <context context-type="linenumber">1335</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6999515396807067782" datatype="html">
         <source>Trial</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1874</context>
+          <context context-type="linenumber">1871</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">2708</context>
+          <context context-type="linenumber">2705</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9070768663485888935" datatype="html">


### PR DESCRIPTION
## Changes
Moved `calculateMean()` to GraphStudentComponent, since it is only used there.

## Test
Make sure generating regression lines for Graph component scatterplots still work as before.

Closes #1162. 