### PR TITLE
refactor(Authoring): Create NodeAdvancedAuthoringModule

### DIFF
--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -5,11 +5,6 @@ import { ChooseNewNodeLocation } from '../../assets/wise5/authoringTool/addNode/
 import { ChooseNewNodeTemplate } from '../../assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component';
 import { AdvancedProjectAuthoringComponent } from '../../assets/wise5/authoringTool/advanced/advanced-project-authoring.component';
 import { CardSelectorComponent } from '../../assets/wise5/authoringTool/components/card-selector/card-selector.component';
-import { NodeAdvancedBranchAuthoringComponent } from '../../assets/wise5/authoringTool/node/advanced/branch/node-advanced-branch-authoring.component';
-import { NodeAdvancedConstraintAuthoringComponent } from '../../assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component';
-import { NodeAdvancedGeneralAuthoringComponent } from '../../assets/wise5/authoringTool/node/advanced/general/node-advanced-general-authoring.component';
-import { NodeAdvancedJsonAuthoringComponent } from '../../assets/wise5/authoringTool/node/advanced/json/node-advanced-json-authoring.component';
-import { NodeAdvancedPathAuthoringComponent } from '../../assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component';
 import { RequiredErrorLabelComponent } from '../../assets/wise5/authoringTool/node/advanced/required-error-label/required-error-label.component';
 import { RubricAuthoringComponent } from '../../assets/wise5/authoringTool/rubric/rubric-authoring.component';
 import { NodeIconChooserDialog } from '../../assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component';
@@ -24,11 +19,10 @@ import { StudentTeacherCommonModule } from '../student-teacher-common.module';
 import { RecoveryAuthoringComponent } from '../../assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component';
 import { AddLessonConfigureComponent } from '../../assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component';
 import { AddLessonChooseLocationComponent } from '../../assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component';
-import { NodeConstraintAuthoringComponent } from '../../assets/wise5/authoringTool/constraint/node-constraint-authoring/node-constraint-authoring.component';
 import { ConcurrentAuthorsMessageComponent } from '../../assets/wise5/authoringTool/concurrent-authors-message/concurrent-authors-message.component';
 import { EditNodeRubricComponent } from '../../assets/wise5/authoringTool/node/editRubric/edit-node-rubric.component';
 import { ImportComponentModule } from '../../assets/wise5/authoringTool/importComponent/import-component-module';
-import { NodeAdvancedAuthoringComponent } from '../../assets/wise5/authoringTool/node/advanced/node-advanced-authoring/node-advanced-authoring.component';
+import { NodeAdvancedAuthoringModule } from '../../assets/wise5/authoringTool/node/advanced/node-advanced-authoring.module';
 
 @NgModule({
   declarations: [
@@ -45,13 +39,6 @@ import { NodeAdvancedAuthoringComponent } from '../../assets/wise5/authoringTool
     ChooseNewNodeTemplate,
     ConcurrentAuthorsMessageComponent,
     EditNodeRubricComponent,
-    NodeAdvancedAuthoringComponent,
-    NodeAdvancedBranchAuthoringComponent,
-    NodeAdvancedConstraintAuthoringComponent,
-    NodeAdvancedGeneralAuthoringComponent,
-    NodeAdvancedJsonAuthoringComponent,
-    NodeAdvancedPathAuthoringComponent,
-    NodeConstraintAuthoringComponent,
     NodeIconChooserDialog,
     RecoveryAuthoringComponent,
     RequiredErrorLabelComponent,
@@ -62,6 +49,7 @@ import { NodeAdvancedAuthoringComponent } from '../../assets/wise5/authoringTool
     ComponentAuthoringModule,
     ComponentStudentModule,
     ImportComponentModule,
+    NodeAdvancedAuthoringModule,
     PreviewComponentModule,
     RouterModule
   ]

--- a/src/app/teacher/component-authoring.module.ts
+++ b/src/app/teacher/component-authoring.module.ts
@@ -79,7 +79,7 @@ import { EditQuestionBankRulesComponent } from '../authoring-tool/edit-question-
 import { SelectStepAndComponentComponent } from '../authoring-tool/select-step-and-component/select-step-and-component.component';
 import { EditComponentConstraintsComponent } from '../authoring-tool/edit-component-constraints/edit-component-constraints.component';
 import { ComponentConstraintAuthoringComponent } from '../../assets/wise5/authoringTool/constraint/component-constraint-authoring/component-constraint-authoring.component';
-import { EditConstraintRemovalCriteriaComponent } from '../../assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component';
+import { ConstraintAuthoringModule } from '../../assets/wise5/authoringTool/constraint/constraint-authoring.module';
 
 @NgModule({
   declarations: [
@@ -117,7 +117,6 @@ import { EditConstraintRemovalCriteriaComponent } from '../../assets/wise5/autho
     EditConnectedComponentsWithBackgroundComponent,
     EditConnectedComponentDeleteButtonComponent,
     EditConnectedComponentTypeSelectComponent,
-    EditConstraintRemovalCriteriaComponent,
     EditDialogGuidanceAdvancedComponent,
     EditDialogGuidanceComputerAvatarComponent,
     EditDiscussionAdvancedComponent,
@@ -163,7 +162,7 @@ import { EditConstraintRemovalCriteriaComponent } from '../../assets/wise5/autho
     TableAuthoring,
     WiseAuthoringTinymceEditorComponent
   ],
-  imports: [StudentTeacherCommonModule, PeerGroupingAuthoringModule],
+  imports: [ConstraintAuthoringModule, StudentTeacherCommonModule, PeerGroupingAuthoringModule],
   exports: [
     AnimationAuthoring,
     AudioOscillatorAuthoring,
@@ -195,7 +194,6 @@ import { EditConstraintRemovalCriteriaComponent } from '../../assets/wise5/autho
     EditConnectedComponentsWithBackgroundComponent,
     EditConnectedComponentDeleteButtonComponent,
     EditConnectedComponentTypeSelectComponent,
-    EditConstraintRemovalCriteriaComponent,
     EditDialogGuidanceAdvancedComponent,
     EditDiscussionAdvancedComponent,
     EditDiscussionConnectedComponentsComponent,

--- a/src/assets/wise5/authoringTool/constraint/constraint-authoring.module.ts
+++ b/src/assets/wise5/authoringTool/constraint/constraint-authoring.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { EditConstraintRemovalCriteriaComponent } from './edit-constraint-removal-criteria/edit-constraint-removal-criteria.component';
+import { StudentTeacherCommonModule } from '../../../../app/student-teacher-common.module';
+
+@NgModule({
+  declarations: [EditConstraintRemovalCriteriaComponent],
+  exports: [EditConstraintRemovalCriteriaComponent],
+  imports: [StudentTeacherCommonModule]
+})
+export class ConstraintAuthoringModule {}

--- a/src/assets/wise5/authoringTool/node/advanced/node-advanced-authoring.module.ts
+++ b/src/assets/wise5/authoringTool/node/advanced/node-advanced-authoring.module.ts
@@ -1,0 +1,24 @@
+import { NgModule } from '@angular/core';
+import { NodeAdvancedBranchAuthoringComponent } from './branch/node-advanced-branch-authoring.component';
+import { NodeAdvancedConstraintAuthoringComponent } from './constraint/node-advanced-constraint-authoring.component';
+import { NodeAdvancedGeneralAuthoringComponent } from './general/node-advanced-general-authoring.component';
+import { NodeAdvancedJsonAuthoringComponent } from './json/node-advanced-json-authoring.component';
+import { NodeAdvancedAuthoringComponent } from './node-advanced-authoring/node-advanced-authoring.component';
+import { NodeAdvancedPathAuthoringComponent } from './path/node-advanced-path-authoring.component';
+import { StudentTeacherCommonModule } from '../../../../../app/student-teacher-common.module';
+import { NodeConstraintAuthoringComponent } from '../../constraint/node-constraint-authoring/node-constraint-authoring.component';
+import { ConstraintAuthoringModule } from '../../constraint/constraint-authoring.module';
+
+@NgModule({
+  declarations: [
+    NodeAdvancedAuthoringComponent,
+    NodeAdvancedBranchAuthoringComponent,
+    NodeAdvancedConstraintAuthoringComponent,
+    NodeAdvancedGeneralAuthoringComponent,
+    NodeAdvancedJsonAuthoringComponent,
+    NodeAdvancedPathAuthoringComponent,
+    NodeConstraintAuthoringComponent
+  ],
+  imports: [ConstraintAuthoringModule, StudentTeacherCommonModule]
+})
+export class NodeAdvancedAuthoringModule {}


### PR DESCRIPTION
## Changes

Created NodeAdvancedAuthoringModule and ConstraintAuthoringModule. ConstraintAuthoringModule is needed because NodeAdvancedAuthoringModule and ComponentAuthoringModule both use the EditContraintRemovalCriteriaComponent.

## Test

Make sure the step advanced authoring views work.
Make sure the component constraint authoring still works.

Closes #1240