### PR TITLE
refactor(ConfigService): Move getAvatarColorForWorkgroupId()

### DIFF
--- a/src/app/student/top-bar/top-bar.component.ts
+++ b/src/app/student/top-bar/top-bar.component.ts
@@ -10,6 +10,7 @@ import { StudentDataService } from '../../../assets/wise5/services/studentDataSe
 import { NotificationsDialogComponent } from '../../../assets/wise5/vle/notifications-dialog/notifications-dialog.component';
 import { StudentAccountMenuComponent } from '../../../assets/wise5/vle/student-account-menu/student-account-menu.component';
 import { Notification } from '../../domain/notification';
+import { getAvatarColorForWorkgroupId } from '../../../assets/wise5/common/workgroup/workgroup';
 
 @Component({
   selector: 'top-bar',
@@ -41,9 +42,7 @@ export class TopBarComponent {
   ) {}
 
   ngOnInit() {
-    this.avatarColor = this.configService.getAvatarColorForWorkgroupId(
-      this.configService.getWorkgroupId()
-    );
+    this.avatarColor = getAvatarColorForWorkgroupId(this.configService.getWorkgroupId());
     this.logoURL = `${this.projectService.getThemePath()}/images/WISE-logo-ffffff.svg`;
     this.projectName = this.projectService.getProjectTitle();
     this.isPreview = this.configService.isPreview();

--- a/src/assets/wise5/authoringTool/components/shared/topBar/topBar.ts
+++ b/src/assets/wise5/authoringTool/components/shared/topBar/topBar.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '../../../../services/configService';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
 import { SessionService } from '../../../../services/sessionService';
 import { TeacherDataService } from '../../../../services/teacherDataService';
+import { getAvatarColorForWorkgroupId } from '../../../../common/workgroup/workgroup';
 
 class TopBarController {
   translate: any;
@@ -31,20 +32,20 @@ class TopBarController {
     private $filter: any,
     private $state: any,
     private $window: any,
-    private ConfigService: ConfigService,
-    private ProjectService: TeacherProjectService,
-    private SessionService: SessionService,
-    private TeacherDataService: TeacherDataService
+    private configService: ConfigService,
+    private projectService: TeacherProjectService,
+    private sessionService: SessionService,
+    private teacherDataService: TeacherDataService
   ) {
     this.translate = this.$filter('translate');
-    this.workgroupId = this.ConfigService.getWorkgroupId();
+    this.workgroupId = this.configService.getWorkgroupId();
     if (this.workgroupId == null) {
       this.workgroupId = 100 * Math.random();
     }
-    this.avatarColor = this.ConfigService.getAvatarColorForWorkgroupId(this.workgroupId);
-    this.userInfo = this.ConfigService.getMyUserInfo();
-    this.themePath = this.ProjectService.getThemePath();
-    this.contextPath = this.ConfigService.getContextPath();
+    this.avatarColor = getAvatarColorForWorkgroupId(this.workgroupId);
+    this.userInfo = this.configService.getMyUserInfo();
+    this.themePath = this.projectService.getThemePath();
+    this.contextPath = this.configService.getContextPath();
   }
 
   $onChanges() {
@@ -85,8 +86,8 @@ class TopBarController {
   }
 
   goHome() {
-    this.ProjectService.notifyAuthorProjectEnd().then(() => {
-      this.SessionService.goHome();
+    this.projectService.notifyAuthorProjectEnd().then(() => {
+      this.sessionService.goHome();
     });
   }
 
@@ -98,17 +99,11 @@ class TopBarController {
     const componentId = null;
     const componentType = null;
     const data = {};
-    this.TeacherDataService.saveEvent(
-      context,
-      nodeId,
-      componentId,
-      componentType,
-      category,
-      eventName,
-      data
-    ).then((result) => {
-      this.SessionService.logOut();
-    });
+    this.teacherDataService
+      .saveEvent(context, nodeId, componentId, componentType, category, eventName, data)
+      .then((result) => {
+        this.sessionService.logOut();
+      });
   }
 }
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.spec.ts
@@ -9,7 +9,6 @@ import { ManageTeamComponent } from './manage-team.component';
 
 class ConfigServiceStub {
   getPermissions() {}
-  getAvatarColorForWorkgroupId() {}
   retrieveConfig() {
     return {};
   }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
@@ -13,6 +13,7 @@ import {
 } from '@angular/cdk/drag-drop';
 import { MoveUserConfirmDialogComponent } from '../move-user-confirm-dialog/move-user-confirm-dialog.component';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { getAvatarColorForWorkgroupId } from '../../../../common/workgroup/workgroup';
 
 @Component({
   selector: 'manage-team',
@@ -33,7 +34,7 @@ export class ManageTeamComponent {
   ) {}
 
   ngOnInit() {
-    this.avatarColor = this.configService.getAvatarColorForWorkgroupId(this.team.workgroupId);
+    this.avatarColor = getAvatarColorForWorkgroupId(this.team.workgroupId);
     this.isUnassigned = this.team.workgroupId == null;
     this.canChangePeriod =
       this.configService.getPermissions().canGradeStudentWork &&

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-details/milestone-details.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-details/milestone-details.component.ts
@@ -7,6 +7,7 @@ import { ConfigService } from '../../../../services/configService';
 import { Subscription } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { ShowNodeInfoDialogComponent } from '../../../../../../app/classroom-monitor/show-node-info-dialog/show-node-info-dialog.component';
+import { getAvatarColorForWorkgroupId } from '../../../../common/workgroup/workgroup';
 
 @Component({
   selector: 'milestone-details',
@@ -60,7 +61,7 @@ export class MilestoneDetailsComponent implements OnInit {
   }
 
   getAvatarColorForWorkgroupId(workgroupId: number): string {
-    return this.configService.getAvatarColorForWorkgroupId(workgroupId);
+    return getAvatarColorForWorkgroupId(workgroupId);
   }
 
   getDisplayNamesByWorkgroupId(workgroupId: number): string {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroupInfo/workgroup-info.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroupInfo/workgroup-info.component.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import { Component, Input } from '@angular/core';
-import { ConfigService } from '../../../../services/configService';
+import { getAvatarColorForWorkgroupId } from '../../../../common/workgroup/workgroup';
 
 @Component({
   selector: 'workgroup-info',
@@ -28,10 +28,10 @@ export class WorkgroupInfoComponent {
   @Input()
   workgroupId: number;
 
-  constructor(private ConfigService: ConfigService) {}
+  constructor() {}
 
   ngOnInit() {
-    this.avatarColor = this.ConfigService.getAvatarColorForWorkgroupId(this.workgroupId);
+    this.avatarColor = getAvatarColorForWorkgroupId(this.workgroupId);
     this.alertIconClass = this.hasNewAlert ? 'warn' : 'text-disabled';
     this.alertIconName = 'notifications';
     this.alertLabel = this.hasNewAlert

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-grouping/peer-group-grouping.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-grouping/peer-group-grouping.component.spec.ts
@@ -33,7 +33,6 @@ describe('PeerGroupGroupingComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PeerGroupGroupingComponent);
-    spyOn(TestBed.inject(ConfigService), 'getAvatarColorForWorkgroupId').and.returnValue('#E91E63');
     container1 = createContainer(1);
     container2 = createContainer(2);
     component = fixture.componentInstance;

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-grouping/peer-group-grouping.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-grouping/peer-group-grouping.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { ConfigService } from '../../../../services/configService';
 import { PeerGroupWorkgroupsContainerComponent } from '../peer-group-workgroups-container/peer-group-workgroups-container.component';
+import { getAvatarColorForWorkgroupId } from '../../../../common/workgroup/workgroup';
 
 @Component({
   selector: 'peer-group-grouping',
@@ -13,11 +13,11 @@ export class PeerGroupGroupingComponent extends PeerGroupWorkgroupsContainerComp
 
   avatarColor: string;
 
-  constructor(private ConfigService: ConfigService, protected dialog: MatDialog) {
+  constructor(protected dialog: MatDialog) {
     super(dialog);
   }
 
   ngOnInit(): void {
-    this.avatarColor = this.ConfigService.getAvatarColorForWorkgroupId(this.grouping.id);
+    this.avatarColor = getAvatarColorForWorkgroupId(this.grouping.id);
   }
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { ConfigService } from '../../../../services/configService';
+import { getAvatarColorForWorkgroupId } from '../../../../common/workgroup/workgroup';
 
 @Component({
   selector: 'peer-group-workgroup',
@@ -23,6 +24,6 @@ export class PeerGroupWorkgroupComponent implements OnInit {
       this.isEmptyWorkgroup = true;
       this.workgroupUsernames = $localize`Empty Team`;
     }
-    this.avatarColor = this.configService.getAvatarColorForWorkgroupId(this.workgroup.id);
+    this.avatarColor = getAvatarColorForWorkgroupId(this.workgroup.id);
   }
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/top-bar/top-bar.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/top-bar/top-bar.component.ts
@@ -7,6 +7,7 @@ import { TeacherProjectService } from '../../../../services/teacherProjectServic
 import { NotificationService } from '../../../../services/notificationService';
 import { Notification } from '../../../../../../app/domain/notification';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { getAvatarColorForWorkgroupId } from '../../../../common/workgroup/workgroup';
 
 @Component({
   selector: 'top-bar',
@@ -46,7 +47,7 @@ export class TopBarComponent implements OnInit {
     if (this.workgroupId == null) {
       this.workgroupId = 100 * Math.random();
     }
-    this.avatarColor = this.configService.getAvatarColorForWorkgroupId(this.workgroupId);
+    this.avatarColor = getAvatarColorForWorkgroupId(this.workgroupId);
     this.userInfo = this.configService.getMyUserInfo();
     this.notificationChangedSubscription = this.notificationService.notificationChanged$.subscribe(
       () => {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/topBar/topBar.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/topBar/topBar.ts
@@ -8,6 +8,7 @@ import { NotificationService } from '../../../../services/notificationService';
 import { Directive } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { Notification } from '../../../../../../app/domain/notification';
+import { getAvatarColorForWorkgroupId } from '../../../../common/workgroup/workgroup';
 
 @Directive()
 class TopBarController {
@@ -42,26 +43,26 @@ class TopBarController {
     $filter: any,
     private $scope: any,
     private $state: any,
-    private ConfigService: ConfigService,
-    private NotificationService: NotificationService,
-    private ProjectService: TeacherProjectService,
-    private TeacherDataService: TeacherDataService,
-    private SessionService: SessionService
+    private configService: ConfigService,
+    private notificationService: NotificationService,
+    private projectService: TeacherProjectService,
+    private teacherDataService: TeacherDataService,
+    private sessionService: SessionService
   ) {
     this.translate = $filter('translate');
-    this.workgroupId = this.ConfigService.getWorkgroupId();
+    this.workgroupId = this.configService.getWorkgroupId();
     if (this.workgroupId == null) {
       this.workgroupId = 100 * Math.random();
     }
-    this.avatarColor = this.ConfigService.getAvatarColorForWorkgroupId(this.workgroupId);
-    this.userInfo = this.ConfigService.getMyUserInfo();
-    this.notificationChangedSubscription = this.NotificationService.notificationChanged$.subscribe(
+    this.avatarColor = getAvatarColorForWorkgroupId(this.workgroupId);
+    this.userInfo = this.configService.getMyUserInfo();
+    this.notificationChangedSubscription = this.notificationService.notificationChanged$.subscribe(
       () => {
         this.setNotifications();
       }
     );
-    this.themePath = this.ProjectService.getThemePath();
-    this.contextPath = this.ConfigService.getContextPath();
+    this.themePath = this.projectService.getThemePath();
+    this.contextPath = this.configService.getContextPath();
     this.$scope.$on('$destroy', () => {
       this.ngOnDestroy();
     });
@@ -72,7 +73,7 @@ class TopBarController {
   }
 
   $onInit() {
-    const permissions = this.ConfigService.getPermissions();
+    const permissions = this.configService.getPermissions();
     this.canAuthorProject = permissions.canAuthorProject;
     this.runInfo = this.getRunInfo();
   }
@@ -95,11 +96,11 @@ class TopBarController {
    */
   setNotifications() {
     // TODO: take into account shared teacher users!
-    this.newNotifications = this.NotificationService.getLatestActiveNotificationsFromUniqueSource(
+    this.newNotifications = this.notificationService.getLatestActiveNotificationsFromUniqueSource(
       this.notifications,
       this.workgroupId
     );
-    this.dismissedNotifications = this.NotificationService.getDismissedNotificationsForWorkgroup(
+    this.dismissedNotifications = this.notificationService.getDismissedNotificationsForWorkgroup(
       this.notifications,
       this.workgroupId
     );
@@ -110,7 +111,7 @@ class TopBarController {
    * @return Boolean whether any of the periods are paused
    */
   isAnyPeriodPaused() {
-    return this.TeacherDataService.isAnyPeriodPaused();
+    return this.teacherDataService.isAnyPeriodPaused();
   }
 
   switchToAuthoringView() {
@@ -139,19 +140,19 @@ class TopBarController {
 
   previewProject() {
     this.saveEvent('projectPreviewed').then(() => {
-      window.open(`${this.ConfigService.getConfigParam('previewProjectURL')}`);
+      window.open(`${this.configService.getConfigParam('previewProjectURL')}`);
     });
   }
 
   goHome() {
     this.saveEvent('goHomeButtonClicked').then(() => {
-      this.SessionService.goHome();
+      this.sessionService.goHome();
     });
   }
 
   logOut() {
     this.saveEvent('logOutButtonClicked').then(() => {
-      this.SessionService.logOut();
+      this.sessionService.logOut();
     });
   }
 
@@ -162,17 +163,11 @@ class TopBarController {
     const componentId = null;
     const componentType = null;
     const data = {};
-    return this.TeacherDataService.saveEvent(
-      context,
-      nodeId,
-      componentId,
-      componentType,
-      category,
-      eventName,
-      data
-    ).then((result) => {
-      return result;
-    });
+    return this.teacherDataService
+      .saveEvent(context, nodeId, componentId, componentType, category, eventName, data)
+      .then((result) => {
+        return result;
+      });
   }
 }
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/student-grading-tools/student-grading-tools.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/student-grading-tools/student-grading-tools.component.ts
@@ -4,6 +4,7 @@ import { Subscription } from 'rxjs/internal/Subscription';
 import { copy } from '../../../../common/object/object';
 import { ConfigService } from '../../../../services/configService';
 import { TeacherDataService } from '../../../../services/teacherDataService';
+import { getAvatarColorForWorkgroupId } from '../../../../common/workgroup/workgroup';
 
 class Workgroup {
   periodId: number;
@@ -51,7 +52,7 @@ export class StudentGradingToolsComponent implements OnInit {
   }
 
   private updateModel(): void {
-    this.avatarColor = this.configService.getAvatarColorForWorkgroupId(this.workgroupId);
+    this.avatarColor = getAvatarColorForWorkgroupId(this.workgroupId);
     this.periodId = this.dataService.getCurrentPeriod().periodId;
     this.filterWorkgroupsForPeriod();
     this.workgroups = this.workgroups.sort(this.sortByWorkgroupId);

--- a/src/assets/wise5/common/workgroup/workgroup.spec.ts
+++ b/src/assets/wise5/common/workgroup/workgroup.spec.ts
@@ -1,0 +1,10 @@
+import { getAvatarColorForWorkgroupId } from './workgroup';
+
+describe('getAvatarColorForWorkgroupId()', () => {
+  it('should return #E91E63 when workgroup id is 1000', () => {
+    expect(getAvatarColorForWorkgroupId(10000)).toEqual('#E91E63');
+  });
+  it('should return #C62828 when workgroup id is 10008', () => {
+    expect(getAvatarColorForWorkgroupId(10008)).toEqual('#C62828');
+  });
+});

--- a/src/assets/wise5/common/workgroup/workgroup.ts
+++ b/src/assets/wise5/common/workgroup/workgroup.ts
@@ -1,0 +1,15 @@
+export function getAvatarColorForWorkgroupId(workgroupId: number): string {
+  const avatarColors = [
+    '#E91E63',
+    '#9C27B0',
+    '#CDDC39',
+    '#2196F3',
+    '#FDD835',
+    '#43A047',
+    '#795548',
+    '#EF6C00',
+    '#C62828',
+    '#607D8B'
+  ];
+  return avatarColors[workgroupId % 10];
+}

--- a/src/assets/wise5/components/dialogGuidance/dialog-response/dialog-response.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-response/dialog-response.component.ts
@@ -5,6 +5,7 @@ import { ComputerAvatar } from '../../../common/ComputerAvatar';
 import { ComputerAvatarService } from '../../../services/computerAvatarService';
 import { ConfigService } from '../../../services/configService';
 import { DialogResponse } from '../DialogResponse';
+import { getAvatarColorForWorkgroupId } from '../../../common/workgroup/workgroup';
 
 @Component({
   selector: 'dialog-response',
@@ -33,7 +34,7 @@ export class DialogResponseComponent implements OnInit {
   ngOnInit(): void {
     this.isStudent = this.response.user === 'Student';
     if (this.isStudent) {
-      this.avatarColor = this.configService.getAvatarColorForWorkgroupId(this.response.workgroupId);
+      this.avatarColor = getAvatarColorForWorkgroupId(this.response.workgroupId);
       const firstNames = this.configService.getStudentFirstNamesByWorkgroupId(
         this.response.workgroupId
       );

--- a/src/assets/wise5/components/discussion/class-response/class-response.component.ts
+++ b/src/assets/wise5/components/discussion/class-response/class-response.component.ts
@@ -7,6 +7,7 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import { ConfigService } from '../../../services/configService';
+import { getAvatarColorForWorkgroupId } from '../../../common/workgroup/workgroup';
 
 @Component({
   selector: 'class-response',
@@ -40,7 +41,7 @@ export class ClassResponse {
   expanded: boolean = false;
   repliesToShow: any[] = [];
 
-  constructor(private ConfigService: ConfigService) {}
+  constructor(private configService: ConfigService) {}
 
   ngOnInit(): void {
     this.injectLinksIntoResponse();
@@ -88,11 +89,11 @@ export class ClassResponse {
   }
 
   getAvatarColorForWorkgroupId(workgroupId: number): string {
-    return this.ConfigService.getAvatarColorForWorkgroupId(workgroupId);
+    return getAvatarColorForWorkgroupId(workgroupId);
   }
 
   adjustClientSaveTime(time: any): number {
-    return this.ConfigService.convertToClientTimestamp(time);
+    return this.configService.convertToClientTimestamp(time);
   }
 
   replyEntered($event: any): void {

--- a/src/assets/wise5/components/peerChat/peerChatService.ts
+++ b/src/assets/wise5/components/peerChat/peerChatService.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { ConfigService } from '../../services/configService';
 import { ComponentService } from '../componentService';
 import { PeerChatMessage } from './PeerChatMessage';
+import { getAvatarColorForWorkgroupId } from '../../common/workgroup/workgroup';
 
 @Injectable()
 export class PeerChatService extends ComponentService {
@@ -59,7 +60,7 @@ export class PeerChatService extends ComponentService {
   setPeerChatWorkgroups(peerChatWorkgroupInfos: any, workgroupIds: number[]): any {
     for (const workgroupId of workgroupIds) {
       peerChatWorkgroupInfos[workgroupId] = {
-        avatarColor: this.configService.getAvatarColorForWorkgroupId(workgroupId),
+        avatarColor: getAvatarColorForWorkgroupId(workgroupId),
         displayNames: this.configService.isTeacherWorkgroupId(workgroupId)
           ? $localize`Teacher`
           : this.configService.getUsernamesStringByWorkgroupId(workgroupId),

--- a/src/assets/wise5/components/showGroupWork/show-group-work-display/show-group-work-display.component.spec.ts
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-display/show-group-work-display.component.spec.ts
@@ -44,9 +44,6 @@ class MockConfigService {
   getWorkgroupId() {
     return workgroupId;
   }
-  getAvatarColorForWorkgroupId(workgroupId: any) {
-    return '#000000';
-  }
   getUsernamesStringByWorkgroupId(workgroupId: number) {
     return `Student ${workgroupId}`;
   }

--- a/src/assets/wise5/components/showGroupWork/show-group-work-display/show-group-work-display.component.ts
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-display/show-group-work-display.component.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '../../../services/configService';
 import { PeerGroupService } from '../../../services/peerGroupService';
 import { ProjectService } from '../../../services/projectService';
 import { PeerGroup } from '../../peerChat/PeerGroup';
+import { getAvatarColorForWorkgroupId } from '../../../common/workgroup/workgroup';
 
 @Component({
   selector: 'show-group-work-display',
@@ -93,7 +94,7 @@ export class ShowGroupWorkDisplayComponent implements OnInit {
 
   private setWorkgroupInfo(workgroupId: number): void {
     this.workgroupInfos[workgroupId] = {
-      avatarColor: this.configService.getAvatarColorForWorkgroupId(workgroupId),
+      avatarColor: getAvatarColorForWorkgroupId(workgroupId),
       displayNames: this.configService.getUsernamesStringByWorkgroupId(workgroupId)
     };
   }

--- a/src/assets/wise5/services/configService.ts
+++ b/src/assets/wise5/services/configService.ts
@@ -801,22 +801,6 @@ export class ConfigService {
     return content;
   }
 
-  getAvatarColorForWorkgroupId(workgroupId) {
-    const avatarColors = [
-      '#E91E63',
-      '#9C27B0',
-      '#CDDC39',
-      '#2196F3',
-      '#FDD835',
-      '#43A047',
-      '#795548',
-      '#EF6C00',
-      '#C62828',
-      '#607D8B'
-    ];
-    return avatarColors[workgroupId % 10];
-  }
-
   /**
    * Get the project assets folder path
    * @param includeHost whether to include the host in the URL

--- a/src/assets/wise5/vle/student-account-menu/student-account-menu.component.ts
+++ b/src/assets/wise5/vle/student-account-menu/student-account-menu.component.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '../../services/configService';
 import { ProjectService } from '../../services/projectService';
 import { SessionService } from '../../services/sessionService';
 import { StudentDataService } from '../../services/studentDataService';
+import { getAvatarColorForWorkgroupId } from '../../common/workgroup/workgroup';
 
 @Component({
   selector: 'student-account-menu',
@@ -107,7 +108,7 @@ export class StudentAccountMenuComponent implements OnInit, OnDestroy {
   }
 
   getAvatarColorForWorkgroupId(workgroupId: number): string {
-    return this.configService.getAvatarColorForWorkgroupId(workgroupId);
+    return getAvatarColorForWorkgroupId(workgroupId);
   }
 
   goHome() {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10676,7 +10676,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Moved student to Team <x id="PH" equiv-text="this.team.workgroupId"/>.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts</context>
-          <context context-type="linenumber">107</context>
+          <context context-type="linenumber">110</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9b83b532c3f74e3d6e25a6ba749eef54324bea48" datatype="html">
@@ -11460,7 +11460,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Empty Team</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-workgroup/peer-group-workgroup.component.ts</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4fc1ce64a0242febe825d1737eb8b0da1f5c3865" datatype="html">
@@ -11606,7 +11606,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Run ID: <x id="PH" equiv-text="this.runId"/> | Access Code: <x id="PH_1" equiv-text="this.runCode"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/top-bar/top-bar.component.ts</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3546597756684436742" datatype="html">
@@ -11615,7 +11615,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
 Are you sure you want to proceed?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/top-bar/top-bar.component.ts</context>
-          <context context-type="linenumber">106</context>
+          <context context-type="linenumber">107</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2533bf42152adabc1092cc52494ab0cc211c350a" datatype="html">
@@ -14843,14 +14843,14 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Are you sure you want to delete this post?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response/class-response.component.ts</context>
-          <context context-type="linenumber">116</context>
+          <context context-type="linenumber">117</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1602604839411386059" datatype="html">
         <source>Are you sure you want to show this post?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response/class-response.component.ts</context>
-          <context context-type="linenumber">122</context>
+          <context context-type="linenumber">123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1037affb09c3a77f83838b47e805b78b82314e6c" datatype="html">
@@ -17513,14 +17513,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Peer Chat</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peerChatService.ts</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="linenumber">16</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4250948520990652627" datatype="html">
         <source>Teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peerChatService.ts</context>
-          <context context-type="linenumber">64</context>
+          <context context-type="linenumber">65</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3eadcc6c36867a6d135be94da38b992e5dbd2f2f" datatype="html">


### PR DESCRIPTION
## Changes
- Moved getAvatarColorForWorkgroupId() from UtilService to `workgroup.ts`.
- Updated references and removed unused UtilService dependency.

## Test
Make sure that avatar colors still work as before in the following places:
- Top bar and account menu for VLE, Teacher Tools, Authoring
- Discussions
- Dialog Guidance
- Peer Chat
- Show Group Work
- Grade by Step (NodeGrading)
- Manage Students
- Milestone Details

Closes #1110.