### PR TITLE
refactor(FeedbackRuleEvaluator): Evaluate rules for multiple students in new class

### DIFF
--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.spec.ts
@@ -1,132 +1,27 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { TestBed } from '@angular/core/testing';
-import { FormsModule } from '@angular/forms';
-import { MatCardModule } from '@angular/material/card';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatIconModule } from '@angular/material/icon';
-import { MatInputModule } from '@angular/material/input';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
-import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
-import { ComponentHeader } from '../../../directives/component-header/component-header.component';
-import { DialogGuidanceFeedbackService } from '../../../services/dialogGuidanceFeedbackService';
-import { CRaterIdea } from '../cRater/CRaterIdea';
-import { CRaterResponse } from '../cRater/CRaterResponse';
 import { CRaterScore } from '../cRater/CRaterScore';
-import { DialogGuidanceStudentComponent } from '../../dialogGuidance/dialog-guidance-student/dialog-guidance-student.component';
-import { DialogResponsesComponent } from '../../dialogGuidance/dialog-responses/dialog-responses.component';
 import { FeedbackRuleEvaluator } from './FeedbackRuleEvaluator';
 import { FeedbackRule } from './FeedbackRule';
 import { FeedbackRuleComponent } from '../../feedbackRule/FeedbackRuleComponent';
+import {
+  DEFAULT_FEEDBACK_RULES,
+  HAS_KI_SCORE_FEEDBACK_RULES,
+  KI_SCORE_0,
+  KI_SCORE_1,
+  KI_SCORE_3,
+  KI_SCORE_5,
+  KI_SCORE_6,
+  createCRaterResponse
+} from './test-utils';
+import { CRaterResponse } from '../cRater/CRaterResponse';
 
-const defaultFeedbackRules = [
-  new FeedbackRule({
-    id: 'finalSubmit',
-    expression: 'isFinalSubmit',
-    feedback: 'This is a generic response that is shown on a final submission'
-  }),
-  new FeedbackRule({
-    id: 'secondToLastSubmit',
-    expression: 'isSecondToLastSubmit',
-    feedback: 'This is a generic response that is shown on the second to last submission'
-  }),
-  new FeedbackRule({
-    id: 'thirdSubmit',
-    expression: 'isSubmitNumber(3)',
-    feedback: 'Is third submit'
-  }),
-  new FeedbackRule({
-    id: 'isNonScorable',
-    expression: 'isNonScorable',
-    feedback: 'isNonScorable'
-  }),
-  new FeedbackRule({
-    id: 'idea1 && idea2',
-    expression: 'idea1 && idea2',
-    feedback: 'You hit idea1 and idea2'
-  }),
-  new FeedbackRule({
-    id: 'idea2 && idea3 && idea4',
-    expression: 'idea2 && idea3 && idea4',
-    feedback: 'You hit idea2, idea3 and idea4'
-  }),
-  new FeedbackRule({
-    id: 'zlh8oip6hp',
-    expression: 'idea5 || idea6',
-    feedback: 'You hit idea5 or idea6'
-  }),
-  new FeedbackRule({
-    id: 'idea7 || idea8 && idea9',
-    expression: 'idea7 || idea8 && idea9',
-    feedback: 'You hit idea7 or idea8 and idea9'
-  }),
-  new FeedbackRule({
-    id: 'idea7 && idea8 || idea9',
-    expression: 'idea7 && idea8 || idea9',
-    feedback: 'You hit idea7 and idea8 or idea9'
-  }),
-  new FeedbackRule({
-    id: 'idea1',
-    expression: 'idea1',
-    feedback: 'You hit idea1'
-  }),
-  new FeedbackRule({
-    id: '!idea10',
-    expression: '!idea10',
-    feedback: '!idea10'
-  }),
-  new FeedbackRule({
-    id: 'idea10 && !idea11',
-    expression: 'idea10 && !idea11',
-    feedback: 'idea10 && !idea11'
-  }),
-  new FeedbackRule({
-    id: '!idea11 || idea12',
-    expression: '!idea11 || idea12',
-    feedback: '!idea11 || idea12'
-  }),
-  new FeedbackRule({
-    id: 'default',
-    expression: 'isDefault',
-    feedback: 'This is a default feedback'
-  })
-];
-let evaluator: FeedbackRuleEvaluator;
-const KI_SCORE_0 = new CRaterScore('ki', 0, 0, 1, 5);
-const KI_SCORE_1 = new CRaterScore('ki', 1, 1, 1, 5);
-const KI_SCORE_3 = new CRaterScore('ki', 3, 3, 1, 5);
-const KI_SCORE_5 = new CRaterScore('ki', 5, 5, 1, 5);
-const KI_SCORE_6 = new CRaterScore('ki', 6, 6, 1, 5);
-
+let evaluator: FeedbackRuleEvaluator<CRaterResponse>;
 describe('FeedbackRuleEvaluator', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [
-        ComponentHeader,
-        DialogGuidanceStudentComponent,
-        DialogResponsesComponent,
-        PossibleScoreComponent
-      ],
-      imports: [
-        BrowserAnimationsModule,
-        FormsModule,
-        HttpClientTestingModule,
-        MatCardModule,
-        MatDialogModule,
-        MatFormFieldModule,
-        MatIconModule,
-        MatInputModule,
-        StudentTeacherCommonServicesModule
-      ],
-      providers: [DialogGuidanceFeedbackService]
-    }).compileComponents();
-  });
   beforeEach(() => {
-    evaluator = new FeedbackRuleEvaluator(new FeedbackRuleComponent(defaultFeedbackRules, 5, true));
+    evaluator = new FeedbackRuleEvaluator(
+      new FeedbackRuleComponent(DEFAULT_FEEDBACK_RULES, 5, true)
+    );
   });
   matchRule_OneIdea();
-  matchRules_OneIdea();
   matchRule_MultipleIdeasUsingAnd();
   matchRule_MultipleIdeasUsingOr();
   matchRule_MultipleIdeasUsingAndOr();
@@ -144,15 +39,6 @@ describe('FeedbackRuleEvaluator', () => {
 function matchRule_OneIdea() {
   it('should find first rule matching one idea', () => {
     expectFeedback(['idea1'], [KI_SCORE_1], 1, 'You hit idea1');
-  });
-}
-
-function matchRules_OneIdea() {
-  it('should find all rules matching one idea', () => {
-    expectRules(
-      [createCRaterResponse(['idea1'], [KI_SCORE_1], 1)],
-      ['idea1', '!idea10', '!idea11 || idea12']
-    );
   });
 }
 
@@ -189,32 +75,11 @@ function matchRule_MultipleIdeasUsingNotAndOr() {
 function matchRule_hasKIScore() {
   describe('hasKIScore()', () => {
     beforeEach(() => {
-      const feedbackRules = [
-        new FeedbackRule({
-          id: 'hasKIScore(1)',
-          expression: 'hasKIScore(1)',
-          feedback: 'hasKIScore(1)'
-        }),
-        new FeedbackRule({
-          id: 'hasKIScore(3)',
-          expression: 'hasKIScore(3)',
-          feedback: 'hasKIScore(3)'
-        }),
-        new FeedbackRule({
-          id: 'hasKIScore(5)',
-          expression: 'hasKIScore(5)',
-          feedback: 'hasKIScore(5)'
-        }),
-        new FeedbackRule({
-          id: 'default',
-          expression: 'isDefault',
-          feedback: 'isDefault'
-        })
-      ];
-      evaluator = new FeedbackRuleEvaluator(new FeedbackRuleComponent(feedbackRules, 5, true));
+      evaluator = new FeedbackRuleEvaluator(
+        new FeedbackRuleComponent(HAS_KI_SCORE_FEEDBACK_RULES, 5, true)
+      );
     });
     matchRule_hasKIScoreScoreInRange_ShouldMatchRule();
-    matchRules_hasKIScoreScoreInRange_ShouldMatchRule();
     matchRule_hasKIScoreScoreNotInRange_ShouldNotMatchRule();
   });
 }
@@ -227,19 +92,10 @@ function matchRule_hasKIScoreScoreInRange_ShouldMatchRule() {
   });
 }
 
-function matchRules_hasKIScoreScoreInRange_ShouldMatchRule() {
-  it('should match all rules if KI score is in range [1-5]', () => {
-    expectRules([createCRaterResponse([], [KI_SCORE_1], 1)], ['hasKIScore(1)']);
-    expectRules([createCRaterResponse([], [KI_SCORE_3], 1)], ['hasKIScore(3)']);
-    expectRules([createCRaterResponse([], [KI_SCORE_5], 1)], ['hasKIScore(5)']);
-  });
-}
-
 function matchRule_hasKIScoreScoreNotInRange_ShouldNotMatchRule() {
   it('should not match rule if KI score is out of range [1-5]', () => {
     expectFeedback([], [KI_SCORE_0], 1, 'isDefault');
     expectFeedback([], [KI_SCORE_6], 1, 'isDefault');
-    expectRules([createCRaterResponse([], [KI_SCORE_6], 1)], ['default']);
   });
 }
 
@@ -280,7 +136,6 @@ function matchRule_ideaCount_MatchRulesBasedOnNumIdeasFound() {
 function matchNoRule_ReturnDefault() {
   it('should return default idea when no rule is matched', () => {
     expectFeedback(['idea10', 'idea11'], [KI_SCORE_1], 1, 'default feedback');
-    expectRules([createCRaterResponse(['idea10', 'idea11'], [KI_SCORE_1], 1)], ['default']);
   });
 }
 
@@ -289,17 +144,12 @@ function matchNoRule_NoDefaultFeedbackAuthored_ReturnApplicationDefault() {
       authored`, () => {
     evaluator = new FeedbackRuleEvaluator(new FeedbackRuleComponent([], 5, true));
     expectFeedback(['idea10', 'idea11'], [KI_SCORE_1], 1, evaluator.defaultFeedback);
-    expectRules([createCRaterResponse(['idea10', 'idea11'], [KI_SCORE_1], 1)], ['default']);
   });
 }
 
 function thirdSubmit() {
   it('should return third submit rule when this is the third submit', () => {
     expectFeedback([], [KI_SCORE_1], 3, 'Is third submit');
-    expectRules(
-      [createCRaterResponse([], [KI_SCORE_1], 3)],
-      ['thirdSubmit', '!idea10', '!idea11 || idea12']
-    );
   });
 }
 
@@ -321,11 +171,6 @@ function nonScorable() {
   });
 }
 
-function expectRules(response: CRaterResponse[], expectedRuleIds: string[]): void {
-  const matchedRules = evaluator.getFeedbackRules(response);
-  expect(matchedRules.map((rule) => rule.id)).toEqual(expectedRuleIds);
-}
-
 function expectFeedback(
   ideas: string[],
   scores: CRaterScore[],
@@ -334,18 +179,4 @@ function expectFeedback(
 ) {
   const rule = evaluator.getFeedbackRule(createCRaterResponse(ideas, scores, submitCounter));
   expect(rule.feedback).toContain(expectedFeedback);
-}
-
-function createCRaterResponse(
-  ideas: string[],
-  scores: CRaterScore[],
-  submitCounter: number
-): CRaterResponse {
-  const response = new CRaterResponse();
-  response.ideas = ideas.map((idea) => {
-    return new CRaterIdea(idea, true);
-  });
-  response.scores = scores;
-  response.submitCounter = submitCounter;
-  return response;
 }

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.ts
@@ -5,12 +5,13 @@ import { FeedbackRuleExpression } from './FeedbackRuleExpression';
 import { TermEvaluator } from './TermEvaluator/TermEvaluator';
 import { TermEvaluatorFactory } from './TermEvaluator/TermEvaluatorFactory';
 
-export class FeedbackRuleEvaluator {
+export class FeedbackRuleEvaluator<T extends CRaterResponse | CRaterResponse[]> {
   defaultFeedback = $localize`Thanks for submitting your response.`;
+  protected factory = new TermEvaluatorFactory();
 
-  constructor(private component: FeedbackRuleComponent) {}
+  constructor(protected component: FeedbackRuleComponent) {}
 
-  getFeedbackRule(response: CRaterResponse | CRaterResponse[]): FeedbackRule {
+  getFeedbackRule(response: T): FeedbackRule {
     for (const feedbackRule of this.component.getFeedbackRules()) {
       if (this.satisfiesRule(response, Object.assign(new FeedbackRule(), feedbackRule))) {
         return feedbackRule;
@@ -19,28 +20,13 @@ export class FeedbackRuleEvaluator {
     return this.getDefaultRule(this.component.getFeedbackRules());
   }
 
-  getFeedbackRules(response: CRaterResponse[]): FeedbackRule[] {
-    const matchedRules = this.component
-      .getFeedbackRules()
-      .filter((rule) => this.satisfiesRule(response, Object.assign(new FeedbackRule(), rule)));
-    return matchedRules.length > 0
-      ? matchedRules
-      : [this.getDefaultRule(this.component.getFeedbackRules())];
-  }
-
-  private satisfiesRule(
-    response: CRaterResponse | CRaterResponse[],
-    feedbackRule: FeedbackRule
-  ): boolean {
+  protected satisfiesRule(response: T, feedbackRule: FeedbackRule): boolean {
     return this.isSpecialRule(feedbackRule)
       ? this.satisfiesSpecialRule(response, feedbackRule)
       : this.satisfiesSpecificRule(response, feedbackRule);
   }
 
-  private satisfiesSpecialRule(
-    response: CRaterResponse | CRaterResponse[],
-    feedbackRule: FeedbackRule
-  ): boolean {
+  private satisfiesSpecialRule(response: T, feedbackRule: FeedbackRule): boolean {
     return (
       this.satisfiesNonScorableRule(response, feedbackRule) ||
       this.satisfiesFinalSubmitRule(response, feedbackRule) ||
@@ -48,59 +34,37 @@ export class FeedbackRuleEvaluator {
     );
   }
 
-  private satisfiesFinalSubmitRule(
-    response: CRaterResponse | CRaterResponse[],
-    feedbackRule: FeedbackRule
-  ): boolean {
+  protected satisfiesFinalSubmitRule(response: T, feedbackRule: FeedbackRule): boolean {
     return (
       this.hasMaxSubmitAndIsFinalSubmitRule(feedbackRule) &&
-      (response instanceof CRaterResponse
-        ? this.component.hasMaxSubmitCountAndUsedAllSubmits(response.submitCounter)
-        : response.some((response: CRaterResponse) => {
-            return this.component.hasMaxSubmitCountAndUsedAllSubmits(response.submitCounter);
-          }))
+      this.component.hasMaxSubmitCountAndUsedAllSubmits((response as CRaterResponse).submitCounter)
     );
   }
 
-  private hasMaxSubmitAndIsFinalSubmitRule(feedbackRule: FeedbackRule): boolean {
+  protected hasMaxSubmitAndIsFinalSubmitRule(feedbackRule: FeedbackRule): boolean {
     return this.component.hasMaxSubmitCount() && FeedbackRule.isFinalSubmitRule(feedbackRule);
   }
 
-  private satisfiesSecondToLastSubmitRule(
-    response: CRaterResponse | CRaterResponse[],
-    feedbackRule: FeedbackRule
-  ): boolean {
+  protected satisfiesSecondToLastSubmitRule(response: T, feedbackRule: FeedbackRule): boolean {
     return (
       this.hasMaxSubmitAndIsSecondToLastSubmitRule(feedbackRule) &&
-      (response instanceof CRaterResponse
-        ? this.isSecondToLastSubmit(response.submitCounter)
-        : response.some((response: CRaterResponse) => {
-            return this.isSecondToLastSubmit(response.submitCounter);
-          }))
+      this.isSecondToLastSubmit((response as CRaterResponse).submitCounter)
     );
   }
 
-  private hasMaxSubmitAndIsSecondToLastSubmitRule(feedbackRule: FeedbackRule): boolean {
+  protected hasMaxSubmitAndIsSecondToLastSubmitRule(feedbackRule: FeedbackRule): boolean {
     return (
       this.component.hasMaxSubmitCount() && FeedbackRule.isSecondToLastSubmitRule(feedbackRule)
     );
   }
 
-  private isSecondToLastSubmit(submitCounter: number): boolean {
+  protected isSecondToLastSubmit(submitCounter: number): boolean {
     return this.component.getNumberOfSubmitsLeft(submitCounter) === 1;
   }
 
-  private satisfiesNonScorableRule(
-    response: CRaterResponse | CRaterResponse[],
-    feedbackRule: FeedbackRule
-  ): boolean {
+  protected satisfiesNonScorableRule(response: T, feedbackRule: FeedbackRule): boolean {
     return (
-      feedbackRule.expression === 'isNonScorable' &&
-      (response instanceof CRaterResponse
-        ? response.isNonScorable()
-        : response.some((response: CRaterResponse) => {
-            return response.isNonScorable();
-          }))
+      feedbackRule.expression === 'isNonScorable' && (response as CRaterResponse).isNonScorable()
     );
   }
 
@@ -110,10 +74,7 @@ export class FeedbackRuleEvaluator {
     );
   }
 
-  private satisfiesSpecificRule(
-    response: CRaterResponse | CRaterResponse[],
-    feedbackRule: FeedbackRule
-  ): boolean {
+  private satisfiesSpecificRule(response: T, feedbackRule: FeedbackRule): boolean {
     const termStack = [];
     for (const term of feedbackRule.getPostfixExpression()) {
       if (FeedbackRuleExpression.isOperand(term)) {
@@ -128,11 +89,7 @@ export class FeedbackRuleEvaluator {
     return true;
   }
 
-  private evaluateOperator(
-    operator: string,
-    termStack: string[],
-    response: CRaterResponse | CRaterResponse[]
-  ) {
+  private evaluateOperator(operator: string, termStack: string[], response: T) {
     if (this.evaluateOperatorExpression(operator, termStack, response)) {
       termStack.push('true');
     } else {
@@ -140,11 +97,7 @@ export class FeedbackRuleEvaluator {
     }
   }
 
-  private evaluateOperatorExpression(
-    operator: string,
-    termStack: string[],
-    response: CRaterResponse | CRaterResponse[]
-  ): boolean {
+  private evaluateOperatorExpression(operator: string, termStack: string[], response: T): boolean {
     if (['&&', '||'].includes(operator)) {
       return this.evaluateAndOrExpression(operator, termStack, response);
     } else {
@@ -152,11 +105,7 @@ export class FeedbackRuleEvaluator {
     }
   }
 
-  private evaluateAndOrExpression(
-    operator: string,
-    termStack: string[],
-    response: CRaterResponse | CRaterResponse[]
-  ): boolean {
+  private evaluateAndOrExpression(operator: string, termStack: string[], response: T): boolean {
     const term1 = termStack.pop();
     const term2 = termStack.pop();
     return operator === '&&'
@@ -164,24 +113,16 @@ export class FeedbackRuleEvaluator {
       : this.evaluateTerm(term1, response) || this.evaluateTerm(term2, response);
   }
 
-  private evaluateNotExpression(
-    termStack: string[],
-    response: CRaterResponse | CRaterResponse[]
-  ): boolean {
+  private evaluateNotExpression(termStack: string[], response: T): boolean {
     return !this.evaluateTerm(termStack.pop(), response);
   }
 
-  private evaluateTerm(term: string, response: CRaterResponse | CRaterResponse[]): boolean {
-    const factory = new TermEvaluatorFactory();
-    const evaluator: TermEvaluator = factory.getTermEvaluator(term);
-    return response instanceof CRaterResponse
-      ? evaluator.evaluate(response)
-      : response.some((response: CRaterResponse) => {
-          return evaluator.evaluate(response);
-        });
+  protected evaluateTerm(term: string, response: T): boolean {
+    const evaluator: TermEvaluator = this.factory.getTermEvaluator(term);
+    return evaluator.evaluate(response as CRaterResponse);
   }
 
-  private getDefaultRule(feedbackRules: FeedbackRule[]): FeedbackRule {
+  protected getDefaultRule(feedbackRules: FeedbackRule[]): FeedbackRule {
     return (
       feedbackRules.find((rule) => FeedbackRule.isDefaultRule(rule)) ||
       Object.assign(new FeedbackRule(), {

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluatorMultipleStudents.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluatorMultipleStudents.spec.ts
@@ -1,0 +1,89 @@
+import { CRaterResponse } from '../cRater/CRaterResponse';
+import { FeedbackRuleEvaluatorMultipleStudents } from './FeedbackRuleEvaluatorMultipleStudents';
+import {
+  DEFAULT_FEEDBACK_RULES,
+  HAS_KI_SCORE_FEEDBACK_RULES,
+  KI_SCORE_1,
+  KI_SCORE_3,
+  KI_SCORE_5,
+  KI_SCORE_6,
+  createCRaterResponse
+} from './test-utils';
+import { FeedbackRuleComponent } from '../../feedbackRule/FeedbackRuleComponent';
+
+let evaluator: FeedbackRuleEvaluatorMultipleStudents;
+describe('FeedbackRuleEvaluatorMultipleStudents', () => {
+  beforeEach(() => {
+    evaluator = new FeedbackRuleEvaluatorMultipleStudents(
+      new FeedbackRuleComponent(DEFAULT_FEEDBACK_RULES, 5, true)
+    );
+  });
+  matchRules_OneIdea();
+  matchRules_HasKIScore();
+  matchNoRule_ReturnDefault();
+  matchNoRule_NoDefaultFeedbackAuthored_ReturnApplicationDefault();
+  thirdSubmit();
+});
+
+function matchRules_OneIdea() {
+  it('should find all rules matching one idea', () => {
+    expectRules(
+      [createCRaterResponse(['idea1'], [KI_SCORE_1], 1)],
+      ['idea1', '!idea10', '!idea11 || idea12']
+    );
+  });
+}
+
+function matchRules_HasKIScore() {
+  describe('hasKIScoreScore', () => {
+    beforeEach(() => {
+      evaluator = new FeedbackRuleEvaluatorMultipleStudents(
+        new FeedbackRuleComponent(HAS_KI_SCORE_FEEDBACK_RULES, 5, true)
+      );
+    });
+    matchRules_hasKIScoreScoreInRange_ShouldMatchRule();
+    matchRules_hasKIScoreScoreNotInRange_ShouldReturnDefaultRule();
+  });
+}
+
+function matchRules_hasKIScoreScoreInRange_ShouldMatchRule() {
+  it('should match all rules if KI score is in range [1-5]', () => {
+    expectRules([createCRaterResponse([], [KI_SCORE_1], 1)], ['hasKIScore(1)']);
+    expectRules([createCRaterResponse([], [KI_SCORE_3], 1)], ['hasKIScore(3)']);
+    expectRules([createCRaterResponse([], [KI_SCORE_5], 1)], ['hasKIScore(5)']);
+  });
+}
+
+function matchRules_hasKIScoreScoreNotInRange_ShouldReturnDefaultRule() {
+  it('should not match rule if KI score is out of range [1-5]', () => {
+    expectRules([createCRaterResponse([], [KI_SCORE_6], 1)], ['default']);
+  });
+}
+
+function matchNoRule_ReturnDefault() {
+  it('should return default idea when no rule is matched', () => {
+    expectRules([createCRaterResponse(['idea10', 'idea11'], [KI_SCORE_1], 1)], ['default']);
+  });
+}
+
+function matchNoRule_NoDefaultFeedbackAuthored_ReturnApplicationDefault() {
+  it(`should return application default rule when no rule is matched and no default is
+      authored`, () => {
+    evaluator = new FeedbackRuleEvaluatorMultipleStudents(new FeedbackRuleComponent([], 5, true));
+    expectRules([createCRaterResponse(['idea10', 'idea11'], [KI_SCORE_1], 1)], ['default']);
+  });
+}
+
+function thirdSubmit() {
+  it('should return third submit rule when this is the third submit', () => {
+    expectRules(
+      [createCRaterResponse([], [KI_SCORE_1], 3)],
+      ['thirdSubmit', '!idea10', '!idea11 || idea12']
+    );
+  });
+}
+
+function expectRules(response: CRaterResponse[], expectedRuleIds: string[]): void {
+  const matchedRules = evaluator.getFeedbackRules(response);
+  expect(matchedRules.map((rule) => rule.id)).toEqual(expectedRuleIds);
+}

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluatorMultipleStudents.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluatorMultipleStudents.ts
@@ -1,0 +1,67 @@
+import { CRaterResponse } from '../cRater/CRaterResponse';
+import { FeedbackRule } from './FeedbackRule';
+import { FeedbackRuleEvaluator } from './FeedbackRuleEvaluator';
+import { TermEvaluator } from './TermEvaluator/TermEvaluator';
+
+export class FeedbackRuleEvaluatorMultipleStudents extends FeedbackRuleEvaluator<CRaterResponse[]> {
+  getFeedbackRules(responses: CRaterResponse[]): FeedbackRule[] {
+    const matchedRules = this.component
+      .getFeedbackRules()
+      .filter((rule) => this.satisfiesRule(responses, Object.assign(new FeedbackRule(), rule)));
+    return matchedRules.length > 0
+      ? matchedRules
+      : [this.getDefaultRule(this.component.getFeedbackRules())];
+  }
+
+  getFeedbackRule(responses: CRaterResponse[]): FeedbackRule {
+    for (const feedbackRule of this.component.getFeedbackRules()) {
+      if (this.satisfiesRule(responses, Object.assign(new FeedbackRule(), feedbackRule))) {
+        return feedbackRule;
+      }
+    }
+    return this.getDefaultRule(this.component.getFeedbackRules());
+  }
+
+  protected satisfiesFinalSubmitRule(
+    responses: CRaterResponse[],
+    feedbackRule: FeedbackRule
+  ): boolean {
+    return (
+      this.hasMaxSubmitAndIsFinalSubmitRule(feedbackRule) &&
+      responses.some((response: CRaterResponse) => {
+        return this.component.hasMaxSubmitCountAndUsedAllSubmits(response.submitCounter);
+      })
+    );
+  }
+
+  protected satisfiesSecondToLastSubmitRule(
+    responses: CRaterResponse[],
+    feedbackRule: FeedbackRule
+  ): boolean {
+    return (
+      this.hasMaxSubmitAndIsSecondToLastSubmitRule(feedbackRule) &&
+      responses.some((response: CRaterResponse) => {
+        return this.isSecondToLastSubmit(response.submitCounter);
+      })
+    );
+  }
+
+  protected satisfiesNonScorableRule(
+    responses: CRaterResponse[],
+    feedbackRule: FeedbackRule
+  ): boolean {
+    return (
+      feedbackRule.expression === 'isNonScorable' &&
+      responses.some((response: CRaterResponse) => {
+        return response.isNonScorable();
+      })
+    );
+  }
+
+  protected evaluateTerm(term: string, responses: CRaterResponse[]): boolean {
+    const evaluator: TermEvaluator = this.factory.getTermEvaluator(term);
+    return responses.some((response: CRaterResponse) => {
+      return evaluator.evaluate(response);
+    });
+  }
+}

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluatorMultipleStudents.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluatorMultipleStudents.ts
@@ -13,15 +13,6 @@ export class FeedbackRuleEvaluatorMultipleStudents extends FeedbackRuleEvaluator
       : [this.getDefaultRule(this.component.getFeedbackRules())];
   }
 
-  getFeedbackRule(responses: CRaterResponse[]): FeedbackRule {
-    for (const feedbackRule of this.component.getFeedbackRules()) {
-      if (this.satisfiesRule(responses, Object.assign(new FeedbackRule(), feedbackRule))) {
-        return feedbackRule;
-      }
-    }
-    return this.getDefaultRule(this.component.getFeedbackRules());
-  }
-
   protected satisfiesFinalSubmitRule(
     responses: CRaterResponse[],
     feedbackRule: FeedbackRule

--- a/src/assets/wise5/components/common/feedbackRule/test-utils.ts
+++ b/src/assets/wise5/components/common/feedbackRule/test-utils.ts
@@ -1,0 +1,120 @@
+import { CRaterIdea } from '../cRater/CRaterIdea';
+import { CRaterResponse } from '../cRater/CRaterResponse';
+import { CRaterScore } from '../cRater/CRaterScore';
+import { FeedbackRule } from './FeedbackRule';
+
+export const KI_SCORE_0 = new CRaterScore('ki', 0, 0, 1, 5);
+export const KI_SCORE_1 = new CRaterScore('ki', 1, 1, 1, 5);
+export const KI_SCORE_3 = new CRaterScore('ki', 3, 3, 1, 5);
+export const KI_SCORE_5 = new CRaterScore('ki', 5, 5, 1, 5);
+export const KI_SCORE_6 = new CRaterScore('ki', 6, 6, 1, 5);
+
+export const DEFAULT_FEEDBACK_RULES = [
+  new FeedbackRule({
+    id: 'finalSubmit',
+    expression: 'isFinalSubmit',
+    feedback: 'This is a generic response that is shown on a final submission'
+  }),
+  new FeedbackRule({
+    id: 'secondToLastSubmit',
+    expression: 'isSecondToLastSubmit',
+    feedback: 'This is a generic response that is shown on the second to last submission'
+  }),
+  new FeedbackRule({
+    id: 'thirdSubmit',
+    expression: 'isSubmitNumber(3)',
+    feedback: 'Is third submit'
+  }),
+  new FeedbackRule({
+    id: 'isNonScorable',
+    expression: 'isNonScorable',
+    feedback: 'isNonScorable'
+  }),
+  new FeedbackRule({
+    id: 'idea1 && idea2',
+    expression: 'idea1 && idea2',
+    feedback: 'You hit idea1 and idea2'
+  }),
+  new FeedbackRule({
+    id: 'idea2 && idea3 && idea4',
+    expression: 'idea2 && idea3 && idea4',
+    feedback: 'You hit idea2, idea3 and idea4'
+  }),
+  new FeedbackRule({
+    id: 'zlh8oip6hp',
+    expression: 'idea5 || idea6',
+    feedback: 'You hit idea5 or idea6'
+  }),
+  new FeedbackRule({
+    id: 'idea7 || idea8 && idea9',
+    expression: 'idea7 || idea8 && idea9',
+    feedback: 'You hit idea7 or idea8 and idea9'
+  }),
+  new FeedbackRule({
+    id: 'idea7 && idea8 || idea9',
+    expression: 'idea7 && idea8 || idea9',
+    feedback: 'You hit idea7 and idea8 or idea9'
+  }),
+  new FeedbackRule({
+    id: 'idea1',
+    expression: 'idea1',
+    feedback: 'You hit idea1'
+  }),
+  new FeedbackRule({
+    id: '!idea10',
+    expression: '!idea10',
+    feedback: '!idea10'
+  }),
+  new FeedbackRule({
+    id: 'idea10 && !idea11',
+    expression: 'idea10 && !idea11',
+    feedback: 'idea10 && !idea11'
+  }),
+  new FeedbackRule({
+    id: '!idea11 || idea12',
+    expression: '!idea11 || idea12',
+    feedback: '!idea11 || idea12'
+  }),
+  new FeedbackRule({
+    id: 'default',
+    expression: 'isDefault',
+    feedback: 'This is a default feedback'
+  })
+];
+
+export const HAS_KI_SCORE_FEEDBACK_RULES = [
+  new FeedbackRule({
+    id: 'hasKIScore(1)',
+    expression: 'hasKIScore(1)',
+    feedback: 'hasKIScore(1)'
+  }),
+  new FeedbackRule({
+    id: 'hasKIScore(3)',
+    expression: 'hasKIScore(3)',
+    feedback: 'hasKIScore(3)'
+  }),
+  new FeedbackRule({
+    id: 'hasKIScore(5)',
+    expression: 'hasKIScore(5)',
+    feedback: 'hasKIScore(5)'
+  }),
+  new FeedbackRule({
+    id: 'default',
+    expression: 'isDefault',
+    feedback: 'isDefault'
+  })
+];
+
+export function createCRaterResponse(
+  ideas: string[],
+  scores: CRaterScore[],
+  submitCounter: number
+): CRaterResponse {
+  const response = new CRaterResponse();
+  response.ideas = ideas.map((idea) => {
+    return new CRaterIdea(idea, true);
+  });
+  response.scores = scores;
+  response.submitCounter = submitCounter;
+  return response;
+}

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
@@ -35,7 +35,7 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
   component: DialogGuidanceComponent;
   computerAvatar: ComputerAvatar;
   cRaterTimeout: number = 40000;
-  feedbackRuleEvaluator: FeedbackRuleEvaluator;
+  feedbackRuleEvaluator: FeedbackRuleEvaluator<CRaterResponse>;
   isShowComputerAvatarSelector: boolean = false;
   isSubmitEnabled: boolean = false;
   isWaitingForComputerResponse: boolean = false;

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
@@ -7,7 +7,7 @@ import { QuestionBank } from './QuestionBank';
 import { Component as WISEComponent } from '../../../common/Component';
 import { PeerGroupStudentData } from '../../../../../app/domain/peerGroupStudentData';
 import { CRaterResponse } from '../../common/cRater/CRaterResponse';
-import { FeedbackRuleEvaluator } from '../../common/feedbackRule/FeedbackRuleEvaluator';
+import { FeedbackRuleEvaluatorMultipleStudents } from '../../common/feedbackRule/FeedbackRuleEvaluatorMultipleStudents';
 import { FeedbackRuleComponent } from '../../feedbackRule/FeedbackRuleComponent';
 import { QuestionBankRule } from './QuestionBankRule';
 import { concatMap, map } from 'rxjs/operators';
@@ -75,7 +75,7 @@ export class PeerChatQuestionBankComponent implements OnInit {
         submitCounter: peerMemberData.studentWork.studentData.submitCounter
       });
     });
-    const feedbackRuleEvaluator = new FeedbackRuleEvaluator(
+    const feedbackRuleEvaluator = new FeedbackRuleEvaluatorMultipleStudents(
       new FeedbackRuleComponent(
         this.content.questionBank.getRules(),
         (referenceComponent.content as OpenResponseContent).maxSubmitCount,

--- a/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.ts
@@ -15,6 +15,7 @@ import { PeerGroupService } from '../../services/peerGroupService';
 import { ProjectService } from '../../services/projectService';
 import { StudentDataService } from '../../services/studentDataService';
 import { DynamicPrompt } from './DynamicPrompt';
+import { FeedbackRuleEvaluatorMultipleStudents } from '../../components/common/feedbackRule/FeedbackRuleEvaluatorMultipleStudents';
 
 @Component({
   selector: 'dynamic-prompt',
@@ -70,9 +71,12 @@ export class DynamicPromptComponent implements OnInit {
           submitCounter: this.getSubmitCounter(peerMemberData.studentWork)
         });
       });
-      const feedbackRuleEvaluator = this.getFeedbackRuleEvaluator(
-        this.dynamicPrompt.getRules(),
-        referenceComponentContent.maxSubmitCount
+      const feedbackRuleEvaluator = new FeedbackRuleEvaluatorMultipleStudents(
+        new FeedbackRuleComponent(
+          this.dynamicPrompt.getRules(),
+          referenceComponentContent.maxSubmitCount,
+          false
+        )
       );
       const feedbackRule: FeedbackRule = feedbackRuleEvaluator.getFeedbackRule(cRaterResponses);
       this.prompt = feedbackRule.prompt;
@@ -117,21 +121,17 @@ export class DynamicPromptComponent implements OnInit {
         scores: latestAutoScoreAnnotation.data.scores,
         submitCounter: this.getSubmitCounter(latestComponentState)
       });
-      const feedbackRuleEvaluator = this.getFeedbackRuleEvaluator(
-        this.dynamicPrompt.getRules(),
-        referenceComponentContent.maxSubmitCount
+      const feedbackRuleEvaluator = new FeedbackRuleEvaluator(
+        new FeedbackRuleComponent(
+          this.dynamicPrompt.getRules(),
+          referenceComponentContent.maxSubmitCount,
+          false
+        )
       );
       const feedbackRule: FeedbackRule = feedbackRuleEvaluator.getFeedbackRule(cRaterResponse);
       this.prompt = feedbackRule.prompt;
       this.dynamicPromptChanged.emit(feedbackRule);
     }
-  }
-
-  private getFeedbackRuleEvaluator(
-    rules: FeedbackRule[],
-    maxSubmitCount: number
-  ): FeedbackRuleEvaluator {
-    return new FeedbackRuleEvaluator(new FeedbackRuleComponent(rules, maxSubmitCount, false));
   }
 
   private getSubmitCounter(componentState: any): number {


### PR DESCRIPTION
## Changes
- Extract the functionality for handling rule evaluation for multiple students into a new class, FeedbackRuleEvaluatorMultipleStudents, that extends FeedbackRuleEvaluator
- Update references to create and use the correct class
- Clean up code

## Test Regression
Feedback rule evaluation should work as before in these places:
- Single Student
  - Dialog Guidance 
  - OpenResponse annotation using Feedback Rules
  - Dynamic Prompt 
- Multiple Students
   - Dynamic Prompt
   - Question Bank

Closes #1252