### PR TITLE
feat(Match): Implement component export for choice reuse

### DIFF
--- a/src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts
@@ -1225,7 +1225,7 @@ export class DataExportComponent implements OnInit {
       .filter((bucket: Bucket) => bucket.id !== '0')
       .forEach((bucket: Bucket) => {
         bucket.items.forEach((item: Choice) => {
-          this.setBucketValueWithAppending(row, columnNameToNumber, component, bucket, item);
+          this.setBucketValue(row, columnNameToNumber, component, bucket, item);
           if (
             this.includeCorrectnessColumns &&
             this.matchService.componentHasCorrectAnswer(component)
@@ -1236,23 +1236,24 @@ export class DataExportComponent implements OnInit {
       });
   }
 
-  private setBucketValueWithAppending(
+  private setBucketValue(
     row: string[],
     columnNameToNumber: any,
     component: any,
-    bucket: any,
-    item: any
+    bucket: Bucket,
+    item: Choice
   ): void {
-    if (row[columnNameToNumber[item.id]] == null || row[columnNameToNumber[item.id]] === '') {
-      row[columnNameToNumber[item.id]] = this.getBucketValueById(component, bucket.id);
-    } else {
-      row[columnNameToNumber[item.id]] = `${
-        row[columnNameToNumber[item.id]]
-      }, ${this.getBucketValueById(component, bucket.id)}`;
-    }
+    const previousValue = row[columnNameToNumber[item.id]];
+    const bucketValue = this.getBucketValueById(component, bucket.id);
+    row[columnNameToNumber[item.id]] =
+      previousValue === '' ? bucketValue : `${previousValue}, ${bucketValue}`;
   }
 
-  private setCorrectnessValueForChoiceReuse(row: any[], columnNameToNumber: any, item: any): void {
+  private setCorrectnessValueForChoiceReuse(
+    row: any[],
+    columnNameToNumber: any,
+    item: Choice
+  ): void {
     const columnName = item.id + '-boolean';
     if (item.isCorrect == null) {
       // The item does not have an isCorrect field so we will not show anything in the cell.
@@ -1289,26 +1290,30 @@ export class DataExportComponent implements OnInit {
     row: any,
     columnNameToNumber: any,
     columnName: string,
-    newValue: any
+    newValue: number
   ): void {
     const previousValue = row[columnNameToNumber[columnName]];
     if (previousValue === '') {
       row[columnNameToNumber[columnName]] = newValue;
-    } else if (this.bothValuesAreX(previousValue, newValue, 1)) {
+    } else if (this.bothValuesAreCorrect(previousValue, newValue)) {
       row[columnNameToNumber[columnName]] = 1;
-    } else if (this.eitherValuesAreX(previousValue, newValue, 0)) {
+    } else if (this.eitherValuesAreIncorrect(previousValue, newValue)) {
       row[columnNameToNumber[columnName]] = 0;
-    } else if (this.eitherValuesAreX(previousValue, newValue, 2)) {
+    } else if (this.eitherValuesAreIncorrectPosition(previousValue, newValue)) {
       row[columnNameToNumber[columnName]] = 2;
     }
   }
 
-  private bothValuesAreX(value1: number, value2: number, expectedValue: number): boolean {
-    return value1 === expectedValue && value2 === expectedValue;
+  private bothValuesAreCorrect(value1: number, value2: number): boolean {
+    return value1 === 1 && value2 === 1;
   }
 
-  private eitherValuesAreX(value1: number, value2: number, expectedValue: number): boolean {
-    return value1 === expectedValue || value2 === expectedValue;
+  private eitherValuesAreIncorrect(value1: number, value2: number): boolean {
+    return value1 === 0 || value2 === 0;
+  }
+
+  private eitherValuesAreIncorrectPosition(value1: number, value2: number): boolean {
+    return value1 === 2 || value2 === 2;
   }
 
   getBucketValueById(component: any, id: string): string {

--- a/src/assets/wise5/components/match/bucket.ts
+++ b/src/assets/wise5/components/match/bucket.ts
@@ -1,0 +1,12 @@
+import { Choice } from './choice';
+
+export class Bucket {
+  id: string;
+  items?: Choice[];
+  value: string;
+
+  constructor(id: string, value: string) {
+    this.id = id;
+    this.value = value;
+  }
+}


### PR DESCRIPTION
## Changes

Match component export now properly exports data when a Match component can reuse choices.

## Test

- Create a Match component with choice reuse enabled as well as correctness and correct positions
- Generate some work for that Match component with choice reuse enabled
- Generate the Match component export
  - Classroom Monitor > Data Export view > Export Component Data > Find the Match component and click "All" button
- In the export, check
  - If a choice is in multiple buckets, those bucket names should show up in the cell separated by commas
  - Make sure the correctness value is correct when a choice is placed in multiple buckets based on the matrix below. The previous and next is in reference to when we loop through the buckets to check for correctness.
Examples
    - If choice "Apple" was placed in bucket "A", which is correct, and also placed in bucket "Wildcard", which is also correct, then we would say the previous value was 1 (because it was correct in bucket "A") and the new value is 1 (because it was correct in bucket "Wildcard") and the result correctness value that is shown in the export for the choice "Apple" is 1.
    - If choice "Apple" was placed in bucket "A", which is correct, and also placed in bucket "B", which is incorrect, then we would say the previous value was 1 (because it was correct in bucket "A") and the new value is 0 (because it was incorrect in bucket "B") and the result correctness value that is shown in the export for the choice "Apple" is 0.
```
e = empty
0 = incorrect
1 = correct
2 = correct bucket but incorrect position

       Previous Value
       e 0 1 2
      --------
N  0 | 0 0 0 0
e  1 | 1 0 1 2
w  2 | 2 0 2 2

V
a
l
u
e
```
- Make sure Match component export without choice reuse still works properly

Closes #1251