### PR TITLE
feat(FeedbackRule): accumulatedIdeaCount[LessThan|Equals|MoreThan] tokens

### DIFF
--- a/src/app/services/cRaterService.spec.ts
+++ b/src/app/services/cRaterService.spec.ts
@@ -5,7 +5,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { UtilService } from '../../assets/wise5/services/utilService';
 import { CRaterIdea } from '../../assets/wise5/components/common/cRater/CRaterIdea';
 import { CRaterScore } from '../../assets/wise5/components/common/cRater/CRaterScore';
-import { CRaterResponses } from '../../assets/wise5/components/common/cRater/CRaterResponses';
+import { RawCRaterResponse } from '../../assets/wise5/components/common/cRater/RawCRaterResponse';
 let service: CRaterService;
 let configService: ConfigService;
 let http: HttpTestingController;
@@ -194,7 +194,7 @@ function getDataFromResponse() {
         scores: {
           raw_trim_round: score
         }
-      } as CRaterResponses;
+      } as RawCRaterResponse;
       const cRaterResponse = service.getCRaterResponse(response, 1);
       expect(cRaterResponse.score).toEqual(score);
       expect(cRaterResponse.ideas).toEqual([new CRaterIdea('1', idea1Detected)]);
@@ -236,7 +236,7 @@ function getDataFromResponse() {
             score_range_min: dciScoreRangeMin
           }
         }
-      } as CRaterResponses;
+      } as RawCRaterResponse;
       const cRaterResponse = service.getCRaterResponse(response, 1);
       expect(cRaterResponse.scores).toEqual([
         new CRaterScore('ki', kiRawTrimRound, kiRaw, kiScoreRangeMin, kiScoreRangeMax),
@@ -257,7 +257,7 @@ function getDataFromResponse() {
         scores: {
           raw_trim_round: score
         }
-      } as CRaterResponses;
+      } as RawCRaterResponse;
       const cRaterResponse = service.getCRaterResponse(response, 1);
       expect(cRaterResponse.score).toEqual(score);
       expect(cRaterResponse.ideas).toEqual([]);

--- a/src/app/services/cRaterService.spec.ts
+++ b/src/app/services/cRaterService.spec.ts
@@ -5,6 +5,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { UtilService } from '../../assets/wise5/services/utilService';
 import { CRaterIdea } from '../../assets/wise5/components/common/cRater/CRaterIdea';
 import { CRaterScore } from '../../assets/wise5/components/common/cRater/CRaterScore';
+import { CRaterResponses } from '../../assets/wise5/components/common/cRater/CRaterResponses';
 let service: CRaterService;
 let configService: ConfigService;
 let http: HttpTestingController;
@@ -183,19 +184,17 @@ function getDataFromResponse() {
       const score = 1;
       const idea1Detected = true;
       const response = {
-        responses: {
-          feedback: {
-            ideas: {
-              1: {
-                detected: idea1Detected
-              }
+        feedback: {
+          ideas: {
+            1: {
+              detected: idea1Detected
             }
-          },
-          scores: {
-            raw_trim_round: score
           }
+        },
+        scores: {
+          raw_trim_round: score
         }
-      };
+      } as CRaterResponses;
       const cRaterResponse = service.getCRaterResponse(response, 1);
       expect(cRaterResponse.score).toEqual(score);
       expect(cRaterResponse.ideas).toEqual([new CRaterIdea('1', idea1Detected)]);
@@ -213,33 +212,31 @@ function getDataFromResponse() {
       const idea1Detected = true;
       const idea2Detected = false;
       const response = {
-        responses: {
-          feedback: {
-            ideas: {
-              1: {
-                detected: idea1Detected
-              },
-              2: {
-                detected: idea2Detected
-              }
-            }
-          },
-          trait_scores: {
-            ki: {
-              raw: kiRaw,
-              raw_trim_round: kiRawTrimRound,
-              score_range_max: kiScoreRangeMax,
-              score_range_min: kiScoreRangeMin
+        feedback: {
+          ideas: {
+            1: {
+              detected: idea1Detected
             },
-            dci: {
-              raw: dciRaw,
-              raw_trim_round: dciRawTrimRound,
-              score_range_max: dciScoreRangeMax,
-              score_range_min: dciScoreRangeMin
+            2: {
+              detected: idea2Detected
             }
           }
+        },
+        trait_scores: {
+          ki: {
+            raw: kiRaw,
+            raw_trim_round: kiRawTrimRound,
+            score_range_max: kiScoreRangeMax,
+            score_range_min: kiScoreRangeMin
+          },
+          dci: {
+            raw: dciRaw,
+            raw_trim_round: dciRawTrimRound,
+            score_range_max: dciScoreRangeMax,
+            score_range_min: dciScoreRangeMin
+          }
         }
-      };
+      } as CRaterResponses;
       const cRaterResponse = service.getCRaterResponse(response, 1);
       expect(cRaterResponse.scores).toEqual([
         new CRaterScore('ki', kiRawTrimRound, kiRaw, kiScoreRangeMin, kiScoreRangeMax),
@@ -254,15 +251,13 @@ function getDataFromResponse() {
     it('should get data from response when there are no ideas', () => {
       const score = 1;
       const response = {
-        responses: {
-          feedback: {
-            ideas: {}
-          },
-          scores: {
-            raw_trim_round: score
-          }
+        feedback: {
+          ideas: {}
+        },
+        scores: {
+          raw_trim_round: score
         }
-      };
+      } as CRaterResponses;
       const cRaterResponse = service.getCRaterResponse(response, 1);
       expect(cRaterResponse.score).toEqual(score);
       expect(cRaterResponse.ideas).toEqual([]);

--- a/src/assets/wise5/components/common/cRater/CRaterResponses.ts
+++ b/src/assets/wise5/components/common/cRater/CRaterResponses.ts
@@ -1,0 +1,12 @@
+/**
+ * CRaterResponses is the response object from the CRater API.
+ * This is different from CRaterResponse, which is the object that WISE creates to store the
+ * response.
+ */
+export interface CRaterResponses {
+  advisories: string[];
+  feedback: any;
+  response_id: string;
+  scores?: any;
+  trait_scores: any;
+}

--- a/src/assets/wise5/components/common/cRater/RawCRaterResponse.ts
+++ b/src/assets/wise5/components/common/cRater/RawCRaterResponse.ts
@@ -3,7 +3,7 @@
  * This is different from CRaterResponse, which is the object that WISE creates to store the
  * response.
  */
-export interface CRaterResponses {
+export interface RawCRaterResponse {
   advisories: string[];
   feedback: any;
   response_id: string;

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRule.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRule.ts
@@ -14,6 +14,12 @@ export class FeedbackRule {
     }
   }
 
+  static isSpecialRule(feedbackRule: FeedbackRule): boolean {
+    return ['isFinalSubmit', 'isSecondToLastSubmit', 'isNonScorable'].includes(
+      feedbackRule.expression
+    );
+  }
+
   static isSecondToLastSubmitRule(feedbackRule: FeedbackRule): boolean {
     return feedbackRule.expression === 'isSecondToLastSubmit';
   }

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.spec.ts
@@ -14,7 +14,7 @@ import {
 } from './test-utils';
 import { CRaterResponse } from '../cRater/CRaterResponse';
 
-let evaluator: FeedbackRuleEvaluator<CRaterResponse>;
+let evaluator: FeedbackRuleEvaluator<CRaterResponse[]>;
 describe('FeedbackRuleEvaluator', () => {
   beforeEach(() => {
     evaluator = new FeedbackRuleEvaluator(
@@ -177,6 +177,6 @@ function expectFeedback(
   submitCounter: number,
   expectedFeedback: string
 ) {
-  const rule = evaluator.getFeedbackRule(createCRaterResponse(ideas, scores, submitCounter));
+  const rule = evaluator.getFeedbackRule([createCRaterResponse(ideas, scores, submitCounter)]);
   expect(rule.feedback).toContain(expectedFeedback);
 }

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.ts
@@ -5,126 +5,121 @@ import { FeedbackRuleExpression } from './FeedbackRuleExpression';
 import { TermEvaluator } from './TermEvaluator/TermEvaluator';
 import { TermEvaluatorFactory } from './TermEvaluator/TermEvaluatorFactory';
 
-export class FeedbackRuleEvaluator<T extends CRaterResponse | CRaterResponse[]> {
+export class FeedbackRuleEvaluator<T extends CRaterResponse[]> {
   defaultFeedback = $localize`Thanks for submitting your response.`;
   protected factory = new TermEvaluatorFactory();
 
   constructor(protected component: FeedbackRuleComponent) {}
 
-  getFeedbackRule(response: T): FeedbackRule {
-    for (const feedbackRule of this.component.getFeedbackRules()) {
-      if (this.satisfiesRule(response, Object.assign(new FeedbackRule(), feedbackRule))) {
-        return feedbackRule;
-      }
-    }
-    return this.getDefaultRule(this.component.getFeedbackRules());
-  }
-
-  protected satisfiesRule(response: T, feedbackRule: FeedbackRule): boolean {
-    return this.isSpecialRule(feedbackRule)
-      ? this.satisfiesSpecialRule(response, feedbackRule)
-      : this.satisfiesSpecificRule(response, feedbackRule);
-  }
-
-  private satisfiesSpecialRule(response: T, feedbackRule: FeedbackRule): boolean {
+  getFeedbackRule(responses: T): FeedbackRule {
     return (
-      this.satisfiesNonScorableRule(response, feedbackRule) ||
-      this.satisfiesFinalSubmitRule(response, feedbackRule) ||
-      this.satisfiesSecondToLastSubmitRule(response, feedbackRule)
+      this.component
+        .getFeedbackRules()
+        .find((rule) => this.satisfiesRule(responses, Object.assign(new FeedbackRule(), rule))) ??
+      this.getDefaultRule(this.component.getFeedbackRules())
     );
   }
 
-  protected satisfiesFinalSubmitRule(response: T, feedbackRule: FeedbackRule): boolean {
+  protected satisfiesRule(responses: T, rule: FeedbackRule): boolean {
+    return FeedbackRule.isSpecialRule(rule)
+      ? this.satisfiesSpecialRule(responses, rule)
+      : this.satisfiesSpecificRule(responses, rule);
+  }
+
+  private satisfiesSpecialRule(responses: T, rule: FeedbackRule): boolean {
     return (
-      this.hasMaxSubmitAndIsFinalSubmitRule(feedbackRule) &&
-      this.component.hasMaxSubmitCountAndUsedAllSubmits((response as CRaterResponse).submitCounter)
+      this.satisfiesNonScorableRule(responses, rule) ||
+      this.satisfiesFinalSubmitRule(responses, rule) ||
+      this.satisfiesSecondToLastSubmitRule(responses, rule)
     );
   }
 
-  protected hasMaxSubmitAndIsFinalSubmitRule(feedbackRule: FeedbackRule): boolean {
-    return this.component.hasMaxSubmitCount() && FeedbackRule.isFinalSubmitRule(feedbackRule);
-  }
-
-  protected satisfiesSecondToLastSubmitRule(response: T, feedbackRule: FeedbackRule): boolean {
+  protected satisfiesFinalSubmitRule(responses: T, rule: FeedbackRule): boolean {
     return (
-      this.hasMaxSubmitAndIsSecondToLastSubmitRule(feedbackRule) &&
-      this.isSecondToLastSubmit((response as CRaterResponse).submitCounter)
+      this.hasMaxSubmitAndIsFinalSubmitRule(rule) &&
+      this.component.hasMaxSubmitCountAndUsedAllSubmits(
+        (responses[responses.length - 1] as CRaterResponse).submitCounter
+      )
     );
   }
 
-  protected hasMaxSubmitAndIsSecondToLastSubmitRule(feedbackRule: FeedbackRule): boolean {
+  protected hasMaxSubmitAndIsFinalSubmitRule(rule: FeedbackRule): boolean {
+    return this.component.hasMaxSubmitCount() && FeedbackRule.isFinalSubmitRule(rule);
+  }
+
+  protected satisfiesSecondToLastSubmitRule(responses: T, rule: FeedbackRule): boolean {
     return (
-      this.component.hasMaxSubmitCount() && FeedbackRule.isSecondToLastSubmitRule(feedbackRule)
+      this.hasMaxSubmitAndIsSecondToLastSubmitRule(rule) &&
+      this.isSecondToLastSubmit((responses[responses.length - 1] as CRaterResponse).submitCounter)
     );
+  }
+
+  protected hasMaxSubmitAndIsSecondToLastSubmitRule(rule: FeedbackRule): boolean {
+    return this.component.hasMaxSubmitCount() && FeedbackRule.isSecondToLastSubmitRule(rule);
   }
 
   protected isSecondToLastSubmit(submitCounter: number): boolean {
     return this.component.getNumberOfSubmitsLeft(submitCounter) === 1;
   }
 
-  protected satisfiesNonScorableRule(response: T, feedbackRule: FeedbackRule): boolean {
+  protected satisfiesNonScorableRule(responses: T, rule: FeedbackRule): boolean {
     return (
-      feedbackRule.expression === 'isNonScorable' && (response as CRaterResponse).isNonScorable()
+      rule.expression === 'isNonScorable' &&
+      (responses[responses.length - 1] as CRaterResponse).isNonScorable()
     );
   }
 
-  private isSpecialRule(feedbackRule: FeedbackRule): boolean {
-    return ['isFinalSubmit', 'isSecondToLastSubmit', 'isNonScorable'].includes(
-      feedbackRule.expression
-    );
-  }
-
-  private satisfiesSpecificRule(response: T, feedbackRule: FeedbackRule): boolean {
+  private satisfiesSpecificRule(responses: T, rule: FeedbackRule): boolean {
     const termStack = [];
-    for (const term of feedbackRule.getPostfixExpression()) {
+    for (const term of rule.getPostfixExpression()) {
       if (FeedbackRuleExpression.isOperand(term)) {
         termStack.push(term);
       } else {
-        this.evaluateOperator(term, termStack, response);
+        this.evaluateOperator(term, termStack, responses);
       }
     }
     if (termStack.length === 1) {
-      return this.evaluateTerm(termStack.pop(), response);
+      return this.evaluateTerm(termStack.pop(), responses);
     }
     return true;
   }
 
-  private evaluateOperator(operator: string, termStack: string[], response: T) {
-    if (this.evaluateOperatorExpression(operator, termStack, response)) {
+  private evaluateOperator(operator: string, termStack: string[], responses: T) {
+    if (this.evaluateOperatorExpression(operator, termStack, responses)) {
       termStack.push('true');
     } else {
       termStack.push('false');
     }
   }
 
-  private evaluateOperatorExpression(operator: string, termStack: string[], response: T): boolean {
+  private evaluateOperatorExpression(operator: string, termStack: string[], responses: T): boolean {
     if (['&&', '||'].includes(operator)) {
-      return this.evaluateAndOrExpression(operator, termStack, response);
+      return this.evaluateAndOrExpression(operator, termStack, responses);
     } else {
-      return this.evaluateNotExpression(termStack, response);
+      return this.evaluateNotExpression(termStack, responses);
     }
   }
 
-  private evaluateAndOrExpression(operator: string, termStack: string[], response: T): boolean {
+  private evaluateAndOrExpression(operator: string, termStack: string[], responses: T): boolean {
     const term1 = termStack.pop();
     const term2 = termStack.pop();
     return operator === '&&'
-      ? this.evaluateTerm(term1, response) && this.evaluateTerm(term2, response)
-      : this.evaluateTerm(term1, response) || this.evaluateTerm(term2, response);
+      ? this.evaluateTerm(term1, responses) && this.evaluateTerm(term2, responses)
+      : this.evaluateTerm(term1, responses) || this.evaluateTerm(term2, responses);
   }
 
-  private evaluateNotExpression(termStack: string[], response: T): boolean {
-    return !this.evaluateTerm(termStack.pop(), response);
+  private evaluateNotExpression(termStack: string[], responses: T): boolean {
+    return !this.evaluateTerm(termStack.pop(), responses);
   }
 
-  protected evaluateTerm(term: string, response: T): boolean {
+  protected evaluateTerm(term: string, responses: T): boolean {
     const evaluator: TermEvaluator = this.factory.getTermEvaluator(term);
-    return evaluator.evaluate(response as CRaterResponse);
+    return evaluator.evaluate(responses[responses.length - 1]);
   }
 
-  protected getDefaultRule(feedbackRules: FeedbackRule[]): FeedbackRule {
+  protected getDefaultRule(rules: FeedbackRule[]): FeedbackRule {
     return (
-      feedbackRules.find((rule) => FeedbackRule.isDefaultRule(rule)) ||
+      rules.find((rule) => FeedbackRule.isDefaultRule(rule)) ||
       Object.assign(new FeedbackRule(), {
         id: 'default',
         expression: 'isDefault',

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.ts
@@ -114,7 +114,9 @@ export class FeedbackRuleEvaluator<T extends CRaterResponse[]> {
 
   protected evaluateTerm(term: string, responses: T): boolean {
     const evaluator: TermEvaluator = this.factory.getTermEvaluator(term);
-    return evaluator.evaluate(responses[responses.length - 1]);
+    return TermEvaluator.isAccumulatedIdeaCountTerm(term)
+      ? evaluator.evaluate(responses)
+      : evaluator.evaluate(responses[responses.length - 1]);
   }
 
   protected getDefaultRule(rules: FeedbackRule[]): FeedbackRule {

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.ts
@@ -114,7 +114,7 @@ export class FeedbackRuleEvaluator<T extends CRaterResponse[]> {
 
   protected evaluateTerm(term: string, responses: T): boolean {
     const evaluator: TermEvaluator = this.factory.getTermEvaluator(term);
-    return TermEvaluator.isAccumulatedIdeaCountTerm(term)
+    return TermEvaluator.requiresAllResponses(term)
       ? evaluator.evaluate(responses)
       : evaluator.evaluate(responses[responses.length - 1]);
   }

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleExpression.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleExpression.ts
@@ -28,7 +28,7 @@ export class FeedbackRuleExpression {
     return this.text
       .replace(/ /g, '')
       .split(
-        /(hasKIScore\(\d\)|ideaCountEquals\(\d\)|ideaCountLessThan\(\d\)|ideaCountMoreThan\(\d\)|isSubmitNumber\(\d+\)|&&|\|\||!|\(|\))/g
+        /(hasKIScore\(\d\)|accumulatedIdeaCountEquals\(\d\)|accumulatedIdeaCountLessThan\(\d\)|accumulatedIdeaCountMoreThan\(\d\)|ideaCountEquals\(\d\)|ideaCountLessThan\(\d\)|ideaCountMoreThan\(\d\)|isSubmitNumber\(\d+\)|&&|\|\||!|\(|\))/g
       )
       .filter((el) => el !== '');
   }

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleExpression.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleExpression.ts
@@ -28,7 +28,7 @@ export class FeedbackRuleExpression {
     return this.text
       .replace(/ /g, '')
       .split(
-        /(hasKIScore\(\d\)|accumulatedIdeaCountEquals\(\d\)|accumulatedIdeaCountLessThan\(\d\)|accumulatedIdeaCountMoreThan\(\d\)|ideaCountEquals\(\d\)|ideaCountLessThan\(\d\)|ideaCountMoreThan\(\d\)|isSubmitNumber\(\d+\)|&&|\|\||!|\(|\))/g
+        /(hasKIScore\(\d\)|accumulatedIdeaCountEquals\(\d\)|accumulatedIdeaCountLessThan\(\d\)|accumulatedIdeaCountMoreThan\(\d\)|ideaCountEquals\(\S+\)|ideaCountLessThan\(\S+\)|ideaCountMoreThan\(\S+\)|isSubmitNumber\(\d+\)|&&|\|\||!|\(|\))/g
       )
       .filter((el) => el !== '');
   }

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/AbstractIdeaCountTermEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/AbstractIdeaCountTermEvaluator.ts
@@ -4,12 +4,13 @@ import { TermEvaluator } from './TermEvaluator';
 export abstract class AbstractIdeaCountTermEvaluator extends TermEvaluator {
   comparer: 'MoreThan' | 'Equals' | 'LessThan';
   expectedIdeaCount: number;
+  matches: RegExpMatchArray;
 
   constructor(term: string, matcher: RegExp) {
     super(term);
-    const matches = term.match(matcher);
-    this.comparer = matches[1] as 'MoreThan' | 'Equals' | 'LessThan';
-    this.expectedIdeaCount = parseInt(matches[2]);
+    this.matches = term.match(matcher);
+    this.comparer = this.matches[1] as 'MoreThan' | 'Equals' | 'LessThan';
+    this.expectedIdeaCount = parseInt(this.matches[2]);
   }
 
   evaluate(response: CRaterResponse | CRaterResponse[]): boolean {

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/AbstractIdeaCountTermEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/AbstractIdeaCountTermEvaluator.ts
@@ -1,0 +1,28 @@
+import { CRaterResponse } from '../../cRater/CRaterResponse';
+import { TermEvaluator } from './TermEvaluator';
+
+export abstract class AbstractIdeaCountTermEvaluator extends TermEvaluator {
+  comparer: 'MoreThan' | 'Equals' | 'LessThan';
+  expectedIdeaCount: number;
+
+  constructor(term: string, matcher: RegExp) {
+    super(term);
+    const matches = term.match(matcher);
+    this.comparer = matches[1] as 'MoreThan' | 'Equals' | 'LessThan';
+    this.expectedIdeaCount = parseInt(matches[2]);
+  }
+
+  evaluate(response: CRaterResponse | CRaterResponse[]): boolean {
+    const detectedIdeaCount = this.getDetectedIdeaCount(response);
+    switch (this.comparer) {
+      case 'MoreThan':
+        return detectedIdeaCount > this.expectedIdeaCount;
+      case 'Equals':
+        return detectedIdeaCount === this.expectedIdeaCount;
+      case 'LessThan':
+        return detectedIdeaCount < this.expectedIdeaCount;
+    }
+  }
+
+  protected abstract getDetectedIdeaCount(response: CRaterResponse | CRaterResponse[]): number;
+}

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/AccumulatedIdeaCountTermEvaluator.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/AccumulatedIdeaCountTermEvaluator.spec.ts
@@ -1,0 +1,34 @@
+import { AccumulatedIdeaCountTermEvaluator } from './AccumulatedIdeaCountTermEvaluator';
+import {
+  IdeaCountTermEvaluatorTester,
+  response_with_idea_1,
+  response_with_idea_2,
+  response_with_ideas_1_2,
+  response_with_ideas_1_2_3
+} from './test-utils';
+
+describe('AccumulatedIdeaCountTermEvaluator', () => {
+  describe('evaluate()', () => {
+    it('should check whether number of detected ideas meets criteria', () => {
+      const evaluatorTester = new IdeaCountTermEvaluatorTester([
+        new AccumulatedIdeaCountTermEvaluator('accumulatedIdeaCountMoreThan(2)'),
+        new AccumulatedIdeaCountTermEvaluator('accumulatedIdeaCountEquals(2)'),
+        new AccumulatedIdeaCountTermEvaluator('accumulatedIdeaCountLessThan(2)')
+      ]);
+      evaluatorTester.expectEvaluations([response_with_idea_1], [false, false, true]);
+      evaluatorTester.expectEvaluations([response_with_ideas_1_2], [false, true, false]);
+      evaluatorTester.expectEvaluations(
+        [response_with_idea_1, response_with_idea_2],
+        [false, true, false]
+      );
+      evaluatorTester.expectEvaluations(
+        [response_with_idea_1, response_with_ideas_1_2],
+        [false, true, false]
+      );
+      evaluatorTester.expectEvaluations(
+        [response_with_idea_1, response_with_ideas_1_2_3],
+        [true, false, false]
+      );
+    });
+  });
+});

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/AccumulatedIdeaCountTermEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/AccumulatedIdeaCountTermEvaluator.ts
@@ -1,0 +1,12 @@
+import { CRaterResponse } from '../../cRater/CRaterResponse';
+import { AbstractIdeaCountTermEvaluator } from './AbstractIdeaCountTermEvaluator';
+
+export class AccumulatedIdeaCountTermEvaluator extends AbstractIdeaCountTermEvaluator {
+  constructor(term: string) {
+    super(term, /accumulatedIdeaCount(.*)\((.*)\)/);
+  }
+
+  protected getDetectedIdeaCount(responses: CRaterResponse[]): number {
+    return new Set(responses.flatMap((response) => response.getDetectedIdeaNames())).size;
+  }
+}

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaCountTermEvaluator.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaCountTermEvaluator.spec.ts
@@ -1,36 +1,22 @@
-import { CRaterIdea } from '../../cRater/CRaterIdea';
-import { CRaterResponse } from '../../cRater/CRaterResponse';
 import { IdeaCountTermEvaluator } from './IdeaCountTermEvaluator';
+import {
+  IdeaCountTermEvaluatorTester,
+  response_with_idea_1,
+  response_with_ideas_1_2,
+  response_with_ideas_1_2_3
+} from './test-utils';
 
-const evaluator_more_than_2 = new IdeaCountTermEvaluator('ideaCountMoreThan(2)');
-const evaluator_equals_2 = new IdeaCountTermEvaluator('ideaCountEquals(2)');
-const evaluator_less_than_2 = new IdeaCountTermEvaluator('ideaCountLessThan(2)');
 describe('IdeaCountTermEvaluator', () => {
   describe('evaluate()', () => {
     it('should check whether number of detected ideas meets criteria', () => {
-      const idea1 = new CRaterIdea('1', true);
-      const idea2 = new CRaterIdea('2', true);
-      const idea3 = new CRaterIdea('3', true);
-      const response_with_1_idea = new CRaterResponse();
-      response_with_1_idea.ideas = [idea1];
-      const response_with_2_ideas = new CRaterResponse();
-      response_with_2_ideas.ideas = [idea1, idea2];
-      const response_with_3_ideas = new CRaterResponse();
-      response_with_3_ideas.ideas = [idea1, idea2, idea3];
-      expectEvaluations(response_with_1_idea, false, false, true);
-      expectEvaluations(response_with_2_ideas, false, true, false);
-      expectEvaluations(response_with_3_ideas, true, false, false);
+      const evaluatorTester = new IdeaCountTermEvaluatorTester([
+        new IdeaCountTermEvaluator('ideaCountMoreThan(2)'),
+        new IdeaCountTermEvaluator('ideaCountEquals(2)'),
+        new IdeaCountTermEvaluator('ideaCountLessThan(2)')
+      ]);
+      evaluatorTester.expectEvaluations(response_with_idea_1, [false, false, true]);
+      evaluatorTester.expectEvaluations(response_with_ideas_1_2, [false, true, false]);
+      evaluatorTester.expectEvaluations(response_with_ideas_1_2_3, [true, false, false]);
     });
   });
 });
-
-function expectEvaluations(
-  response: CRaterResponse,
-  expectedResultMoreThan2: boolean,
-  expectedResultEquals2: boolean,
-  expectedResultLessThan2: boolean
-) {
-  expect(evaluator_more_than_2.evaluate(response)).toBe(expectedResultMoreThan2);
-  expect(evaluator_equals_2.evaluate(response)).toBe(expectedResultEquals2);
-  expect(evaluator_less_than_2.evaluate(response)).toBe(expectedResultLessThan2);
-}

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaCountTermEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaCountTermEvaluator.ts
@@ -1,25 +1,12 @@
 import { CRaterResponse } from '../../cRater/CRaterResponse';
-import { TermEvaluator } from './TermEvaluator';
+import { AbstractIdeaCountTermEvaluator } from './AbstractIdeaCountTermEvaluator';
 
-export class IdeaCountTermEvaluator extends TermEvaluator {
-  comparer: string;
-  expectedIdeaCount: number;
-
+export class IdeaCountTermEvaluator extends AbstractIdeaCountTermEvaluator {
   constructor(term: string) {
-    super(term);
-    const matches = term.match(/ideaCount(.*)\((.*)\)/);
-    this.comparer = matches[1];
-    this.expectedIdeaCount = parseInt(matches[2]);
+    super(term, /ideaCount(.*)\((.*)\)/);
   }
 
-  evaluate(response: CRaterResponse): boolean {
-    switch (this.comparer) {
-      case 'MoreThan':
-        return response.getDetectedIdeaCount() > this.expectedIdeaCount;
-      case 'Equals':
-        return response.getDetectedIdeaCount() === this.expectedIdeaCount;
-      case 'LessThan':
-        return response.getDetectedIdeaCount() < this.expectedIdeaCount;
-    }
+  protected getDetectedIdeaCount(response: CRaterResponse): number {
+    return response.getDetectedIdeaCount();
   }
 }

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaCountWithResponseIndexTermEvaluator.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaCountWithResponseIndexTermEvaluator.spec.ts
@@ -1,0 +1,47 @@
+import { IdeaCountWithResponseIndexTermEvaluator } from './IdeaCountWithResponseIndexTermEvaluator';
+import {
+  IdeaCountTermEvaluatorTester,
+  response_with_idea_1,
+  response_with_ideas_1_2,
+  response_with_ideas_1_2_3
+} from './test-utils';
+
+const evaluatorTester = new IdeaCountTermEvaluatorTester([
+  new IdeaCountWithResponseIndexTermEvaluator('ideaCountMoreThan(2, 2)'),
+  new IdeaCountWithResponseIndexTermEvaluator('ideaCountEquals(2,2)'),
+  new IdeaCountWithResponseIndexTermEvaluator('ideaCountLessThan(2,2)')
+]);
+describe('IdeaCountWithResponseIndexTermEvaluator', () => {
+  describe('evaluate()', () => {
+    evaluate_NotEnoughResponses_ReturnFalse();
+    evaluate_EnoughResponses_CheckNumberOfDetectedIdeas();
+  });
+});
+
+function evaluate_NotEnoughResponses_ReturnFalse() {
+  describe('response index is more than number of responses', () => {
+    it('should return false', () => {
+      evaluatorTester.expectEvaluations([], [false, false, false]);
+      evaluatorTester.expectEvaluations([response_with_idea_1], [false, false, false]);
+    });
+  });
+}
+
+function evaluate_EnoughResponses_CheckNumberOfDetectedIdeas() {
+  describe('response index is more than number of responses', () => {
+    it('should check whether number of detected ideas at the index meets criteria', () => {
+      evaluatorTester.expectEvaluations(
+        [response_with_idea_1, response_with_idea_1],
+        [false, false, true]
+      );
+      evaluatorTester.expectEvaluations(
+        [response_with_idea_1, response_with_ideas_1_2],
+        [false, true, false]
+      );
+      evaluatorTester.expectEvaluations(
+        [response_with_idea_1, response_with_ideas_1_2_3],
+        [true, false, false]
+      );
+    });
+  });
+}

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaCountWithResponseIndexTermEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaCountWithResponseIndexTermEvaluator.ts
@@ -1,0 +1,19 @@
+import { CRaterResponse } from '../../cRater/CRaterResponse';
+import { AbstractIdeaCountTermEvaluator } from './AbstractIdeaCountTermEvaluator';
+
+export class IdeaCountWithResponseIndexTermEvaluator extends AbstractIdeaCountTermEvaluator {
+  responseIndex: number;
+
+  constructor(term: string) {
+    super(term, /ideaCount(.*)\((\d+),\s*(\d+)\)/);
+    this.responseIndex = parseInt(this.matches[3]) - 1; // authored index starts at 1
+  }
+
+  evaluate(responses: CRaterResponse[]): boolean {
+    return responses.length <= this.responseIndex ? false : super.evaluate(responses);
+  }
+
+  protected getDetectedIdeaCount(responses: CRaterResponse[]): number {
+    return responses[this.responseIndex].getDetectedIdeaCount();
+  }
+}

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluator.ts
@@ -2,5 +2,21 @@ import { CRaterResponse } from '../../cRater/CRaterResponse';
 
 export abstract class TermEvaluator {
   constructor(protected term: string) {}
-  abstract evaluate(response: CRaterResponse): boolean;
+  abstract evaluate(response: CRaterResponse | CRaterResponse[]): boolean;
+
+  static isAccumulatedIdeaCountTerm(term: string): boolean {
+    return /accumulatedIdeaCount(MoreThan|Equals|LessThan)\([\d+]\)/.test(term);
+  }
+
+  static isHasKIScoreTerm(term: string): boolean {
+    return /hasKIScore\([1-5]\)/.test(term);
+  }
+
+  static isIdeaCountTerm(term: string): boolean {
+    return /ideaCount(MoreThan|Equals|LessThan)\([\d+]\)/.test(term);
+  }
+
+  static isSubmitNumberTerm(term: string): boolean {
+    return /isSubmitNumber\(\d+\)/.test(term);
+  }
 }

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluator.ts
@@ -16,7 +16,18 @@ export abstract class TermEvaluator {
     return /ideaCount(MoreThan|Equals|LessThan)\([\d+]\)/.test(term);
   }
 
+  static isIdeaCountWithResponseIndexTerm(term: string): boolean {
+    return /ideaCount(MoreThan|Equals|LessThan)\(\d+,\s*\d+\)/.test(term);
+  }
+
   static isSubmitNumberTerm(term: string): boolean {
     return /isSubmitNumber\(\d+\)/.test(term);
+  }
+
+  static requiresAllResponses(term: string): boolean {
+    return (
+      TermEvaluator.isAccumulatedIdeaCountTerm(term) ||
+      TermEvaluator.isIdeaCountWithResponseIndexTerm(term)
+    );
   }
 }

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluatorFactory.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluatorFactory.ts
@@ -1,6 +1,7 @@
 import { AccumulatedIdeaCountTermEvaluator } from './AccumulatedIdeaCountTermEvaluator';
 import { HasKIScoreTermEvaluator } from './HasKIScoreTermEvaluator';
 import { IdeaCountTermEvaluator } from './IdeaCountTermEvaluator';
+import { IdeaCountWithResponseIndexTermEvaluator } from './IdeaCountWithResponseIndexTermEvaluator';
 import { IdeaTermEvaluator } from './IdeaTermEvaluator';
 import { IsSubmitNumberEvaluator } from './IsSubmitNumberEvaluator';
 import { TermEvaluator } from './TermEvaluator';
@@ -12,6 +13,8 @@ export class TermEvaluatorFactory {
       evaluator = new HasKIScoreTermEvaluator(term);
     } else if (TermEvaluator.isIdeaCountTerm(term)) {
       evaluator = new IdeaCountTermEvaluator(term);
+    } else if (TermEvaluator.isIdeaCountWithResponseIndexTerm(term)) {
+      evaluator = new IdeaCountWithResponseIndexTermEvaluator(term);
     } else if (TermEvaluator.isSubmitNumberTerm(term)) {
       evaluator = new IsSubmitNumberEvaluator(term);
     } else if (TermEvaluator.isAccumulatedIdeaCountTerm(term)) {

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluatorFactory.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluatorFactory.ts
@@ -1,3 +1,4 @@
+import { AccumulatedIdeaCountTermEvaluator } from './AccumulatedIdeaCountTermEvaluator';
 import { HasKIScoreTermEvaluator } from './HasKIScoreTermEvaluator';
 import { IdeaCountTermEvaluator } from './IdeaCountTermEvaluator';
 import { IdeaTermEvaluator } from './IdeaTermEvaluator';
@@ -7,27 +8,17 @@ import { TermEvaluator } from './TermEvaluator';
 export class TermEvaluatorFactory {
   getTermEvaluator(term: string): TermEvaluator {
     let evaluator: TermEvaluator;
-    if (this.isHasKIScoreTerm(term)) {
+    if (TermEvaluator.isHasKIScoreTerm(term)) {
       evaluator = new HasKIScoreTermEvaluator(term);
-    } else if (this.isIdeaCountTerm(term)) {
+    } else if (TermEvaluator.isIdeaCountTerm(term)) {
       evaluator = new IdeaCountTermEvaluator(term);
-    } else if (this.isSubmitNumberTerm(term)) {
+    } else if (TermEvaluator.isSubmitNumberTerm(term)) {
       evaluator = new IsSubmitNumberEvaluator(term);
+    } else if (TermEvaluator.isAccumulatedIdeaCountTerm(term)) {
+      evaluator = new AccumulatedIdeaCountTermEvaluator(term);
     } else {
       evaluator = new IdeaTermEvaluator(term);
     }
     return evaluator;
-  }
-
-  private isHasKIScoreTerm(term: string): boolean {
-    return /hasKIScore\([1-5]\)/.test(term);
-  }
-
-  private isIdeaCountTerm(term: string): boolean {
-    return /ideaCount(MoreThan|Equals|LessThan)\([\d+]\)/.test(term);
-  }
-
-  private isSubmitNumberTerm(term: string): boolean {
-    return /isSubmitNumber\(\d+\)/.test(term);
   }
 }

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/test-utils.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/test-utils.ts
@@ -1,0 +1,28 @@
+import { CRaterIdea } from '../../cRater/CRaterIdea';
+import { CRaterResponse } from '../../cRater/CRaterResponse';
+import { AbstractIdeaCountTermEvaluator } from './AbstractIdeaCountTermEvaluator';
+
+const idea1 = new CRaterIdea('1', true);
+const idea2 = new CRaterIdea('2', true);
+const idea3 = new CRaterIdea('3', true);
+const response_with_idea_1 = new CRaterResponse({ ideas: [idea1] });
+const response_with_idea_2 = new CRaterResponse({ ideas: [idea2] });
+const response_with_ideas_1_2 = new CRaterResponse({ ideas: [idea1, idea2] });
+const response_with_ideas_1_2_3 = new CRaterResponse({ ideas: [idea1, idea2, idea3] });
+
+export {
+  response_with_idea_1,
+  response_with_idea_2,
+  response_with_ideas_1_2,
+  response_with_ideas_1_2_3
+};
+
+export class IdeaCountTermEvaluatorTester {
+  constructor(private evaluators: AbstractIdeaCountTermEvaluator[]) {}
+
+  expectEvaluations(response: CRaterResponse | CRaterResponse[], expectedValues: boolean[]) {
+    this.evaluators.forEach((evaluator, index) => {
+      expect(evaluator.evaluate(response)).toBe(expectedValues[index]);
+    });
+  }
+}

--- a/src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html
+++ b/src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html
@@ -1,3 +1,9 @@
+<ng-template #accumulatedIdeaCountSupportMessage
+  ><i i18n>
+    Note: this term currently works in the Dialog Guidance component only. Support in the Open
+    Response component and the Dynamic Prompt will be coming soon.</i
+  ></ng-template
+>
 <h2 class="mat-dialog-title" i18n>Feedback Rule Authoring</h2>
 <mat-dialog-content class="dialog-content-scroll">
   <h3 i18n>Introduction</h3>
@@ -35,7 +41,8 @@
         Evaluates to true if more than X ideas were found in all (both past and current) of
         student's responses.<br />
         Ex: <b>accumulatedIdeaCountMoreThan(2)</b> evaluates to true if the student had more than 2
-        ideas in all of their responses.
+        ideas in all of their responses.<br />
+        <ng-template [ngTemplateOutlet]="accumulatedIdeaCountSupportMessage"></ng-template>
       </td>
     </tr>
     <tr>
@@ -44,7 +51,8 @@
         Evaluates to true if less than X ideas were found in all (both past and current) of
         student's responses.<br />
         Ex: <b>accumulatedIdeaCountLessThan(2)</b> evaluates to true if the student had less than 2
-        ideas in all of their responses.
+        ideas in all of their responses.<br />
+        <ng-template [ngTemplateOutlet]="accumulatedIdeaCountSupportMessage"></ng-template>
       </td>
     </tr>
     <tr>
@@ -53,7 +61,8 @@
         Evaluates to true if exactly X ideas were found in all (both past and current) of student's
         responses.<br />
         Ex: <b>accumulatedIdeaCountEquals(2)</b> evaluates to true if the student had exactly 2
-        ideas in all of their responses.
+        ideas in all of their responses.<br />
+        <ng-template [ngTemplateOutlet]="accumulatedIdeaCountSupportMessage"></ng-template>
       </td>
     </tr>
     <tr>

--- a/src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html
+++ b/src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html
@@ -70,6 +70,15 @@
       </td>
     </tr>
     <tr>
+      <td class="term">ideaCountMoreThan(X, Y)</td>
+      <td i18n>
+        Evaluates to true if more than X ideas were found in the student's Y-th response.<br />
+        Ex: <b>ideaCountMoreThan(2, 3)</b> evaluates to true if the student had more than 2 ideas in
+        their 3rd response.<br />
+        <ng-template [ngTemplateOutlet]="accumulatedIdeaCountSupportMessage"></ng-template>
+      </td>
+    </tr>
+    <tr>
       <td class="term">ideaCountLessThan(X)</td>
       <td i18n>
         Evaluates to true if less than X ideas were found in the student's response.<br />
@@ -77,10 +86,28 @@
       </td>
     </tr>
     <tr>
+      <td class="term">ideaCountLessThan(X, Y)</td>
+      <td i18n>
+        Evaluates to true if less than X ideas were found in the student's Y-th response.<br />
+        Ex: <b>ideaCountLessThan(2, 3)</b> evaluates to true if the student had less than 2 ideas in
+        their 3rd response.<br />
+        <ng-template [ngTemplateOutlet]="accumulatedIdeaCountSupportMessage"></ng-template>
+      </td>
+    </tr>
+    <tr>
       <td class="term">ideaCountEquals(X)</td>
       <td i18n>
         Evaluates to true if exactly X ideas were found in the student's response.<br />
         Ex: <b>ideaCountEquals(2)</b> evaluates to true if the student had exactly 2 ideas.
+      </td>
+    </tr>
+    <tr>
+      <td class="term">ideaCountEquals(X, Y)</td>
+      <td i18n>
+        Evaluates to true if exactly X ideas were found in the student's Y-th response.<br />
+        Ex: <b>ideaCountEquals(2, 3)</b> evaluates to true if the student had exactly 2 ideas in
+        their 3rd response.<br />
+        <ng-template [ngTemplateOutlet]="accumulatedIdeaCountSupportMessage"></ng-template>
       </td>
     </tr>
     <tr>

--- a/src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html
+++ b/src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html
@@ -1,8 +1,5 @@
 <ng-template #accumulatedIdeaCountSupportMessage
-  ><i i18n>
-    Note: this term currently works in the Dialog Guidance component only. Support in the Open
-    Response component and the Dynamic Prompt will be coming soon.</i
-  ></ng-template
+  ><i i18n>Note: this term currently only works in the Dialog Guidance component.</i></ng-template
 >
 <h2 class="mat-dialog-title" i18n>Feedback Rule Authoring</h2>
 <mat-dialog-content class="dialog-content-scroll">

--- a/src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html
+++ b/src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html
@@ -30,6 +30,33 @@
       </td>
     </tr>
     <tr>
+      <td class="term">accumulatedIdeaCountMoreThan(X)</td>
+      <td i18n>
+        Evaluates to true if more than X ideas were found in all (both past and current) of
+        student's responses.<br />
+        Ex: <b>accumulatedIdeaCountMoreThan(2)</b> evaluates to true if the student had more than 2
+        ideas in all of their responses.
+      </td>
+    </tr>
+    <tr>
+      <td class="term">accumulatedIdeaCountLessThan(X)</td>
+      <td i18n>
+        Evaluates to true if less than X ideas were found in all (both past and current) of
+        student's responses.<br />
+        Ex: <b>accumulatedIdeaCountLessThan(2)</b> evaluates to true if the student had less than 2
+        ideas in all of their responses.
+      </td>
+    </tr>
+    <tr>
+      <td class="term">accumulatedIdeaCountEquals(X)</td>
+      <td i18n>
+        Evaluates to true if exactly X ideas were found in all (both past and current) of student's
+        responses.<br />
+        Ex: <b>accumulatedIdeaCountEquals(2)</b> evaluates to true if the student had exactly 2
+        ideas in all of their responses.
+      </td>
+    </tr>
+    <tr>
       <td class="term">ideaCountMoreThan(X)</td>
       <td i18n>
         Evaluates to true if more than X ideas were found in the student's response.<br />

--- a/src/assets/wise5/components/dialogGuidance/ComputerDialogResponse.ts
+++ b/src/assets/wise5/components/dialogGuidance/ComputerDialogResponse.ts
@@ -4,10 +4,17 @@ import { DialogResponse } from './DialogResponse';
 export class ComputerDialogResponse extends DialogResponse {
   feedbackRuleId?: string;
   ideas: CRaterIdea[];
+  initialResponse: boolean;
   user: string = 'Computer';
 
-  constructor(text: string, ideas: CRaterIdea[], timestamp: number) {
+  constructor(
+    text: string,
+    ideas: CRaterIdea[],
+    timestamp: number,
+    initialResponse: boolean = false
+  ) {
     super(text, timestamp);
     this.ideas = ideas;
+    this.initialResponse = initialResponse;
   }
 }

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.spec.ts
@@ -24,6 +24,7 @@ import { DialogResponsesComponent } from '../dialog-responses/dialog-responses.c
 import { DialogGuidanceService } from '../dialogGuidanceService';
 import { DialogGuidanceStudentComponent } from './dialog-guidance-student.component';
 import { DialogGuidanceComponent } from '../DialogGuidanceComponent';
+import { CRaterResponses } from '../../common/cRater/CRaterResponses';
 
 let component: DialogGuidanceStudentComponent;
 let fixture: ComponentFixture<DialogGuidanceStudentComponent>;
@@ -231,15 +232,13 @@ function expectIsShowComputerAvatarSelector(
   expect(component.isShowComputerAvatarSelector).toEqual(expectedIsShowComputerAvatarSelector);
 }
 
-function createDummyScoringResponse() {
+function createDummyScoringResponse(): CRaterResponses {
   return {
-    responses: {
-      feedback: {
-        ideas: [{ 2: false }, { 3: false }]
-      },
-      trait_scores: {
-        ki: { score: 1 }
-      }
+    feedback: {
+      ideas: [{ 2: false }, { 3: false }]
+    },
+    trait_scores: {
+      ki: { score: 1 }
     }
-  };
+  } as CRaterResponses;
 }

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.spec.ts
@@ -24,7 +24,7 @@ import { DialogResponsesComponent } from '../dialog-responses/dialog-responses.c
 import { DialogGuidanceService } from '../dialogGuidanceService';
 import { DialogGuidanceStudentComponent } from './dialog-guidance-student.component';
 import { DialogGuidanceComponent } from '../DialogGuidanceComponent';
-import { CRaterResponses } from '../../common/cRater/CRaterResponses';
+import { RawCRaterResponse } from '../../common/cRater/RawCRaterResponse';
 
 let component: DialogGuidanceStudentComponent;
 let fixture: ComponentFixture<DialogGuidanceStudentComponent>;
@@ -232,7 +232,7 @@ function expectIsShowComputerAvatarSelector(
   expect(component.isShowComputerAvatarSelector).toEqual(expectedIsShowComputerAvatarSelector);
 }
 
-function createDummyScoringResponse(): CRaterResponses {
+function createDummyScoringResponse(): RawCRaterResponse {
   return {
     feedback: {
       ideas: [{ 2: false }, { 3: false }]
@@ -240,5 +240,5 @@ function createDummyScoringResponse(): CRaterResponses {
     trait_scores: {
       ki: { score: 1 }
     }
-  } as CRaterResponses;
+  } as RawCRaterResponse;
 }

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
@@ -169,7 +169,7 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
     const computerAvatarInitialResponse = this.component.getComputerAvatarInitialResponse();
     if (computerAvatarInitialResponse != null && computerAvatarInitialResponse !== '') {
       this.addDialogResponse(
-        new ComputerDialogResponse(computerAvatarInitialResponse, [], new Date().getTime())
+        new ComputerDialogResponse(computerAvatarInitialResponse, [], new Date().getTime(), true)
       );
     }
   }
@@ -274,7 +274,10 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
     return (
       this.dataService
         .getLatestComponentStateByNodeIdAndComponentId(this.nodeId, this.componentId)
-        ?.studentData.responses.filter((response: DialogResponse) => response.user === 'Computer')
+        ?.studentData.responses.filter(
+          (response: DialogResponse) =>
+            response.user === 'Computer' && !(response as ComputerDialogResponse).initialResponse
+        )
         .map((response: DialogResponse) => {
           const cRaterResponse = new CRaterResponse(response);
           cRaterResponse.submitCounter = submitCounter++;

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
@@ -25,6 +25,7 @@ import { FeedbackRuleComponent } from '../../feedbackRule/FeedbackRuleComponent'
 import { ComponentStudent } from '../../component-student.component';
 import { DialogGuidanceComponent } from '../DialogGuidanceComponent';
 import { copy } from '../../../common/object/object';
+import { CRaterResponses } from '../../common/cRater/CRaterResponses';
 
 @Component({
   selector: 'dialog-guidance-student',
@@ -35,7 +36,7 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
   component: DialogGuidanceComponent;
   computerAvatar: ComputerAvatar;
   cRaterTimeout: number = 40000;
-  feedbackRuleEvaluator: FeedbackRuleEvaluator<CRaterResponse>;
+  feedbackRuleEvaluator: FeedbackRuleEvaluator<CRaterResponse[]>;
   isShowComputerAvatarSelector: boolean = false;
   isSubmitEnabled: boolean = false;
   isWaitingForComputerResponse: boolean = false;
@@ -55,7 +56,7 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
     protected nodeService: NodeService,
     protected notebookService: NotebookService,
     protected studentAssetService: StudentAssetService,
-    protected studentDataService: StudentDataService,
+    protected dataService: StudentDataService,
     protected studentStatusService: StudentStatusService
   ) {
     super(
@@ -66,7 +67,7 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
       nodeService,
       notebookService,
       studentAssetService,
-      studentDataService
+      dataService
     );
   }
 
@@ -204,7 +205,7 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
       .pipe(timeout(this.cRaterTimeout))
       .subscribe(
         (response: any) => {
-          this.cRaterSuccessResponse(response);
+          this.cRaterSuccessResponse(response.responses);
         },
         () => {
           this.cRaterErrorResponse();
@@ -232,10 +233,10 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
     this.studentCanRespond = false;
   }
 
-  cRaterSuccessResponse(response: any): void {
+  cRaterSuccessResponse(responses: CRaterResponses): void {
     this.hideWaitingForComputerResponse();
     this.submitButtonClicked();
-    const cRaterResponse = this.cRaterService.getCRaterResponse(response, this.submitCounter);
+    const cRaterResponse = this.cRaterService.getCRaterResponse(responses, this.submitCounter);
     this.addDialogResponse(this.createComputerDialogResponse(cRaterResponse));
     if (this.hasMaxSubmitCountAndUsedAllSubmits()) {
       this.disableStudentResponse();
@@ -245,11 +246,9 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
   }
 
   createComputerDialogResponse(response: CRaterResponse): ComputerDialogResponse {
-    const feedbackRule: FeedbackRule = this.feedbackRuleEvaluator.getFeedbackRule(response);
-    const feedbackText = this.dialogGuidanceFeedbackService.getFeedbackText(
-      this.component,
-      feedbackRule
-    );
+    const allCRaterResponses = this.getCRaterResponses().concat(response);
+    const rule: FeedbackRule = this.feedbackRuleEvaluator.getFeedbackRule(allCRaterResponses);
+    const feedbackText = this.dialogGuidanceFeedbackService.getFeedbackText(this.component, rule);
     const computerResponse =
       response.scores != null
         ? new ComputerDialogResponseMultipleScores(
@@ -265,9 +264,23 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
             new Date().getTime()
           );
     if (this.component.isVersion2()) {
-      computerResponse.feedbackRuleId = feedbackRule.id;
+      computerResponse.feedbackRuleId = rule.id;
     }
     return computerResponse;
+  }
+
+  private getCRaterResponses(): CRaterResponse[] {
+    let submitCounter = 1;
+    return (
+      this.dataService
+        .getLatestComponentStateByNodeIdAndComponentId(this.nodeId, this.componentId)
+        ?.studentData.responses.filter((response: DialogResponse) => response.user === 'Computer')
+        .map((response: DialogResponse) => {
+          const cRaterResponse = new CRaterResponse(response);
+          cRaterResponse.submitCounter = submitCounter++;
+          return cRaterResponse;
+        }) ?? []
+    );
   }
 
   cRaterErrorResponse() {

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
@@ -25,7 +25,7 @@ import { FeedbackRuleComponent } from '../../feedbackRule/FeedbackRuleComponent'
 import { ComponentStudent } from '../../component-student.component';
 import { DialogGuidanceComponent } from '../DialogGuidanceComponent';
 import { copy } from '../../../common/object/object';
-import { CRaterResponses } from '../../common/cRater/CRaterResponses';
+import { RawCRaterResponse } from '../../common/cRater/RawCRaterResponse';
 
 @Component({
   selector: 'dialog-guidance-student',
@@ -233,7 +233,7 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
     this.studentCanRespond = false;
   }
 
-  cRaterSuccessResponse(responses: CRaterResponses): void {
+  cRaterSuccessResponse(responses: RawCRaterResponse): void {
     this.hideWaitingForComputerResponse();
     this.submitButtonClicked();
     const cRaterResponse = this.cRaterService.getCRaterResponse(responses, this.submitCounter);

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
@@ -20,7 +20,7 @@ import { FeedbackRule } from '../../common/feedbackRule/FeedbackRule';
 import { FeedbackRuleComponent } from '../../feedbackRule/FeedbackRuleComponent';
 import { OpenResponseService } from '../openResponseService';
 import { copy } from '../../../common/object/object';
-import { CRaterResponses } from '../../common/cRater/CRaterResponses';
+import { RawCRaterResponse } from '../../common/cRater/RawCRaterResponse';
 
 @Component({
   selector: 'open-response-student',
@@ -326,7 +326,7 @@ export class OpenResponseStudent extends ComponentStudent {
   }
 
   private cRaterSuccessResponse(
-    responses: CRaterResponses,
+    responses: RawCRaterResponse,
     componentState: any,
     deferred: any,
     dialogRef: any

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
@@ -20,6 +20,7 @@ import { FeedbackRule } from '../../common/feedbackRule/FeedbackRule';
 import { FeedbackRuleComponent } from '../../feedbackRule/FeedbackRuleComponent';
 import { OpenResponseService } from '../openResponseService';
 import { copy } from '../../../common/object/object';
+import { CRaterResponses } from '../../common/cRater/CRaterResponses';
 
 @Component({
   selector: 'open-response-student',
@@ -305,7 +306,7 @@ export class OpenResponseStudent extends ComponentStudent {
       .pipe(timeout(this.cRaterTimeout))
       .subscribe(
         (response: any) => {
-          this.cRaterSuccessResponse(response, componentState, deferred, dialogRef);
+          this.cRaterSuccessResponse(response.responses, componentState, deferred, dialogRef);
         },
         () => {
           this.cRaterErrorResponse(componentState, deferred, dialogRef);
@@ -325,12 +326,12 @@ export class OpenResponseStudent extends ComponentStudent {
   }
 
   private cRaterSuccessResponse(
-    response: any,
+    responses: CRaterResponses,
     componentState: any,
     deferred: any,
     dialogRef: any
   ): void {
-    const cRaterResponse = this.CRaterService.getCRaterResponse(response, this.submitCounter);
+    const cRaterResponse = this.CRaterService.getCRaterResponse(responses, this.submitCounter);
     let score = cRaterResponse.score;
     if (cRaterResponse.scores != null) {
       const maxSoFarFunc = (accumulator, currentValue) => {
@@ -346,7 +347,7 @@ export class OpenResponseStudent extends ComponentStudent {
   }
 
   private processCRaterSuccessResponse(
-    score: any,
+    score: number,
     response: CRaterResponse,
     componentState: any
   ): void {
@@ -401,9 +402,9 @@ export class OpenResponseStudent extends ComponentStudent {
             this.isMultipleFeedbackTextsForSameRuleAllowed()
           )
         );
-        const feedbackRule: FeedbackRule = feedbackRuleEvaluator.getFeedbackRule(response);
-        autoComment = this.getFeedbackText(feedbackRule);
-        feedbackRuleId = feedbackRule.id;
+        const rule: FeedbackRule = feedbackRuleEvaluator.getFeedbackRule([response]);
+        autoComment = this.getFeedbackText(rule);
+        feedbackRuleId = rule.id;
       } else {
         autoComment = this.CRaterService.getCRaterFeedbackTextByScore(this.componentContent, score);
       }

--- a/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.ts
@@ -34,7 +34,7 @@ export class DynamicPromptComponent implements OnInit {
     private configService: ConfigService,
     private peerGroupService: PeerGroupService,
     private projectService: ProjectService,
-    private studentDataService: StudentDataService
+    private dataService: StudentDataService
   ) {}
 
   ngOnInit(): void {
@@ -105,7 +105,7 @@ export class DynamicPromptComponent implements OnInit {
   private evaluatePersonalOpenResponse(referenceComponentContent: OpenResponseContent): void {
     const nodeId = this.dynamicPrompt.getReferenceNodeId();
     const componentId = referenceComponentContent.id;
-    const latestComponentState = this.studentDataService.getLatestComponentStateByNodeIdAndComponentId(
+    const latestComponentState = this.dataService.getLatestComponentStateByNodeIdAndComponentId(
       nodeId,
       componentId
     );
@@ -128,7 +128,7 @@ export class DynamicPromptComponent implements OnInit {
           false
         )
       );
-      const feedbackRule: FeedbackRule = feedbackRuleEvaluator.getFeedbackRule(cRaterResponse);
+      const feedbackRule: FeedbackRule = feedbackRuleEvaluator.getFeedbackRule([cRaterResponse]);
       this.prompt = feedbackRule.prompt;
       this.dynamicPromptChanged.emit(feedbackRule);
     }

--- a/src/assets/wise5/services/cRaterService.ts
+++ b/src/assets/wise5/services/cRaterService.ts
@@ -7,7 +7,7 @@ import { Observable, of } from 'rxjs';
 import { CRaterIdea } from '../components/common/cRater/CRaterIdea';
 import { CRaterScore } from '../components/common/cRater/CRaterScore';
 import { CRaterResponse } from '../components/common/cRater/CRaterResponse';
-import { CRaterResponses } from '../components/common/cRater/CRaterResponses';
+import { RawCRaterResponse } from '../components/common/cRater/RawCRaterResponse';
 
 @Injectable()
 export class CRaterService {
@@ -215,7 +215,7 @@ export class CRaterService {
       });
   }
 
-  getCRaterResponse(responses: CRaterResponses, submitCounter: number): CRaterResponse {
+  getCRaterResponse(responses: RawCRaterResponse, submitCounter: number): CRaterResponse {
     const cRaterResponse: CRaterResponse = new CRaterResponse();
     if (this.isSingleScore(responses)) {
       cRaterResponse.score = this.getScore(responses);
@@ -227,15 +227,15 @@ export class CRaterService {
     return cRaterResponse;
   }
 
-  private isSingleScore(responses: CRaterResponses): boolean {
+  private isSingleScore(responses: RawCRaterResponse): boolean {
     return responses.scores != null;
   }
 
-  private getScore(responses: CRaterResponses): number {
+  private getScore(responses: RawCRaterResponse): number {
     return parseInt(responses.scores.raw_trim_round);
   }
 
-  private getScores(responses: CRaterResponses): CRaterScore[] {
+  private getScores(responses: RawCRaterResponse): CRaterScore[] {
     const scores = [];
     for (const key in responses.trait_scores) {
       const value = responses.trait_scores[key];
@@ -252,7 +252,7 @@ export class CRaterService {
     return scores;
   }
 
-  private getIdeas(responses: CRaterResponses): CRaterIdea[] {
+  private getIdeas(responses: RawCRaterResponse): CRaterIdea[] {
     const ideas = [];
     for (const key in responses.feedback.ideas) {
       const value = responses.feedback.ideas[key];

--- a/src/assets/wise5/services/cRaterService.ts
+++ b/src/assets/wise5/services/cRaterService.ts
@@ -7,6 +7,7 @@ import { Observable, of } from 'rxjs';
 import { CRaterIdea } from '../components/common/cRater/CRaterIdea';
 import { CRaterScore } from '../components/common/cRater/CRaterScore';
 import { CRaterResponse } from '../components/common/cRater/CRaterResponse';
+import { CRaterResponses } from '../components/common/cRater/CRaterResponses';
 
 @Injectable()
 export class CRaterService {
@@ -214,30 +215,30 @@ export class CRaterService {
       });
   }
 
-  getCRaterResponse(response: any, submitCounter: number): CRaterResponse {
+  getCRaterResponse(responses: CRaterResponses, submitCounter: number): CRaterResponse {
     const cRaterResponse: CRaterResponse = new CRaterResponse();
-    if (this.isSingleScore(response)) {
-      cRaterResponse.score = this.getScore(response);
+    if (this.isSingleScore(responses)) {
+      cRaterResponse.score = this.getScore(responses);
     } else {
-      cRaterResponse.scores = this.getScores(response);
+      cRaterResponse.scores = this.getScores(responses);
     }
-    cRaterResponse.ideas = this.getIdeas(response);
+    cRaterResponse.ideas = this.getIdeas(responses);
     cRaterResponse.submitCounter = submitCounter;
     return cRaterResponse;
   }
 
-  private isSingleScore(response: any): boolean {
-    return response.responses.scores != null;
+  private isSingleScore(responses: CRaterResponses): boolean {
+    return responses.scores != null;
   }
 
-  private getScore(response: any): number {
-    return parseInt(response.responses.scores.raw_trim_round);
+  private getScore(responses: CRaterResponses): number {
+    return parseInt(responses.scores.raw_trim_round);
   }
 
-  private getScores(response: any): CRaterScore[] {
+  private getScores(responses: CRaterResponses): CRaterScore[] {
     const scores = [];
-    for (const key in response.responses.trait_scores) {
-      const value = response.responses.trait_scores[key];
+    for (const key in responses.trait_scores) {
+      const value = responses.trait_scores[key];
       scores.push(
         new CRaterScore(
           key,
@@ -251,10 +252,10 @@ export class CRaterService {
     return scores;
   }
 
-  private getIdeas(response: any): CRaterIdea[] {
+  private getIdeas(responses: CRaterResponses): CRaterIdea[] {
     const ideas = [];
-    for (const key in response.responses.feedback.ideas) {
-      const value = response.responses.feedback.ideas[key];
+    for (const key in responses.feedback.ideas) {
+      const value = responses.feedback.ideas[key];
       ideas.push(new CRaterIdea(key, value.detected));
     }
     return ideas;

--- a/src/assets/wise5/services/studentDataService.ts
+++ b/src/assets/wise5/services/studentDataService.ts
@@ -8,6 +8,8 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, Subject } from 'rxjs';
 import { DataService } from '../../../app/services/data.service';
 import { generateRandomKey } from '../common/string/string';
+import { CRaterResponse } from '../components/common/cRater/CRaterResponse';
+import { DialogResponse } from '../components/dialogGuidance/DialogResponse';
 
 @Injectable()
 export class StudentDataService extends DataService {

--- a/src/assets/wise5/services/studentDataService.ts
+++ b/src/assets/wise5/services/studentDataService.ts
@@ -8,8 +8,6 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, Subject } from 'rxjs';
 import { DataService } from '../../../app/services/data.service';
 import { generateRandomKey } from '../common/string/string';
-import { CRaterResponse } from '../components/common/cRater/CRaterResponse';
-import { DialogResponse } from '../components/dialogGuidance/DialogResponse';
 
 @Injectable()
 export class StudentDataService extends DataService {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -315,7 +315,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">145</context>
+          <context context-type="linenumber">172</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/dialog-with-close/dialog-with-close.component.html</context>
@@ -1883,11 +1883,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">91</context>
+          <context context-type="linenumber">118</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">125</context>
+          <context context-type="linenumber">152</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7491b1ebfc5dd457492a5c481e2d2254216dc1fc" datatype="html">
@@ -13860,151 +13860,172 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">27,30</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="fbe19657096a0fbacfecaa4520034eb6ad2fc3e7" datatype="html">
+        <source> Evaluates to true if more than X ideas were found in all (both past and current) of student&apos;s responses.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>accumulatedIdeaCountMoreThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had more than 2 ideas in all of their responses. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
+          <context context-type="linenumber">34,39</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="d3bc88aa2697b5c1f5c349727863babcb6cfb941" datatype="html">
+        <source> Evaluates to true if less than X ideas were found in all (both past and current) of student&apos;s responses.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>accumulatedIdeaCountLessThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had less than 2 ideas in all of their responses. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
+          <context context-type="linenumber">43,48</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6886e601fd927fd7a822eefd8da89dd39682f4a4" datatype="html">
+        <source> Evaluates to true if exactly X ideas were found in all (both past and current) of student&apos;s responses.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>accumulatedIdeaCountEquals(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had exactly 2 ideas in all of their responses. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
+          <context context-type="linenumber">52,57</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="e5f60118e592df5cd7aed342976c7b0ecc4da547" datatype="html">
         <source> Evaluates to true if more than X ideas were found in the student&apos;s response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountMoreThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had more than 2 ideas. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">34,37</context>
+          <context context-type="linenumber">61,64</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6b884914cb98d7d84efe99d0b60f778c30c3a9f3" datatype="html">
         <source> Evaluates to true if less than X ideas were found in the student&apos;s response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountLessThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had less than 2 ideas. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">41,44</context>
+          <context context-type="linenumber">68,71</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c299449835a6844a97d1120d96268ec889e221ee" datatype="html">
         <source> Evaluates to true if exactly X ideas were found in the student&apos;s response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountEquals(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had exactly 2 ideas. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">48,51</context>
+          <context context-type="linenumber">75,78</context>
         </context-group>
       </trans-unit>
       <trans-unit id="acb957d799796d719108eeb1d0ed9ca4880c9f0c" datatype="html">
         <source> Evaluates to true if this is the student&apos;s X-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>isSubmitNumber(3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if this is the student&apos;s third response. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">55,58</context>
+          <context context-type="linenumber">82,85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ab15bc35d4c4c975e2cd82171bd30ef3fbf8f226" datatype="html">
         <source> Evaluates to true if this is the student&apos;s second to last response when the max number of submits is specified. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">62,65</context>
+          <context context-type="linenumber">89,92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bc1cca966f287a319703db89b22d379a6c1455cb" datatype="html">
         <source> Evaluates to true if this is the student&apos;s final response when the max number of submits is specified. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">69,72</context>
+          <context context-type="linenumber">96,99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3783efe04c66c9d80d09506ec8b7ad29167aacd8" datatype="html">
         <source>Evaluates to true if the student&apos;s response was not scorable.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">103</context>
         </context-group>
       </trans-unit>
       <trans-unit id="298fc1d863b0fb7a33b6825d43981e09e151cb5a" datatype="html">
         <source> Evaluates to true if no other terms were matched. Add this term as the final rule to specify a default feedback. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">80,83</context>
+          <context context-type="linenumber">107,110</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9d4ed1f582fafcfd1035ea83e58a5e1fe8d6a1a5" datatype="html">
         <source>Operators</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">86</context>
+          <context context-type="linenumber">113</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b2145d0c97ccffaf79c5770f967a429c84af4123" datatype="html">
         <source>Operators let you combine one or more terms together to make a rule.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">87</context>
+          <context context-type="linenumber">114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c39d43f18d10f925621abc77ad15de80a9cc7516" datatype="html">
         <source>Operator</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">90</context>
+          <context context-type="linenumber">117</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e4b8724800156a9aef6d6f0f31f67431957cc24e" datatype="html">
         <source> Evaluates to true if terms on both sides of this operator evaluate to true.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; hasKIScore(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if idea 1 was found and the student received a KI score of 2. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">95,100</context>
+          <context context-type="linenumber">122,127</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1f50d4313ef8ddef3a1d6d3fd464ec3dd3c21f03" datatype="html">
         <source> Evaluates to true if a term on either side of this operator evaluates to true.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 || 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if either idea 1 or 2 was found.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2 || 3<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found or idea 3 was found. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">104,109</context>
+          <context context-type="linenumber">131,136</context>
         </context-group>
       </trans-unit>
       <trans-unit id="414f2fd4ea5c948c6ebbf8417e6afe371bea442d" datatype="html">
         <source> Evaluates to true if a term following this operator evaluates to false.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>!1<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if idea 1 was not found. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">113,116</context>
+          <context context-type="linenumber">140,143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="46b1ed215e53246db19c5bde05ea87e08a5c2705" datatype="html">
         <source>Parentheses</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">119</context>
+          <context context-type="linenumber">146</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8df5a6f6a83598ccc0f22b86f8ca75661ef5a302" datatype="html">
         <source>Parentheses let you group expressions and prioritize evaluation.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">147</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dae69adfd569cdbaa366470ec24471bf01c7db66" datatype="html">
         <source>You can add multiple parentheses in an expression. You can even nest parentheses.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">148</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6db909a826f1878ad78bf853a62b6cc5cbda3d3f" datatype="html">
         <source>Example</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">124</context>
+          <context context-type="linenumber">151</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f5d726bee0fd8a545258990d929f39b68549dd87" datatype="html">
         <source>Evaluates to true if neither idea 4a nor idea 12 were found.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">129</context>
+          <context context-type="linenumber">156</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a8eebb4afda178aca31b3fdc61eb0f6d91837041" datatype="html">
         <source>Evaluates to true if idea 5a and either idea 4a or idea 12 was found.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">133</context>
+          <context context-type="linenumber">160</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5dcea69981a857fdd51521e3a1ba0b455ce1fdc9" datatype="html">
         <source> Evaluates to true if idea 5a and either idea 4a or idea 12 was found, and the student received a KI score of 3. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">137,140</context>
+          <context context-type="linenumber">164,167</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dc34bee07a6ceed8f010d89d1fcbda15a5abee8c" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -315,7 +315,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">178</context>
+          <context context-type="linenumber">205</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/dialog-with-close/dialog-with-close.component.html</context>
@@ -1883,11 +1883,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">124</context>
+          <context context-type="linenumber">151</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">158</context>
+          <context context-type="linenumber">185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7491b1ebfc5dd457492a5c481e2d2254216dc1fc" datatype="html">
@@ -13895,144 +13895,165 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">67,70</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="e04b6cd0cf044eabd1d5f09a51d88a54f10aacbe" datatype="html">
+        <source> Evaluates to true if more than X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountMoreThan(2, 3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had more than 2 ideas in their 3rd response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="START_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;ng-template [ngTemplateOutlet]=&quot;accumulatedIdeaCountSupportMessage&quot;&gt;"/><x id="CLOSE_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;/ng-template&gt;"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
+          <context context-type="linenumber">74,78</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="6b884914cb98d7d84efe99d0b60f778c30c3a9f3" datatype="html">
         <source> Evaluates to true if less than X ideas were found in the student&apos;s response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountLessThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had less than 2 ideas. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">74,77</context>
+          <context context-type="linenumber">83,86</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="79beee3a035e6163a916539a4f9493ed5e8e40c3" datatype="html">
+        <source> Evaluates to true if less than X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountLessThan(2, 3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had less than 2 ideas in their 3rd response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="START_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;ng-template [ngTemplateOutlet]=&quot;accumulatedIdeaCountSupportMessage&quot;&gt;"/><x id="CLOSE_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;/ng-template&gt;"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
+          <context context-type="linenumber">90,94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c299449835a6844a97d1120d96268ec889e221ee" datatype="html">
         <source> Evaluates to true if exactly X ideas were found in the student&apos;s response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountEquals(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had exactly 2 ideas. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">81,84</context>
+          <context context-type="linenumber">99,102</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2d05e3d5853bc13670778644a91cb4a915d5b3ce" datatype="html">
+        <source> Evaluates to true if exactly X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountEquals(2, 3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had exactly 2 ideas in their 3rd response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="START_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;ng-template [ngTemplateOutlet]=&quot;accumulatedIdeaCountSupportMessage&quot;&gt;"/><x id="CLOSE_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;/ng-template&gt;"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
+          <context context-type="linenumber">106,110</context>
         </context-group>
       </trans-unit>
       <trans-unit id="acb957d799796d719108eeb1d0ed9ca4880c9f0c" datatype="html">
         <source> Evaluates to true if this is the student&apos;s X-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>isSubmitNumber(3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if this is the student&apos;s third response. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">88,91</context>
+          <context context-type="linenumber">115,118</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ab15bc35d4c4c975e2cd82171bd30ef3fbf8f226" datatype="html">
         <source> Evaluates to true if this is the student&apos;s second to last response when the max number of submits is specified. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">95,98</context>
+          <context context-type="linenumber">122,125</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bc1cca966f287a319703db89b22d379a6c1455cb" datatype="html">
         <source> Evaluates to true if this is the student&apos;s final response when the max number of submits is specified. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">102,105</context>
+          <context context-type="linenumber">129,132</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3783efe04c66c9d80d09506ec8b7ad29167aacd8" datatype="html">
         <source>Evaluates to true if the student&apos;s response was not scorable.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">136</context>
         </context-group>
       </trans-unit>
       <trans-unit id="298fc1d863b0fb7a33b6825d43981e09e151cb5a" datatype="html">
         <source> Evaluates to true if no other terms were matched. Add this term as the final rule to specify a default feedback. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">113,116</context>
+          <context context-type="linenumber">140,143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9d4ed1f582fafcfd1035ea83e58a5e1fe8d6a1a5" datatype="html">
         <source>Operators</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">119</context>
+          <context context-type="linenumber">146</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b2145d0c97ccffaf79c5770f967a429c84af4123" datatype="html">
         <source>Operators let you combine one or more terms together to make a rule.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">147</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c39d43f18d10f925621abc77ad15de80a9cc7516" datatype="html">
         <source>Operator</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">123</context>
+          <context context-type="linenumber">150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e4b8724800156a9aef6d6f0f31f67431957cc24e" datatype="html">
         <source> Evaluates to true if terms on both sides of this operator evaluate to true.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; hasKIScore(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if idea 1 was found and the student received a KI score of 2. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">128,133</context>
+          <context context-type="linenumber">155,160</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1f50d4313ef8ddef3a1d6d3fd464ec3dd3c21f03" datatype="html">
         <source> Evaluates to true if a term on either side of this operator evaluates to true.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 || 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if either idea 1 or 2 was found.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2 || 3<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found or idea 3 was found. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">137,142</context>
+          <context context-type="linenumber">164,169</context>
         </context-group>
       </trans-unit>
       <trans-unit id="414f2fd4ea5c948c6ebbf8417e6afe371bea442d" datatype="html">
         <source> Evaluates to true if a term following this operator evaluates to false.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>!1<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if idea 1 was not found. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">146,149</context>
+          <context context-type="linenumber">173,176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="46b1ed215e53246db19c5bde05ea87e08a5c2705" datatype="html">
         <source>Parentheses</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">152</context>
+          <context context-type="linenumber">179</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8df5a6f6a83598ccc0f22b86f8ca75661ef5a302" datatype="html">
         <source>Parentheses let you group expressions and prioritize evaluation.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">153</context>
+          <context context-type="linenumber">180</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dae69adfd569cdbaa366470ec24471bf01c7db66" datatype="html">
         <source>You can add multiple parentheses in an expression. You can even nest parentheses.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6db909a826f1878ad78bf853a62b6cc5cbda3d3f" datatype="html">
         <source>Example</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">157</context>
+          <context context-type="linenumber">184</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f5d726bee0fd8a545258990d929f39b68549dd87" datatype="html">
         <source>Evaluates to true if neither idea 4a nor idea 12 were found.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">162</context>
+          <context context-type="linenumber">189</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a8eebb4afda178aca31b3fdc61eb0f6d91837041" datatype="html">
         <source>Evaluates to true if idea 5a and either idea 4a or idea 12 was found.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">166</context>
+          <context context-type="linenumber">193</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5dcea69981a857fdd51521e3a1ba0b455ce1fdc9" datatype="html">
         <source> Evaluates to true if idea 5a and either idea 4a or idea 12 was found, and the student received a KI score of 3. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">170,173</context>
+          <context context-type="linenumber">197,200</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dc34bee07a6ceed8f010d89d1fcbda15a5abee8c" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -315,7 +315,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">172</context>
+          <context context-type="linenumber">178</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/dialog-with-close/dialog-with-close.component.html</context>
@@ -1879,15 +1879,15 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">19</context>
+          <context context-type="linenumber">22</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">118</context>
+          <context context-type="linenumber">124</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">152</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7491b1ebfc5dd457492a5c481e2d2254216dc1fc" datatype="html">
@@ -13790,242 +13790,249 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">80</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="82efdf880fe90640388310171d05401a6fc62663" datatype="html">
+        <source>Note: this term currently only works in the Dialog Guidance component.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="21a9fc818b21be4ca6e733d9cf3defc9b28f3879" datatype="html">
         <source>Feedback Rule Authoring</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">1</context>
+          <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5499b81e5db6d551e39b1731b360d787148bfea2" datatype="html">
         <source>Introduction</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">3</context>
+          <context context-type="linenumber">6</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2b697376f40eff0851d7401d0e93b7243059e8ef" datatype="html">
         <source> Rules are evaluated top to bottom. The first rule <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>Expression<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> that matches the student&apos;s response is used to provide feedback. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">4,7</context>
+          <context context-type="linenumber">7,10</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2f65cedf60cf1bf82125ec83f1de1859614cf944" datatype="html">
         <source> You can add multiple <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>Feedback<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> items per rule. The first time a rule matches, Feedback #1 will be shown to the student.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> If the rule matches a second time (in a subsequent round), Feedback #2 will be shown, and so on. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">8,12</context>
+          <context context-type="linenumber">11,15</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d8b6142c3d02b165711db70e94cc65d49a2dfabe" datatype="html">
         <source><x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>Expressions<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> are made up of terms, operators, and parentheses:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">13</context>
+          <context context-type="linenumber">16</context>
         </context-group>
       </trans-unit>
       <trans-unit id="69580f2c2dbf4edf7096820ba8c393367352d774" datatype="html">
         <source>Terms</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">14</context>
+          <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4386e2f920c44a2d81df324615b6daba105a6d92" datatype="html">
         <source>Terms lets you specify what to look for in a student response.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="be1c273fc76e686667bff39d321970c9487f9ee7" datatype="html">
         <source>Term</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">18</context>
+          <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a8ea043c9dd022c74447e7e816841d378138ecd9" datatype="html">
         <source>Evaluates to true if idea 1, 2, 18, etc was found in the student&apos;s response.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">23</context>
+          <context context-type="linenumber">26</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b76eb1dfebc7cbec7f95dae60708804c3eb23e15" datatype="html">
         <source> Evaluates to true if the student received a KI score of X.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>hasKIScore(3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student received KI score 3. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">27,30</context>
+          <context context-type="linenumber">30,33</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="fbe19657096a0fbacfecaa4520034eb6ad2fc3e7" datatype="html">
-        <source> Evaluates to true if more than X ideas were found in all (both past and current) of student&apos;s responses.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>accumulatedIdeaCountMoreThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had more than 2 ideas in all of their responses. </source>
+      <trans-unit id="71a4930ba088b909b7923626580adac30640c167" datatype="html">
+        <source> Evaluates to true if more than X ideas were found in all (both past and current) of student&apos;s responses.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>accumulatedIdeaCountMoreThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had more than 2 ideas in all of their responses.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="START_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;ng-template [ngTemplateOutlet]=&quot;accumulatedIdeaCountSupportMessage&quot;&gt;"/><x id="CLOSE_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;/ng-template&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">34,39</context>
+          <context context-type="linenumber">37,42</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="d3bc88aa2697b5c1f5c349727863babcb6cfb941" datatype="html">
-        <source> Evaluates to true if less than X ideas were found in all (both past and current) of student&apos;s responses.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>accumulatedIdeaCountLessThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had less than 2 ideas in all of their responses. </source>
+      <trans-unit id="734b33e9a431f6b0663b3aca75e1fd1321dce3dd" datatype="html">
+        <source> Evaluates to true if less than X ideas were found in all (both past and current) of student&apos;s responses.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>accumulatedIdeaCountLessThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had less than 2 ideas in all of their responses.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="START_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;ng-template [ngTemplateOutlet]=&quot;accumulatedIdeaCountSupportMessage&quot;&gt;"/><x id="CLOSE_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;/ng-template&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">43,48</context>
+          <context context-type="linenumber">47,52</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6886e601fd927fd7a822eefd8da89dd39682f4a4" datatype="html">
-        <source> Evaluates to true if exactly X ideas were found in all (both past and current) of student&apos;s responses.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>accumulatedIdeaCountEquals(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had exactly 2 ideas in all of their responses. </source>
+      <trans-unit id="10049e4579770c0e82f53ae155be74d948eae034" datatype="html">
+        <source> Evaluates to true if exactly X ideas were found in all (both past and current) of student&apos;s responses.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>accumulatedIdeaCountEquals(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had exactly 2 ideas in all of their responses.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="START_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;ng-template [ngTemplateOutlet]=&quot;accumulatedIdeaCountSupportMessage&quot;&gt;"/><x id="CLOSE_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;/ng-template&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">52,57</context>
+          <context context-type="linenumber">57,62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e5f60118e592df5cd7aed342976c7b0ecc4da547" datatype="html">
         <source> Evaluates to true if more than X ideas were found in the student&apos;s response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountMoreThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had more than 2 ideas. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">61,64</context>
+          <context context-type="linenumber">67,70</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6b884914cb98d7d84efe99d0b60f778c30c3a9f3" datatype="html">
         <source> Evaluates to true if less than X ideas were found in the student&apos;s response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountLessThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had less than 2 ideas. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">68,71</context>
+          <context context-type="linenumber">74,77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c299449835a6844a97d1120d96268ec889e221ee" datatype="html">
         <source> Evaluates to true if exactly X ideas were found in the student&apos;s response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountEquals(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had exactly 2 ideas. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">75,78</context>
+          <context context-type="linenumber">81,84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="acb957d799796d719108eeb1d0ed9ca4880c9f0c" datatype="html">
         <source> Evaluates to true if this is the student&apos;s X-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>isSubmitNumber(3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if this is the student&apos;s third response. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">82,85</context>
+          <context context-type="linenumber">88,91</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ab15bc35d4c4c975e2cd82171bd30ef3fbf8f226" datatype="html">
         <source> Evaluates to true if this is the student&apos;s second to last response when the max number of submits is specified. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">89,92</context>
+          <context context-type="linenumber">95,98</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bc1cca966f287a319703db89b22d379a6c1455cb" datatype="html">
         <source> Evaluates to true if this is the student&apos;s final response when the max number of submits is specified. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">96,99</context>
+          <context context-type="linenumber">102,105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3783efe04c66c9d80d09506ec8b7ad29167aacd8" datatype="html">
         <source>Evaluates to true if the student&apos;s response was not scorable.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">103</context>
+          <context context-type="linenumber">109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="298fc1d863b0fb7a33b6825d43981e09e151cb5a" datatype="html">
         <source> Evaluates to true if no other terms were matched. Add this term as the final rule to specify a default feedback. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">107,110</context>
+          <context context-type="linenumber">113,116</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9d4ed1f582fafcfd1035ea83e58a5e1fe8d6a1a5" datatype="html">
         <source>Operators</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">113</context>
+          <context context-type="linenumber">119</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b2145d0c97ccffaf79c5770f967a429c84af4123" datatype="html">
         <source>Operators let you combine one or more terms together to make a rule.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">114</context>
+          <context context-type="linenumber">120</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c39d43f18d10f925621abc77ad15de80a9cc7516" datatype="html">
         <source>Operator</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">117</context>
+          <context context-type="linenumber">123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e4b8724800156a9aef6d6f0f31f67431957cc24e" datatype="html">
         <source> Evaluates to true if terms on both sides of this operator evaluate to true.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; hasKIScore(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if idea 1 was found and the student received a KI score of 2. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">122,127</context>
+          <context context-type="linenumber">128,133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1f50d4313ef8ddef3a1d6d3fd464ec3dd3c21f03" datatype="html">
         <source> Evaluates to true if a term on either side of this operator evaluates to true.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 || 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if either idea 1 or 2 was found.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2 || 3<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found or idea 3 was found. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">131,136</context>
+          <context context-type="linenumber">137,142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="414f2fd4ea5c948c6ebbf8417e6afe371bea442d" datatype="html">
         <source> Evaluates to true if a term following this operator evaluates to false.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>!1<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if idea 1 was not found. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">140,143</context>
+          <context context-type="linenumber">146,149</context>
         </context-group>
       </trans-unit>
       <trans-unit id="46b1ed215e53246db19c5bde05ea87e08a5c2705" datatype="html">
         <source>Parentheses</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">146</context>
+          <context context-type="linenumber">152</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8df5a6f6a83598ccc0f22b86f8ca75661ef5a302" datatype="html">
         <source>Parentheses let you group expressions and prioritize evaluation.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">147</context>
+          <context context-type="linenumber">153</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dae69adfd569cdbaa366470ec24471bf01c7db66" datatype="html">
         <source>You can add multiple parentheses in an expression. You can even nest parentheses.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">148</context>
+          <context context-type="linenumber">154</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6db909a826f1878ad78bf853a62b6cc5cbda3d3f" datatype="html">
         <source>Example</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">151</context>
+          <context context-type="linenumber">157</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f5d726bee0fd8a545258990d929f39b68549dd87" datatype="html">
         <source>Evaluates to true if neither idea 4a nor idea 12 were found.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">156</context>
+          <context context-type="linenumber">162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a8eebb4afda178aca31b3fdc61eb0f6d91837041" datatype="html">
         <source>Evaluates to true if idea 5a and either idea 4a or idea 12 was found.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">160</context>
+          <context context-type="linenumber">166</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5dcea69981a857fdd51521e3a1ba0b455ce1fdc9" datatype="html">
         <source> Evaluates to true if idea 5a and either idea 4a or idea 12 was found, and the student received a KI score of 3. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">164,167</context>
+          <context context-type="linenumber">170,173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dc34bee07a6ceed8f010d89d1fcbda15a5abee8c" datatype="html">
@@ -18871,28 +18878,28 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Preview Student</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">78</context>
+          <context context-type="linenumber">76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1967824796880640028" datatype="html">
         <source>StudentDataService.saveComponentEvent: component, category, event args must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">255</context>
+          <context context-type="linenumber">253</context>
         </context-group>
       </trans-unit>
       <trans-unit id="944638387659785956" datatype="html">
         <source>StudentDataService.saveComponentEvent: nodeId, componentId, componentType must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">265</context>
+          <context context-type="linenumber">263</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4924640921903672943" datatype="html">
         <source>StudentDataService.saveVLEEvent: category and event args must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">274</context>
+          <context context-type="linenumber">272</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8725215606116054825" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13419,11 +13419,11 @@ Are you sure you want to proceed?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">158</context>
+          <context context-type="linenumber">159</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">174</context>
+          <context context-type="linenumber">175</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4965414112249568013" datatype="html">
@@ -14264,7 +14264,7 @@ Are you ready to receive feedback on this answer?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">161</context>
+          <context context-type="linenumber">162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8429316238784832901" datatype="html">
@@ -17253,7 +17253,7 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">165</context>
+          <context context-type="linenumber">166</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7482125205220618294" datatype="html">
@@ -17262,7 +17262,7 @@ Are you ready to receive feedback on this answer?</source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">177</context>
+          <context context-type="linenumber">178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6316287012266891697" datatype="html">
@@ -17271,21 +17271,21 @@ Are you ready to receive feedback on this answer?</source>
 Are you ready to submit this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">181</context>
+          <context context-type="linenumber">182</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8936495196157450285" datatype="html">
         <source>We are scoring your work...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">295</context>
+          <context context-type="linenumber">296</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2283191014272031538" datatype="html">
         <source>Please Wait</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">296</context>
+          <context context-type="linenumber">297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8785209093929133444" datatype="html">
@@ -17293,7 +17293,7 @@ Are you ready to submit this answer?</source>
 If this problem continues, let your teacher know and move on to the next activity. Your work will still be saved.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">318</context>
+          <context context-type="linenumber">319</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5623290610025495479" datatype="html">
@@ -18850,28 +18850,28 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Preview Student</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1967824796880640028" datatype="html">
         <source>StudentDataService.saveComponentEvent: component, category, event args must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">253</context>
+          <context context-type="linenumber">255</context>
         </context-group>
       </trans-unit>
       <trans-unit id="944638387659785956" datatype="html">
         <source>StudentDataService.saveComponentEvent: nodeId, componentId, componentType must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">263</context>
+          <context context-type="linenumber">265</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4924640921903672943" datatype="html">
         <source>StudentDataService.saveVLEEvent: category and event args must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">272</context>
+          <context context-type="linenumber">274</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8725215606116054825" datatype="html">


### PR DESCRIPTION
## Changes
- Add support for accumulatedIdeaCount[LessThan|Equals|MoreThan] tokens, (**Note: currently only works in the DialogGuidance component** We need to do a bit more extra work to get it to work in OpenResponse feedback and DynamicPrompt because we don't store c-rater response in those cases that's needed to compute)
- FeedbackRuleEvaluator now takes in an array of CRaterResponses instead of just the latest
- DialogGuidanceStudent now passes in all CRaterResponses to the FeedbackRuleEvaluator
- OpenResponse and DynamicPrompt now passes in an array, but it only contains the latest CRaterResponse. So accumulatedIdeaCount tokens won't work in these places
- Clean up code
   - Define CRaterResponses interface
   - Abstract common idea count evaluation code to AbstractIdeaCountTermEvaluator

## Test accumulatedIdeaCount[LessThan|Equals|MoreThan] tokens
- Add accumulatedIdeaCount[LessThan|Equals|MoreThan] tokens and see that they are matched
   - accumulatedIdeaCountLessThan(3): returns true if they had less than 3 ideas across all (both past and current) responses
   - accumulatedIdeaCountEquals(3): returns true if they had exactly 3 ideas across all (both past and current) responses
   - accumulatedIdeaCountMoreThan(3): returns true if they had more than 3 ideas across all (both past and current) responses
- Feedback Rule help popup in the AT shows info about the new tokens 

## Test Regression
Feedback rule evaluation should work as before in these places. Test existing items and make sure that they still work.
- Single Student
  - Dialog Guidance 
  - OpenResponse annotation using Feedback Rules
  - Dynamic Prompt 
- Multiple Students
   - Dynamic Prompt
   - Question Bank

Closes #1257 
