### PR TITLE
feat(FeedbackRule): idea count token with response index parameter

### DIFF
--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.ts
@@ -114,7 +114,7 @@ export class FeedbackRuleEvaluator<T extends CRaterResponse[]> {
 
   protected evaluateTerm(term: string, responses: T): boolean {
     const evaluator: TermEvaluator = this.factory.getTermEvaluator(term);
-    return TermEvaluator.isAccumulatedIdeaCountTerm(term)
+    return TermEvaluator.requiresAllResponses(term)
       ? evaluator.evaluate(responses)
       : evaluator.evaluate(responses[responses.length - 1]);
   }

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleExpression.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleExpression.ts
@@ -28,7 +28,7 @@ export class FeedbackRuleExpression {
     return this.text
       .replace(/ /g, '')
       .split(
-        /(hasKIScore\(\d\)|accumulatedIdeaCountEquals\(\d\)|accumulatedIdeaCountLessThan\(\d\)|accumulatedIdeaCountMoreThan\(\d\)|ideaCountEquals\(\d\)|ideaCountLessThan\(\d\)|ideaCountMoreThan\(\d\)|isSubmitNumber\(\d+\)|&&|\|\||!|\(|\))/g
+        /(hasKIScore\(\d\)|accumulatedIdeaCountEquals\(\d\)|accumulatedIdeaCountLessThan\(\d\)|accumulatedIdeaCountMoreThan\(\d\)|ideaCountEquals\(\S+\)|ideaCountLessThan\(\S+\)|ideaCountMoreThan\(\S+\)|isSubmitNumber\(\d+\)|&&|\|\||!|\(|\))/g
       )
       .filter((el) => el !== '');
   }

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/AbstractIdeaCountTermEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/AbstractIdeaCountTermEvaluator.ts
@@ -4,12 +4,13 @@ import { TermEvaluator } from './TermEvaluator';
 export abstract class AbstractIdeaCountTermEvaluator extends TermEvaluator {
   comparer: 'MoreThan' | 'Equals' | 'LessThan';
   expectedIdeaCount: number;
+  matches: RegExpMatchArray;
 
   constructor(term: string, matcher: RegExp) {
     super(term);
-    const matches = term.match(matcher);
-    this.comparer = matches[1] as 'MoreThan' | 'Equals' | 'LessThan';
-    this.expectedIdeaCount = parseInt(matches[2]);
+    this.matches = term.match(matcher);
+    this.comparer = this.matches[1] as 'MoreThan' | 'Equals' | 'LessThan';
+    this.expectedIdeaCount = parseInt(this.matches[2]);
   }
 
   evaluate(response: CRaterResponse | CRaterResponse[]): boolean {

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaCountWithResponseIndexTermEvaluator.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaCountWithResponseIndexTermEvaluator.spec.ts
@@ -1,0 +1,47 @@
+import { IdeaCountWithResponseIndexTermEvaluator } from './IdeaCountWithResponseIndexTermEvaluator';
+import {
+  IdeaCountTermEvaluatorTester,
+  response_with_idea_1,
+  response_with_ideas_1_2,
+  response_with_ideas_1_2_3
+} from './test-utils';
+
+const evaluatorTester = new IdeaCountTermEvaluatorTester([
+  new IdeaCountWithResponseIndexTermEvaluator('ideaCountMoreThan(2, 2)'),
+  new IdeaCountWithResponseIndexTermEvaluator('ideaCountEquals(2,2)'),
+  new IdeaCountWithResponseIndexTermEvaluator('ideaCountLessThan(2,2)')
+]);
+describe('IdeaCountWithResponseIndexTermEvaluator', () => {
+  describe('evaluate()', () => {
+    evaluate_NotEnoughResponses_ReturnFalse();
+    evaluate_EnoughResponses_CheckNumberOfDetectedIdeas();
+  });
+});
+
+function evaluate_NotEnoughResponses_ReturnFalse() {
+  describe('response index is more than number of responses', () => {
+    it('should return false', () => {
+      evaluatorTester.expectEvaluations([], [false, false, false]);
+      evaluatorTester.expectEvaluations([response_with_idea_1], [false, false, false]);
+    });
+  });
+}
+
+function evaluate_EnoughResponses_CheckNumberOfDetectedIdeas() {
+  describe('response index is more than number of responses', () => {
+    it('should check whether number of detected ideas at the index meets criteria', () => {
+      evaluatorTester.expectEvaluations(
+        [response_with_idea_1, response_with_idea_1],
+        [false, false, true]
+      );
+      evaluatorTester.expectEvaluations(
+        [response_with_idea_1, response_with_ideas_1_2],
+        [false, true, false]
+      );
+      evaluatorTester.expectEvaluations(
+        [response_with_idea_1, response_with_ideas_1_2_3],
+        [true, false, false]
+      );
+    });
+  });
+}

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaCountWithResponseIndexTermEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaCountWithResponseIndexTermEvaluator.ts
@@ -1,0 +1,19 @@
+import { CRaterResponse } from '../../cRater/CRaterResponse';
+import { AbstractIdeaCountTermEvaluator } from './AbstractIdeaCountTermEvaluator';
+
+export class IdeaCountWithResponseIndexTermEvaluator extends AbstractIdeaCountTermEvaluator {
+  responseIndex: number;
+
+  constructor(term: string) {
+    super(term, /ideaCount(.*)\((\d+),\s*(\d+)\)/);
+    this.responseIndex = parseInt(this.matches[3]) - 1; // authored index starts at 1
+  }
+
+  evaluate(responses: CRaterResponse[]): boolean {
+    return responses.length <= this.responseIndex ? false : super.evaluate(responses);
+  }
+
+  protected getDetectedIdeaCount(responses: CRaterResponse[]): number {
+    return responses[this.responseIndex].getDetectedIdeaCount();
+  }
+}

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluator.ts
@@ -16,7 +16,18 @@ export abstract class TermEvaluator {
     return /ideaCount(MoreThan|Equals|LessThan)\([\d+]\)/.test(term);
   }
 
+  static isIdeaCountWithResponseIndexTerm(term: string): boolean {
+    return /ideaCount(MoreThan|Equals|LessThan)\(\d+,\s*\d+\)/.test(term);
+  }
+
   static isSubmitNumberTerm(term: string): boolean {
     return /isSubmitNumber\(\d+\)/.test(term);
+  }
+
+  static requiresAllResponses(term: string): boolean {
+    return (
+      TermEvaluator.isAccumulatedIdeaCountTerm(term) ||
+      TermEvaluator.isIdeaCountWithResponseIndexTerm(term)
+    );
   }
 }

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluatorFactory.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluatorFactory.ts
@@ -1,6 +1,7 @@
 import { AccumulatedIdeaCountTermEvaluator } from './AccumulatedIdeaCountTermEvaluator';
 import { HasKIScoreTermEvaluator } from './HasKIScoreTermEvaluator';
 import { IdeaCountTermEvaluator } from './IdeaCountTermEvaluator';
+import { IdeaCountWithResponseIndexTermEvaluator } from './IdeaCountWithResponseIndexTermEvaluator';
 import { IdeaTermEvaluator } from './IdeaTermEvaluator';
 import { IsSubmitNumberEvaluator } from './IsSubmitNumberEvaluator';
 import { TermEvaluator } from './TermEvaluator';
@@ -12,6 +13,8 @@ export class TermEvaluatorFactory {
       evaluator = new HasKIScoreTermEvaluator(term);
     } else if (TermEvaluator.isIdeaCountTerm(term)) {
       evaluator = new IdeaCountTermEvaluator(term);
+    } else if (TermEvaluator.isIdeaCountWithResponseIndexTerm(term)) {
+      evaluator = new IdeaCountWithResponseIndexTermEvaluator(term);
     } else if (TermEvaluator.isSubmitNumberTerm(term)) {
       evaluator = new IsSubmitNumberEvaluator(term);
     } else if (TermEvaluator.isAccumulatedIdeaCountTerm(term)) {

--- a/src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html
+++ b/src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html
@@ -70,6 +70,14 @@
       </td>
     </tr>
     <tr>
+      <td class="term">ideaCountMoreThan(X, Y)</td>
+      <td i18n>
+        Evaluates to true if more than X ideas were found in the student's Y-th response.<br />
+        Ex: <b>ideaCountMoreThan(2, 3)</b> evaluates to true if the student had more than 2 ideas in
+        their third response.
+      </td>
+    </tr>
+    <tr>
       <td class="term">ideaCountLessThan(X)</td>
       <td i18n>
         Evaluates to true if less than X ideas were found in the student's response.<br />
@@ -77,10 +85,26 @@
       </td>
     </tr>
     <tr>
+      <td class="term">ideaCountLessThan(X, Y)</td>
+      <td i18n>
+        Evaluates to true if less than X ideas were found in the student's Y-th response.<br />
+        Ex: <b>ideaCountLessThan(2, 3)</b> evaluates to true if the student had less than 2 ideas in
+        their third response.
+      </td>
+    </tr>
+    <tr>
       <td class="term">ideaCountEquals(X)</td>
       <td i18n>
         Evaluates to true if exactly X ideas were found in the student's response.<br />
         Ex: <b>ideaCountEquals(2)</b> evaluates to true if the student had exactly 2 ideas.
+      </td>
+    </tr>
+    <tr>
+      <td class="term">ideaCountEquals(X, Y)</td>
+      <td i18n>
+        Evaluates to true if exactly X ideas were found in the student's Y-th response.<br />
+        Ex: <b>ideaCountEquals(2, 3)</b> evaluates to true if the student had exactly 2 ideas in
+        their third response.
       </td>
     </tr>
     <tr>

--- a/src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html
+++ b/src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html
@@ -74,7 +74,8 @@
       <td i18n>
         Evaluates to true if more than X ideas were found in the student's Y-th response.<br />
         Ex: <b>ideaCountMoreThan(2, 3)</b> evaluates to true if the student had more than 2 ideas in
-        their third response.
+        their third response.<br />
+        <ng-template [ngTemplateOutlet]="accumulatedIdeaCountSupportMessage"></ng-template>
       </td>
     </tr>
     <tr>
@@ -89,7 +90,8 @@
       <td i18n>
         Evaluates to true if less than X ideas were found in the student's Y-th response.<br />
         Ex: <b>ideaCountLessThan(2, 3)</b> evaluates to true if the student had less than 2 ideas in
-        their third response.
+        their third response.<br />
+        <ng-template [ngTemplateOutlet]="accumulatedIdeaCountSupportMessage"></ng-template>
       </td>
     </tr>
     <tr>
@@ -104,7 +106,8 @@
       <td i18n>
         Evaluates to true if exactly X ideas were found in the student's Y-th response.<br />
         Ex: <b>ideaCountEquals(2, 3)</b> evaluates to true if the student had exactly 2 ideas in
-        their third response.
+        their third response.<br />
+        <ng-template [ngTemplateOutlet]="accumulatedIdeaCountSupportMessage"></ng-template>
       </td>
     </tr>
     <tr>

--- a/src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html
+++ b/src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html
@@ -74,7 +74,7 @@
       <td i18n>
         Evaluates to true if more than X ideas were found in the student's Y-th response.<br />
         Ex: <b>ideaCountMoreThan(2, 3)</b> evaluates to true if the student had more than 2 ideas in
-        their third response.<br />
+        their 3rd response.<br />
         <ng-template [ngTemplateOutlet]="accumulatedIdeaCountSupportMessage"></ng-template>
       </td>
     </tr>
@@ -90,7 +90,7 @@
       <td i18n>
         Evaluates to true if less than X ideas were found in the student's Y-th response.<br />
         Ex: <b>ideaCountLessThan(2, 3)</b> evaluates to true if the student had less than 2 ideas in
-        their third response.<br />
+        their 3rd response.<br />
         <ng-template [ngTemplateOutlet]="accumulatedIdeaCountSupportMessage"></ng-template>
       </td>
     </tr>
@@ -106,7 +106,7 @@
       <td i18n>
         Evaluates to true if exactly X ideas were found in the student's Y-th response.<br />
         Ex: <b>ideaCountEquals(2, 3)</b> evaluates to true if the student had exactly 2 ideas in
-        their third response.<br />
+        their 3rd response.<br />
         <ng-template [ngTemplateOutlet]="accumulatedIdeaCountSupportMessage"></ng-template>
       </td>
     </tr>

--- a/src/assets/wise5/components/dialogGuidance/ComputerDialogResponse.ts
+++ b/src/assets/wise5/components/dialogGuidance/ComputerDialogResponse.ts
@@ -4,10 +4,17 @@ import { DialogResponse } from './DialogResponse';
 export class ComputerDialogResponse extends DialogResponse {
   feedbackRuleId?: string;
   ideas: CRaterIdea[];
+  initialResponse: boolean;
   user: string = 'Computer';
 
-  constructor(text: string, ideas: CRaterIdea[], timestamp: number) {
+  constructor(
+    text: string,
+    ideas: CRaterIdea[],
+    timestamp: number,
+    initialResponse: boolean = false
+  ) {
     super(text, timestamp);
     this.ideas = ideas;
+    this.initialResponse = initialResponse;
   }
 }

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
@@ -169,7 +169,7 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
     const computerAvatarInitialResponse = this.component.getComputerAvatarInitialResponse();
     if (computerAvatarInitialResponse != null && computerAvatarInitialResponse !== '') {
       this.addDialogResponse(
-        new ComputerDialogResponse(computerAvatarInitialResponse, [], new Date().getTime())
+        new ComputerDialogResponse(computerAvatarInitialResponse, [], new Date().getTime(), true)
       );
     }
   }
@@ -274,7 +274,10 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
     return (
       this.dataService
         .getLatestComponentStateByNodeIdAndComponentId(this.nodeId, this.componentId)
-        ?.studentData.responses.filter((response: DialogResponse) => response.user === 'Computer')
+        ?.studentData.responses.filter(
+          (response: DialogResponse) =>
+            response.user === 'Computer' && !(response as ComputerDialogResponse).initialResponse
+        )
         .map((response: DialogResponse) => {
           const cRaterResponse = new CRaterResponse(response);
           cRaterResponse.submitCounter = submitCounter++;

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13895,8 +13895,8 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">67,70</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="62a78a93ebb5236c1a6ade1793758c83b54e87cd" datatype="html">
-        <source> Evaluates to true if more than X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountMoreThan(2, 3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had more than 2 ideas in their third response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="START_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;ng-template [ngTemplateOutlet]=&quot;accumulatedIdeaCountSupportMessage&quot;&gt;"/><x id="CLOSE_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;/ng-template&gt;"/></source>
+      <trans-unit id="e04b6cd0cf044eabd1d5f09a51d88a54f10aacbe" datatype="html">
+        <source> Evaluates to true if more than X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountMoreThan(2, 3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had more than 2 ideas in their 3rd response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="START_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;ng-template [ngTemplateOutlet]=&quot;accumulatedIdeaCountSupportMessage&quot;&gt;"/><x id="CLOSE_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;/ng-template&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
           <context context-type="linenumber">74,78</context>
@@ -13909,8 +13909,8 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">83,86</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="268845fd30e31dce1afa239f99bb88b094439b55" datatype="html">
-        <source> Evaluates to true if less than X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountLessThan(2, 3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had less than 2 ideas in their third response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="START_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;ng-template [ngTemplateOutlet]=&quot;accumulatedIdeaCountSupportMessage&quot;&gt;"/><x id="CLOSE_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;/ng-template&gt;"/></source>
+      <trans-unit id="79beee3a035e6163a916539a4f9493ed5e8e40c3" datatype="html">
+        <source> Evaluates to true if less than X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountLessThan(2, 3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had less than 2 ideas in their 3rd response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="START_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;ng-template [ngTemplateOutlet]=&quot;accumulatedIdeaCountSupportMessage&quot;&gt;"/><x id="CLOSE_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;/ng-template&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
           <context context-type="linenumber">90,94</context>
@@ -13923,8 +13923,8 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">99,102</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="c55a2693ca5f800e3c28e971526b5950d4637d02" datatype="html">
-        <source> Evaluates to true if exactly X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountEquals(2, 3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had exactly 2 ideas in their third response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="START_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;ng-template [ngTemplateOutlet]=&quot;accumulatedIdeaCountSupportMessage&quot;&gt;"/><x id="CLOSE_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;/ng-template&gt;"/></source>
+      <trans-unit id="2d05e3d5853bc13670778644a91cb4a915d5b3ce" datatype="html">
+        <source> Evaluates to true if exactly X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountEquals(2, 3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had exactly 2 ideas in their 3rd response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="START_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;ng-template [ngTemplateOutlet]=&quot;accumulatedIdeaCountSupportMessage&quot;&gt;"/><x id="CLOSE_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;/ng-template&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
           <context context-type="linenumber">106,110</context>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -315,7 +315,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">178</context>
+          <context context-type="linenumber">202</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/dialog-with-close/dialog-with-close.component.html</context>
@@ -1883,11 +1883,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">124</context>
+          <context context-type="linenumber">148</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">158</context>
+          <context context-type="linenumber">182</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7491b1ebfc5dd457492a5c481e2d2254216dc1fc" datatype="html">
@@ -13895,144 +13895,165 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">67,70</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="b86b38d37538df9ff0cac2f392314b48c3b83d4e" datatype="html">
+        <source> Evaluates to true if more than X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountMoreThan(2, 2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had more than 2 ideas in their second response. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
+          <context context-type="linenumber">74,78</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="6b884914cb98d7d84efe99d0b60f778c30c3a9f3" datatype="html">
         <source> Evaluates to true if less than X ideas were found in the student&apos;s response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountLessThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had less than 2 ideas. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">74,77</context>
+          <context context-type="linenumber">82,85</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="625f661282983007cf002e27fb289b8565a5e536" datatype="html">
+        <source> Evaluates to true if less than X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountLessThan(2, 2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had less than 2 ideas in their second response. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
+          <context context-type="linenumber">89,93</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c299449835a6844a97d1120d96268ec889e221ee" datatype="html">
         <source> Evaluates to true if exactly X ideas were found in the student&apos;s response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountEquals(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had exactly 2 ideas. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">81,84</context>
+          <context context-type="linenumber">97,100</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2cd04901a8717e3044bc77b2f88084fec7bbf60b" datatype="html">
+        <source> Evaluates to true if exactly X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountEquals(2, 2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had exactly 2 ideas in their second response. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
+          <context context-type="linenumber">104,108</context>
         </context-group>
       </trans-unit>
       <trans-unit id="acb957d799796d719108eeb1d0ed9ca4880c9f0c" datatype="html">
         <source> Evaluates to true if this is the student&apos;s X-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>isSubmitNumber(3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if this is the student&apos;s third response. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">88,91</context>
+          <context context-type="linenumber">112,115</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ab15bc35d4c4c975e2cd82171bd30ef3fbf8f226" datatype="html">
         <source> Evaluates to true if this is the student&apos;s second to last response when the max number of submits is specified. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">95,98</context>
+          <context context-type="linenumber">119,122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bc1cca966f287a319703db89b22d379a6c1455cb" datatype="html">
         <source> Evaluates to true if this is the student&apos;s final response when the max number of submits is specified. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">102,105</context>
+          <context context-type="linenumber">126,129</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3783efe04c66c9d80d09506ec8b7ad29167aacd8" datatype="html">
         <source>Evaluates to true if the student&apos;s response was not scorable.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="298fc1d863b0fb7a33b6825d43981e09e151cb5a" datatype="html">
         <source> Evaluates to true if no other terms were matched. Add this term as the final rule to specify a default feedback. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">113,116</context>
+          <context context-type="linenumber">137,140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9d4ed1f582fafcfd1035ea83e58a5e1fe8d6a1a5" datatype="html">
         <source>Operators</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">119</context>
+          <context context-type="linenumber">143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b2145d0c97ccffaf79c5770f967a429c84af4123" datatype="html">
         <source>Operators let you combine one or more terms together to make a rule.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">144</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c39d43f18d10f925621abc77ad15de80a9cc7516" datatype="html">
         <source>Operator</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">123</context>
+          <context context-type="linenumber">147</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e4b8724800156a9aef6d6f0f31f67431957cc24e" datatype="html">
         <source> Evaluates to true if terms on both sides of this operator evaluate to true.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; hasKIScore(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if idea 1 was found and the student received a KI score of 2. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">128,133</context>
+          <context context-type="linenumber">152,157</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1f50d4313ef8ddef3a1d6d3fd464ec3dd3c21f03" datatype="html">
         <source> Evaluates to true if a term on either side of this operator evaluates to true.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 || 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if either idea 1 or 2 was found.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2 || 3<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found or idea 3 was found. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">137,142</context>
+          <context context-type="linenumber">161,166</context>
         </context-group>
       </trans-unit>
       <trans-unit id="414f2fd4ea5c948c6ebbf8417e6afe371bea442d" datatype="html">
         <source> Evaluates to true if a term following this operator evaluates to false.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>!1<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if idea 1 was not found. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">146,149</context>
+          <context context-type="linenumber">170,173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="46b1ed215e53246db19c5bde05ea87e08a5c2705" datatype="html">
         <source>Parentheses</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">152</context>
+          <context context-type="linenumber">176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8df5a6f6a83598ccc0f22b86f8ca75661ef5a302" datatype="html">
         <source>Parentheses let you group expressions and prioritize evaluation.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">153</context>
+          <context context-type="linenumber">177</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dae69adfd569cdbaa366470ec24471bf01c7db66" datatype="html">
         <source>You can add multiple parentheses in an expression. You can even nest parentheses.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6db909a826f1878ad78bf853a62b6cc5cbda3d3f" datatype="html">
         <source>Example</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">157</context>
+          <context context-type="linenumber">181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f5d726bee0fd8a545258990d929f39b68549dd87" datatype="html">
         <source>Evaluates to true if neither idea 4a nor idea 12 were found.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">162</context>
+          <context context-type="linenumber">186</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a8eebb4afda178aca31b3fdc61eb0f6d91837041" datatype="html">
         <source>Evaluates to true if idea 5a and either idea 4a or idea 12 was found.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">166</context>
+          <context context-type="linenumber">190</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5dcea69981a857fdd51521e3a1ba0b455ce1fdc9" datatype="html">
         <source> Evaluates to true if idea 5a and either idea 4a or idea 12 was found, and the student received a KI score of 3. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">170,173</context>
+          <context context-type="linenumber">194,197</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dc34bee07a6ceed8f010d89d1fcbda15a5abee8c" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -315,7 +315,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">202</context>
+          <context context-type="linenumber">205</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/dialog-with-close/dialog-with-close.component.html</context>
@@ -1883,11 +1883,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">148</context>
+          <context context-type="linenumber">151</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">182</context>
+          <context context-type="linenumber">185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7491b1ebfc5dd457492a5c481e2d2254216dc1fc" datatype="html">
@@ -13895,8 +13895,8 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">67,70</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="b86b38d37538df9ff0cac2f392314b48c3b83d4e" datatype="html">
-        <source> Evaluates to true if more than X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountMoreThan(2, 2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had more than 2 ideas in their second response. </source>
+      <trans-unit id="62a78a93ebb5236c1a6ade1793758c83b54e87cd" datatype="html">
+        <source> Evaluates to true if more than X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountMoreThan(2, 3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had more than 2 ideas in their third response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="START_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;ng-template [ngTemplateOutlet]=&quot;accumulatedIdeaCountSupportMessage&quot;&gt;"/><x id="CLOSE_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;/ng-template&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
           <context context-type="linenumber">74,78</context>
@@ -13906,154 +13906,154 @@ Are you ready to receive feedback on this answer?</source>
         <source> Evaluates to true if less than X ideas were found in the student&apos;s response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountLessThan(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had less than 2 ideas. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">82,85</context>
+          <context context-type="linenumber">83,86</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="625f661282983007cf002e27fb289b8565a5e536" datatype="html">
-        <source> Evaluates to true if less than X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountLessThan(2, 2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had less than 2 ideas in their second response. </source>
+      <trans-unit id="268845fd30e31dce1afa239f99bb88b094439b55" datatype="html">
+        <source> Evaluates to true if less than X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountLessThan(2, 3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had less than 2 ideas in their third response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="START_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;ng-template [ngTemplateOutlet]=&quot;accumulatedIdeaCountSupportMessage&quot;&gt;"/><x id="CLOSE_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;/ng-template&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">89,93</context>
+          <context context-type="linenumber">90,94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c299449835a6844a97d1120d96268ec889e221ee" datatype="html">
         <source> Evaluates to true if exactly X ideas were found in the student&apos;s response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountEquals(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had exactly 2 ideas. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">97,100</context>
+          <context context-type="linenumber">99,102</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2cd04901a8717e3044bc77b2f88084fec7bbf60b" datatype="html">
-        <source> Evaluates to true if exactly X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountEquals(2, 2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had exactly 2 ideas in their second response. </source>
+      <trans-unit id="c55a2693ca5f800e3c28e971526b5950d4637d02" datatype="html">
+        <source> Evaluates to true if exactly X ideas were found in the student&apos;s Y-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>ideaCountEquals(2, 3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if the student had exactly 2 ideas in their third response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="START_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;ng-template [ngTemplateOutlet]=&quot;accumulatedIdeaCountSupportMessage&quot;&gt;"/><x id="CLOSE_TAG_NG_TEMPLATE" ctype="x-ng_template" equiv-text="&lt;/ng-template&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">104,108</context>
+          <context context-type="linenumber">106,110</context>
         </context-group>
       </trans-unit>
       <trans-unit id="acb957d799796d719108eeb1d0ed9ca4880c9f0c" datatype="html">
         <source> Evaluates to true if this is the student&apos;s X-th response.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>isSubmitNumber(3)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if this is the student&apos;s third response. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">112,115</context>
+          <context context-type="linenumber">115,118</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ab15bc35d4c4c975e2cd82171bd30ef3fbf8f226" datatype="html">
         <source> Evaluates to true if this is the student&apos;s second to last response when the max number of submits is specified. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">119,122</context>
+          <context context-type="linenumber">122,125</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bc1cca966f287a319703db89b22d379a6c1455cb" datatype="html">
         <source> Evaluates to true if this is the student&apos;s final response when the max number of submits is specified. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">126,129</context>
+          <context context-type="linenumber">129,132</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3783efe04c66c9d80d09506ec8b7ad29167aacd8" datatype="html">
         <source>Evaluates to true if the student&apos;s response was not scorable.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">133</context>
+          <context context-type="linenumber">136</context>
         </context-group>
       </trans-unit>
       <trans-unit id="298fc1d863b0fb7a33b6825d43981e09e151cb5a" datatype="html">
         <source> Evaluates to true if no other terms were matched. Add this term as the final rule to specify a default feedback. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">137,140</context>
+          <context context-type="linenumber">140,143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9d4ed1f582fafcfd1035ea83e58a5e1fe8d6a1a5" datatype="html">
         <source>Operators</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">143</context>
+          <context context-type="linenumber">146</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b2145d0c97ccffaf79c5770f967a429c84af4123" datatype="html">
         <source>Operators let you combine one or more terms together to make a rule.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">144</context>
+          <context context-type="linenumber">147</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c39d43f18d10f925621abc77ad15de80a9cc7516" datatype="html">
         <source>Operator</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">147</context>
+          <context context-type="linenumber">150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e4b8724800156a9aef6d6f0f31f67431957cc24e" datatype="html">
         <source> Evaluates to true if terms on both sides of this operator evaluate to true.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; hasKIScore(2)<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if idea 1 was found and the student received a KI score of 2. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">152,157</context>
+          <context context-type="linenumber">155,160</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1f50d4313ef8ddef3a1d6d3fd464ec3dd3c21f03" datatype="html">
         <source> Evaluates to true if a term on either side of this operator evaluates to true.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 || 2<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if either idea 1 or 2 was found.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>1 &amp;&amp; 2 || 3<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if both idea 1 and 2 were found or idea 3 was found. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">161,166</context>
+          <context context-type="linenumber">164,169</context>
         </context-group>
       </trans-unit>
       <trans-unit id="414f2fd4ea5c948c6ebbf8417e6afe371bea442d" datatype="html">
         <source> Evaluates to true if a term following this operator evaluates to false.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Ex: <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>!1<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> evaluates to true if idea 1 was not found. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">170,173</context>
+          <context context-type="linenumber">173,176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="46b1ed215e53246db19c5bde05ea87e08a5c2705" datatype="html">
         <source>Parentheses</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">176</context>
+          <context context-type="linenumber">179</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8df5a6f6a83598ccc0f22b86f8ca75661ef5a302" datatype="html">
         <source>Parentheses let you group expressions and prioritize evaluation.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">177</context>
+          <context context-type="linenumber">180</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dae69adfd569cdbaa366470ec24471bf01c7db66" datatype="html">
         <source>You can add multiple parentheses in an expression. You can even nest parentheses.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">178</context>
+          <context context-type="linenumber">181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6db909a826f1878ad78bf853a62b6cc5cbda3d3f" datatype="html">
         <source>Example</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">181</context>
+          <context context-type="linenumber">184</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f5d726bee0fd8a545258990d929f39b68549dd87" datatype="html">
         <source>Evaluates to true if neither idea 4a nor idea 12 were found.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">186</context>
+          <context context-type="linenumber">189</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a8eebb4afda178aca31b3fdc61eb0f6d91837041" datatype="html">
         <source>Evaluates to true if idea 5a and either idea 4a or idea 12 was found.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">193</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5dcea69981a857fdd51521e3a1ba0b455ce1fdc9" datatype="html">
         <source> Evaluates to true if idea 5a and either idea 4a or idea 12 was found, and the student received a KI score of 3. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">194,197</context>
+          <context context-type="linenumber">197,200</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dc34bee07a6ceed8f010d89d1fcbda15a5abee8c" datatype="html">


### PR DESCRIPTION
## Changes
- Add support to pass in a second parameter to ideaCount[LessThan|Equals|MoreThan] tokens for specifying the response index number, starting at 1.
   - Syntax: ```ideaCount[LessThan|Equals|MoreThan](detectedIdeas: number, responseIndex: number)``` 
   - **Note: the token currently only works in the DialogGuidance component.** We need to do a bit more extra work to get it to work in OpenResponse feedback and DynamicPrompt because we don't store c-rater response in those cases that's needed to compute

## Test ideaCount[LessThan|Equals|MoreThan] tokens with second parameter
- Add various ideaCount[LessThan|Equals|MoreThan] tokens with a second parameter and see that they are matched
   - ideaCountLessThan(3, 2): returns true if they had less than 3 ideas in their second response
   - ideaCountLessThan(3, 2): returns true if they had exactly 3 ideas in their second response
   - ideaCountLessThan(3, 2): returns true if they had more than 3 ideas in their second response
- Feedback Rule help popup in the AT shows info about the new tokens 

## Test Regression
Feedback rule evaluation should work as before in these places. Test existing items and make sure that they still work.
- Single Student
  - Dialog Guidance 
  - OpenResponse annotation using Feedback Rules
  - Dynamic Prompt 
- Multiple Students
   - Dynamic Prompt
   - Question Bank

Closes #1260
