### PR TITLE
feat(Authoring): Hide component advanced button until expanded

### DIFF
--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
@@ -259,6 +259,10 @@
       <div
         (click)="toggleComponent(component.id)"
         class="component-header"
+        [ngClass]="{
+          'component-header-highlight':
+            !insertComponentMode && !componentsToIsExpanded[component.id]
+        }"
         fxLayout="row"
         fxLayoutAlign="start center"
         fxLayoutGap="20px"
@@ -279,7 +283,12 @@
           >
         </mat-checkbox>
         <ng-container *ngIf="!insertComponentMode && showComponentAuthoringViews">
+          <preview-component-button
+            [nodeId]="nodeId"
+            [componentId]="component.id"
+          ></preview-component-button>
           <button
+            *ngIf="componentsToIsExpanded[component.id]"
             mat-raised-button
             color="primary"
             class="top-button"
@@ -290,10 +299,6 @@
           >
             <mat-icon>build</mat-icon>
           </button>
-          <preview-component-button
-            [nodeId]="nodeId"
-            [componentId]="component.id"
-          ></preview-component-button>
         </ng-container>
         <div
           *ngIf="!insertComponentMode"
@@ -312,7 +317,10 @@
           </div>
         </div>
       </div>
-      <div *ngIf="showComponentAuthoringViews && componentsToIsExpanded[component.id]">
+      <div
+        *ngIf="showComponentAuthoringViews && componentsToIsExpanded[component.id]"
+        class="component-authoring"
+      >
         <ng-container [ngSwitch]="component.type">
           <animation-authoring
             *ngSwitchCase="'Animation'"

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.scss
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.scss
@@ -56,12 +56,16 @@
   margin: 16px;
   border: 2px solid #dddddd;
   border-radius: 6px;
-  padding: 0px 20px;
 }
 
 .component-header {
   height: 48px;
+  padding: 0px 20px;
   cursor: pointer;
+}
+
+.component-header-highlight:hover {
+    background-color: #add8e6;
 }
 
 .component-label {
@@ -71,6 +75,10 @@
 .component-expand-collapse-div {
   flex-grow: 1;
   align-self: stretch;
+}
+
+.component-authoring {
+  padding: 0px 20px;
 }
 
 .insert-after-div {


### PR DESCRIPTION
## Changes

- Only show the component advanced authoring button when the component is expanded
- Highlight the component bar on mouse over

## Test

- Component advanced authoring button should only be displayed when a component is expanded
- When you mouse over a component bar, it should be highlighted. When a component is expanded, it should not be highlighted.

Closes #1266