### PR TITLE
fix(Authoring): Can't load step you were previously on

### DIFF
--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
@@ -123,7 +123,7 @@ export class NodeAuthoringComponent implements OnInit {
   }
 
   ngOnDestroy(): void {
-    if (this.teacherDataService.getCurrentNodeId() === this.nodeId) {
+    if (this.$state.current.name !== 'root.at.project.node') {
       this.teacherDataService.setCurrentNode(null);
     }
     this.subscriptions.unsubscribe();

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
@@ -123,6 +123,9 @@ export class NodeAuthoringComponent implements OnInit {
   }
 
   ngOnDestroy(): void {
+    if (this.teacherDataService.getCurrentNodeId() === this.nodeId) {
+      this.teacherDataService.setCurrentNode(null);
+    }
     this.subscriptions.unsubscribe();
   }
 


### PR DESCRIPTION
## Changes

Call teacherDataService.setCurrentNode(null) in node-authoring.component.ts ngOnDestroy() if the current node id is the same as this node id.

## Test

1. Open a project in the Authoring Tool
2. Click on a step to go into it
3. Click the "Unit Home" button at the upper left to go back to the project view
4. Click on the same step you were previously on. Before, you would not be taken into the step but now you should.
5. Make sure the step drop down and previous step and next step buttons still work properly

Closes #1268