### PR TITLE
refactor(StudentAssetsDialogComponent): Pass in WISEComponent

### DIFF
--- a/src/assets/wise5/common/Component.ts
+++ b/src/assets/wise5/common/Component.ts
@@ -31,6 +31,11 @@ export class Component {
     return false;
   }
 
+  isAcceptsAssets(): boolean {
+    // TODO: move these to individual component classes when we have them
+    return ['ConceptMap', 'Discussion', 'Draw', 'Label', 'Table'].includes(this.content.type);
+  }
+
   isGradable(): boolean {
     return true;
   }

--- a/src/assets/wise5/components/component-student.component.ts
+++ b/src/assets/wise5/components/component-student.component.ts
@@ -201,16 +201,20 @@ export abstract class ComponentStudent {
       this.StudentAssetService.attachStudentAsset$.subscribe(
         (studentAssetRequest: StudentAssetRequest) => {
           if (this.isSameComponent(studentAssetRequest.component)) {
-            this.copyAndAttachStudentAsset(studentAssetRequest.asset);
+            this.doAttachStudentAsset(studentAssetRequest);
           }
         }
       )
     );
   }
 
+  protected doAttachStudentAsset(studentAssetRequest: StudentAssetRequest): void {
+    this.copyAndAttachStudentAsset(studentAssetRequest.asset);
+  }
+
   generateStarterState() {}
 
-  copyAndAttachStudentAsset(studentAsset: any): any {
+  private copyAndAttachStudentAsset(studentAsset: any): void {
     this.StudentAssetService.copyAssetForReference(studentAsset).then((copiedAsset: any) => {
       const attachment = {
         studentAssetId: copiedAsset.id,

--- a/src/assets/wise5/components/component-student.component.ts
+++ b/src/assets/wise5/components/component-student.component.ts
@@ -184,7 +184,11 @@ export abstract class ComponentStudent {
     // overridden by children
   }
 
-  isForThisComponent(object: any) {
+  protected isSameComponent(component: Component): boolean {
+    return component.nodeId === this.nodeId && component.content.id === this.componentId;
+  }
+
+  isForThisComponent(object: any): boolean {
     return this.nodeId === object.nodeId && this.componentId === object.componentId;
   }
 
@@ -192,11 +196,11 @@ export abstract class ComponentStudent {
     return componentState.workgroupId !== this.ConfigService.getWorkgroupId();
   }
 
-  subscribeToAttachStudentAsset() {
+  protected subscribeToAttachStudentAsset(): void {
     this.subscriptions.add(
       this.StudentAssetService.attachStudentAsset$.subscribe(
         (studentAssetRequest: StudentAssetRequest) => {
-          if (this.isForThisComponent(studentAssetRequest)) {
+          if (this.isSameComponent(studentAssetRequest.component)) {
             this.copyAndAttachStudentAsset(studentAssetRequest.asset);
           }
         }
@@ -639,12 +643,9 @@ export abstract class ComponentStudent {
     return this.NotebookService.isStudentNoteClippingEnabled();
   }
 
-  showStudentAssets() {
+  protected showStudentAssets(): void {
     this.dialog.open(StudentAssetsDialogComponent, {
-      data: {
-        nodeId: this.nodeId,
-        componentId: this.componentId
-      },
+      data: this.component,
       panelClass: 'dialog-md'
     });
   }

--- a/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.ts
+++ b/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.ts
@@ -282,16 +282,8 @@ export class DiscussionStudent extends ComponentStudent {
     }
   }
 
-  protected subscribeToAttachStudentAsset(): void {
-    this.subscriptions.add(
-      this.StudentAssetService.attachStudentAsset$.subscribe(
-        (studentAssetRequest: StudentAssetRequest) => {
-          if (this.isSameComponent(studentAssetRequest.component)) {
-            this.attachStudentAsset(studentAssetRequest.asset);
-          }
-        }
-      )
-    );
+  protected doAttachStudentAsset(studentAssetRequest: StudentAssetRequest): void {
+    this.attachStudentAsset(studentAssetRequest.asset);
   }
 
   registerStudentWorkReceivedListener() {

--- a/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.ts
+++ b/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.ts
@@ -282,11 +282,11 @@ export class DiscussionStudent extends ComponentStudent {
     }
   }
 
-  subscribeToAttachStudentAsset() {
+  protected subscribeToAttachStudentAsset(): void {
     this.subscriptions.add(
       this.StudentAssetService.attachStudentAsset$.subscribe(
         (studentAssetRequest: StudentAssetRequest) => {
-          if (this.isForThisComponent(studentAssetRequest)) {
+          if (this.isSameComponent(studentAssetRequest.component)) {
             this.attachStudentAsset(studentAssetRequest.asset);
           }
         }

--- a/src/assets/wise5/services/studentAssetService.ts
+++ b/src/assets/wise5/services/studentAssetService.ts
@@ -6,6 +6,7 @@ import { ConfigService } from './configService';
 import { Observable, Subject } from 'rxjs';
 import { StudentAssetRequest } from '../vle/studentAsset/StudentAssetRequest';
 import { isAudio, isImage } from '../common/file/file';
+import { Component } from '../common/Component';
 
 @Injectable()
 export class StudentAssetService {
@@ -205,11 +206,10 @@ export class StudentAssetService {
     }
   }
 
-  broadcastAttachStudentAsset(nodeId: string, componentId: string, asset: any): void {
+  broadcastAttachStudentAsset(component: Component, asset: any): void {
     this.attachStudentAssetSource.next({
-      nodeId: nodeId,
-      componentId: componentId,
-      asset: asset
+      asset: asset,
+      component: component
     });
   }
 }

--- a/src/assets/wise5/vle/studentAsset/StudentAssetRequest.ts
+++ b/src/assets/wise5/vle/studentAsset/StudentAssetRequest.ts
@@ -1,5 +1,6 @@
+import { Component } from '../../common/Component';
+
 export interface StudentAssetRequest {
-  nodeId: string;
-  componentId: string;
   asset: any;
+  component: Component;
 }

--- a/src/assets/wise5/vle/studentAsset/student-assets-dialog/student-assets-dialog.component.html
+++ b/src/assets/wise5/vle/studentAsset/student-assets-dialog/student-assets-dialog.component.html
@@ -1,6 +1,6 @@
 <h2 mat-dialog-title i18n>My Files</h2>
 <mat-dialog-content>
-  <student-assets [nodeId]="nodeId" [componentId]="componentId"></student-assets>
+  <student-assets [component]="component"></student-assets>
 </mat-dialog-content>
 <mat-dialog-actions fxLayout="row" fxLayoutAlign="end">
   <button mat-button mat-dialog-close cdkFocusRegionStart i18n>Close</button>

--- a/src/assets/wise5/vle/studentAsset/student-assets-dialog/student-assets-dialog.component.ts
+++ b/src/assets/wise5/vle/studentAsset/student-assets-dialog/student-assets-dialog.component.ts
@@ -1,15 +1,10 @@
 import { Component, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Component as WISEComponent } from '../../../common/Component';
 
 @Component({
   templateUrl: 'student-assets-dialog.component.html'
 })
 export class StudentAssetsDialogComponent {
-  componentId: string;
-  nodeId: string;
-
-  constructor(@Inject(MAT_DIALOG_DATA) public data: any) {
-    this.componentId = data.componentId;
-    this.nodeId = data.nodeId;
-  }
+  constructor(@Inject(MAT_DIALOG_DATA) protected component: WISEComponent) {}
 }

--- a/src/assets/wise5/vle/studentAsset/student-assets/student-assets.component.spec.ts
+++ b/src/assets/wise5/vle/studentAsset/student-assets/student-assets.component.spec.ts
@@ -1,10 +1,10 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { StudentAssetsComponent } from './student-assets.component';
-import { ProjectService } from '../../../services/projectService';
 import { StudentAssetService } from '../../../services/studentAssetService';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { ComponentContent } from '../../../common/ComponentContent';
+import { Component } from '../../../common/Component';
 
 describe('StudentAssetsComponent', () => {
   let component: StudentAssetsComponent;
@@ -28,6 +28,7 @@ describe('StudentAssetsComponent', () => {
     assetFile1 = createAssetFile(fileName1, filePath1);
     assetFile2 = createAssetFile(fileName2, filePath2);
     component = fixture.componentInstance;
+    component.component = new Component({ type: 'Draw' } as ComponentContent, 'node1');
     fixture.detectChanges();
   });
 
@@ -40,27 +41,22 @@ describe('StudentAssetsComponent', () => {
 
   it('should upload student assets', fakeAsync(() => {
     const uploadAssetSpy = spyOnUploadAsset();
-    const getComponentSpy = spyOnGetComponent('Draw');
     const files = [assetFile1, assetFile2];
     component.uploadStudentAssets(files);
     tick();
     expect(uploadAssetSpy).toHaveBeenCalledTimes(2);
-    expect(getComponentSpy).toHaveBeenCalledTimes(2);
   }));
 
-  it('should attach student asset', () => {
-    const getComponentSpy = spyOnGetComponent('Draw');
+  it('should attach student asset if component accepts assets', () => {
     const broadcastAttachStudentAssetSpy = spyOnBroadcastAttachStudentAsset();
     component.attachStudentAsset(assetFile1);
-    expect(getComponentSpy).toHaveBeenCalled();
     expect(broadcastAttachStudentAssetSpy).toHaveBeenCalled();
   });
 
-  it('should not attach student asset', () => {
-    const getComponentSpy = spyOnGetComponent('MultipleChoice');
+  it('should not attach student asset if component does not accept assets', () => {
+    component.component = new Component({ type: 'MultipleChoice' } as ComponentContent, 'node1');
     const broadcastAttachStudentAssetSpy = spyOnBroadcastAttachStudentAsset();
     component.attachStudentAsset(assetFile1);
-    expect(getComponentSpy).toHaveBeenCalled();
     expect(broadcastAttachStudentAssetSpy).not.toHaveBeenCalled();
   });
 
@@ -68,12 +64,6 @@ describe('StudentAssetsComponent', () => {
     return spyOn(TestBed.inject(StudentAssetService), 'uploadAsset').and.returnValue(
       Promise.resolve({})
     );
-  }
-
-  function spyOnGetComponent(componentType: string) {
-    return spyOn(TestBed.inject(ProjectService), 'getComponent').and.returnValue({
-      type: componentType
-    } as ComponentContent);
   }
 
   function spyOnBroadcastAttachStudentAsset() {

--- a/src/assets/wise5/vle/studentAsset/student-assets/student-assets.component.ts
+++ b/src/assets/wise5/vle/studentAsset/student-assets/student-assets.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { ConfigService } from '../../../services/configService';
-import { ProjectService } from '../../../services/projectService';
 import { StudentAssetService } from '../../../services/studentAssetService';
+import { Component as WISEComponent } from '../../../common/Component';
 
 @Component({
   selector: 'student-assets',
@@ -9,19 +9,12 @@ import { StudentAssetService } from '../../../services/studentAssetService';
   styleUrls: ['./student-assets.component.scss']
 })
 export class StudentAssetsComponent implements OnInit {
-  @Input()
-  componentId: string;
-
-  @Input()
-  nodeId: string;
-
-  mode: string;
+  @Input() component: WISEComponent;
+  protected mode: string;
   studentAssets: any;
-  componentsThatCanAcceptAssets: string[] = ['ConceptMap', 'Discussion', 'Draw', 'Label', 'Table'];
 
   constructor(
     private configService: ConfigService,
-    private projectService: ProjectService,
     private studentAssetService: StudentAssetService
   ) {}
 
@@ -33,7 +26,7 @@ export class StudentAssetsComponent implements OnInit {
     }
   }
 
-  retrieveStudentAssets(): void {
+  private retrieveStudentAssets(): void {
     this.studentAssetService.retrieveAssets().then((studentAssets) => {
       this.studentAssets = studentAssets;
     });
@@ -48,7 +41,7 @@ export class StudentAssetsComponent implements OnInit {
     }
   }
 
-  attachStudentAssetToComponent($event, studentAsset: any): void {
+  protected attachStudentAssetToComponent($event, studentAsset: any): void {
     // prevents parent student asset list item from getting the onclick event so this item won't be
     // re-selected.
     $event.stopPropagation();
@@ -56,13 +49,8 @@ export class StudentAssetsComponent implements OnInit {
   }
 
   attachStudentAsset(studentAsset: any): void {
-    const component = this.projectService.getComponent(this.nodeId, this.componentId);
-    if (this.componentsThatCanAcceptAssets.includes(component.type)) {
-      this.studentAssetService.broadcastAttachStudentAsset(
-        this.nodeId,
-        this.componentId,
-        studentAsset
-      );
+    if (this.component.isAcceptsAssets()) {
+      this.studentAssetService.broadcastAttachStudentAsset(this.component, studentAsset);
     }
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -19099,14 +19099,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>There was an error uploading.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentAssetService.ts</context>
-          <context context-type="linenumber">116</context>
+          <context context-type="linenumber">117</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7911256030566990381" datatype="html">
         <source>There was an error uploading. You might have reached your file upload limit or the file you tried to upload was too large. Please ask your teacher for help.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentAssetService.ts</context>
-          <context context-type="linenumber">127</context>
+          <context context-type="linenumber">128</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7178340069631637479" datatype="html">


### PR DESCRIPTION
## Changes
- Instead of passing in nodeId and componentId to this dialog as data, pass in a WISEComponent object. 
   - Pass this along to the StudentAssetsComponent, and also to the call of ```studentAssetService.broadcastAttachStudentAsset()```.
- Change StudentAssetRequest to have component instead of nodeId/componentId and update references
- Define Component.isAcceptsAssets() 
- Code cleanup
   - Extract duplicate function subscribeToAttachStudentAsset()
   - Add protected/private keywords and function return types 

## Test
- Can use student assets as background for 
   - Draw, ConceptMap, Label, Table
- Can use student asset in Discussion posts 

Closes #1284