### PR TITLE
refactor(NodeService): Move MoveComponent() to Node

### DIFF
--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
@@ -375,18 +375,14 @@ export class NodeAuthoringComponent implements OnInit {
         alert($localize`You are not allowed to insert the selected items after itself.`);
       }
     } else {
-      const newComponents = this.nodeService.moveComponent(
-        this.nodeId,
-        selectedComponentIds,
-        componentId
-      );
+      this.projectService.getNode(this.nodeId).moveComponents(selectedComponentIds, componentId);
       this.projectService.saveProject();
       const eventData = {
         componentsMoved: this.getComponentObjectsForEventData(selectedComponentIds)
       };
       this.saveEvent('componentMoved', 'Authoring', eventData);
       this.turnOffMoveComponentMode();
-      this.highlightNewComponentsAndThenShowComponentAuthoring(newComponents);
+      this.highlightNewComponentsAndThenShowComponentAuthoring();
     }
   }
 

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
@@ -382,7 +382,10 @@ export class NodeAuthoringComponent implements OnInit {
       };
       this.saveEvent('componentMoved', 'Authoring', eventData);
       this.turnOffMoveComponentMode();
-      this.highlightNewComponentsAndThenShowComponentAuthoring();
+      this.highlightNewComponentsAndThenShowComponentAuthoring(
+        selectedComponentIds.map((componentId) => ({ id: componentId })),
+        false
+      );
     }
   }
 
@@ -419,8 +422,12 @@ export class NodeAuthoringComponent implements OnInit {
    * Temporarily highlight the new components and then show the component
    * authoring views. Used to bring user's attention to new changes.
    * @param newComponents an array of the new components we have just added
+   * @param expandComponents expand component(s)' authoring views after highlighting
    */
-  private highlightNewComponentsAndThenShowComponentAuthoring(newComponents: any = []): void {
+  private highlightNewComponentsAndThenShowComponentAuthoring(
+    newComponents: any = [],
+    expandComponents: boolean = true
+  ): void {
     this.showComponentAuthoring();
     this.turnOffInsertComponentMode();
     this.showDefaultComponentsView();
@@ -433,7 +440,7 @@ export class NodeAuthoringComponent implements OnInit {
         $('#content').scrollTop(componentElement.offset().top - 200);
         for (const newComponent of newComponents) {
           temporarilyHighlightElement(newComponent.id);
-          this.componentsToIsExpanded[newComponent.id] = true;
+          this.componentsToIsExpanded[newComponent.id] = expandComponents;
         }
       }
     });

--- a/src/assets/wise5/common/Node.spec.ts
+++ b/src/assets/wise5/common/Node.spec.ts
@@ -1,8 +1,10 @@
 import { Node } from './Node';
 
+let node = new Node();
 describe('Node', () => {
   getNodeIcon();
   getNodeIdComponentIds();
+  moveComponents();
 });
 
 function getNodeIcon() {
@@ -37,7 +39,6 @@ function getNodeIcon_iconSpecified_returnMergedIcon() {
 
 function getNodeIdComponentIds() {
   it('should get the node id and component id objects', () => {
-    const node = new Node();
     node.id = 'node1';
     node.components = [{ id: 'abc' }, { id: 'xyz' }];
     const nodeIdAndComponentIds = node.getNodeIdComponentIds();
@@ -46,5 +47,33 @@ function getNodeIdComponentIds() {
     expect(nodeIdAndComponentIds[0].componentId).toEqual('abc');
     expect(nodeIdAndComponentIds[1].nodeId).toEqual('node1');
     expect(nodeIdAndComponentIds[1].componentId).toEqual('xyz');
+  });
+}
+
+function moveComponents() {
+  describe('moveComponents()', () => {
+    beforeEach(() => {
+      node.components = [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }, { id: 'e' }];
+    });
+    moveComponents_NullInsertAfterComponentId_MoveComponentsToBeginning();
+    moveComponents_NonNullInsertAfterComponentId_MoveMultipleComponentsAfterComponent();
+  });
+}
+
+function moveComponents_NullInsertAfterComponentId_MoveComponentsToBeginning() {
+  describe('insertAfterComponentId is null', () => {
+    it('should move components to the beginning of the node', () => {
+      node.moveComponents(['b', 'c', 'e'], null);
+      expect(node.components.map((component) => component.id).join(',')).toEqual('b,c,e,a,d');
+    });
+  });
+}
+
+function moveComponents_NonNullInsertAfterComponentId_MoveMultipleComponentsAfterComponent() {
+  describe('insertAfterComponentId is not null', () => {
+    it('should move components after the specified component', () => {
+      node.moveComponents(['b', 'c', 'e'], 'a');
+      expect(node.components.map((component) => component.id).join(',')).toEqual('a,b,c,e,d');
+    });
   });
 }

--- a/src/assets/wise5/common/Node.ts
+++ b/src/assets/wise5/common/Node.ts
@@ -65,4 +65,36 @@ export class Node {
     }
     return this.transitionLogic;
   }
+
+  /**
+   * Move the component(s) within this node
+   * @param componentIds the id(s) of the component(s) to move
+   * @param insertAfterComponentId insert the component(s) after this component id.
+   * If this argument is null, place the new component(s) in the first position.
+   */
+  moveComponents(componentIds: string[], insertAfterComponentId: string = null): void {
+    const components = this.extractComponents(componentIds);
+    if (insertAfterComponentId == null) {
+      this.components.unshift(...components);
+    } else {
+      this.insertComponentsAfter(components, insertAfterComponentId);
+    }
+  }
+
+  private extractComponents(componentIds: string[]): any[] {
+    const components = [];
+    for (let i = 0; i < this.components.length; i++) {
+      if (componentIds.includes(this.components[i].id)) {
+        components.push(this.components.splice(i--, 1)[0]);
+      }
+    }
+    return components;
+  }
+
+  private insertComponentsAfter(components: any[], insertAfterComponentId: string): void {
+    const insertAfterComponentIndex = this.components.findIndex(
+      (component) => component.id === insertAfterComponentId
+    );
+    this.components.splice(insertAfterComponentIndex + 1, 0, ...components);
+  }
 }

--- a/src/assets/wise5/services/nodeService.ts
+++ b/src/assets/wise5/services/nodeService.ts
@@ -551,44 +551,6 @@ export class NodeService {
     this.chooseTransitionPromises[nodeId] = promise;
   }
 
-  /**
-   * Move the component(s) within the node
-   * @param nodeId we are moving component(s) in this node
-   * @param componentIds the component(s) we are moving
-   * @param insertAfterComponentId Insert the component(s) after this given
-   * component id. If this argument is null, we will place the new
-   * component(s) in the first position.
-   */
-  moveComponent(nodeId: string, componentIds: string[], insertAfterComponentId: string): void {
-    const node = this.ProjectService.getNodeById(nodeId);
-    const components = node.components;
-    const extractedComponents = this.extractComponents(components, componentIds);
-    if (insertAfterComponentId == null) {
-      components.unshift(...extractedComponents);
-    } else {
-      this.insertComponentsAfter(extractedComponents, components, insertAfterComponentId);
-    }
-  }
-
-  extractComponents(components, componentIds) {
-    const extractedComponents = [];
-    for (let i = 0; i < components.length; i++) {
-      if (componentIds.includes(components[i].id)) {
-        extractedComponents.push(components.splice(i--, 1)[0]);
-      }
-    }
-    return extractedComponents;
-  }
-
-  insertComponentsAfter(componentsToInsert, components, insertAfterComponentId) {
-    for (let i = 0; i < components.length; i++) {
-      if (components[i].id === insertAfterComponentId) {
-        components.splice(i + 1, 0, ...componentsToInsert);
-        return;
-      }
-    }
-  }
-
   broadcastNodeSubmitClicked(args: any) {
     this.nodeSubmitClickedSource.next(args);
   }

--- a/src/assets/wise5/test-unit/services/nodeService.spec.js
+++ b/src/assets/wise5/test-unit/services/nodeService.spec.js
@@ -24,7 +24,6 @@ describe('NodeService', () => {
   getNextNodeId();
   extractComponents();
   insertComponentsAfter();
-  moveComponent();
 });
 
 function getNextNodeId() {
@@ -76,47 +75,5 @@ function extractComponents_MultipleComponents() {
     expect(extractedComponents[1].id).toEqual(10);
     expect(components.length).toEqual(1);
     expect(components[0].id).toEqual(2);
-  });
-}
-
-function moveComponent() {
-  describe('moveComponent', () => {
-    moveComponent_MoveOneComponentToBeginning();
-    moveComponent_MoveMultipleComponentsToBeginning();
-    moveComponent_MoveMultipleComponentsAfterComponent();
-  });
-}
-
-function moveComponent_MoveOneComponentToBeginning() {
-  it('should move one component to the beginning of the node', () => {
-    expect(ProjectService.getComponentPosition('node10', 'cjv5kq5290')).toEqual(4);
-    expect(ProjectService.getComponentPosition('node10', 'm97kyu4d4v')).toEqual(0);
-    NodeService.moveComponent('node10', ['cjv5kq5290'], null);
-    expect(ProjectService.getComponentPosition('node10', 'cjv5kq5290')).toEqual(0);
-    expect(ProjectService.getComponentPosition('node10', 'm97kyu4d4v')).toEqual(1);
-  });
-}
-
-function moveComponent_MoveMultipleComponentsToBeginning() {
-  it('should move multiple components to the beginning of the node', () => {
-    expect(ProjectService.getComponentPosition('node10', '2upmb3om1q')).toEqual(2);
-    expect(ProjectService.getComponentPosition('node10', 'cjv5kq5290')).toEqual(4);
-    expect(ProjectService.getComponentPosition('node10', 'm97kyu4d4v')).toEqual(0);
-    NodeService.moveComponent('node10', ['2upmb3om1q', 'cjv5kq5290'], null);
-    expect(ProjectService.getComponentPosition('node10', '2upmb3om1q')).toEqual(0);
-    expect(ProjectService.getComponentPosition('node10', 'cjv5kq5290')).toEqual(1);
-    expect(ProjectService.getComponentPosition('node10', 'm97kyu4d4v')).toEqual(2);
-  });
-}
-
-function moveComponent_MoveMultipleComponentsAfterComponent() {
-  it('should move multiple components after another component', () => {
-    expect(ProjectService.getComponentPosition('node10', '2upmb3om1q')).toEqual(2);
-    expect(ProjectService.getComponentPosition('node10', 'cjv5kq5290')).toEqual(4);
-    expect(ProjectService.getComponentPosition('node10', 'm97kyu4d4v')).toEqual(0);
-    NodeService.moveComponent('node10', ['2upmb3om1q', 'cjv5kq5290'], 'm97kyu4d4v');
-    expect(ProjectService.getComponentPosition('node10', '2upmb3om1q')).toEqual(1);
-    expect(ProjectService.getComponentPosition('node10', 'cjv5kq5290')).toEqual(2);
-    expect(ProjectService.getComponentPosition('node10', 'm97kyu4d4v')).toEqual(0);
   });
 }


### PR DESCRIPTION
## Changes
- Move NodeService.moveComponent() to Node.moveComponents() and cleaned up the code a bit.
- Remove parameter from call to this.highlightNewComponentsAndThenShowComponentAuthoring(). It wasn't being called with a parameter in the previous version either.
- Add tests for Node.moveComponents().

## Test
In the AT node authoring view, test the following
- Move component(s) to the top
- Move component(s) after an existing component

Closes #1226