### PR TITLE
feat(Constraint Authoring): Automatically choose component if possible

### DIFF
--- a/src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria-helper.ts
+++ b/src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria-helper.ts
@@ -1,0 +1,80 @@
+import { ComponentContent } from '../../../common/ComponentContent';
+import { ProjectService } from '../../../services/projectService';
+
+export class EditConstraintRemovalCriteriaHelper {
+  criteriaNameToComponentType: Map<string, string> = new Map(
+    Object.entries({
+      choiceChosen: 'MultipleChoice',
+      fillXNumberOfRows: 'Table',
+      wroteXNumberOfWords: 'OpenResponse'
+    })
+  );
+
+  constructor(private projectService: ProjectService, private componentIdToIsSelectable: any) {}
+
+  hasCriteriaNameToComponentType(criteriaName: string): boolean {
+    return this.criteriaNameToComponentType.has(criteriaName);
+  }
+
+  getCriteriaNameToComponentType(criteriaName: string): string {
+    return this.criteriaNameToComponentType.get(criteriaName);
+  }
+
+  stepContainsAcceptableComponent(nodeId: string, criteria: any): boolean {
+    if (this.criteriaNameToComponentType.has(criteria.name)) {
+      return this.hasComponentType(nodeId, this.criteriaNameToComponentType.get(criteria.name));
+    }
+    return true;
+  }
+
+  private hasComponentType(nodeId: string, componentType: string): boolean {
+    return (
+      this.projectService
+        .getComponents(nodeId)
+        .filter((component) => component.type === componentType).length > 0
+    );
+  }
+
+  calculateSelectableComponents(criteria: any): void {
+    const components = this.projectService.getComponents(criteria.params.nodeId);
+    if (this.criteriaNameToComponentType.has(criteria.name)) {
+      this.setSelectableComponents(components, this.criteriaNameToComponentType.get(criteria.name));
+    } else {
+      this.makeAllComponentsSelectable(components);
+    }
+  }
+
+  private setSelectableComponents(components: ComponentContent[], componentType: string): void {
+    components.forEach((component) => {
+      this.componentIdToIsSelectable[component.id] = component.type === componentType;
+    });
+  }
+
+  private makeAllComponentsSelectable(components: ComponentContent[]): void {
+    components.forEach((component) => {
+      this.componentIdToIsSelectable[component.id] = true;
+    });
+  }
+
+  automaticallySelectComponentIfPossible(criteria: any): void {
+    if (this.criteriaNameToComponentType.has(criteria.name)) {
+      this.selectIfOnlyOneOfComponentType(
+        criteria,
+        this.projectService.getComponents(criteria.params.nodeId),
+        this.criteriaNameToComponentType.get(criteria.name)
+      );
+    }
+  }
+
+  private selectIfOnlyOneOfComponentType(
+    criteria: any,
+    components: ComponentContent[],
+    componentType: string
+  ): void {
+    if (components.filter((component) => component.type === componentType).length === 1) {
+      criteria.params.componentId = components.find(
+        (component) => component.type === componentType
+      ).id;
+    }
+  }
+}

--- a/src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.spec.ts
+++ b/src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.spec.ts
@@ -149,40 +149,51 @@ function nameChanged_BranchPathTaken() {
 }
 
 function nameChanged_ChoiceChosen() {
-  describe('nameChanged_ChoiceChosen()', () => {
-    describe('there are steps with and without Multiple Choice components', () => {
-      it('should only show the steps with Multiple Choice components', () => {
-        chooseSelectOptionByLabel('Removal Criteria Name', 'Choice Chosen');
-        clickSelectElement('Step');
-        expectOptions(['', nodeId1, nodeId2]);
-      });
-    });
+  choiceChosen_StepsWithAndWithoutMultipleChoice_ShouldOnlyShowStepsWithMultipleChoice();
+  choiceChosen_StepWithAndWithoutMultipleChoice_ShouldOnlyShowMultipleChoiceComponents();
+  choiceChosen_WithOneMultipleChoiceComponent_ShouldAutomaticallySelect();
+  choiceChosen_WithTwoMultipleChoiceComponents_ShouldNotAutomaticallySelect();
+}
 
-    describe('choose a step with and without Multiple Choice components', () => {
-      it('should only show the Multiple Choice components', () => {
-        chooseSelectOptionByLabel('Removal Criteria Name', 'Choice Chosen');
-        chooseSelectOptionByValue('Step', nodeId1);
-        clickSelectElement('Component');
-        expectOptions(['', componentId1]);
-      });
+function choiceChosen_StepsWithAndWithoutMultipleChoice_ShouldOnlyShowStepsWithMultipleChoice() {
+  describe('there are steps with and without Multiple Choice components', () => {
+    it('should only show the steps with Multiple Choice components', () => {
+      chooseSelectOptionByLabel('Removal Criteria Name', 'Choice Chosen');
+      clickSelectElement('Step');
+      expectOptions(['', nodeId1, nodeId2]);
     });
+  });
+}
 
-    describe('choose step with one Multiple Choice component', () => {
-      it('should automatically select the one Multiple Choice component', () => {
-        chooseSelectOptionByLabel('Removal Criteria Name', 'Choice Chosen');
-        chooseSelectOptionByValue('Step', nodeId1);
-        expectComponentIdToEqual(componentId1);
-        expectEmptyRemovalCriterialParamValue('choiceIds');
-      });
+function choiceChosen_StepWithAndWithoutMultipleChoice_ShouldOnlyShowMultipleChoiceComponents() {
+  describe('choose a step with and without Multiple Choice components', () => {
+    it('should only show the Multiple Choice components', () => {
+      chooseSelectOptionByLabel('Removal Criteria Name', 'Choice Chosen');
+      chooseSelectOptionByValue('Step', nodeId1);
+      clickSelectElement('Component');
+      expectOptions(['', componentId1]);
     });
+  });
+}
 
-    describe('choose step with two Multiple Choice components', () => {
-      it('should not automatically select a Multiple Choice compoennt', () => {
-        chooseSelectOptionByLabel('Removal Criteria Name', 'Choice Chosen');
-        chooseSelectOptionByValue('Step', nodeId2);
-        expectComponentIdToEqual('');
-        expectEmptyRemovalCriterialParamValue('choiceIds');
-      });
+function choiceChosen_WithOneMultipleChoiceComponent_ShouldAutomaticallySelect() {
+  describe('choose step with one Multiple Choice component', () => {
+    it('should automatically select the one Multiple Choice component', () => {
+      chooseSelectOptionByLabel('Removal Criteria Name', 'Choice Chosen');
+      chooseSelectOptionByValue('Step', nodeId1);
+      expectComponentIdToEqual(componentId1);
+      expectEmptyRemovalCriterialParamValue('choiceIds');
+    });
+  });
+}
+
+function choiceChosen_WithTwoMultipleChoiceComponents_ShouldNotAutomaticallySelect() {
+  describe('choose step with two Multiple Choice components', () => {
+    it('should not automatically select a Multiple Choice compoennt', () => {
+      chooseSelectOptionByLabel('Removal Criteria Name', 'Choice Chosen');
+      chooseSelectOptionByValue('Step', nodeId2);
+      expectComponentIdToEqual('');
+      expectEmptyRemovalCriterialParamValue('choiceIds');
     });
   });
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9143,28 +9143,28 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4250686915350181595" datatype="html">
         <source>Please Choose a Removal Criteria</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">34</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6460463610153137840" datatype="html">
         <source>Is Completed</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">35</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7123653594948067002" datatype="html">
         <source>Score</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">29</context>
+          <context context-type="linenumber">36</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/branch/node-advanced-branch-authoring.component.ts</context>
@@ -9179,35 +9179,35 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Score(s)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="16986194959433746" datatype="html">
         <source>Branch Path Taken</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">34</context>
+          <context context-type="linenumber">41</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6380325907263903883" datatype="html">
         <source>From Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">42</context>
         </context-group>
       </trans-unit>
       <trans-unit id="455666817590621118" datatype="html">
         <source>To Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">36</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8352660755693654653" datatype="html">
         <source>Choice Chosen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">38</context>
+          <context context-type="linenumber">45</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/branch/node-advanced-branch-authoring.component.ts</context>
@@ -9218,7 +9218,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Choices</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">41</context>
+          <context context-type="linenumber">48</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
@@ -9237,112 +9237,112 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Is Correct</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">43</context>
+          <context context-type="linenumber">50</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4268291134905709874" datatype="html">
         <source>Used X Submits</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">44</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="767433972334291022" datatype="html">
         <source>Required Submit Count</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">47</context>
+          <context context-type="linenumber">54</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2997822456018079719" datatype="html">
         <source>Is Visible</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">56</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2226381985639556979" datatype="html">
         <source>Is Visitable</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3284330787067886212" datatype="html">
         <source>Is Visited</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3120562623622017132" datatype="html">
         <source>Wrote X Number of Words</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3793469420585389570" datatype="html">
         <source>Required Number of Words</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">55</context>
+          <context context-type="linenumber">62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2346474241177154844" datatype="html">
         <source>Add X Number of Notes On This Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">59</context>
+          <context context-type="linenumber">66</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2215706295447985195" datatype="html">
         <source>Required Number of Notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">62</context>
+          <context context-type="linenumber">69</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3753898460381641212" datatype="html">
         <source>Fill X Number of Rows</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">65</context>
+          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8868642264052368211" datatype="html">
         <source>Required Number of Filled Rows (Not Including Header Row)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">70</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3373179210544883044" datatype="html">
         <source>Table Has Header Row</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">79</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3682483624336387760" datatype="html">
         <source>Require All Cells In a Row To Be Filled</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">75</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6549053190457916462" datatype="html">
         <source>Teacher Removes Constraint</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">79</context>
+          <context context-type="linenumber">86</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8870343237719695349" datatype="html">
         <source>Are you sure you want to delete this removal criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts</context>
-          <context context-type="linenumber">102</context>
+          <context context-type="linenumber">115</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8564983557318479146" datatype="html">
@@ -16284,46 +16284,46 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Are you sure you want to overwrite the current line data?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">236</context>
+          <context context-type="linenumber">233</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6882380861047606832" datatype="html">
         <source>The series you are trying to add a point to is currently hidden. Please show the series by clicking the series name in the legend and try adding the point again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1079</context>
+          <context context-type="linenumber">848</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2852989551014711458" datatype="html">
         <source>You can not edit this series. Please choose a series that can be edited.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1093</context>
+          <context context-type="linenumber">862</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7053114367342967943" datatype="html">
         <source>Are you sure you want to reset the series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1326</context>
+          <context context-type="linenumber">1095</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7889560203726829643" datatype="html">
         <source>Are you sure you want to reset the &quot;<x id="PH" equiv-text="seriesName"/>&quot; series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1328</context>
+          <context context-type="linenumber">1097</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6999515396807067782" datatype="html">
         <source>Trial</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1826</context>
+          <context context-type="linenumber">1595</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">2650</context>
+          <context context-type="linenumber">2419</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9070768663485888935" datatype="html">


### PR DESCRIPTION
## Changes

If a constraint "Removal Criteria Name" is set to "Choice Chosen" or "Wrote X Number of Words" or "Fill X Number of Rows"
- Only show steps that only have the associated component type
- Only show components of the associated component type
- Automatically select component if there is only one of the associated component type in the step

## Test

Author a constraint and set "Removal Criteria Name" to "Choice Chosen"
- If the current step does not have a "Multiple Choice" component, make sure no step is automatically selected
- If the current step has a "Multiple Choice" component, make sure it is automatically selected
- Make sure the "Step" select only contains steps that have a "Multiple Choice" component
- When a step is selected, make sure the "Component" select only contains "Multiple Choice" components
- If there is only one "Multiple Choice" component in the step, that "Multiple Choice" component should be automatically selected

Make sure the tests above also work for
- "Wrote X Number of Words" removal criteria name and "Open Response" components
- "Fill X Number of Rows" removal criteria name and "Table" components

Closes #1231