### PR TITLE
fix(Login): Users in China can't sign in

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,7 +22,7 @@ import { MobileMenuModule } from './modules/mobile-menu/mobile-menu.module';
 import { AnnouncementComponent } from './announcement/announcement.component';
 import { AnnouncementDialogComponent } from './announcement/announcement.component';
 import { TrackScrollDirective } from './track-scroll.directive';
-import { RecaptchaV3Module, RECAPTCHA_V3_SITE_KEY } from 'ng-recaptcha';
+import { RecaptchaV3Module, RECAPTCHA_V3_SITE_KEY, RECAPTCHA_BASE_URL } from 'ng-recaptcha';
 
 export function initialize(
   configService: ConfigService,
@@ -94,6 +94,10 @@ export function initialize(
         return configService.getRecaptchaPublicKey();
       },
       deps: [ConfigService]
+    },
+    {
+      provide: RECAPTCHA_BASE_URL,
+      useValue: 'https://recaptcha.net/recaptcha/api.js'
     }
   ],
   bootstrap: [AppComponent]


### PR DESCRIPTION
## Changes

When making the Recaptcha verification request, use https://recaptcha.net/recaptcha/api.js instead of https://www.google.com/recaptcha/api.js.

## Test

Make sure you can still sign in when Recaptcha is enabled.

Closes #1315