### PR TITLE
fix(Authoring): Outside Resource model images extend beyond card

### DIFF
--- a/src/assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component.html
+++ b/src/assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component.html
@@ -67,7 +67,7 @@
           class="oer-card-image"
           style="background-image: url('{{ openEducationalResource.thumbnail }}');"
         ></div>
-        <mat-card-actions fxLayout="row" fxLayoutAlign="start center">
+        <mat-card-actions class="oer-card-actions" fxLayout="row" fxLayoutAlign="start center">
           <mat-icon
             class="success"
             aria-label="Selected"

--- a/src/assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component.scss
+++ b/src/assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component.scss
@@ -46,15 +46,19 @@ p.select-oer-instructions {
 
 .oer-card-title {
   font-size: 14px;
+  padding-left: 16px;
+  padding-right: 16px;
 }
 
 .oer-card-image {
-  margin-left: -16px;
-  margin-right: -16px;
   position: relative;
   padding-top: 60%;
   background-size: cover;
   background-position: center;
+}
+
+.oer-card-actions {
+  padding: 0px 16px 0px 16px !important;
 }
 
 .oer-card-actions-spacer {


### PR DESCRIPTION
## Changes

Changed margin styling for model card title, image, and actions.

## Test

Open the authoring view for an Outside Resource component and make sure the model images do not extend beyond the card. Also make sure the card title and actions have padding so that they are not right up against the edge of the card.

#1320