### PR TITLE
refactor(Node Authoring): copyComponent()

### DIFF
--- a/src/assets/wise5/authoringTool/node/chooseComponentLocation/choose-component-location.component.ts
+++ b/src/assets/wise5/authoringTool/node/chooseComponentLocation/choose-component-location.component.ts
@@ -47,9 +47,10 @@ export class ChooseComponentLocationComponent {
   }
 
   private copyComponents(insertAfterComponentId: string = null): any[] {
-    const newComponents = this.node.copyComponents(this.selectedComponents.map((c) => c.id));
-    this.node.insertComponents(newComponents, insertAfterComponentId);
-    return newComponents;
+    return this.node.copyComponents(
+      this.selectedComponents.map((c) => c.id),
+      insertAfterComponentId
+    );
   }
 
   private moveComponents(insertAfterComponentId: string = null): any[] {

--- a/src/assets/wise5/common/Node.spec.ts
+++ b/src/assets/wise5/common/Node.spec.ts
@@ -3,8 +3,6 @@ import { Node } from './Node';
 
 const componentId1 = 'c1';
 const componentId2 = 'c2';
-const componentId3 = 'c3';
-const componentId4 = 'c4';
 let node: Node;
 
 describe('Node', () => {
@@ -19,15 +17,15 @@ describe('Node', () => {
   deleteComponent();
   getNodeIcon();
   getNodeIdComponentIds();
-  insertComponents();
   moveComponents();
   replaceComponent();
 });
 
 function copyComponents() {
-  describe('copyComponents()', () => {
-    it('should return a copy of the specified components with new ids', () => {
+  describe('copyComponents() without specifying insertAfterComponentId', () => {
+    it('should copy the components, insert at the beginning and return new components', () => {
       const copies = node.copyComponents([componentId1, componentId2]);
+      expect(node.components.length).toEqual(4);
       expect(copies.length).toEqual(2);
       expect(copies[0].id).not.toEqual(componentId1);
       expect(copies[1].id).not.toEqual(componentId2);
@@ -85,37 +83,6 @@ function getNodeIdComponentIds() {
     expect(nodeIdAndComponentIds[0].componentId).toEqual('abc');
     expect(nodeIdAndComponentIds[1].nodeId).toEqual('node1');
     expect(nodeIdAndComponentIds[1].componentId).toEqual('xyz');
-  });
-}
-
-function insertComponents() {
-  describe('insertComponents()', () => {
-    it('should insert components at the beginning of the node', () => {
-      node.insertComponents([{ id: componentId3 }, { id: componentId4 }], null);
-      expectComponentsMatchIds(node.components, [
-        componentId3,
-        componentId4,
-        componentId1,
-        componentId2
-      ]);
-    });
-
-    it('should insert components after the specified component', () => {
-      node.insertComponents([{ id: componentId3 }, { id: componentId4 }], componentId1);
-      expectComponentsMatchIds(node.components, [
-        componentId1,
-        componentId3,
-        componentId4,
-        componentId2
-      ]);
-    });
-  });
-}
-
-function expectComponentsMatchIds(components: any[], ids: string[]) {
-  expect(components.length).toEqual(ids.length);
-  components.forEach((component, i) => {
-    expect(component.id).toEqual(ids[i]);
   });
 }
 

--- a/src/assets/wise5/common/Node.ts
+++ b/src/assets/wise5/common/Node.ts
@@ -101,7 +101,7 @@ export class Node {
     this.components.splice(insertAfterComponentIndex + 1, 0, ...components);
   }
 
-  copyComponents(componentIds: string[]): any[] {
+  copyComponents(componentIds: string[], insertAfterComponentId: string = null): any[] {
     const newComponents = [];
     const newComponentIds = [];
     for (const componentId of componentIds) {
@@ -109,6 +109,7 @@ export class Node {
       newComponents.push(newComponent);
       newComponentIds.push(newComponent.id);
     }
+    this.insertComponents(newComponents, insertAfterComponentId);
     return newComponents;
   }
 
@@ -131,7 +132,7 @@ export class Node {
     return this.components.some((component) => component.id === componentId);
   }
 
-  insertComponents(components: any[], insertAfterComponentId: string): void {
+  private insertComponents(components: any[], insertAfterComponentId: string): void {
     const insertPosition = this.getInitialInsertPosition(insertAfterComponentId);
     this.components.splice(insertPosition, 0, ...components);
   }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10700,14 +10700,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>There are no changes to undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">164</context>
+          <context context-type="linenumber">167</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5830582794567943525" datatype="html">
         <source>Are you sure you want to undo the last change?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">166</context>
+          <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7035134055292483273" datatype="html">
@@ -10715,7 +10715,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">269</context>
+          <context context-type="linenumber">260</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5170405945214763287" datatype="html">
@@ -10723,7 +10723,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">270</context>
+          <context context-type="linenumber">261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bb39841df2c03f771748c1f986e615bffa7f2593" datatype="html">


### PR DESCRIPTION
## Changes
- No longer call insertComponent() after call to copyComponent(). The call to insertComponent() occurs inside the copyComponent() now
- Remove unused code in NodeAuthoringComponent

## Test
- Node authoring works as before