### PR TITLE
refactor(UtilService): Move connected component functions

### DIFF
--- a/src/app/services/graphService.spec.ts
+++ b/src/app/services/graphService.spec.ts
@@ -63,6 +63,7 @@ function createComponentState(studentData: any, isSubmit: boolean = false) {
 
 function createComponentContent(series: any[] = [], xAxis: any = {}, yAxis: any = {}) {
   return {
+    connectedComponents: [],
     series: series,
     xAxis: xAxis,
     yAxis: yAxis
@@ -205,16 +206,17 @@ function hasSubmitComponentState() {
 }
 
 function canEdit() {
-  function expectCanEdit(component: any, expectedResult: boolean) {
-    expect(service.canEdit(component)).toEqual(expectedResult);
-  }
-  it('should check if the student can edit the graph when they can not edit', () => {
-    const multipleSeries = [createSingleSeries([], false), createSingleSeries([], false)];
-    expectCanEdit(createComponentContent(multipleSeries), false);
-  });
-  it('should check if the student can edit the graph when they can edit', () => {
-    const multipleSeries = [createSingleSeries([], false), createSingleSeries([], true)];
-    expectCanEdit(createComponentContent(multipleSeries), true);
+  describe('canEdit()', () => {
+    it('should return false when they can not edit', () => {
+      const multipleSeries = [createSingleSeries([], false), createSingleSeries([], false)];
+      const content = createComponentContent(multipleSeries);
+      content.connectedComponents = [{ type: 'showWork' }];
+      expect(service.canEdit(content)).toEqual(false);
+    });
+    it('should return true when they can edit', () => {
+      const multipleSeries = [createSingleSeries([], false), createSingleSeries([], true)];
+      expect(service.canEdit(createComponentContent(multipleSeries))).toEqual(true);
+    });
   });
 }
 

--- a/src/app/services/labelService.spec.ts
+++ b/src/app/services/labelService.spec.ts
@@ -4,13 +4,11 @@ import { ConfigService } from '../../assets/wise5/services/configService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
 import { StudentAssetService } from '../../assets/wise5/services/studentAssetService';
 import { TagService } from '../../assets/wise5/services/tagService';
-import { UtilService } from '../../assets/wise5/services/utilService';
 import { LabelService } from '../../assets/wise5/components/label/labelService';
 import { TestBed } from '@angular/core/testing';
 import { SessionService } from '../../assets/wise5/services/sessionService';
 
 let service: LabelService;
-let utilService: UtilService;
 let label1: any;
 let label2: any;
 let label1Text: any = 'Label 1';
@@ -46,12 +44,10 @@ describe('LabelService', () => {
         ProjectService,
         SessionService,
         StudentAssetService,
-        TagService,
-        UtilService
+        TagService
       ]
     });
-    service = TestBed.get(LabelService);
-    utilService = TestBed.get(UtilService);
+    service = TestBed.inject(LabelService);
     label1 = createLabel(label1Text, label1PointX, label1PointY, label1TextX, label1TextY, color1);
     label2 = createLabel(label2Text, label2PointX, label2PointY, label2TextX, label2TextY, color2);
   });
@@ -233,15 +229,13 @@ function componentStateHasLabel() {
 }
 
 function canEdit() {
-  it(`should check if the component can be edited when it does not have a show work connected
-      component`, () => {
-    spyOn(utilService, 'hasShowWorkConnectedComponent').and.returnValue(false);
-    expect(service.canEdit({})).toEqual(true);
-  });
-  it(`should check if the component can be edited when it does have a show work connected
-      component`, () => {
-    spyOn(utilService, 'hasShowWorkConnectedComponent').and.returnValue(true);
-    expect(service.canEdit({})).toEqual(false);
+  describe('canEdit()', () => {
+    it(`should return true when it does not have a show work connected component`, () => {
+      expect(service.canEdit({})).toEqual(true);
+    });
+    it(`should return false when it does have a show work connected component`, () => {
+      expect(service.canEdit({ connectedComponents: [{ type: 'showWork' }] })).toEqual(false);
+    });
   });
 }
 

--- a/src/assets/wise5/common/ComponentContent.spec.ts
+++ b/src/assets/wise5/common/ComponentContent.spec.ts
@@ -1,0 +1,18 @@
+import { ComponentContent, hasConnectedComponent } from './ComponentContent';
+
+describe('ComponentContent', () => {
+  describe('hasConnectedComponent()', () => {
+    it('returns false when content does not have any connected components', () => {
+      const content = {} as ComponentContent;
+      expect(hasConnectedComponent(content, 'importWork')).toBeFalse();
+    });
+    it('returns false when content does not have the specified connected component type', () => {
+      const content = { connectedComponents: [{ type: 'showWork' }] } as ComponentContent;
+      expect(hasConnectedComponent(content, 'importWork')).toBeFalse();
+    });
+    it('returns true when content has the specified connected component type', () => {
+      const content = { connectedComponents: [{ type: 'importWork' }] } as ComponentContent;
+      expect(hasConnectedComponent(content, 'importWork')).toBeTrue();
+    });
+  });
+});

--- a/src/assets/wise5/common/ComponentContent.ts
+++ b/src/assets/wise5/common/ComponentContent.ts
@@ -15,3 +15,13 @@ export interface ComponentContent {
   showSubmitButton?: boolean;
   type: string;
 }
+
+export function hasConnectedComponent(
+  content: ComponentContent,
+  connectedComponentType: 'importWork' | 'showWork'
+): boolean {
+  return (
+    content.connectedComponents != null &&
+    content.connectedComponents.some((c) => c.type === connectedComponentType)
+  );
+}

--- a/src/assets/wise5/components/animation/animation-student/animation-student.component.ts
+++ b/src/assets/wise5/components/animation/animation-student/animation-student.component.ts
@@ -7,10 +7,10 @@ import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
 import { StudentAssetService } from '../../../services/studentAssetService';
 import { StudentDataService } from '../../../services/studentDataService';
-import { UtilService } from '../../../services/utilService';
 import { ComponentStudent } from '../../component-student.component';
 import { ComponentService } from '../../componentService';
 import { AnimationService } from '../animationService';
+import { hasConnectedComponent } from '../../../common/ComponentContent';
 
 @Component({
   selector: 'animation-student',
@@ -52,8 +52,7 @@ export class AnimationStudent extends ComponentStudent {
     protected NodeService: NodeService,
     protected NotebookService: NotebookService,
     protected StudentAssetService: StudentAssetService,
-    protected StudentDataService: StudentDataService,
-    protected UtilService: UtilService
+    protected StudentDataService: StudentDataService
   ) {
     super(
       AnnotationService,
@@ -77,7 +76,7 @@ export class AnimationStudent extends ComponentStudent {
     this.svgId = this.AnimationService.getSvgId(domIdEnding);
     this.initializeCoordinates();
 
-    if (this.UtilService.hasShowWorkConnectedComponent(this.componentContent)) {
+    if (hasConnectedComponent(this.componentContent, 'showWork')) {
       this.handleConnectedComponents();
     } else if (
       this.AnimationService.componentStateHasStudentWork(this.componentState, this.componentContent)

--- a/src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.ts
+++ b/src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.ts
@@ -7,10 +7,10 @@ import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
 import { StudentAssetService } from '../../../services/studentAssetService';
 import { StudentDataService } from '../../../services/studentDataService';
-import { UtilService } from '../../../services/utilService';
 import { ComponentStudent } from '../../component-student.component';
 import { ComponentService } from '../../componentService';
 import { AudioOscillatorService } from '../audioOscillatorService';
+import { hasConnectedComponent } from '../../../common/ComponentContent';
 
 @Component({
   selector: 'audio-oscillator-student',
@@ -71,8 +71,7 @@ export class AudioOscillatorStudent extends ComponentStudent {
     protected NodeService: NodeService,
     protected NotebookService: NotebookService,
     protected StudentAssetService: StudentAssetService,
-    protected StudentDataService: StudentDataService,
-    protected UtilService: UtilService
+    protected StudentDataService: StudentDataService
   ) {
     super(
       AnnotationService,
@@ -97,7 +96,7 @@ export class AudioOscillatorStudent extends ComponentStudent {
     this.setButtonTextToPlay();
     this.setParametersFromComponentContent();
 
-    if (this.UtilService.hasShowWorkConnectedComponent(this.componentContent)) {
+    if (hasConnectedComponent(this.componentContent, 'showWork')) {
       this.handleConnectedComponents();
     } else if (
       this.AudioOscillatorService.componentStateHasStudentWork(

--- a/src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts
+++ b/src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts
@@ -9,13 +9,13 @@ import { NotebookService } from '../../../services/notebookService';
 import { ProjectService } from '../../../services/projectService';
 import { StudentAssetService } from '../../../services/studentAssetService';
 import { StudentDataService } from '../../../services/studentDataService';
-import { UtilService } from '../../../services/utilService';
 import { ComponentStudent } from '../../component-student.component';
 import { ComponentService } from '../../componentService';
 import { ConceptMapService } from '../conceptMapService';
 import { DialogWithCloseComponent } from '../../../directives/dialog-with-close/dialog-with-close.component';
 import { copy } from '../../../common/object/object';
 import { convertToPNGFile } from '../../../common/canvas/canvas';
+import { hasConnectedComponent } from '../../../common/ComponentContent';
 
 @Component({
   selector: 'concept-map-student',
@@ -75,8 +75,7 @@ export class ConceptMapStudent extends ComponentStudent {
     protected NotebookService: NotebookService,
     private ProjectService: ProjectService,
     protected StudentAssetService: StudentAssetService,
-    protected StudentDataService: StudentDataService,
-    protected UtilService: UtilService
+    protected StudentDataService: StudentDataService
   ) {
     super(
       AnnotationService,
@@ -156,7 +155,7 @@ export class ConceptMapStudent extends ComponentStudent {
 
   initializeSVG(): void {
     this.setupSVG();
-    if (this.UtilService.hasShowWorkConnectedComponent(this.componentContent)) {
+    if (hasConnectedComponent(this.componentContent, 'showWork')) {
       this.handleConnectedComponents();
     } else if (this.componentStateHasStudentWork(this.componentState, this.componentContent)) {
       this.componentState = this.ProjectService.injectAssetPaths(this.componentState);

--- a/src/assets/wise5/components/draw/draw-student/draw-student.component.spec.ts
+++ b/src/assets/wise5/components/draw/draw-student/draw-student.component.spec.ts
@@ -6,7 +6,6 @@ import { StudentTeacherCommonServicesModule } from '../../../../../app/student-t
 import { Component } from '../../../common/Component';
 import { ProjectService } from '../../../services/projectService';
 import { StudentDataService } from '../../../services/studentDataService';
-import { UtilService } from '../../../services/utilService';
 import { DrawService } from '../drawService';
 import { DrawStudent } from './draw-student.component';
 
@@ -87,9 +86,8 @@ function createCanvasObject(type: string): any {
 function initializeStudentData() {
   it('should initialize student data when there is a show work connected component', () => {
     component.componentContent.connectedComponents = [
-      { nodeId: 'node', componentId: 'component1' }
+      { nodeId: 'node', componentId: 'component1', type: 'showWork' }
     ];
-    spyOn(TestBed.inject(UtilService), 'hasShowWorkConnectedComponent').and.returnValue(true);
     spyOn(
       TestBed.inject(StudentDataService),
       'getLatestComponentStateByNodeIdAndComponentId'

--- a/src/assets/wise5/components/draw/draw-student/draw-student.component.ts
+++ b/src/assets/wise5/components/draw/draw-student/draw-student.component.ts
@@ -7,13 +7,13 @@ import { NotebookService } from '../../../services/notebookService';
 import { ProjectService } from '../../../services/projectService';
 import { StudentAssetService } from '../../../services/studentAssetService';
 import { StudentDataService } from '../../../services/studentDataService';
-import { UtilService } from '../../../services/utilService';
 import { ComponentStudent } from '../../component-student.component';
 import { ComponentService } from '../../componentService';
 import { DrawService } from '../drawService';
 import { MatDialog } from '@angular/material/dialog';
 import { copy } from '../../../common/object/object';
 import { convertToPNGFile } from '../../../common/canvas/canvas';
+import { hasConnectedComponent } from '../../../common/ComponentContent';
 
 @Component({
   selector: 'draw-student',
@@ -41,8 +41,7 @@ export class DrawStudent extends ComponentStudent {
     protected NotebookService: NotebookService,
     private ProjectService: ProjectService,
     protected StudentAssetService: StudentAssetService,
-    protected StudentDataService: StudentDataService,
-    protected UtilService: UtilService
+    protected StudentDataService: StudentDataService
   ) {
     super(
       AnnotationService,
@@ -113,7 +112,7 @@ export class DrawStudent extends ComponentStudent {
   }
 
   initializeStudentData(): void {
-    if (this.UtilService.hasShowWorkConnectedComponent(this.componentContent)) {
+    if (hasConnectedComponent(this.componentContent, 'showWork')) {
       this.handleConnectedComponents();
     } else if (
       this.DrawService.componentStateHasStudentWork(this.componentState, this.componentContent)

--- a/src/assets/wise5/components/graph/graphService.ts
+++ b/src/assets/wise5/components/graph/graphService.ts
@@ -4,10 +4,10 @@ import * as html2canvas from 'html2canvas';
 import { Injectable } from '@angular/core';
 import { ComponentService } from '../componentService';
 import { StudentAssetService } from '../../services/studentAssetService';
-import { UtilService } from '../../services/utilService';
 import { ConfigService } from '../../services/configService';
 import { HttpClient } from '@angular/common/http';
 import { convertToPNGFile } from '../../common/canvas/canvas';
+import { hasConnectedComponent } from '../../common/ComponentContent';
 
 @Injectable()
 export class GraphService extends ComponentService {
@@ -16,8 +16,7 @@ export class GraphService extends ComponentService {
   constructor(
     private configService: ConfigService,
     private http: HttpClient,
-    private StudentAssetService: StudentAssetService,
-    protected UtilService: UtilService
+    private StudentAssetService: StudentAssetService
   ) {
     super();
   }
@@ -128,17 +127,14 @@ export class GraphService extends ComponentService {
    * @param component The component content.
    * @return Whether the student can perform any work on this component.
    */
-  canEdit(component: any) {
+  canEdit(component: any): boolean {
     const series = component.series;
     for (const singleSeries of series) {
       if (singleSeries.canEdit) {
         return true;
       }
     }
-    if (this.UtilService.hasImportWorkConnectedComponent(component)) {
-      return true;
-    }
-    return false;
+    return hasConnectedComponent(component, 'importWork');
   }
 
   hasSeriesData(studentData: any) {

--- a/src/assets/wise5/components/label/label-student/label-student.component.ts
+++ b/src/assets/wise5/components/label/label-student/label-student.component.ts
@@ -5,7 +5,6 @@ import { ConfigService } from '../../../services/configService';
 import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
 import { StudentDataService } from '../../../services/studentDataService';
-import { UtilService } from '../../../services/utilService';
 import { ComponentStudent } from '../../component-student.component';
 import { ComponentService } from '../../componentService';
 import { LabelService } from '../labelService';
@@ -13,6 +12,7 @@ import { StudentAssetService } from '../../../services/studentAssetService';
 import { MatDialog } from '@angular/material/dialog';
 import { convertToPNGFile } from '../../../common/canvas/canvas';
 import { wordWrap } from '../../../common/string/string';
+import { hasConnectedComponent } from '../../../common/ComponentContent';
 
 @Component({
   selector: 'label-student',
@@ -55,8 +55,7 @@ export class LabelStudent extends ComponentStudent {
     protected NodeService: NodeService,
     protected NotebookService: NotebookService,
     protected StudentAssetService: StudentAssetService,
-    protected StudentDataService: StudentDataService,
-    protected UtilService: UtilService
+    protected StudentDataService: StudentDataService
   ) {
     super(
       AnnotationService,
@@ -287,7 +286,7 @@ export class LabelStudent extends ComponentStudent {
   }
 
   initializeStudentWork(componentContent: any, componentState: any): void {
-    if (this.UtilService.hasShowWorkConnectedComponent(componentContent)) {
+    if (hasConnectedComponent(componentContent, 'showWork')) {
       this.handleConnectedComponents();
     } else if (this.LabelService.componentStateHasStudentWork(componentState, componentContent)) {
       this.setStudentWork(componentState);

--- a/src/assets/wise5/components/label/labelService.ts
+++ b/src/assets/wise5/components/label/labelService.ts
@@ -5,9 +5,9 @@ import SVG from 'svg.js';
 import { ComponentService } from '../componentService';
 import { StudentAssetService } from '../../services/studentAssetService';
 import { Injectable } from '@angular/core';
-import { UtilService } from '../../services/utilService';
 import { convertToPNGFile } from '../../common/canvas/canvas';
 import { wordWrap } from '../../common/string/string';
+import { hasConnectedComponent } from '../../common/ComponentContent';
 
 @Injectable()
 export class LabelService extends ComponentService {
@@ -16,10 +16,7 @@ export class LabelService extends ComponentService {
   circleZIndex: number = 2;
   defaultTextBackgroundColor: string = 'blue';
 
-  constructor(
-    private StudentAssetService: StudentAssetService,
-    protected UtilService: UtilService
-  ) {
+  constructor(private StudentAssetService: StudentAssetService) {
     super();
   }
 
@@ -83,8 +80,8 @@ export class LabelService extends ComponentService {
    * @param component The component content.
    * @return Whether the student can perform any work on this component.
    */
-  canEdit(component: any) {
-    return !this.UtilService.hasShowWorkConnectedComponent(component);
+  canEdit(component: any): boolean {
+    return !hasConnectedComponent(component, 'showWork');
   }
 
   componentStateHasStudentWork(componentState: any, componentContent: any): boolean {

--- a/src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts
+++ b/src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts
@@ -16,7 +16,6 @@ import { NotebookService } from '../../../../services/notebookService';
 import { ProjectService } from '../../../../services/projectService';
 import { StudentAssetService } from '../../../../services/studentAssetService';
 import { StudentDataService } from '../../../../services/studentDataService';
-import { UtilService } from '../../../../services/utilService';
 import { ComponentStudent } from '../../../component-student.component';
 import { ComponentService } from '../../../componentService';
 import { Choice, createChoiceFromNotebookItem } from '../../choice';
@@ -26,6 +25,7 @@ import { copy } from '../../../../common/object/object';
 import { MatchCdkDragDrop } from '../MatchCdkDragDrop';
 import { Container } from '../container';
 import { Item } from '../item';
+import { hasConnectedComponent } from '../../../../common/ComponentContent';
 
 @Component({
   templateUrl: 'match-student-default.component.html',
@@ -58,8 +58,7 @@ export class MatchStudentDefault extends ComponentStudent {
     protected notebookService: NotebookService,
     private projectService: ProjectService,
     protected studentAssetService: StudentAssetService,
-    protected studentDataService: StudentDataService,
-    protected utilService: UtilService
+    protected studentDataService: StudentDataService
   ) {
     super(
       annotationService,
@@ -86,7 +85,7 @@ export class MatchStudentDefault extends ComponentStudent {
       this.subscribeToNewNotes();
     }
     this.initializeBuckets();
-    if (this.utilService.hasShowWorkConnectedComponent(this.componentContent)) {
+    if (hasConnectedComponent(this.componentContent, 'showWork')) {
       this.handleConnectedComponents();
     } else if (
       this.matchService.componentStateHasStudentWork(this.componentState, this.componentContent)

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.ts
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.ts
@@ -9,12 +9,12 @@ import { NotebookService } from '../../../services/notebookService';
 import { ProjectService } from '../../../services/projectService';
 import { StudentAssetService } from '../../../services/studentAssetService';
 import { StudentDataService } from '../../../services/studentDataService';
-import { UtilService } from '../../../services/utilService';
 import { ComponentStudent } from '../../component-student.component';
 import { ComponentService } from '../../componentService';
 import { MultipleChoiceComponent } from '../MultipleChoiceComponent';
 import { MultipleChoiceService } from '../multipleChoiceService';
 import { MultipleChoiceContent } from '../MultipleChoiceContent';
+import { hasConnectedComponent } from '../../../common/ComponentContent';
 
 @Component({
   selector: 'multiple-choice-student',
@@ -42,8 +42,7 @@ export class MultipleChoiceStudent extends ComponentStudent {
     protected notebookService: NotebookService,
     private projectService: ProjectService,
     protected studentAssetService: StudentAssetService,
-    protected studentDataService: StudentDataService,
-    protected utilService: UtilService
+    protected studentDataService: StudentDataService
   ) {
     super(
       annotationService,
@@ -70,7 +69,7 @@ export class MultipleChoiceStudent extends ComponentStudent {
       this.component.id
     ) as MultipleChoiceContent;
 
-    if (this.utilService.hasShowWorkConnectedComponent(this.componentContent)) {
+    if (hasConnectedComponent(this.componentContent, 'showWork')) {
       this.handleConnectedComponents();
     } else if (this.componentStateHasStudentWork(this.componentState, this.componentContent)) {
       this.setStudentWork(this.componentState);

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
@@ -11,7 +11,6 @@ import { NotificationService } from '../../../services/notificationService';
 import { ProjectService } from '../../../services/projectService';
 import { StudentAssetService } from '../../../services/studentAssetService';
 import { StudentDataService } from '../../../services/studentDataService';
-import { UtilService } from '../../../services/utilService';
 import { ComponentStudent } from '../../component-student.component';
 import { ComponentService } from '../../componentService';
 import { CRaterResponse } from '../../common/cRater/CRaterResponse';
@@ -21,6 +20,7 @@ import { FeedbackRuleComponent } from '../../feedbackRule/FeedbackRuleComponent'
 import { OpenResponseService } from '../openResponseService';
 import { copy } from '../../../common/object/object';
 import { RawCRaterResponse } from '../../common/cRater/RawCRaterResponse';
+import { hasConnectedComponent } from '../../../common/ComponentContent';
 
 @Component({
   selector: 'open-response-student',
@@ -47,8 +47,7 @@ export class OpenResponseStudent extends ComponentStudent {
     private NotificationService: NotificationService,
     private ProjectService: ProjectService,
     protected StudentAssetService: StudentAssetService,
-    protected StudentDataService: StudentDataService,
-    protected UtilService: UtilService
+    protected StudentDataService: StudentDataService
   ) {
     super(
       AnnotationService,
@@ -64,7 +63,7 @@ export class OpenResponseStudent extends ComponentStudent {
 
   ngOnInit(): void {
     super.ngOnInit();
-    if (this.UtilService.hasShowWorkConnectedComponent(this.componentContent)) {
+    if (hasConnectedComponent(this.componentContent, 'showWork')) {
       this.handleConnectedComponents();
     } else if (
       this.componentState != null &&

--- a/src/assets/wise5/components/table/table-student/table-student.component.ts
+++ b/src/assets/wise5/components/table/table-student/table-student.component.ts
@@ -8,7 +8,6 @@ import { NotebookService } from '../../../services/notebookService';
 import { ProjectService } from '../../../services/projectService';
 import { StudentAssetService } from '../../../services/studentAssetService';
 import { StudentDataService } from '../../../services/studentDataService';
-import { UtilService } from '../../../services/utilService';
 import { ComponentStudent } from '../../component-student.component';
 import { ComponentService } from '../../componentService';
 import { TableService } from '../tableService';
@@ -17,6 +16,7 @@ import { TabulatorData } from '../TabulatorData';
 import { TabulatorDataService } from '../tabulatorDataService';
 import { copy } from '../../../common/object/object';
 import { convertToPNGFile } from '../../../common/canvas/canvas';
+import { hasConnectedComponent } from '../../../common/ComponentContent';
 
 @Component({
   selector: 'table-student',
@@ -63,8 +63,7 @@ export class TableStudent extends ComponentStudent {
     protected StudentAssetService: StudentAssetService,
     protected StudentDataService: StudentDataService,
     private TableService: TableService,
-    private TabulatorDataService: TabulatorDataService,
-    protected UtilService: UtilService
+    private TabulatorDataService: TabulatorDataService
   ) {
     super(
       AnnotationService,
@@ -100,7 +99,7 @@ export class TableStudent extends ComponentStudent {
     this.isSaveButtonVisible = this.componentContent.showSaveButton;
     this.isSubmitButtonVisible = this.componentContent.showSubmitButton;
 
-    if (this.UtilService.hasShowWorkConnectedComponent(this.componentContent)) {
+    if (hasConnectedComponent(this.componentContent, 'showWork')) {
       // we will show work from another component
       this.handleConnectedComponents();
     } else if (

--- a/src/assets/wise5/services/utilService.ts
+++ b/src/assets/wise5/services/utilService.ts
@@ -6,42 +6,6 @@ import '../lib/jquery/jquery-global';
 @Injectable()
 export class UtilService {
   constructor() {}
-
-  /**
-   * Determine whether the component has been authored to import work.
-   * @param componentContent The component content.
-   * @return Whether to import work in this component.
-   */
-  hasImportWorkConnectedComponent(componentContent) {
-    return this.hasXConnectedComponent(componentContent, 'importWork');
-  }
-
-  /**
-   * Determine whether the component has been authored to show work.
-   * @param componentContent The component content.
-   * @return Whether to show work in this component.
-   */
-  hasShowWorkConnectedComponent(componentContent) {
-    return this.hasXConnectedComponent(componentContent, 'showWork');
-  }
-
-  /**
-   * Determine whether the component has a connected component of the given type.
-   * @param componentContent The component content.
-   * @param connectedComponentType The connected component type.
-   * @return Whether the component has a connected component of the given type.
-   */
-  hasXConnectedComponent(componentContent, connectedComponentType) {
-    if (componentContent.connectedComponents != null) {
-      let connectedComponents = componentContent.connectedComponents;
-      for (let connectedComponent of connectedComponents) {
-        if (connectedComponent.type == connectedComponentType) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
 }
 
 declare global {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9205,7 +9205,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">397</context>
+          <context context-type="linenumber">396</context>
         </context-group>
       </trans-unit>
       <trans-unit id="185559960832537937" datatype="html">
@@ -9263,7 +9263,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts</context>
-          <context context-type="linenumber">394</context>
+          <context context-type="linenumber">393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1944363997751399240" datatype="html">
@@ -14489,15 +14489,15 @@ Are you sure you want to proceed?</source>
         <source>You do not have any more chances to receive feedback on your answer.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/animation/animation-student/animation-student.component.ts</context>
-          <context context-type="linenumber">908</context>
+          <context context-type="linenumber">907</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">159</context>
+          <context context-type="linenumber">158</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">175</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4965414112249568013" datatype="html">
@@ -14506,7 +14506,7 @@ Are you sure you want to proceed?</source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/animation/animation-student/animation-student.component.ts</context>
-          <context context-type="linenumber">911</context>
+          <context context-type="linenumber">910</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1556483130839173989" datatype="html">
@@ -14515,11 +14515,11 @@ Are you ready to receive feedback on this answer?</source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/animation/animation-student/animation-student.component.ts</context>
-          <context context-type="linenumber">915</context>
+          <context context-type="linenumber">914</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">331</context>
+          <context context-type="linenumber">330</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7885570895165894241" datatype="html">
@@ -14772,14 +14772,14 @@ Are you ready to receive feedback on this answer?</source>
         <source>Play</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.ts</context>
-          <context context-type="linenumber">281</context>
+          <context context-type="linenumber">280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3133539296286953705" datatype="html">
         <source>Stop</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.ts</context>
-          <context context-type="linenumber">285</context>
+          <context context-type="linenumber">284</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8869226125397640676" datatype="html">
@@ -15374,7 +15374,7 @@ Label: <x id="PH" equiv-text="linkLabel"/></source>
         <source>You have no more chances to receive feedback on your answer.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">325</context>
+          <context context-type="linenumber">324</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1088900768760788337" datatype="html">
@@ -15383,22 +15383,22 @@ Label: <x id="PH" equiv-text="linkLabel"/></source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">328</context>
+          <context context-type="linenumber">327</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">162</context>
+          <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8429316238784832901" datatype="html">
         <source>Feedback</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">406</context>
+          <context context-type="linenumber">405</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">415</context>
+          <context context-type="linenumber">414</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/componentAnnotations/component-annotations.component.ts</context>
@@ -15409,7 +15409,7 @@ Are you ready to receive feedback on this answer?</source>
         <source>Are you sure you want to reset your work?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">1414</context>
+          <context context-type="linenumber">1413</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3948212117337409586" datatype="html">
@@ -16223,14 +16223,14 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Are you sure you want to clear your drawing?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/draw/draw-student/draw-student.component.ts</context>
-          <context context-type="linenumber">199</context>
+          <context context-type="linenumber">198</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7020890278107204483" datatype="html">
         <source>Do you want to update the connected drawing?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/draw/draw-student/draw-student.component.ts</context>
-          <context context-type="linenumber">286</context>
+          <context context-type="linenumber">285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8647687729200262691" datatype="html">
@@ -17145,42 +17145,42 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Graph</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graphService.ts</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7500488806315952979" datatype="html">
         <source>Time (seconds)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graphService.ts</context>
-          <context context-type="linenumber">48</context>
+          <context context-type="linenumber">47</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2155832126259145609" datatype="html">
         <source>s</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graphService.ts</context>
-          <context context-type="linenumber">53</context>
+          <context context-type="linenumber">52</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2074112513968400781" datatype="html">
         <source>Position (meters)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graphService.ts</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8033953731717586115" datatype="html">
         <source>m</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graphService.ts</context>
-          <context context-type="linenumber">73</context>
+          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2165011258157601810" datatype="html">
         <source>Prediction</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graphService.ts</context>
-          <context context-type="linenumber">79</context>
+          <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1391027585017325946" datatype="html">
@@ -17379,7 +17379,7 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-student/label-student.component.ts</context>
-          <context context-type="linenumber">740</context>
+          <context context-type="linenumber">739</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d0416d769e2f5f38e271f36c0e263f02e2f3b603" datatype="html">
@@ -17400,28 +17400,28 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>A New Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-student/label-student.component.ts</context>
-          <context context-type="linenumber">487</context>
+          <context context-type="linenumber">486</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4546757591980718173" datatype="html">
         <source>Are you sure you want to reset to the initial state?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-student/label-student.component.ts</context>
-          <context context-type="linenumber">846</context>
+          <context context-type="linenumber">845</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4725019513729542053" datatype="html">
         <source>Are you sure you want to delete the background image?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-student/label-student.component.ts</context>
-          <context context-type="linenumber">907</context>
+          <context context-type="linenumber">906</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4077520913910941990" datatype="html">
         <source>Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/labelService.ts</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">24</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a7d56850122574ce933b94051d73d65817e8369b" datatype="html">
@@ -17723,14 +17723,14 @@ Warning: This will delete all existing choices and buckets in this component.</s
         <source>Correct bucket but wrong position</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts</context>
-          <context context-type="linenumber">488</context>
+          <context context-type="linenumber">487</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7841430672042223267" datatype="html">
         <source>Correct</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts</context>
-          <context context-type="linenumber">495</context>
+          <context context-type="linenumber">494</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summary-display/summary-display.component.ts</context>
@@ -17745,7 +17745,7 @@ Warning: This will delete all existing choices and buckets in this component.</s
         <source>Incorrect</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts</context>
-          <context context-type="linenumber">495</context>
+          <context context-type="linenumber">494</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/summary-display/summary-display.component.ts</context>
@@ -18339,7 +18339,7 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">166</context>
+          <context context-type="linenumber">165</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7482125205220618294" datatype="html">
@@ -18348,7 +18348,7 @@ Are you ready to receive feedback on this answer?</source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">178</context>
+          <context context-type="linenumber">177</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6316287012266891697" datatype="html">
@@ -18357,21 +18357,21 @@ Are you ready to receive feedback on this answer?</source>
 Are you ready to submit this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">182</context>
+          <context context-type="linenumber">181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8936495196157450285" datatype="html">
         <source>We are scoring your work...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">296</context>
+          <context context-type="linenumber">295</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2283191014272031538" datatype="html">
         <source>Please Wait</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">297</context>
+          <context context-type="linenumber">296</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8785209093929133444" datatype="html">
@@ -18379,7 +18379,7 @@ Are you ready to submit this answer?</source>
 If this problem continues, let your teacher know and move on to the next activity. Your work will still be saved.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">319</context>
+          <context context-type="linenumber">318</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5623290610025495479" datatype="html">


### PR DESCRIPTION
## Notes
- To limit review scope, I left UtilService as a mostly-empty class. Removing this class should be done in a future task.
  
## Changes
1. Move these functions from UtilService to ComponentContent.ts
- hasImportWorkConnectedComponent()
- hasShowWorkConnectedComponent()
- hasXConnectedComponent()
2. Merge the functions to one function, hasConnectedComponent(), that takes in a connectedComponentType as a second parameter.
```
hasConnectedComponent(content: ComponentContent, connectedComponentType: 'showWork' | 'importWork') {}
```
3. Write tests and update references

## Test
- Connected components works as before

Closes #1347