### PR TITLE
style(Dialog Guidance): Align computer avatar to start of response

### DIFF
--- a/src/assets/wise5/components/dialogGuidance/dialog-response/dialog-response.component.html
+++ b/src/assets/wise5/components/dialogGuidance/dialog-response/dialog-response.component.html
@@ -15,7 +15,7 @@
         class="mat-36"
         color="accent"
         aria-label="Automated guidance response"
-        i18n-aria-label[fxFlex.gt-sm]=""
+        i18n-aria-label
         >smart_toy</mat-icon
       >
     </ng-container>

--- a/src/assets/wise5/components/dialogGuidance/dialog-response/dialog-response.component.html
+++ b/src/assets/wise5/components/dialogGuidance/dialog-response/dialog-response.component.html
@@ -15,8 +15,7 @@
         class="mat-36"
         color="accent"
         aria-label="Automated guidance response"
-        i18n-aria-label
-        fxFlexOrder="2"
+        i18n-aria-label[fxFlex.gt-sm]=""
         >smart_toy</mat-icon
       >
     </ng-container>
@@ -26,7 +25,6 @@
         class="computer-avatar"
         aria-label="Automated guidance response"
         i18n-aria-label
-        fxFlexOrder="2"
       />
     </ng-container>
   </ng-container>

--- a/src/style/themes/_default.scss
+++ b/src/style/themes/_default.scss
@@ -135,7 +135,7 @@ $default-colors: (
   'primary': mat.get-color-from-palette($default-theme-primary, 500),
   'score': #FFC107,
   'secondary-text': mat.get-color-from-palette($foreground, 'secondary-text'),
-  'selected-bg': mat.get-color-from-palette($default-theme-primary, 500),
+  'selected-bg': mat.get-color-from-palette($default-theme-primary, 50),
   'success': #00C853,
   'success-contrast': black,
   'text': mat.get-color-from-palette($foreground, 'text'),


### PR DESCRIPTION
## Changes
- Moves computer avatar to beginning of Dialog Guidance response
- Also fixes `selected-bg` color for default theme

Closes #1259.

## Test
Make sure Dialog Guidance components work properly.