### PR TITLE
fix(Classroom Monitor): Update workgroup name on previous/next click

### DIFF
--- a/src/app/classroom-monitor/workgroup-select/workgroup-select-autocomplete/workgroup-select-autocomplete.component.ts
+++ b/src/app/classroom-monitor/workgroup-select/workgroup-select-autocomplete/workgroup-select-autocomplete.component.ts
@@ -16,20 +16,20 @@ import { copy } from '../../../../assets/wise5/common/object/object';
   encapsulation: ViewEncapsulation.None
 })
 export class WorkgroupSelectAutocompleteComponent extends WorkgroupSelectComponent {
-  myControl = new FormControl();
   filteredWorkgroups: Observable<any>;
+  myControl = new FormControl();
 
   constructor(
-    protected ConfigService: ConfigService,
-    protected TeacherDataService: TeacherDataService
+    protected configService: ConfigService,
+    protected teacherDataService: TeacherDataService
   ) {
-    super(ConfigService, TeacherDataService);
+    super(configService, teacherDataService);
   }
 
   ngOnInit() {
     super.ngOnInit();
     this.updateFilteredWorkgroups();
-    const currentWorkgroup = this.TeacherDataService.getCurrentWorkgroup();
+    const currentWorkgroup = this.teacherDataService.getCurrentWorkgroup();
     if (currentWorkgroup) {
       this.myControl.setValue(currentWorkgroup.displayNames);
     }

--- a/src/app/classroom-monitor/workgroup-select/workgroup-select-autocomplete/workgroup-select-autocomplete.component.ts
+++ b/src/app/classroom-monitor/workgroup-select/workgroup-select-autocomplete/workgroup-select-autocomplete.component.ts
@@ -8,7 +8,6 @@ import { filter, map, startWith } from 'rxjs/operators';
 import { ConfigService } from '../../../../assets/wise5/services/configService';
 import { TeacherDataService } from '../../../../assets/wise5/services/teacherDataService';
 import { copy } from '../../../../assets/wise5/common/object/object';
-import { EventEmitter } from 'stream';
 
 @Component({
   selector: 'workgroup-select-autocomplete',
@@ -67,6 +66,10 @@ export class WorkgroupSelectAutocompleteComponent extends WorkgroupSelectCompone
     this.updateFilteredWorkgroups();
   }
 
+  protected setWorkgroup(workgroup: any): void {
+    this.updateWorkgroupDisplay(workgroup);
+  }
+
   getStudentsFromWorkgroups() {
     const students = [];
     for (const workgroup of this.workgroups) {
@@ -93,6 +96,10 @@ export class WorkgroupSelectAutocompleteComponent extends WorkgroupSelectCompone
 
   itemSelected(workgroup: any) {
     this.setCurrentWorkgroup(workgroup);
+    this.updateWorkgroupDisplay(workgroup);
+  }
+
+  private updateWorkgroupDisplay(workgroup: any): void {
     if (workgroup) {
       this.myControl.setValue(workgroup.displayNames);
     } else {

--- a/src/app/classroom-monitor/workgroup-select/workgroup-select.component.ts
+++ b/src/app/classroom-monitor/workgroup-select/workgroup-select.component.ts
@@ -7,25 +7,24 @@ import { TeacherDataService } from '../../../assets/wise5/services/teacherDataSe
 
 @Directive({ selector: 'workgroup-select' })
 export class WorkgroupSelectComponent {
-  @Input()
-  customClass: string;
+  @Input() customClass: string;
   canViewStudentNames: boolean;
   periodId: number;
   selectedItem: any;
-  workgroups: any;
   subscriptions: Subscription = new Subscription();
+  workgroups: any;
 
   constructor(
-    protected ConfigService: ConfigService,
-    protected TeacherDataService: TeacherDataService
+    protected configService: ConfigService,
+    protected teacherDataService: TeacherDataService
   ) {}
 
   ngOnInit() {
-    this.canViewStudentNames = this.ConfigService.getPermissions().canViewStudentNames;
-    this.periodId = this.TeacherDataService.getCurrentPeriod().periodId;
+    this.canViewStudentNames = this.configService.getPermissions().canViewStudentNames;
+    this.periodId = this.teacherDataService.getCurrentPeriod().periodId;
     this.setWorkgroups();
     this.subscriptions.add(
-      this.TeacherDataService.currentWorkgroupChanged$.subscribe(({ currentWorkgroup }) => {
+      this.teacherDataService.currentWorkgroupChanged$.subscribe(({ currentWorkgroup }) => {
         if (currentWorkgroup != null) {
           this.setWorkgroups();
           this.setWorkgroup(currentWorkgroup);
@@ -33,7 +32,7 @@ export class WorkgroupSelectComponent {
       })
     );
     this.subscriptions.add(
-      this.TeacherDataService.currentPeriodChanged$.subscribe(({ currentPeriod }) => {
+      this.teacherDataService.currentPeriodChanged$.subscribe(({ currentPeriod }) => {
         this.periodId = currentPeriod.periodId;
         this.setWorkgroups();
         this.currentPeriodChanged();
@@ -64,7 +63,7 @@ export class WorkgroupSelectComponent {
   }
 
   filterWorkgroupsBySelectedPeriod() {
-    this.workgroups = this.ConfigService.getClassmateUserInfos().filter((workgroup) => {
+    this.workgroups = this.configService.getClassmateUserInfos().filter((workgroup) => {
       return (
         (this.periodId === -1 || workgroup.periodId === this.periodId) &&
         workgroup.workgroupId != null
@@ -73,6 +72,6 @@ export class WorkgroupSelectComponent {
   }
 
   setCurrentWorkgroup(workgroup) {
-    this.TeacherDataService.setCurrentWorkgroup(workgroup);
+    this.teacherDataService.setCurrentWorkgroup(workgroup);
   }
 }

--- a/src/app/classroom-monitor/workgroup-select/workgroup-select.component.ts
+++ b/src/app/classroom-monitor/workgroup-select/workgroup-select.component.ts
@@ -28,6 +28,7 @@ export class WorkgroupSelectComponent {
       this.TeacherDataService.currentWorkgroupChanged$.subscribe(({ currentWorkgroup }) => {
         if (currentWorkgroup != null) {
           this.setWorkgroups();
+          this.setWorkgroup(currentWorkgroup);
         }
       })
     );
@@ -45,6 +46,8 @@ export class WorkgroupSelectComponent {
   }
 
   setWorkgroups() {}
+
+  protected setWorkgroup(workgroup: any): void {}
 
   currentPeriodChanged() {}
 


### PR DESCRIPTION
## Changes

Update workgroup name when the workgroup changes. It used to always display the same workgroup name even when the workgroup changed.

## Test

1. Load a run in the Classroom Monitor that has multiple workgroups
2. Go to the "Grade By Team" view
3. Choose a workgroup
4. Click the "Next Team" button, the student data will change but the name displayed in the drop down will remain the same
5. Click the "Previous Team" button, the student data will change but the name displayed in the drop down will remain the same

Closes #1388