### PR TITLE
feat(Project Authoring): Go back to project view after adding new node 

### DIFF
--- a/src/assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component.ts
@@ -35,9 +35,9 @@ export class ChooseNewNodeLocation {
   }
 
   private addInitialComponents(nodeId: string, components: any[]): void {
-    for (const component of components.reverse()) {
-      this.projectService.createComponent(nodeId, component.type);
-    }
+    components
+      .reverse()
+      .forEach((component) => this.projectService.createComponent(nodeId, component.type));
   }
 
   private save(): any {
@@ -47,9 +47,9 @@ export class ChooseNewNodeLocation {
   }
 
   private goToNode(node: any): void {
-    this.router.navigate(['../../node', node.id], {
+    this.router.navigate(['../..'], {
       relativeTo: this.route,
-      state: { newComponents: node.components }
+      state: { newNodes: [node] }
     });
   }
 


### PR DESCRIPTION
## Changes
- Go back to project view after adding a new node (before: open new node for editing)
- Rewrite addInitialComponents() to use HOF to improve readability.

## Test
- Adding new node takes you back to the project view, and also scroll&highlights the new node.

Closes #1406