### PR TITLE
refactor(ProjectAuthoringComponent): deleteNodes() and selectNode()

### DIFF
--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -24,7 +24,7 @@
                 mat-raised-button
                 color="primary"
                 (click)="createNewLesson()"
-                [disabled]="stepNodeSelected || activityNodeSelected"
+                [disabled]="stepNodeSelected || groupNodeSelected"
                 matTooltip="Create New Lesson"
                 matTooltipPosition="above"
                 i18n-matTooltip
@@ -35,7 +35,7 @@
                 mat-raised-button
                 color="primary"
                 (click)="createNewStep()"
-                [disabled]="stepNodeSelected || activityNodeSelected"
+                [disabled]="stepNodeSelected || groupNodeSelected"
                 matTooltip="Create New Step"
                 matTooltipPosition="above"
                 i18n-matTooltip
@@ -46,7 +46,7 @@
                 mat-raised-button
                 color="primary"
                 (click)="addStructure()"
-                [disabled]="stepNodeSelected || activityNodeSelected"
+                [disabled]="stepNodeSelected || groupNodeSelected"
                 matTooltip="Add Lesson Structure"
                 matTooltipPosition="above"
                 i18n-matTooltip
@@ -57,7 +57,7 @@
                 mat-raised-button
                 color="primary"
                 (click)="importStep()"
-                [disabled]="stepNodeSelected || activityNodeSelected"
+                [disabled]="stepNodeSelected || groupNodeSelected"
                 matTooltip="Import Step"
                 matTooltipPosition="above"
                 i18n-matTooltip
@@ -101,7 +101,7 @@
                 mat-raised-button
                 color="primary"
                 (click)="goToAdvancedAuthoring()"
-                [disabled]="stepNodeSelected || activityNodeSelected"
+                [disabled]="stepNodeSelected || groupNodeSelected"
                 matTooltip="Advanced"
                 matTooltipPosition="above"
                 i18n-matTooltip
@@ -139,10 +139,10 @@
                     <mat-checkbox
                       color="primary"
                       [(ngModel)]="item.checked"
-                      (ngModelChange)="projectItemClicked()"
+                      (ngModelChange)="selectNode()"
                       [disabled]="
                         (isGroupNode(item.key) && stepNodeSelected) ||
-                        (!isGroupNode(item.key) && activityNodeSelected)
+                        (!isGroupNode(item.key) && groupNodeSelected)
                       "
                       aria-label="{{ getNodePositionById(item.key) }} {{ getNodeTitle(item.key) }}"
                     >
@@ -238,7 +238,7 @@
                       <mat-checkbox
                         color="primary"
                         [(ngModel)]="inactiveNode.checked"
-                        (ngModelChange)="projectItemClicked()"
+                        (ngModelChange)="selectNode()"
                         [disabled]="stepNodeSelected"
                         aria-label="{{ getNodeTitle(inactiveNode.id) }}"
                       >
@@ -270,9 +270,9 @@
                           <mat-checkbox
                             color="primary"
                             [(ngModel)]="idToNode[inactiveChildId].checked"
-                            (ngModelChange)="projectItemClicked()"
-                            [disabled]="activityNodeSelected"
-                            aria-label="{{ getNodeTitle(inactiveChildId.id) }}"
+                            (ngModelChange)="selectNode()"
+                            [disabled]="groupNodeSelected"
+                            aria-label="{{ getNodeTitle(inactiveChildId) }}"
                           >
                           </mat-checkbox>
                         </div>
@@ -310,8 +310,8 @@
                         <mat-checkbox
                           color="primary"
                           [(ngModel)]="inactiveNode.checked"
-                          (ngModelChange)="projectItemClicked()"
-                          [disabled]="activityNodeSelected"
+                          (ngModelChange)="selectNode()"
+                          [disabled]="groupNodeSelected"
                           aria-label="{{ getNodeTitle(inactiveNode.id) }}"
                         >
                         </mat-checkbox>

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -16,7 +16,7 @@ import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
   styleUrls: ['./project-authoring.component.scss']
 })
 export class ProjectAuthoringComponent {
-  protected activityNodeSelected: boolean = false;
+  protected groupNodeSelected: boolean = false;
   protected authors: string[] = [];
   private idToNode: any;
   protected inactiveGroupNodes: any[];
@@ -164,7 +164,7 @@ export class ProjectAuthoringComponent {
       inactiveStepNode.checked = false;
     });
     this.stepNodeSelected = false;
-    this.activityNodeSelected = false;
+    this.groupNodeSelected = false;
   }
 
   protected createNewLesson(): void {
@@ -258,39 +258,19 @@ export class ProjectAuthoringComponent {
   }
 
   /**
-   * The checkbox for a node was clicked. We will determine whether there are
-   * any activity nodes that are selected or whether there are any step nodes
-   * that are selected. We do this because we do not allow selecting a mix of
-   * activities and steps. If there are any activity nodes that are selected,
-   * we will disable all the step node check boxes. Alternatively, if there are
-   * any step nodes selected, we will disable all the activity node check boxes.
-   * @param nodeId The node id of the node that was clicked.
+   * The checkbox for a node was clicked. We do not allow selecting a mix of group and step nodes.
+   * If any group nodes are selected, disable all step node checkboxes, and vise-versa.
    */
-  protected projectItemClicked(): void {
-    this.stepNodeSelected = false;
-    this.activityNodeSelected = false;
-
-    // this will check the items that are used in the project
-    for (let item of this.items) {
-      if (item.checked) {
-        if (this.isGroupNode(item.key)) {
-          this.activityNodeSelected = true;
-        } else {
-          this.stepNodeSelected = true;
-        }
-      }
-    }
-
-    // this will check the items that are unused in the project
-    for (let key in this.idToNode) {
-      let node = this.idToNode[key];
-      if (node.checked) {
-        if (this.isGroupNode(key)) {
-          this.activityNodeSelected = true;
-        } else {
-          this.stepNodeSelected = true;
-        }
-      }
+  protected selectNode(): void {
+    const checkedNodes = this.items
+      .concat(Object.values(this.idToNode))
+      .filter((item) => item.checked);
+    if (checkedNodes.length === 0) {
+      this.groupNodeSelected = false;
+      this.stepNodeSelected = false;
+    } else {
+      this.groupNodeSelected = this.isGroupNode(checkedNodes[0].id);
+      this.stepNodeSelected = !this.groupNodeSelected;
     }
   }
 

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -3107,7 +3107,7 @@ export class TeacherProjectService extends ProjectService {
   getNodesInOrder(): any[] {
     return Object.entries(this.idToOrder)
       .map((entry: any) => {
-        return { key: entry[0], order: entry[1].order };
+        return { key: entry[0], id: entry[0], order: entry[1].order };
       })
       .sort((a: any, b: any) => {
         return a.order - b.order;


### PR DESCRIPTION
## Changes
- Call DeleteNodeService functions instead of handling it in ProjectAuthoringComponent
- Rename projectItemClicked() to selectNode() and clean up code using HOF
- Rename activityNodeSelected to groupNodeSelected

## Test
- Delete nodes work as before
   - Delete step(s)
   - Delete group(s)
   - Delete first step in the unit should update start node
- Selecting node(s) work as before
   - Shouldn't be able to select mix of groups and steps  