### PR TITLE
feat(Project Authoring): Don't open imported step for editing

### DIFF
--- a/src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html
@@ -11,33 +11,16 @@
     >
       <div fxLayout="row" fxLayoutGap="8px" class="projectItemTitleDiv">
         <div fxLayout="row" fxLayoutAlign="start center">
-          <node-icon [nodeId]="nodeId" size="18"></node-icon>&nbsp;
-          <p style="display: inline; cursor: pointer">
-            {{ getNodePositionById(nodeId) }}: {{ getNodeTitle(nodeId) }}
-          </p>
+          <node-icon-and-title [nodeId]="nodeId" [showPosition]="true"></node-icon-and-title>
         </div>
-        <button
-          mat-raised-button
-          color="primary"
+        <insert-node-inside-button
           *ngIf="isGroupNode(nodeId)"
-          matTooltip="Insert As First Step"
-          i18n-matTooltip
-          matTooltipPosition="above"
-          (click)="importSelectedNodes(nodeId); $event.stopPropagation()"
-        >
-          <mat-icon>call_received</mat-icon>
-        </button>
-        <button
-          mat-raised-button
-          color="primary"
+          (insertEvent)="insert(nodeId, false)"
+        ></insert-node-inside-button>
+        <insert-node-after-button
           *ngIf="!isGroupNode(nodeId)"
-          matTooltip="Insert After"
-          i18n-matTooltip
-          matTooltipPosition="above"
-          (click)="importSelectedNodes(nodeId); $event.stopPropagation()"
-        >
-          <mat-icon>subdirectory_arrow_left</mat-icon>
-        </button>
+          (insertEvent)="insert(nodeId, true)"
+        ></insert-node-after-button>
       </div>
     </div>
   </div>

--- a/src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.ts
+++ b/src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.ts
@@ -37,17 +37,10 @@ export class ChooseImportStepLocationComponent {
         this.insertNodesService.insertNodes(nodesWithNewNodeIds, nodeIdToInsertInsideOrAfter);
         this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
           this.projectService.refreshProject();
-          if (nodesWithNewNodeIds.length === 1) {
-            const newNode = nodesWithNewNodeIds[0];
-            this.router.navigate(['../../node', newNode.id], {
-              relativeTo: this.route,
-              state: {
-                newComponents: newNode.components
-              }
-            });
-          } else {
-            this.router.navigate(['../..'], { relativeTo: this.route });
-          }
+          this.router.navigate(['../..'], {
+            relativeTo: this.route,
+            state: { newNodes: nodesWithNewNodeIds }
+          });
         });
       });
   }

--- a/src/assets/wise5/authoringTool/choose-node-location/choose-copy-node-location/choose-copy-node-location.component.ts
+++ b/src/assets/wise5/authoringTool/choose-node-location/choose-copy-node-location/choose-copy-node-location.component.ts
@@ -18,11 +18,15 @@ export class ChooseCopyNodeLocationComponent extends ChooseNodeLocationComponent
     super(projectService, route, router);
   }
 
-  protected insertAfter(nodeId: string): any[] {
-    return this.copyNodesService.copyNodesAfter(this.selectedNodeIds, nodeId);
+  protected insertAfter(nodeId: string): Promise<any[]> {
+    return new Promise((resolve) => {
+      resolve(this.copyNodesService.copyNodesAfter(this.selectedNodeIds, nodeId));
+    });
   }
 
-  protected insertInside(groupNodeId: string): any[] {
-    return this.copyNodesService.copyNodesInsideGroup(this.selectedNodeIds, groupNodeId);
+  protected insertInside(groupNodeId: string): Promise<any[]> {
+    return new Promise((resolve) => {
+      resolve(this.copyNodesService.copyNodesInsideGroup(this.selectedNodeIds, groupNodeId));
+    });
   }
 }

--- a/src/assets/wise5/authoringTool/choose-node-location/choose-move-node-location/choose-move-node-location.component.ts
+++ b/src/assets/wise5/authoringTool/choose-node-location/choose-move-node-location/choose-move-node-location.component.ts
@@ -32,11 +32,15 @@ export class ChooseMoveNodeLocationComponent extends ChooseNodeLocationComponent
     return !this.selectedNodeIds.includes(nodeId);
   }
 
-  protected insertAfter(nodeId: string): any[] {
-    return this.moveNodesService.moveNodesAfter(this.selectedNodeIds, nodeId);
+  protected insertAfter(nodeId: string): Promise<any[]> {
+    return new Promise((resolve) => {
+      resolve(this.moveNodesService.moveNodesAfter(this.selectedNodeIds, nodeId));
+    });
   }
 
-  protected insertInside(groupNodeId: string): any[] {
-    return this.moveNodesService.moveNodesInsideGroup(this.selectedNodeIds, groupNodeId);
+  protected insertInside(groupNodeId: string): Promise<any[]> {
+    return new Promise((resolve) => {
+      resolve(this.moveNodesService.moveNodesInsideGroup(this.selectedNodeIds, groupNodeId));
+    });
   }
 }

--- a/src/assets/wise5/authoringTool/choose-node-location/choose-node-location.component.ts
+++ b/src/assets/wise5/authoringTool/choose-node-location/choose-node-location.component.ts
@@ -9,6 +9,7 @@ export abstract class ChooseNodeLocationComponent {
   protected inactiveGroupNodes: any[];
   protected inactiveStepNodes: any[];
   protected nodeIds: string[];
+  protected pathToProjectAuthoringView = '..';
   protected selectedNodeIds: string[];
 
   constructor(
@@ -25,18 +26,20 @@ export abstract class ChooseNodeLocationComponent {
     this.selectedNodeIds = history.state.selectedNodeIds;
   }
 
-  protected insert(nodeId: string, after: boolean): void {
-    this.saveAndGoToProjectView(after ? this.insertAfter(nodeId) : this.insertInside(nodeId));
+  protected async insert(nodeId: string, after: boolean): Promise<void> {
+    this.saveAndGoToProjectView(
+      after ? await this.insertAfter(nodeId) : await this.insertInside(nodeId)
+    );
   }
 
-  protected abstract insertAfter(nodeId: string): any[];
+  protected abstract insertAfter(nodeId: string): Promise<any[]>;
 
-  protected abstract insertInside(groupNodeId: string): any[];
+  protected abstract insertInside(groupNodeId: string): Promise<any[]>;
 
   protected saveAndGoToProjectView(newNodes: any[]): void {
     this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
       this.projectService.refreshProject();
-      this.router.navigate(['..'], {
+      this.router.navigate([this.pathToProjectAuthoringView], {
         relativeTo: this.route,
         state: { newNodes: newNodes }
       });

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -3,11 +3,10 @@ import { ConfigService } from '../../services/configService';
 import { DeleteNodeService } from '../../services/deleteNodeService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { TeacherDataService } from '../../services/teacherDataService';
-import * as $ from 'jquery';
 import { Subscription, filter } from 'rxjs';
 import { Message } from '@stomp/stompjs';
 import { RxStomp } from '@stomp/rx-stomp';
-import { temporarilyHighlightElement } from '../../common/dom/dom';
+import { highlightNodesAndScroll } from '../../common/dom/dom';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 
 @Component({
@@ -40,7 +39,7 @@ export class ProjectAuthoringComponent {
     this.subscriptions.add(
       this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
         this.updateShowProjectView();
-        this.temporarilyHighlightNewNodes(history.state.newNodes);
+        highlightNodesAndScroll(history.state.newNodes);
       })
     );
   }
@@ -212,25 +211,6 @@ export class ProjectAuthoringComponent {
       },
       1000
     );
-  }
-
-  /**
-   * Temporarily highlight the new nodes to draw attention to them
-   * @param newNodes the new nodes to highlight
-   */
-  private temporarilyHighlightNewNodes(newNodes = []): void {
-    if (newNodes.length > 0) {
-      setTimeout(() => {
-        newNodes.forEach((newNode) => temporarilyHighlightElement(newNode.id));
-        const firstNodeElementAdded = $('#' + newNodes[0].id);
-        $('#content').animate(
-          {
-            scrollTop: firstNodeElementAdded.prop('offsetTop') - 60
-          },
-          1000
-        );
-      });
-    }
   }
 
   protected getStepBackgroundColor(nodeId: string): string {

--- a/src/assets/wise5/common/dom/dom.ts
+++ b/src/assets/wise5/common/dom/dom.ts
@@ -31,3 +31,21 @@ export function temporarilyHighlightElement(id: string, duration: number = 1000)
     }, 2000);
   }, duration);
 }
+
+/**
+ * Temporarily highlight the nodes and scroll to the first node to draw attention to them
+ * @param nodes the nodes to highlight
+ */
+export function highlightNodesAndScroll(nodes = []): void {
+  if (nodes.length > 0) {
+    setTimeout(() => {
+      nodes.forEach((node) => temporarilyHighlightElement(node.id));
+      $('#content').animate(
+        {
+          scrollTop: $('#' + nodes[0].id).prop('offsetTop') - 60
+        },
+        1000
+      );
+    });
+  }
+}

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -391,7 +391,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">29</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
@@ -1360,40 +1360,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html</context>
           <context context-type="linenumber">1</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2487b6259288414268ebb0273e79a0dbd975205b" datatype="html">
-        <source>Insert As First Step</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html</context>
-          <context context-type="linenumber">23</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component.html</context>
-          <context context-type="linenumber">23</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1e9b22a987b26586870bb920525f8062d24c6267" datatype="html">
-        <source>Insert After</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html</context>
-          <context context-type="linenumber">34</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.html</context>
-          <context context-type="linenumber">34</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component.html</context>
-          <context context-type="linenumber">34</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/chooseComponentLocation/choose-component-location.component.html</context>
-          <context context-type="linenumber">38</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/choose-structure-location/choose-structure-location.component.html</context>
-          <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
       <trans-unit id="64216e7ef99605d9f05614beb1919360ee012177" datatype="html">
@@ -8850,6 +8816,25 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">35,37</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1e9b22a987b26586870bb920525f8062d24c6267" datatype="html">
+        <source>Insert After</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/chooseComponentLocation/choose-component-location.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/choose-structure-location/choose-structure-location.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="24b2aed16c8aef6c967fb04c48adde152cf40193" datatype="html">
         <source>Insert at the Beginning</source>
         <context-group purpose="location">
@@ -9069,6 +9054,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component.html</context>
           <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2487b6259288414268ebb0273e79a0dbd975205b" datatype="html">
+        <source>Insert As First Step</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component.html</context>
+          <context context-type="linenumber">23</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8bff5bc1b934165ac00899643ab91eb5320ad557" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -11991,14 +11991,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete the selected item?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">132</context>
+          <context context-type="linenumber">131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1189930234736223663" datatype="html">
         <source>Are you sure you want to delete the <x id="PH" equiv-text="selectedNodeIds.length"/> selected items?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">133</context>
+          <context context-type="linenumber">132</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e8fb2ceb6f8d4c3e90a6a688e9024461e67f44f0" datatype="html">


### PR DESCRIPTION
## Changes
- Go to project view after importing one or more steps. (before: open step editing view if there was just one imported step)
- Move highlightNodesAndScroll() function from ProjectAuthoringComponent.ts to dom.ts

## Test
- Importing one or more steps should take you back to the project authoring view and highlight and scroll to the newly imported step(s).

Closes #1414