### PR TITLE
feat(Question Bank): Click question to add to student response input

### DIFF
--- a/src/app/authoring-tool/edit-question-bank-rules/edit-question-bank-rules.component.html
+++ b/src/app/authoring-tool/edit-question-bank-rules/edit-question-bank-rules.component.html
@@ -63,13 +63,25 @@
                 <mat-label *ngIf="rule.questions.length > 1" i18n
                   >Question #{{ questionIndex + 1 }}</mat-label
                 >
-                <textarea
-                  matInput
-                  [(ngModel)]="rule.questions[questionIndex]"
-                  (ngModelChange)="inputChanged.next($event)"
-                  cdkTextareaAutosize
-                >
-                </textarea>
+                <ng-container *ngIf="version === 2; then version2; else version1"></ng-container>
+                <ng-template #version2>
+                  <textarea
+                    matInput
+                    [(ngModel)]="rule.questions[questionIndex].text"
+                    (ngModelChange)="inputChanged.next($event)"
+                    cdkTextareaAutosize
+                  >
+                  </textarea>
+                </ng-template>
+                <ng-template #version1>
+                  <textarea
+                    matInput
+                    [(ngModel)]="rule.questions[questionIndex]"
+                    (ngModelChange)="inputChanged.next($event)"
+                    cdkTextareaAutosize
+                  >
+                  </textarea>
+                </ng-template>
                 <button
                   mat-icon-button
                   matSuffix

--- a/src/app/authoring-tool/edit-question-bank-rules/edit-question-bank-rules.component.spec.ts
+++ b/src/app/authoring-tool/edit-question-bank-rules/edit-question-bank-rules.component.spec.ts
@@ -50,7 +50,7 @@ function addNewFeedbackToRule() {
 
 function addNewFeedbackToRuleVersion1() {
   describe('using question bank content version 1', () => {
-    it('should add new question to rule', () => {
+    it('adds new question to rule', () => {
       component.version = undefined;
       const rule = new QuestionBankRule({ questions: [] });
       component.addNewFeedbackToRule(rule);
@@ -63,7 +63,7 @@ function addNewFeedbackToRuleVersion1() {
 
 function addNewFeedbackToRuleVersion2() {
   describe('using question bank content version 2', () => {
-    it('should add new question to rule', () => {
+    it('adds new question to rule', () => {
       component.version = 2;
       const rule = new QuestionBankRule({ questions: [] });
       component.addNewFeedbackToRule(rule);
@@ -78,7 +78,7 @@ function addNewFeedbackToRuleVersion2() {
 
 function deleteFeedbackInRule() {
   describe('deleteFeedbackInRule()', () => {
-    it('should delete specified feedback', () => {
+    it('deletes specified feedback', () => {
       const rule = new QuestionBankRule({ questions: ['Q1', 'Q2'] });
       spyOn(window, 'confirm').and.returnValue(true);
       component.deleteFeedbackInRule(rule, 0);

--- a/src/app/authoring-tool/edit-question-bank-rules/edit-question-bank-rules.component.spec.ts
+++ b/src/app/authoring-tool/edit-question-bank-rules/edit-question-bank-rules.component.spec.ts
@@ -7,11 +7,12 @@ import { QuestionBankRule } from '../../../assets/wise5/components/peerChat/peer
 import { TeacherProjectService } from '../../../assets/wise5/services/teacherProjectService';
 import { StudentTeacherCommonServicesModule } from '../../student-teacher-common-services.module';
 import { EditQuestionBankRulesComponent } from './edit-question-bank-rules.component';
+import { Question } from '../../../assets/wise5/components/peerChat/peer-chat-question-bank/Question';
 
 let component: EditQuestionBankRulesComponent;
 let fixture: ComponentFixture<EditQuestionBankRulesComponent>;
 let projectService: TeacherProjectService;
-let nodeChangedSpy;
+let nodeChangedSpy: jasmine.Spy;
 
 describe('EditQuestionBankRulesComponent', () => {
   beforeEach(async () => {
@@ -42,12 +43,35 @@ describe('EditQuestionBankRulesComponent', () => {
 
 function addNewFeedbackToRule() {
   describe('addNewFeedbackToRule()', () => {
+    addNewFeedbackToRuleVersion1();
+    addNewFeedbackToRuleVersion2();
+  });
+}
+
+function addNewFeedbackToRuleVersion1() {
+  describe('using question bank content version 1', () => {
     it('should add new question to rule', () => {
-      const rule = new QuestionBankRule({ questions: ['Q1'] });
+      component.version = undefined;
+      const rule = new QuestionBankRule({ questions: [] });
       component.addNewFeedbackToRule(rule);
       expect(nodeChangedSpy).toHaveBeenCalled();
-      expect(rule.questions.length).toEqual(2);
-      expect(rule.questions[1]).toEqual('');
+      expect(rule.questions.length).toEqual(1);
+      expect(rule.questions[0]).toEqual('');
+    });
+  });
+}
+
+function addNewFeedbackToRuleVersion2() {
+  describe('using question bank content version 2', () => {
+    it('should add new question to rule', () => {
+      component.version = 2;
+      const rule = new QuestionBankRule({ questions: [] });
+      component.addNewFeedbackToRule(rule);
+      expect(nodeChangedSpy).toHaveBeenCalled();
+      expect(rule.questions.length).toEqual(1);
+      const question = rule.questions[0] as Question;
+      expect(question.hasOwnProperty('id')).toEqual(true);
+      expect(question.text).toEqual('');
     });
   });
 }

--- a/src/app/authoring-tool/edit-question-bank-rules/edit-question-bank-rules.component.ts
+++ b/src/app/authoring-tool/edit-question-bank-rules/edit-question-bank-rules.component.ts
@@ -4,6 +4,7 @@ import { generateRandomKey } from '../../../assets/wise5/common/string/string';
 import { EditFeedbackRulesComponent } from '../../../assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component';
 import { QuestionBankRule } from '../../../assets/wise5/components/peerChat/peer-chat-question-bank/QuestionBankRule';
 import { TeacherProjectService } from '../../../assets/wise5/services/teacherProjectService';
+import { Question } from '../../../assets/wise5/components/peerChat/peer-chat-question-bank/Question';
 
 @Component({
   selector: 'edit-question-bank-rules',
@@ -20,7 +21,11 @@ export class EditQuestionBankRulesComponent extends EditFeedbackRulesComponent {
   }
 
   protected createNewFeedbackRule(): Partial<QuestionBankRule> {
-    return { id: generateRandomKey(), expression: '', questions: [''] };
+    if (this.version === 2) {
+      return { id: generateRandomKey(), expression: '', questions: [new Question()] };
+    } else {
+      return { id: generateRandomKey(), expression: '', questions: [''] };
+    }
   }
 
   deleteRule(ruleIndex: number): void {
@@ -31,7 +36,11 @@ export class EditQuestionBankRulesComponent extends EditFeedbackRulesComponent {
   }
 
   addNewFeedbackToRule(rule: Partial<QuestionBankRule>): void {
-    (rule.questions as string[]).push('');
+    if (this.version === 2) {
+      (rule.questions as any[]).push(new Question());
+    } else {
+      (rule.questions as string[]).push('');
+    }
     this.projectService.nodeChanged();
   }
 

--- a/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html
+++ b/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html
@@ -24,12 +24,12 @@
     </div>
     <div *ngIf="componentContent.questionBank.version === 2">
       <mat-checkbox
-        [(ngModel)]="componentContent.questionBank.clickToAddEnabled"
+        [(ngModel)]="componentContent.questionBank.clickToUseEnabled"
         (ngModelChange)="saveChanges()"
         color="primary"
         i18n
       >
-        Enable Student Click To Add
+        Student can click questions to use in Peer Chat
       </mat-checkbox>
     </div>
     <div class="max-questions">

--- a/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html
+++ b/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html
@@ -29,7 +29,7 @@
         color="primary"
         i18n
       >
-        Student can click questions to use in Peer Chat
+        Student can select questions to use in Peer Chat
       </mat-checkbox>
     </div>
     <div class="max-questions">

--- a/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html
+++ b/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html
@@ -10,6 +10,28 @@
     </mat-checkbox>
   </div>
   <div *ngIf="componentContent.questionBank?.enabled">
+    <div class="custom-label">
+      <mat-form-field appearance="fill">
+        <mat-label i18n>Custom Label</mat-label>
+        <input
+          matInput
+          [(ngModel)]="componentContent.questionBank.label"
+          (ngModelChange)="inputChanged.next($event)"
+          placeholder="Question Bank"
+          i18n-placeholder
+        />
+      </mat-form-field>
+    </div>
+    <div *ngIf="componentContent.questionBank.version === 2">
+      <mat-checkbox
+        [(ngModel)]="componentContent.questionBank.clickToAddEnabled"
+        (ngModelChange)="saveChanges()"
+        color="primary"
+        i18n
+      >
+        Enable Student Click To Add
+      </mat-checkbox>
+    </div>
     <div class="max-questions">
       <mat-form-field appearance="fill">
         <mat-label i18n>Max Number of Questions</mat-label>
@@ -17,7 +39,7 @@
           matInput
           type="number"
           [(ngModel)]="componentContent.questionBank.maxQuestionsToShow"
-          (ngModelChange)="saveChanges()"
+          (ngModelChange)="inputChanged.next($event)"
         />
       </mat-form-field>
     </div>
@@ -40,7 +62,10 @@
       </edit-component-peer-grouping-tag>
     </div>
     <div class="feedback-rules">
-      <edit-question-bank-rules [feedbackRules]="componentContent.questionBank.rules">
+      <edit-question-bank-rules
+        [feedbackRules]="componentContent.questionBank.rules"
+        [version]="componentContent.questionBank.version"
+      >
       </edit-question-bank-rules>
     </div>
   </div>

--- a/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.scss
+++ b/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.scss
@@ -12,7 +12,7 @@
   margin-bottom: 16px;
 }
 
-.reference-component, .max-questions {
+.custom-label, .reference-component, .max-questions {
   margin-top: 16px;
 }
 

--- a/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.ts
+++ b/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { MatCheckboxChange } from '@angular/material/checkbox';
 import { QuestionBank } from '../../../assets/wise5/components/peerChat/peer-chat-question-bank/QuestionBank';
 import { TeacherProjectService } from '../../../assets/wise5/services/teacherProjectService';
+import { Subject, Subscription, debounceTime, distinctUntilChanged } from 'rxjs';
 
 @Component({
   selector: 'edit-question-bank',
@@ -11,16 +12,29 @@ import { TeacherProjectService } from '../../../assets/wise5/services/teacherPro
 export class EditQuestionBankComponent implements OnInit {
   allowedReferenceComponentTypes: string[] = ['OpenResponse'];
   @Input() componentContent: any;
+  inputChanged: Subject<string> = new Subject<string>();
+  subscriptions: Subscription = new Subscription();
 
   constructor(private projectService: TeacherProjectService) {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.subscriptions.add(
+      this.inputChanged.pipe(debounceTime(1000), distinctUntilChanged()).subscribe(() => {
+        this.projectService.nodeChanged();
+      })
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
 
   toggleComponent(event: MatCheckboxChange): void {
     if (this.componentContent.questionBank == null) {
       this.componentContent.questionBank = new QuestionBank({
         referenceComponent: {},
-        rules: []
+        rules: [],
+        version: 2
       });
     }
     this.componentContent.questionBank.enabled = event.checked;

--- a/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.ts
+++ b/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.ts
@@ -10,10 +10,10 @@ import { Subject, Subscription, debounceTime, distinctUntilChanged } from 'rxjs'
   styleUrls: ['./edit-question-bank.component.scss']
 })
 export class EditQuestionBankComponent implements OnInit {
-  allowedReferenceComponentTypes: string[] = ['OpenResponse'];
+  protected allowedReferenceComponentTypes: string[] = ['OpenResponse'];
   @Input() componentContent: any;
-  inputChanged: Subject<string> = new Subject<string>();
-  subscriptions: Subscription = new Subscription();
+  protected inputChanged: Subject<string> = new Subject<string>();
+  private subscriptions: Subscription = new Subscription();
 
   constructor(private projectService: TeacherProjectService) {}
 

--- a/src/assets/wise5/components/peerChat/peer-chat-chat-box/peer-chat-chat-box.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-chat-box/peer-chat-chat-box.component.html
@@ -11,6 +11,8 @@
   ></peer-chat-messages>
   <peer-chat-message-input
     *ngIf="isEnabled"
-    (onSubmit)="submit.emit($event)"
+    [messageText]="response"
+    (onSubmit)="submitResponse($event)"
+    (responseChangedEvent)="responseChanged($event)"
   ></peer-chat-message-input>
 </mat-card>

--- a/src/assets/wise5/components/peerChat/peer-chat-chat-box/peer-chat-chat-box.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-chat-box/peer-chat-chat-box.component.ts
@@ -11,7 +11,7 @@ export class PeerChatChatBoxComponent implements OnInit {
   @Input() isGrading: boolean = false;
   @Input() messages: PeerChatMessage[] = [];
   @Input() myWorkgroupId: number;
-  @Input() response: string;
+  @Input() response: string = '';
   @Input() workgroupInfos: any = {};
   workgroupInfosWithoutTeachers: any[];
 
@@ -42,7 +42,7 @@ export class PeerChatChatBoxComponent implements OnInit {
     this.response = '';
   }
 
-  protected responseChanged(event: string): void {
-    this.responseChangedEvent.emit(event);
+  protected responseChanged(response: string): void {
+    this.responseChangedEvent.emit(response);
   }
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-chat-box/peer-chat-chat-box.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-chat-box/peer-chat-chat-box.component.ts
@@ -7,29 +7,17 @@ import { PeerChatMessage } from '../PeerChatMessage';
   styleUrls: ['./peer-chat-chat-box.component.scss']
 })
 export class PeerChatChatBoxComponent implements OnInit {
-  @Input()
-  isEnabled: boolean = true;
-
-  @Input()
-  isGrading: boolean = false;
-
-  @Input()
-  messages: PeerChatMessage[] = [];
-
-  @Input()
-  myWorkgroupId: number;
-
-  @Input()
-  workgroupInfos: any = {};
-
+  @Input() isEnabled: boolean = true;
+  @Input() isGrading: boolean = false;
+  @Input() messages: PeerChatMessage[] = [];
+  @Input() myWorkgroupId: number;
+  @Input() response: string;
+  @Input() workgroupInfos: any = {};
   workgroupInfosWithoutTeachers: any[];
 
-  @Output()
-  deleteClickedEvent: EventEmitter<PeerChatMessage> = new EventEmitter<PeerChatMessage>();
-
-  @Output('onSubmit')
-  submit: EventEmitter<string> = new EventEmitter<string>();
-
+  @Output() deleteClickedEvent: EventEmitter<PeerChatMessage> = new EventEmitter<PeerChatMessage>();
+  @Output() responseChangedEvent: EventEmitter<string> = new EventEmitter<string>();
+  @Output('onSubmit') submit: EventEmitter<string> = new EventEmitter<string>();
   @Output()
   undeleteClickedEvent: EventEmitter<PeerChatMessage> = new EventEmitter<PeerChatMessage>();
 
@@ -47,5 +35,14 @@ export class PeerChatChatBoxComponent implements OnInit {
 
   protected undeleteClicked(peerChatMessage: PeerChatMessage): void {
     this.undeleteClickedEvent.emit(peerChatMessage);
+  }
+
+  protected submitResponse(event: string): void {
+    this.submit.emit(event);
+    this.response = '';
+  }
+
+  protected responseChanged(event: string): void {
+    this.responseChangedEvent.emit(event);
   }
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.html
@@ -14,7 +14,9 @@
     >
       <peer-chat-question-bank
         *ngIf="componentContent.questionBank?.enabled"
+        [content]="componentContent"
         [displayedQuestionBankRules]="questionBankRules"
+        [questionIdsUsed]="questionIdsUsed"
       ></peer-chat-question-bank>
     </div>
     <div

--- a/src/assets/wise5/components/peerChat/peer-chat-message-input/peer-chat-message-input.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-message-input/peer-chat-message-input.component.html
@@ -5,6 +5,7 @@
       cdkTextareaAutosize
       placeholder="Add response..."
       i18n-placeholder
+      (focus)="onFocus($event)"
       [(ngModel)]="messageText"
       (ngModelChange)="responseChanged()"
       (keypress)="keyPressed($event)"

--- a/src/assets/wise5/components/peerChat/peer-chat-message-input/peer-chat-message-input.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-message-input/peer-chat-message-input.component.ts
@@ -1,20 +1,24 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
 @Component({
   selector: 'peer-chat-message-input',
   templateUrl: './peer-chat-message-input.component.html'
 })
 export class PeerChatMessageInputComponent implements OnInit {
-  @Output('onSubmit')
-  submit: EventEmitter<string> = new EventEmitter<string>();
-
   isSubmitEnabled: boolean = false;
-  messageText: string;
+  @Input() messageText: string;
+  @Output() responseChangedEvent: EventEmitter<string> = new EventEmitter<string>();
+  @Output('onSubmit') submit: EventEmitter<string> = new EventEmitter<string>();
 
   ngOnInit(): void {}
 
+  ngOnChanges(): void {
+    this.responseChanged();
+  }
+
   responseChanged(): void {
-    this.isSubmitEnabled = this.messageText.length > 0;
+    this.isSubmitEnabled = this.messageText?.length > 0;
+    this.responseChangedEvent.emit(this.messageText);
   }
 
   keyPressed(event: any): void {

--- a/src/assets/wise5/components/peerChat/peer-chat-message-input/peer-chat-message-input.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-message-input/peer-chat-message-input.component.ts
@@ -5,7 +5,7 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
   templateUrl: './peer-chat-message-input.component.html'
 })
 export class PeerChatMessageInputComponent implements OnInit {
-  isSubmitEnabled: boolean = false;
+  protected isSubmitEnabled: boolean = false;
   @Input() messageText: string = '';
   @Output() responseChangedEvent: EventEmitter<string> = new EventEmitter<string>();
   @Output('onSubmit') submit: EventEmitter<string> = new EventEmitter<string>();
@@ -16,12 +16,12 @@ export class PeerChatMessageInputComponent implements OnInit {
     this.responseChanged();
   }
 
-  responseChanged(): void {
+  protected responseChanged(): void {
     this.isSubmitEnabled = this.messageText?.length > 0;
     this.responseChangedEvent.emit(this.messageText);
   }
 
-  keyPressed(event: any): void {
+  protected keyPressed(event: any): void {
     if (event.keyCode === 13) {
       event.preventDefault();
       if (this.isSubmitEnabled) {
@@ -30,17 +30,17 @@ export class PeerChatMessageInputComponent implements OnInit {
     }
   }
 
-  submitResponse(): void {
+  protected submitResponse(): void {
     this.submit.emit(this.messageText);
     this.messageText = '';
     this.isSubmitEnabled = false;
   }
 
-  onFocus(event: any): void {
+  protected onFocus(event: any): void {
     this.placeCursorAtEndOfMessageText(event);
   }
 
-  placeCursorAtEndOfMessageText(event: any): void {
+  private placeCursorAtEndOfMessageText(event: any): void {
     const messageLength = this.messageText.length;
     event.srcElement.selectionStart = messageLength;
     event.srcElement.selectionEnd = messageLength;

--- a/src/assets/wise5/components/peerChat/peer-chat-message-input/peer-chat-message-input.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-message-input/peer-chat-message-input.component.ts
@@ -6,7 +6,7 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 })
 export class PeerChatMessageInputComponent implements OnInit {
   isSubmitEnabled: boolean = false;
-  @Input() messageText: string;
+  @Input() messageText: string = '';
   @Output() responseChangedEvent: EventEmitter<string> = new EventEmitter<string>();
   @Output('onSubmit') submit: EventEmitter<string> = new EventEmitter<string>();
 
@@ -34,5 +34,15 @@ export class PeerChatMessageInputComponent implements OnInit {
     this.submit.emit(this.messageText);
     this.messageText = '';
     this.isSubmitEnabled = false;
+  }
+
+  onFocus(event: any): void {
+    this.placeCursorAtEndOfMessageText(event);
+  }
+
+  placeCursorAtEndOfMessageText(event: any): void {
+    const messageLength = this.messageText.length;
+    event.srcElement.selectionStart = messageLength;
+    event.srcElement.selectionEnd = messageLength;
   }
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/Question.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/Question.ts
@@ -1,0 +1,10 @@
+import { generateRandomKey } from '../../../common/string/string';
+
+export class Question {
+  id: string;
+  text: string = '';
+
+  constructor() {
+    this.id = generateRandomKey();
+  }
+}

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/QuestionBank.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/QuestionBank.ts
@@ -2,7 +2,7 @@ import { ReferenceComponentRules } from '../../common/ReferenceComponentRules';
 import { QuestionBankRule } from './QuestionBankRule';
 
 export class QuestionBank extends ReferenceComponentRules {
-  clickToAddEnabled: boolean;
+  clickToUseEnabled: boolean;
   label: string;
   maxQuestionsToShow: number;
   rules: QuestionBankRule[];

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/QuestionBank.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/QuestionBank.ts
@@ -2,6 +2,9 @@ import { ReferenceComponentRules } from '../../common/ReferenceComponentRules';
 import { QuestionBankRule } from './QuestionBankRule';
 
 export class QuestionBank extends ReferenceComponentRules {
+  clickToAddEnabled: boolean;
+  label: string;
   maxQuestionsToShow: number;
   rules: QuestionBankRule[];
+  version: number;
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/QuestionBankRule.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/QuestionBankRule.ts
@@ -1,5 +1,6 @@
 import { FeedbackRule } from '../../common/feedbackRule/FeedbackRule';
+import { Question } from './Question';
 
 export class QuestionBankRule extends FeedbackRule {
-  questions: string[];
+  questions: (string | Question)[];
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.html
@@ -1,12 +1,58 @@
 <mat-card appearance="outlined" class="mat-elevation-z0 primary-bg">
-  <div class="dark-theme mat-subtitle-2" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="4px">
+  <div
+    class="dark-theme mat-subtitle-2"
+    fxLayout="row"
+    fxLayoutAlign="start center"
+    fxLayoutGap="4px"
+  >
     <mat-icon class="mat-30">help</mat-icon>
-    <span i18n>Question Bank</span>
+    <ng-container
+      *ngIf="
+        content.questionBank.label != null && content.questionBank.label !== '';
+        then customLabel;
+        else defaultLabel
+      "
+    ></ng-container>
+    <ng-template #customLabel
+      ><span>{{ content.questionBank.label }}</span></ng-template
+    >
+    <ng-template #defaultLabel><span i18n>Question Bank</span></ng-template>
   </div>
   <mat-card-content class="app-bg-bg">
     <ul>
       <li *ngFor="let question of questions" class="question">
-        {{ question }}
+        <ng-container
+          *ngIf="content.questionBank.version === 2; then version2; else version1"
+        ></ng-container>
+        <ng-template #version2>
+          <ng-container
+            *ngIf="
+              content.questionBank.clickToAddEnabled;
+              then version2ClickToAdd;
+              else version2Default
+            "
+          ></ng-container>
+          <ng-template #version2ClickToAdd>
+            <mat-checkbox
+              color="primary"
+              [disabled]="true"
+              [checked]="questionIdsUsed.includes(question.id)"
+            ></mat-checkbox>
+            <button
+              *ngIf="question.text != null"
+              mat-stroked-button
+              (click)="questionClicked(question)"
+            >
+              {{ question.text }}
+            </button>
+          </ng-template>
+          <ng-template #version2Default>
+            {{ question.text }}
+          </ng-template>
+        </ng-template>
+        <ng-template #version1>
+          {{ question }}
+        </ng-template>
       </li>
     </ul>
   </mat-card-content>

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.html
@@ -44,10 +44,12 @@
               >
                 {{ question.text }}
               </button>
-              <ng-container *ngIf="questionIdsUsed.includes(question.id)">
-                <mat-icon class="secondary-text"> check_circle </mat-icon>
-                <span class="cdk-visually-hidden" i18n>Used in chat</span>
-              </ng-container>
+              <div class="question-used-indicator">
+                <ng-container *ngIf="questionIdsUsed.includes(question.id)">
+                  <mat-icon class="secondary-text"> check_circle </mat-icon>
+                  <span class="cdk-visually-hidden" i18n>Used in chat</span>
+                </ng-container>
+              </div>
             </div>
           </ng-template>
           <ng-template #version2Default>

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.html
@@ -18,9 +18,9 @@
     >
     <ng-template #defaultLabel><span i18n>Question Bank</span></ng-template>
   </div>
-  <mat-card-content class="app-bg-bg">
+  <div class="questions app-bg-bg">
     <ul>
-      <li *ngFor="let question of questions" class="question">
+      <li *ngFor="let question of questions">
         <ng-container
           *ngIf="content.questionBank.version === 2; then version2; else version1"
         ></ng-container>
@@ -33,18 +33,23 @@
             "
           ></ng-container>
           <ng-template #version2ClickToAdd>
-            <mat-checkbox
-              color="primary"
-              [disabled]="true"
-              [checked]="questionIdsUsed.includes(question.id)"
-            ></mat-checkbox>
-            <button
-              *ngIf="question.text != null"
-              mat-stroked-button
-              (click)="questionClicked(question)"
-            >
-              {{ question.text }}
-            </button>
+            <div fxLayoutAlign="start center" fxLayoutGap="8px">
+              <button
+                *ngIf="question.text != null"
+                mat-stroked-button
+                class="question-button"
+                (click)="questionClicked(question)"
+                matTooltip="Add to chat"
+                matTooltipPosition="after"
+                i18n-matTooltip
+              >
+                {{ question.text }}
+              </button>
+              <ng-container *ngIf="questionIdsUsed.includes(question.id)">
+                <mat-icon class="secondary-text"> check_circle </mat-icon>
+                <span class="cdk-visually-hidden" i18n>Used in chat</span>
+              </ng-container>
+            </div>
           </ng-template>
           <ng-template #version2Default>
             {{ question.text }}
@@ -55,5 +60,5 @@
         </ng-template>
       </li>
     </ul>
-  </mat-card-content>
+  </div>
 </mat-card>

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.html
@@ -27,7 +27,7 @@
         <ng-template #version2>
           <ng-container
             *ngIf="
-              content.questionBank.clickToAddEnabled;
+              content.questionBank.clickToUseEnabled;
               then version2ClickToAdd;
               else version2Default
             "
@@ -35,10 +35,9 @@
           <ng-template #version2ClickToAdd>
             <div fxLayoutAlign="start center" fxLayoutGap="8px">
               <button
-                *ngIf="question.text != null"
                 mat-stroked-button
                 class="question-button"
-                (click)="questionClicked(question)"
+                (click)="useQuestion(question)"
                 matTooltip="Add to chat"
                 matTooltipPosition="after"
                 i18n-matTooltip

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.scss
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.scss
@@ -31,3 +31,8 @@ li {
     margin-bottom: 0;
   }
 }
+
+.question-used-indicator {
+  width: 40px;
+  height: 24px;
+}

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.scss
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.scss
@@ -4,19 +4,22 @@
   padding: 8px;
 }
 
-/* TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version. */
-mat-card-content {
+.questions {
   margin-top: 8px;
   padding: 8px;
   border-radius: $button-border-radius;
   overflow: auto;
 }
 
-.question {
-  font-style: italic;
+.question-button {
+  text-transform: none;
+  text-align: start;
+  min-height: 36px;
+  height: auto;
 }
 
 ul {
+  margin: 0;
   padding: 0;
   list-style-type: none;
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.spec.ts
@@ -12,6 +12,7 @@ import { of } from 'rxjs';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
+import { QuestionBankService } from './questionBank.service';
 
 let component: PeerChatQuestionBankComponent;
 let fixture: ComponentFixture<PeerChatQuestionBankComponent>;
@@ -32,7 +33,8 @@ describe('PeerChatQuestionBankComponent', () => {
         MatIconModule,
         StudentTeacherCommonServicesModule
       ],
-      declarations: [PeerChatQuestionBankComponent]
+      declarations: [PeerChatQuestionBankComponent],
+      providers: [QuestionBankService]
     }).compileComponents();
     fixture = TestBed.createComponent(PeerChatQuestionBankComponent);
     peerGroupService = TestBed.inject(PeerGroupService);

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
@@ -14,6 +14,8 @@ import { concatMap, map } from 'rxjs/operators';
 import { PeerGroup } from '../PeerGroup';
 import { QuestionBankContent } from './QuestionBankContent';
 import { copy } from '../../../common/object/object';
+import { Question } from './Question';
+import { QuestionBankService } from './questionBank.service';
 
 @Component({
   selector: 'peer-chat-question-bank',
@@ -24,9 +26,15 @@ export class PeerChatQuestionBankComponent implements OnInit {
   @Input() content: QuestionBankContent;
   @Input() displayedQuestionBankRules: QuestionBankRule[];
   @Output() displayedQuestionBankRulesChange = new EventEmitter<QuestionBankRule[]>();
-  questions: string[];
+  @Output() questionClickedEvent = new EventEmitter<string>();
+  questions: (string | Question)[];
+  @Input() questionIdsUsed: string[] = [];
 
-  constructor(private peerGroupService: PeerGroupService, private projectService: ProjectService) {}
+  constructor(
+    private peerGroupService: PeerGroupService,
+    private projectService: ProjectService,
+    private questionBankService: QuestionBankService
+  ) {}
 
   ngOnInit(): void {
     if (this.displayedQuestionBankRules == null) {
@@ -40,6 +48,13 @@ export class PeerChatQuestionBankComponent implements OnInit {
     } else {
       this.setQuestions(this.displayedQuestionBankRules);
     }
+    this.subscribeToQuestionUsed();
+  }
+
+  private subscribeToQuestionUsed(): void {
+    this.questionBankService.questionUsed$.subscribe((question: Question) => {
+      this.questionIdsUsed.push(question.id);
+    });
   }
 
   private getReferenceComponent(questionBank: QuestionBank): WISEComponent {
@@ -130,5 +145,9 @@ export class PeerChatQuestionBankComponent implements OnInit {
 
   private setQuestions(rules: QuestionBankRule[]): void {
     this.questions = rules.flatMap((rule) => rule.questions);
+  }
+
+  protected questionClicked(question: string): void {
+    this.questionClickedEvent.emit(question);
   }
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
@@ -27,8 +27,8 @@ export class PeerChatQuestionBankComponent implements OnInit {
   @Input() displayedQuestionBankRules: QuestionBankRule[];
   @Output() displayedQuestionBankRulesChange = new EventEmitter<QuestionBankRule[]>();
   @Output() questionClickedEvent = new EventEmitter<string>();
-  questions: (string | Question)[];
   @Input() questionIdsUsed: string[] = [];
+  questions: (string | Question)[];
 
   constructor(
     private peerGroupService: PeerGroupService,

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.ts
@@ -26,9 +26,9 @@ export class PeerChatQuestionBankComponent implements OnInit {
   @Input() content: QuestionBankContent;
   @Input() displayedQuestionBankRules: QuestionBankRule[];
   @Output() displayedQuestionBankRulesChange = new EventEmitter<QuestionBankRule[]>();
-  @Output() questionClickedEvent = new EventEmitter<string>();
   @Input() questionIdsUsed: string[] = [];
   questions: (string | Question)[];
+  @Output() useQuestionEvent = new EventEmitter<string>();
 
   constructor(
     private peerGroupService: PeerGroupService,
@@ -147,7 +147,7 @@ export class PeerChatQuestionBankComponent implements OnInit {
     this.questions = rules.flatMap((rule) => rule.questions);
   }
 
-  protected questionClicked(question: string): void {
-    this.questionClickedEvent.emit(question);
+  protected useQuestion(question: string): void {
+    this.useQuestionEvent.emit(question);
   }
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/question-bank-helper.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/question-bank-helper.ts
@@ -1,0 +1,6 @@
+export function getQuestionIdsUsed(componentStates: any[], workgroupId: number): string[] {
+  return componentStates
+    .filter((componentState) => componentState.workgroupId === workgroupId)
+    .filter((componentState) => componentState.studentData.questionId != null)
+    .map((componentState) => componentState.studentData.questionId);
+}

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/question-bank-helper.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/question-bank-helper.ts
@@ -1,6 +1,8 @@
 export function getQuestionIdsUsed(componentStates: any[], workgroupId: number): string[] {
   return componentStates
-    .filter((componentState) => componentState.workgroupId === workgroupId)
-    .filter((componentState) => componentState.studentData.questionId != null)
+    .filter(
+      (componentState) =>
+        componentState.workgroupId === workgroupId && componentState.studentData.questionId != null
+    )
     .map((componentState) => componentState.studentData.questionId);
 }

--- a/src/assets/wise5/components/peerChat/peer-chat-question-bank/questionBank.service.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-question-bank/questionBank.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+import { Question } from './Question';
+
+@Injectable()
+export class QuestionBankService {
+  private questionUsedSource: Subject<Question> = new Subject<Question>();
+  public questionUsed$: Observable<Question> = this.questionUsedSource.asObservable();
+
+  questionUsed(question: Question): void {
+    this.questionUsedSource.next(question);
+  }
+}

--- a/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.html
@@ -9,7 +9,9 @@
     >
       <peer-chat-question-bank
         *ngIf="componentContent.questionBank?.enabled"
+        [content]="componentContent"
         [displayedQuestionBankRules]="questionBankRules"
+        [questionIdsUsed]="questionIdsUsed"
       ></peer-chat-question-bank>
     </div>
     <div fxFlex fxFlex.gt-md="60" fxFlexOrder="2" fxFlexOrder.gt-md="1">

--- a/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.ts
@@ -12,6 +12,7 @@ import { NodeService } from '../../../services/nodeService';
 import { FeedbackRule } from '../../common/feedbackRule/FeedbackRule';
 import { QuestionBankRule } from '../peer-chat-question-bank/QuestionBankRule';
 import { forkJoin, Observable } from 'rxjs';
+import { getQuestionIdsUsed } from '../peer-chat-question-bank/question-bank-helper';
 
 @Component({
   selector: 'peer-chat-show-work',
@@ -102,7 +103,7 @@ export class PeerChatShowWorkComponent extends ComponentShowWorkDirective {
     this.peerChatService.setPeerChatMessages(this.peerChatMessages, componentStates);
     this.dynamicPrompt = this.getDynamicPrompt(componentStates, this.workgroupId);
     this.questionBankRules = this.getQuestionBankRule(componentStates, this.workgroupId);
-    this.questionIdsUsed = this.getQuestionIdsUsed(componentStates, this.workgroupId);
+    this.questionIdsUsed = getQuestionIdsUsed(componentStates, this.workgroupId);
   }
 
   private getDynamicPrompt(componentStates: any[], workgroupId: number): FeedbackRule {
@@ -132,13 +133,6 @@ export class PeerChatShowWorkComponent extends ComponentShowWorkDirective {
       }
     }
     return null;
-  }
-
-  private getQuestionIdsUsed(componentStates: any[], workgroupId: number): string[] {
-    return componentStates
-      .filter((componentState) => componentState.workgroupId === workgroupId)
-      .filter((componentState) => componentState.studentData.questionId != null)
-      .map((componentState) => componentState.studentData.questionId);
   }
 
   private addWorkgroupIdsFromPeerChatMessages(

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html
@@ -22,7 +22,7 @@
         *ngIf="questionBankContent.questionBank?.enabled"
         [content]="questionBankContent"
         [(displayedQuestionBankRules)]="displayedQuestionBankRules"
-        (questionClickedEvent)="questionClicked($event)"
+        (useQuestionEvent)="useQuestion($event)"
         [questionIdsUsed]="questionIdsUsed"
       ></peer-chat-question-bank>
     </div>

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html
@@ -31,9 +31,9 @@
         [messages]="peerChatMessages"
         [myWorkgroupId]="myWorkgroupId"
         [response]="response"
-        (responseChangedEvent)="responseChanged($event)"
         [workgroupInfos]="peerChatWorkgroupInfos"
         (onSubmit)="submitStudentResponse($event)"
+        (responseChangedEvent)="responseChanged($event)"
       ></peer-chat-chat-box>
     </div>
   </div>

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html
@@ -22,12 +22,16 @@
         *ngIf="questionBankContent.questionBank?.enabled"
         [content]="questionBankContent"
         [(displayedQuestionBankRules)]="displayedQuestionBankRules"
+        (questionClickedEvent)="questionClicked($event)"
+        [questionIdsUsed]="questionIdsUsed"
       ></peer-chat-question-bank>
     </div>
     <div fxFlex fxFlex.gt-sm="60" fxFlexOrder="2" fxFlexOrder.gt-sm="1">
       <peer-chat-chat-box
         [messages]="peerChatMessages"
         [myWorkgroupId]="myWorkgroupId"
+        [response]="response"
+        (responseChangedEvent)="responseChanged($event)"
         [workgroupInfos]="peerChatWorkgroupInfos"
         (onSubmit)="submitStudentResponse($event)"
       ></peer-chat-chat-box>

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
@@ -290,7 +290,7 @@ export class PeerChatStudentComponent extends ComponentStudent {
     this.dynamicPrompt = feedbackRule;
   }
 
-  protected questionClicked(question: Question): void {
+  protected useQuestion(question: Question): void {
     this.question = question;
     this.response = question.text;
   }

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
@@ -291,8 +291,15 @@ export class PeerChatStudentComponent extends ComponentStudent {
   }
 
   protected useQuestion(question: Question): void {
-    this.question = question;
-    this.response = question.text;
+    if (
+      this.response === '' ||
+      confirm(
+        $localize`Are you sure you want to put this question into your input box? The question will overwrite the current text in your input box.`
+      )
+    ) {
+      this.question = question;
+      this.response = question.text;
+    }
   }
 
   protected responseChanged(response: string): void {

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
@@ -288,7 +288,7 @@ export class PeerChatStudentComponent extends ComponentStudent {
     if (
       this.response === '' ||
       confirm(
-        $localize`Are you sure you want to replace the current text in your chat response with this text?`
+        $localize`Are you sure you want to replace the current text in your response input box with this text?`
       )
     ) {
       this.question = question;

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
@@ -21,8 +21,8 @@ import { PeerChatMessage } from '../PeerChatMessage';
 import { PeerChatService } from '../peerChatService';
 import { PeerGroup } from '../PeerGroup';
 import { Question } from '../peer-chat-question-bank/Question';
-import { ComponentState } from '../../../../../app/domain/componentState';
 import { QuestionBankService } from '../peer-chat-question-bank/questionBank.service';
+import { getQuestionIdsUsed } from '../peer-chat-question-bank/question-bank-helper';
 
 @Component({
   selector: 'peer-chat-student',
@@ -124,7 +124,7 @@ export class PeerChatStudentComponent extends ComponentStudent {
             ]).subscribe(([componentStates, annotations]) => {
               this.setPeerChatMessages(componentStates);
               this.peerChatService.processIsDeletedAnnotations(annotations, this.peerChatMessages);
-              this.questionIdsUsed = this.getQuestionIdsUsed(componentStates);
+              this.questionIdsUsed = getQuestionIdsUsed(componentStates, this.myWorkgroupId);
             });
           }
         },
@@ -132,12 +132,6 @@ export class PeerChatStudentComponent extends ComponentStudent {
           this.isPeerChatWorkgroupsResponseReceived = true;
         }
       );
-  }
-
-  private getQuestionIdsUsed(componentStates: ComponentState[]): string[] {
-    return componentStates
-      .filter((componentState) => componentState.studentData.questionId != null)
-      .map((componentState) => componentState.studentData.questionId);
   }
 
   private addTeacherWorkgroupIds(workgroupIds: number[]): void {

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
@@ -288,7 +288,7 @@ export class PeerChatStudentComponent extends ComponentStudent {
     if (
       this.response === '' ||
       confirm(
-        $localize`Are you sure you want to put this question into your input box? The question will overwrite the current text in your input box.`
+        $localize`Are you sure you want to replace the current text in your chat response with this text?`
       )
     ) {
       this.question = question;

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts
@@ -44,7 +44,7 @@ export class PeerChatStudentComponent extends ComponentStudent {
   questionBankContent: QuestionBankContent;
   questionIdsUsed: string[] = [];
   requestTimeout: number = 10000;
-  response: string;
+  response: string = '';
 
   constructor(
     protected annotationService: AnnotationService,
@@ -295,8 +295,9 @@ export class PeerChatStudentComponent extends ComponentStudent {
     this.response = question.text;
   }
 
-  protected responseChanged(event: any): void {
-    if (event?.length < 2) {
+  protected responseChanged(response: string): void {
+    this.response = response;
+    if (response.length < 2) {
       this.question = null;
     }
   }

--- a/src/assets/wise5/components/peerChat/peer-chat.module.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat.module.ts
@@ -6,6 +6,7 @@ import { PeerChatMessagesComponent } from './peer-chat-messages/peer-chat-messag
 import { PeerChatQuestionBankComponent } from './peer-chat-question-bank/peer-chat-question-bank.component';
 import { PeerChatMembersComponent } from './peer-chat-members/peer-chat-members.component';
 import { StudentTeacherCommonModule } from '../../../../app/student-teacher-common.module';
+import { QuestionBankService } from './peer-chat-question-bank/questionBank.service';
 
 @NgModule({
   declarations: [
@@ -24,6 +25,7 @@ import { StudentTeacherCommonModule } from '../../../../app/student-teacher-comm
     PeerChatMessageInputComponent,
     PeerChatMessagesComponent,
     PeerChatQuestionBankComponent
-  ]
+  ],
+  providers: [QuestionBankService]
 })
 export class PeerChatModule {}

--- a/src/assets/wise5/components/peerChat/peerChatService.ts
+++ b/src/assets/wise5/components/peerChat/peerChatService.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ConfigService } from '../../services/configService';

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1366,8 +1366,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="181966d8a82791ada532d8af7b95068102acd3f7" datatype="html">
-        <source> Enable Student Click To Add </source>
+      <trans-unit id="26588ea759dfa38ebc47e7546f2e2ffd4946d28c" datatype="html">
+        <source> Student can click questions to use in Peer Chat </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html</context>
           <context context-type="linenumber">31,33</context>
@@ -19552,11 +19552,11 @@ If this problem continues, let your teacher know and move on to the next activit
         <source> This Peer Chat activity is not yet available. Please check back later or wait for a notification to return. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-grading/peer-chat-grading.component.html</context>
-          <context context-type="linenumber">38,41</context>
+          <context context-type="linenumber">40,43</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-show-work/peer-chat-show-work.component.html</context>
-          <context context-type="linenumber">25,28</context>
+          <context context-type="linenumber">27,30</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.html</context>
@@ -19574,7 +19574,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source> Send </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-message-input/peer-chat-message-input.component.html</context>
-          <context context-type="linenumber">20,22</context>
+          <context context-type="linenumber">21,23</context>
         </context-group>
       </trans-unit>
       <trans-unit id="81a5df0547de12ef2c96486e6618669b3bdd704f" datatype="html">
@@ -19595,14 +19595,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Add to chat</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">41</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4a01d2b686a9af6d84795b6925eb442375af818d" datatype="html">
         <source>Used in chat</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="225777916942997365" datatype="html">
@@ -19610,6 +19610,13 @@ If this problem continues, let your teacher know and move on to the next activit
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts</context>
           <context context-type="linenumber">247</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3115733598954818213" datatype="html">
+        <source>Are you sure you want to put this question into your input box? The question will overwrite the current text in your input box.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts</context>
+          <context context-type="linenumber">297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6310961320545154131" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1366,8 +1366,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="26588ea759dfa38ebc47e7546f2e2ffd4946d28c" datatype="html">
-        <source> Student can click questions to use in Peer Chat </source>
+      <trans-unit id="514cc7de9c98f15069ad4e2e9ed5632bbf69516e" datatype="html">
+        <source> Student can select questions to use in Peer Chat </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html</context>
           <context context-type="linenumber">31,33</context>
@@ -19609,14 +19609,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>You have new chat messages</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts</context>
-          <context context-type="linenumber">247</context>
+          <context context-type="linenumber">241</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3115733598954818213" datatype="html">
-        <source>Are you sure you want to put this question into your input box? The question will overwrite the current text in your input box.</source>
+      <trans-unit id="307281951617783008" datatype="html">
+        <source>Are you sure you want to replace the current text in your chat response with this text?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts</context>
-          <context context-type="linenumber">297</context>
+          <context context-type="linenumber">291</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6310961320545154131" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -19602,7 +19602,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Used in chat</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.html</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">50</context>
         </context-group>
       </trans-unit>
       <trans-unit id="225777916942997365" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -19591,6 +19591,20 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">38</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1626c029c15e27660f33c247cda2b22cdbaf42b1" datatype="html">
+        <source>Add to chat</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4a01d2b686a9af6d84795b6925eb442375af818d" datatype="html">
+        <source>Used in chat</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="225777916942997365" datatype="html">
         <source>You have new chat messages</source>
         <context-group purpose="location">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1184,7 +1184,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank-rules/edit-question-bank-rules.component.html</context>
-          <context context-type="linenumber">102</context>
+          <context context-type="linenumber">114</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.html</context>
@@ -1199,7 +1199,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank-rules/edit-question-bank-rules.component.html</context>
-          <context context-type="linenumber">113</context>
+          <context context-type="linenumber">125</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.html</context>
@@ -1214,7 +1214,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank-rules/edit-question-bank-rules.component.html</context>
-          <context context-type="linenumber">123</context>
+          <context context-type="linenumber">135</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.html</context>
@@ -1229,7 +1229,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank-rules/edit-question-bank-rules.component.html</context>
-          <context context-type="linenumber">138</context>
+          <context context-type="linenumber">150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="703814089292012107" datatype="html">
@@ -1254,7 +1254,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">52</context>
         </context-group>
       </trans-unit>
       <trans-unit id="865b518ad09c5909b84301e6fd1443519f02795c" datatype="html">
@@ -1310,35 +1310,35 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Delete question</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank-rules/edit-question-bank-rules.component.html</context>
-          <context context-type="linenumber">77</context>
+          <context context-type="linenumber">89</context>
         </context-group>
       </trans-unit>
       <trans-unit id="567f8db555f6ade1b92a70eb9eb1255b4c4e05ea" datatype="html">
         <source>Add new question</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank-rules/edit-question-bank-rules.component.html</context>
-          <context context-type="linenumber">88</context>
+          <context context-type="linenumber">100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cc5683cb2acba6dff5d3498acc29fbb9d8af3622" datatype="html">
         <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon&gt;"/>add_circle<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank-rules/edit-question-bank-rules.component.html</context>
-          <context context-type="linenumber">94</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5572453036493787415" datatype="html">
         <source>Are you sure you want to delete this question rule?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank-rules/edit-question-bank-rules.component.ts</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2774207815872923451" datatype="html">
         <source>Are you sure you want to delete this question?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank-rules/edit-question-bank-rules.component.ts</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">48</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e1c75fb9f9b69b490d00a4a741fabfb52080d9b1" datatype="html">
@@ -1348,11 +1348,36 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">8,10</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="2078bbaa8fdb0d6ea414fd06ee2f4802e426fd4c" datatype="html">
+        <source>Custom Label</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="69890220efa72f501c096cd863f5f9dcf16fd321" datatype="html">
+        <source>Question Bank</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="181966d8a82791ada532d8af7b95068102acd3f7" datatype="html">
+        <source> Enable Student Click To Add </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html</context>
+          <context context-type="linenumber">31,33</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="896589cbf4473a405f00a4068706375829758d92" datatype="html">
         <source>Max Number of Questions</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e8c21747e8604f974b3ed6ecf6089306b7cc0aae" datatype="html">
@@ -19566,18 +19591,11 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">38</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="69890220efa72f501c096cd863f5f9dcf16fd321" datatype="html">
-        <source>Question Bank</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-question-bank/peer-chat-question-bank.component.html</context>
-          <context context-type="linenumber">4</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="225777916942997365" datatype="html">
         <source>You have new chat messages</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts</context>
-          <context context-type="linenumber">228</context>
+          <context context-type="linenumber">247</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6310961320545154131" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -19612,8 +19612,8 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">241</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="307281951617783008" datatype="html">
-        <source>Are you sure you want to replace the current text in your chat response with this text?</source>
+      <trans-unit id="8602610569031787041" datatype="html">
+        <source>Are you sure you want to replace the current text in your response input box with this text?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.ts</context>
           <context context-type="linenumber">291</context>


### PR DESCRIPTION
## Changes

- Allow students to click on questions in the question bank to add the question text into the response input. The student can then modify the question if they would like before they submit it.
- Allow authors to enable and disable this feature
- Allow authors to change the name of the question bank
- After a student uses a question, indicate that the question has been used
- Store which question was used in the student response
- When questions are authored, they should now have a unique id
  - New Question Bank content is marked as version 2 which contains question objects that have an id and text field
  - Old Question Bank content contains question strings

## Test

As a teacher
1. Create a new Peer Chat component
2. Enable the Question Bank in the Peer Chat
3. Set a Custom Label for the Question Bank
4. Enable Student Click To Add
5. Set a Reference Component
6. Set Grouping Logic
7. Add some Question Bank Rules

As a student
1. Go to the Peer Chat step and make sure the Question Bank shows up and the questions are clickable
2. Click on a question to add it to the student response input
3. Click "Send" to submit the response. The question in the question bank should show that it has been used.
4. Click on a question to add it to the student response input
5. Delete the question from the student response input. Type something else and submit the response. The question should not show that it has been used.
6. Leave the step
7. Go back to the Peer Chat step. The questions should show which ones have been used.

Make sure the old Peer Chat Question Bank still works as before for teacher and student.

Closes #1413 