### PR TITLE
feat(FeedbackRule): isLowestWorkgroupIdInPeerGroup token

### DIFF
--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.spec.ts
@@ -19,6 +19,7 @@ describe('FeedbackRuleEvaluator', () => {
   beforeEach(() => {
     evaluator = new FeedbackRuleEvaluator(
       new FeedbackRuleComponent(DEFAULT_FEEDBACK_RULES, 5, true),
+      null,
       null
     );
   });
@@ -78,6 +79,7 @@ function matchRule_hasKIScore() {
     beforeEach(() => {
       evaluator = new FeedbackRuleEvaluator(
         new FeedbackRuleComponent(HAS_KI_SCORE_FEEDBACK_RULES, 5, true),
+        null,
         null
       );
     });
@@ -123,6 +125,7 @@ function matchRule_ideaCount() {
       ];
       evaluator = new FeedbackRuleEvaluator(
         new FeedbackRuleComponent(feedbackRules, 5, true),
+        null,
         null
       );
     });
@@ -147,7 +150,7 @@ function matchNoRule_ReturnDefault() {
 function matchNoRule_NoDefaultFeedbackAuthored_ReturnApplicationDefault() {
   it(`should return application default rule when no rule is matched and no default is
       authored`, () => {
-    evaluator = new FeedbackRuleEvaluator(new FeedbackRuleComponent([], 5, true), null);
+    evaluator = new FeedbackRuleEvaluator(new FeedbackRuleComponent([], 5, true), null, null);
     expectFeedback(['idea10', 'idea11'], [KI_SCORE_1], 1, evaluator.defaultFeedback);
   });
 }

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.ts
@@ -1,6 +1,8 @@
 import { Component } from '../../../common/Component';
+import { ConfigService } from '../../../services/configService';
 import { ConstraintService } from '../../../services/constraintService';
 import { FeedbackRuleComponent } from '../../feedbackRule/FeedbackRuleComponent';
+import { PeerGroup } from '../../peerChat/PeerGroup';
 import { CRaterResponse } from '../cRater/CRaterResponse';
 import { FeedbackRule } from './FeedbackRule';
 import { FeedbackRuleExpression } from './FeedbackRuleExpression';
@@ -12,12 +14,14 @@ export class FeedbackRuleEvaluator<T extends Response[]> {
   defaultFeedback = $localize`Thanks for submitting your response.`;
   protected factory;
   protected referenceComponent: Component;
+  protected peerGroup: PeerGroup;
 
   constructor(
     protected component: FeedbackRuleComponent,
+    protected configService: ConfigService,
     protected constraintService: ConstraintService
   ) {
-    this.factory = new TermEvaluatorFactory(constraintService);
+    this.factory = new TermEvaluatorFactory(configService, constraintService);
   }
 
   getFeedbackRule(responses: T): FeedbackRule {
@@ -140,6 +144,10 @@ export class FeedbackRuleEvaluator<T extends Response[]> {
           : this.defaultFeedback
       })
     );
+  }
+
+  setPeerGroup(peerGroup: PeerGroup): void {
+    this.peerGroup = peerGroup;
   }
 
   setReferenceComponent(referenceComponent: Component): void {

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluatorMultipleStudents.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluatorMultipleStudents.spec.ts
@@ -16,6 +16,7 @@ describe('FeedbackRuleEvaluatorMultipleStudents', () => {
   beforeEach(() => {
     evaluator = new FeedbackRuleEvaluatorMultipleStudents(
       new FeedbackRuleComponent(DEFAULT_FEEDBACK_RULES, 5, true),
+      null,
       null
     );
   });
@@ -40,6 +41,7 @@ function matchRules_HasKIScore() {
     beforeEach(() => {
       evaluator = new FeedbackRuleEvaluatorMultipleStudents(
         new FeedbackRuleComponent(HAS_KI_SCORE_FEEDBACK_RULES, 5, true),
+        null,
         null
       );
     });
@@ -73,6 +75,7 @@ function matchNoRule_NoDefaultFeedbackAuthored_ReturnApplicationDefault() {
       authored`, () => {
     evaluator = new FeedbackRuleEvaluatorMultipleStudents(
       new FeedbackRuleComponent([], 5, true),
+      null,
       null
     );
     expectRules([createCRaterResponse(['idea10', 'idea11'], [KI_SCORE_1], 1)], ['default']);

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluatorMultipleStudents.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluatorMultipleStudents.ts
@@ -49,6 +49,7 @@ export class FeedbackRuleEvaluatorMultipleStudents extends FeedbackRuleEvaluator
 
   protected evaluateTerm(term: string, responses: Response[]): boolean {
     const evaluator: TermEvaluator = this.factory.getTermEvaluator(term);
+    evaluator.setPeerGroup(this.peerGroup);
     evaluator.setReferenceComponent(this.referenceComponent);
     return responses.some((response: Response) => {
       return evaluator.evaluate(response);

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/BooleanTermEvaluator.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/BooleanTermEvaluator.spec.ts
@@ -1,0 +1,21 @@
+import { Response } from '../Response';
+import { BooleanTermEvaluator } from './BooleanTermEvaluator';
+
+describe('BooleanTermEvaluator', () => {
+  describe('evaluate()', () => {
+    testEvaluate('true', true);
+    testEvaluate('false', false);
+  });
+});
+
+function testEvaluate(term: string, expectedResult: boolean) {
+  describe(`term is "${term}"`, () => {
+    let evaluator: BooleanTermEvaluator;
+    beforeEach(() => {
+      evaluator = new BooleanTermEvaluator(term);
+    });
+    it(`returns ${expectedResult}`, () => {
+      expect(evaluator.evaluate(new Response())).toBe(expectedResult);
+    });
+  });
+}

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/BooleanTermEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/BooleanTermEvaluator.ts
@@ -1,0 +1,20 @@
+import { Response } from '../Response';
+import { TermEvaluator } from './TermEvaluator';
+
+export class BooleanTermEvaluator extends TermEvaluator {
+  constructor(protected term: string) {
+    super(term);
+  }
+
+  evaluate(response: Response): boolean {
+    /**
+     * The term 'true' or 'false' is usually not authored, but is created and added to the termStack
+     * by the application as it processes operator expressions like "&&", "||", and "!"
+     * (see FeedbackRuleEvaluator.evaluateOperator()).
+     * For example, if the student had ideas 1, 2 and 3, evaluating the postfix expression
+     * ["1", "2", "&&", "3", "&&"] goes like this:
+     * ["1", "2", "&&", "3", "&&"] => ["true", "3", "&&"] => ["true"] => true.
+     */
+    return this.term === 'true';
+  }
+}

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaTermEvaluator.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaTermEvaluator.spec.ts
@@ -3,14 +3,24 @@ import { CRaterResponse } from '../../cRater/CRaterResponse';
 import { IdeaTermEvaluator } from './IdeaTermEvaluator';
 
 describe('IdeaTermEvaluator', () => {
-  describe('evaluate()', () => {
-    const response_with_no_ideas = new CRaterResponse();
-    const response_with_2_ideas = new CRaterResponse();
-    response_with_2_ideas.ideas = [new CRaterIdea('1', true), new CRaterIdea('2', true)];
-    it('returns true iff idea term is found in the response', () => {
-      const evaluator_idea1 = new IdeaTermEvaluator('1');
-      expect(evaluator_idea1.evaluate(response_with_no_ideas)).toBeFalse();
-      expect(evaluator_idea1.evaluate(response_with_2_ideas)).toBeTrue();
+  const evaluator = new IdeaTermEvaluator('1');
+  describe('evaluate(response)', () => {
+    let response: CRaterResponse;
+    beforeEach(() => {
+      response = new CRaterResponse();
+    });
+    describe('response does not contain the idea', () => {
+      it('returns false', () => {
+        expect(evaluator.evaluate(response)).toBeFalse();
+      });
+    });
+    describe('response contains the idea', () => {
+      beforeEach(() => {
+        response.ideas = [new CRaterIdea('1', true), new CRaterIdea('2', true)];
+      });
+      it('returns true', () => {
+        expect(evaluator.evaluate(response)).toBeTrue();
+      });
     });
   });
 });

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaTermEvaluator.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaTermEvaluator.spec.ts
@@ -7,12 +7,7 @@ describe('IdeaTermEvaluator', () => {
     const response_with_no_ideas = new CRaterResponse();
     const response_with_2_ideas = new CRaterResponse();
     response_with_2_ideas.ideas = [new CRaterIdea('1', true), new CRaterIdea('2', true)];
-    it("should always return true if term is 'true'", () => {
-      const evaluator_true = new IdeaTermEvaluator('true');
-      expect(evaluator_true.evaluate(response_with_no_ideas)).toBeTrue();
-      expect(evaluator_true.evaluate(response_with_2_ideas)).toBeTrue();
-    });
-    it('should return true iff idea term is found in the response', () => {
+    it('returns true iff idea term is found in the response', () => {
       const evaluator_idea1 = new IdeaTermEvaluator('1');
       expect(evaluator_idea1.evaluate(response_with_no_ideas)).toBeFalse();
       expect(evaluator_idea1.evaluate(response_with_2_ideas)).toBeTrue();

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaTermEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IdeaTermEvaluator.ts
@@ -7,14 +7,6 @@ export class IdeaTermEvaluator extends TermEvaluator {
   }
 
   evaluate(response: CRaterResponse): boolean {
-    /**
-     * The term 'true' or 'false' is usually not authored, but is created and added to the termStack
-     * by the application as it processes operator expressions like "&&", "||", and "!"
-     * (see FeedbackRuleEvaluator.evaluateOperator()).
-     * For example, if the student had ideas 1, 2 and 3, evaluating the postfix expression
-     * ["1", "2", "&&", "3", "&&"] goes like this:
-     * ["1", "2", "&&", "3", "&&"] => ["true", "3", "&&"] => ["true"] => true.
-     */
-    return this.term === 'true' || response.getDetectedIdeaNames().includes(this.term);
+    return response.getDetectedIdeaNames().includes(this.term);
   }
 }

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IsLowestWorkgroupIdInPeerGroupTermEvaluator.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IsLowestWorkgroupIdInPeerGroupTermEvaluator.spec.ts
@@ -1,0 +1,46 @@
+import { PeerGrouping } from '../../../../../../app/domain/peerGrouping';
+import { PeerGroup } from '../../../peerChat/PeerGroup';
+import { PeerGroupMember } from '../../../peerChat/PeerGroupMember';
+import { CRaterResponse } from '../../cRater/CRaterResponse';
+import { IsLowestWorkgroupIdInPeerGroupTermEvaluator } from './IsLowestWorkgroupIdInPeerGroupTermEvaluator';
+
+class ConfigService {
+  getWorkgroupId() {
+    return 1;
+  }
+}
+
+describe('IsLowestWorkgroupIdInPeerGroupTermEvaluator', () => {
+  let evaluator, mockConfigService;
+  beforeEach(() => {
+    evaluator = new IsLowestWorkgroupIdInPeerGroupTermEvaluator('isLowestWorkgroupIdInPeerGroup');
+    mockConfigService = new ConfigService();
+    evaluator.setConfigService(mockConfigService);
+    evaluator.setPeerGroup(
+      new PeerGroup(1, [{ id: 1 }, { id: 2 }] as PeerGroupMember[], new PeerGrouping())
+    );
+  });
+  describe('evaluate()', () => {
+    [
+      {
+        description: 'your workgroup id is the lowest',
+        myWorkgroupId: 1,
+        expected: true
+      },
+      {
+        description: 'your workgroup id is not the lowest',
+        myWorkgroupId: 2,
+        expected: false
+      }
+    ].forEach(({ description, myWorkgroupId, expected }) => {
+      describe(description, () => {
+        beforeEach(() => {
+          spyOn(mockConfigService, 'getWorkgroupId').and.returnValue(myWorkgroupId);
+        });
+        it(`returns ${expected}`, () => {
+          expect(evaluator.evaluate(new CRaterResponse())).toEqual(expected);
+        });
+      });
+    });
+  });
+});

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IsLowestWorkgroupIdInPeerGroupTermEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/IsLowestWorkgroupIdInPeerGroupTermEvaluator.ts
@@ -1,0 +1,8 @@
+import { Response } from '../Response';
+import { TermEvaluator } from './TermEvaluator';
+
+export class IsLowestWorkgroupIdInPeerGroupTermEvaluator extends TermEvaluator {
+  evaluate(response: Response | Response[]): boolean {
+    return this.peerGroup.getWorkgroupIds().sort().at(0) === this.configService.getWorkgroupId();
+  }
+}

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluator.ts
@@ -1,16 +1,24 @@
 import { Component } from '../../../../common/Component';
+import { ConfigService } from '../../../../services/configService';
 import { ConstraintService } from '../../../../services/constraintService';
+import { PeerGroup } from '../../../peerChat/PeerGroup';
 import { Response } from '../Response';
 
 export abstract class TermEvaluator {
-  protected referenceComponent: Component;
+  protected configService: ConfigService;
   protected constraintService: ConstraintService;
+  protected peerGroup: PeerGroup;
+  protected referenceComponent: Component;
 
   constructor(protected term: string) {}
   abstract evaluate(response: Response | Response[]): boolean;
 
   static isAccumulatedIdeaCountTerm(term: string): boolean {
     return /accumulatedIdeaCount(MoreThan|Equals|LessThan)\([\d+]\)/.test(term);
+  }
+
+  static isLowestWorkgroupIdInPeerGroupTerm(term: string): boolean {
+    return term === 'isLowestWorkgroupIdInPeerGroup';
   }
 
   static isMyChoiceChosenTerm(term: string): boolean {
@@ -40,8 +48,16 @@ export abstract class TermEvaluator {
     );
   }
 
+  setConfigService(service: ConfigService): void {
+    this.configService = service;
+  }
+
   setConstraintService(service: ConstraintService): void {
     this.constraintService = service;
+  }
+
+  setPeerGroup(peerGroup: PeerGroup): void {
+    this.peerGroup = peerGroup;
   }
 
   setReferenceComponent(referenceComponent: Component): void {

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluator.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluator.ts
@@ -17,6 +17,10 @@ export abstract class TermEvaluator {
     return /accumulatedIdeaCount(MoreThan|Equals|LessThan)\([\d+]\)/.test(term);
   }
 
+  static isBooleanTerm(term: string): boolean {
+    return ['true', 'false'].includes(term);
+  }
+
   static isLowestWorkgroupIdInPeerGroupTerm(term: string): boolean {
     return term === 'isLowestWorkgroupIdInPeerGroup';
   }

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluatorFactory.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluatorFactory.spec.ts
@@ -4,25 +4,36 @@ import { IdeaCountTermEvaluator } from './IdeaCountTermEvaluator';
 import { IdeaTermEvaluator } from './IdeaTermEvaluator';
 import { IsSubmitNumberEvaluator } from './IsSubmitNumberEvaluator';
 import { TermEvaluatorFactory } from './TermEvaluatorFactory';
+import { AccumulatedIdeaCountTermEvaluator } from './AccumulatedIdeaCountTermEvaluator';
+import { IsLowestWorkgroupIdInPeerGroupTermEvaluator } from './IsLowestWorkgroupIdInPeerGroupTermEvaluator';
+import { BooleanTermEvaluator } from './BooleanTermEvaluator';
 
 describe('TermEvaluatorFactory', () => {
   const factory = new TermEvaluatorFactory(null, null);
-  describe('getTermEvaluator()', () => {
-    it('should return correct evaluator', () => {
-      [
-        {
-          term: 'myChoiceChosen("choice1")',
-          instanceType: MyChoiceChosenTermEvaluator
-        },
-        { term: 'hasKIScore(3)', instanceType: HasKIScoreTermEvaluator },
-        { term: 'ideaCountMoreThan(1)', instanceType: IdeaCountTermEvaluator },
-        { term: 'ideaCountEquals(3)', instanceType: IdeaCountTermEvaluator },
-        { term: 'ideaCountLessThan(2)', instanceType: IdeaCountTermEvaluator },
-        { term: 'isSubmitNumber(2)', instanceType: IsSubmitNumberEvaluator },
-        { term: 'isSubmitNumber(23)', instanceType: IsSubmitNumberEvaluator },
-        { term: '2', instanceType: IdeaTermEvaluator }
-      ].forEach(({ term, instanceType }) => {
-        expect(factory.getTermEvaluator(term) instanceof instanceType).toBeTrue();
+  describe('getTermEvaluator(term)', () => {
+    [
+      { term: 'true', evaluator: BooleanTermEvaluator },
+      { term: 'false', evaluator: BooleanTermEvaluator },
+      { term: 'hasKIScore(3)', evaluator: HasKIScoreTermEvaluator },
+      { term: 'ideaCountMoreThan(1)', evaluator: IdeaCountTermEvaluator },
+      { term: 'ideaCountEquals(3)', evaluator: IdeaCountTermEvaluator },
+      { term: 'ideaCountLessThan(2)', evaluator: IdeaCountTermEvaluator },
+      { term: 'isSubmitNumber(2)', evaluator: IsSubmitNumberEvaluator },
+      { term: 'isSubmitNumber(23)', evaluator: IsSubmitNumberEvaluator },
+      { term: 'accumulatedIdeaCountMoreThan(1)', evaluator: AccumulatedIdeaCountTermEvaluator },
+      { term: 'accumulatedIdeaCountEquals(3)', evaluator: AccumulatedIdeaCountTermEvaluator },
+      { term: 'accumulatedIdeaCountLessThan(2)', evaluator: AccumulatedIdeaCountTermEvaluator },
+      { term: 'myChoiceChosen("1")', evaluator: MyChoiceChosenTermEvaluator },
+      {
+        term: 'isLowestWorkgroupIdInPeerGroup',
+        evaluator: IsLowestWorkgroupIdInPeerGroupTermEvaluator
+      },
+      { term: '2', evaluator: IdeaTermEvaluator }
+    ].forEach(({ term, evaluator }) => {
+      describe(`term is ${term}`, () => {
+        it(`returns ${evaluator.name}`, () => {
+          expect(factory.getTermEvaluator(term) instanceof evaluator).toBeTrue();
+        });
       });
     });
   });

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluatorFactory.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluatorFactory.spec.ts
@@ -6,7 +6,7 @@ import { IsSubmitNumberEvaluator } from './IsSubmitNumberEvaluator';
 import { TermEvaluatorFactory } from './TermEvaluatorFactory';
 
 describe('TermEvaluatorFactory', () => {
-  const factory = new TermEvaluatorFactory(null);
+  const factory = new TermEvaluatorFactory(null, null);
   describe('getTermEvaluator()', () => {
     it('should return correct evaluator', () => {
       [

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluatorFactory.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluatorFactory.ts
@@ -9,13 +9,16 @@ import { IsSubmitNumberEvaluator } from './IsSubmitNumberEvaluator';
 import { TermEvaluator } from './TermEvaluator';
 import { ConfigService } from '../../../../services/configService';
 import { IsLowestWorkgroupIdInPeerGroupTermEvaluator } from './IsLowestWorkgroupIdInPeerGroupTermEvaluator';
+import { BooleanTermEvaluator } from './BooleanTermEvaluator';
 
 export class TermEvaluatorFactory {
   constructor(private configService: ConfigService, private constraintService: ConstraintService) {}
 
   getTermEvaluator(term: string): TermEvaluator {
     let evaluator: TermEvaluator;
-    if (TermEvaluator.isHasKIScoreTerm(term)) {
+    if (TermEvaluator.isBooleanTerm(term)) {
+      evaluator = new BooleanTermEvaluator(term);
+    } else if (TermEvaluator.isHasKIScoreTerm(term)) {
       evaluator = new HasKIScoreTermEvaluator(term);
     } else if (TermEvaluator.isIdeaCountTerm(term)) {
       evaluator = new IdeaCountTermEvaluator(term);

--- a/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluatorFactory.ts
+++ b/src/assets/wise5/components/common/feedbackRule/TermEvaluator/TermEvaluatorFactory.ts
@@ -7,9 +7,11 @@ import { IdeaCountWithResponseIndexTermEvaluator } from './IdeaCountWithResponse
 import { IdeaTermEvaluator } from './IdeaTermEvaluator';
 import { IsSubmitNumberEvaluator } from './IsSubmitNumberEvaluator';
 import { TermEvaluator } from './TermEvaluator';
+import { ConfigService } from '../../../../services/configService';
+import { IsLowestWorkgroupIdInPeerGroupTermEvaluator } from './IsLowestWorkgroupIdInPeerGroupTermEvaluator';
 
 export class TermEvaluatorFactory {
-  constructor(private constraintService: ConstraintService) {}
+  constructor(private configService: ConfigService, private constraintService: ConstraintService) {}
 
   getTermEvaluator(term: string): TermEvaluator {
     let evaluator: TermEvaluator;
@@ -25,9 +27,12 @@ export class TermEvaluatorFactory {
       evaluator = new AccumulatedIdeaCountTermEvaluator(term);
     } else if (TermEvaluator.isMyChoiceChosenTerm(term)) {
       evaluator = new MyChoiceChosenTermEvaluator(term);
+    } else if (TermEvaluator.isLowestWorkgroupIdInPeerGroupTerm(term)) {
+      evaluator = new IsLowestWorkgroupIdInPeerGroupTermEvaluator(term);
     } else {
       evaluator = new IdeaTermEvaluator(term);
     }
+    evaluator.setConfigService(this.configService);
     evaluator.setConstraintService(this.constraintService);
     return evaluator;
   }

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
@@ -89,6 +89,7 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
         this.getMaxSubmitCount(),
         this.component.isMultipleFeedbackTextsForSameRuleAllowed()
       ),
+      this.configService,
       this.constraintService
     );
     if (this.component.isComputerAvatarEnabled()) {

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
@@ -402,6 +402,7 @@ export class OpenResponseStudent extends ComponentStudent {
             this.getMaxSubmitCount(),
             this.isMultipleFeedbackTextsForSameRuleAllowed()
           ),
+          this.ConfigService,
           this.constraintService
         );
         const rule: FeedbackRule = feedbackRuleEvaluator.getFeedbackRule([response]);

--- a/src/assets/wise5/directives/dynamic-prompt/DynamicPromptEvaluator.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/DynamicPromptEvaluator.ts
@@ -14,7 +14,12 @@ export abstract class DynamicPromptEvaluator {
 
   evaluate(referenceComponent: Component): void {
     if (this.component.dynamicPrompt.isPeerGroupingTagSpecified()) {
-      this.evaluatePeerGroup(referenceComponent);
+      this.component.peerGroupService
+        .retrievePeerGroup(this.component.dynamicPrompt.getPeerGroupingTag())
+        .subscribe((peerGroup) => {
+          this.component.peerGroup = peerGroup;
+          this.evaluatePeerGroup(referenceComponent);
+        });
     } else {
       this.evaluatePersonal(referenceComponent);
     }
@@ -31,9 +36,14 @@ export abstract class DynamicPromptEvaluator {
     const evaluator = this.component.dynamicPrompt.isPeerGroupingTagSpecified()
       ? new FeedbackRuleEvaluatorMultipleStudents(
           feedbackRuleComponent,
+          this.component.configService,
           this.component.constraintService
         )
-      : new FeedbackRuleEvaluator(feedbackRuleComponent, this.component.constraintService);
+      : new FeedbackRuleEvaluator(
+          feedbackRuleComponent,
+          this.component.configService,
+          this.component.constraintService
+        );
     evaluator.setReferenceComponent(referenceComponent);
     return evaluator;
   }

--- a/src/assets/wise5/directives/dynamic-prompt/DynamicPromptMultipleChoiceEvaluator.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/DynamicPromptMultipleChoiceEvaluator.ts
@@ -12,6 +12,7 @@ export class DynamicPromptMultipleChoiceEvaluator extends DynamicPromptEvaluator
         });
       });
       const feedbackRuleEvaluator = this.getFeedbackRuleEvaluator(referenceComponent);
+      feedbackRuleEvaluator.setPeerGroup(this.component.peerGroup);
       this.setPromptAndEmitRule(feedbackRuleEvaluator.getFeedbackRule(responses));
     });
   }

--- a/src/assets/wise5/directives/dynamic-prompt/DynamicPromptOpenResponseEvaluator.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/DynamicPromptOpenResponseEvaluator.ts
@@ -14,6 +14,7 @@ export class DynamicPromptOpenResponseEvaluator extends DynamicPromptEvaluator {
         });
       });
       const feedbackRuleEvaluator = this.getFeedbackRuleEvaluator(referenceComponent);
+      feedbackRuleEvaluator.setPeerGroup(this.component.peerGroup);
       this.setPromptAndEmitRule(feedbackRuleEvaluator.getFeedbackRule(cRaterResponses));
     });
   }

--- a/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.ts
+++ b/src/assets/wise5/directives/dynamic-prompt/dynamic-prompt.component.ts
@@ -9,6 +9,7 @@ import { DynamicPrompt } from './DynamicPrompt';
 import { ConstraintService } from '../../services/constraintService';
 import { DynamicPromptOpenResponseEvaluator } from './DynamicPromptOpenResponseEvaluator';
 import { DynamicPromptMultipleChoiceEvaluator } from './DynamicPromptMultipleChoiceEvaluator';
+import { PeerGroup } from '../../components/peerChat/PeerGroup';
 
 @Component({
   selector: 'dynamic-prompt',
@@ -24,8 +25,9 @@ export class DynamicPromptComponent implements OnInit {
   @Input() dynamicPrompt: DynamicPrompt;
   @Output() dynamicPromptChanged: EventEmitter<FeedbackRule> = new EventEmitter<FeedbackRule>();
   @Input() nodeId: string;
-  prompt: string;
+  peerGroup: PeerGroup;
   peerGroupService: PeerGroupService;
+  prompt: string;
 
   constructor(
     annotationService: AnnotationService,

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15815,7 +15815,7 @@ Are you ready to receive feedback on this answer?</source>
         <source>Thanks for submitting your response.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/FeedbackRuleEvaluator.ts</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ac4a8ebf1347b29327308613dd307970ec899941" datatype="html">


### PR DESCRIPTION
## Changes
Add support for ```isLowestWorkgroupIdInPeerGroup``` token that returns true when the student's workgroup id is lower than all the other student's workgroup id's in the same PeerGroup. This token should only be used in Dynamic Prompt and Question Bank activities, and the activities must specify a Peer Grouping. 

Examples (my workgroup id = 2)
1. Returns false if PeerGroup member's ids are: 
   - [1,2]
   - [1,2,3]
2. Returns true if PeerGroup member's ids are: 
   - [2]
   - [2,3]
   - [2,3,4]

## Test
- Add ```isLowestWorkgroupIdInPeerGroup``` in the FeedbackRule expression for Dynamic Prompt, Question Bank with (remember to specify PeerGrouping) and make sure that the rule is matched if the student's workgroup ID is the lowest in the PeerGroup. If should not match otherwise. 
- ```!isLowestWorkgroupIdInPeerGroup``` should match if your workgroup ID is *not* the lowest in the PeerGroup.
- Existing Peer Chat steps with Dynamic Prompt, Question Bank work as before

Closes  #1418