### PR TITLE
refactor(LibraryComponent): Clean up isSearchMatch()

### DIFF
--- a/src/app/modules/library/library/library.component.ts
+++ b/src/app/modules/library/library/library.component.ts
@@ -84,7 +84,7 @@ export abstract class LibraryComponent implements OnInit {
     this.peValue = this.filterValues.peValue;
     for (let project of this.projects) {
       let filterMatch = false;
-      let searchMatch = this.isSearchMatch(project, this.searchValue);
+      const searchMatch = this.isSearchMatch(project, this.searchValue);
       if (searchMatch) {
         filterMatch = this.isFilterMatch(project);
       }
@@ -108,36 +108,28 @@ export abstract class LibraryComponent implements OnInit {
     );
   }
 
-  isSearchMatch(project: LibraryProject, searchValue: string): boolean {
-    if (searchValue) {
-      let data: any = project.metadata;
-      data.id = project.id;
-      return Object.keys(data).some((prop) => {
-        // only check for match in specific metadata fields
-        if (
-          prop != 'title' &&
-          prop != 'summary' &&
-          prop != 'keywords' &&
-          prop != 'features' &&
-          prop != 'standardsAddressed' &&
-          prop != 'id'
-        ) {
-          return false;
-        } else {
-          let value = data[prop];
+  private isSearchMatch(project: LibraryProject, searchValue: string): boolean {
+    const metadata: any = project.metadata;
+    metadata.id = project.id;
+    return (
+      !searchValue ||
+      Object.keys(metadata)
+        .filter((prop) =>
+          // only check for match in specific metadata fields
+          ['title', 'summary', 'keywords', 'features', 'standardsAddressed', 'id'].includes(prop)
+        )
+        .some((prop) => {
+          let value = metadata[prop];
           if (prop === 'standardsAddressed') {
             value = JSON.stringify(value);
           }
-          if (typeof value === 'undefined' || value === null) {
-            return false;
-          } else {
-            return value.toString().toLocaleLowerCase().indexOf(searchValue) !== -1;
-          }
-        }
-      });
-    } else {
-      return true;
-    }
+          return (
+            typeof value !== 'undefined' &&
+            value != null &&
+            value.toString().toLocaleLowerCase().indexOf(searchValue) !== -1
+          );
+        })
+    );
   }
 
   isFilterMatch(project: LibraryProject): boolean {


### PR DESCRIPTION
## Changes
- Use filter to filter metadata fields we're interested in
- Use includes() instead of multiple &&'s
- Combine return statements
- Change function to private

## Test
- Searching for units (on home page and in your teacher's Unit Library) works as before