### PR TITLE
refactor(RegisterUserFormComponent): Extract duplicate createAccountError()

### DIFF
--- a/src/app/register/register-student-form/register-student-form.component.html
+++ b/src/app/register/register-student-form/register-student-form.component.html
@@ -93,7 +93,7 @@
           >
         </mat-form-field>
       </p>
-      <div *ngIf="studentUser.googleUserId == null">
+      <div *ngIf="user.googleUserId == null">
         <p>
           <mat-form-field appearance="fill" fxFlex>
             <mat-label i18n>Security Question</mat-label>
@@ -130,7 +130,7 @@
           </mat-form-field>
         </p>
       </div>
-      <div *ngIf="studentUser.googleUserId == null" formGroupName="passwords">
+      <div *ngIf="user.googleUserId == null" formGroupName="passwords">
         <new-password-and-confirm
           [formGroup]="passwordsFormGroup"
           [passwordLabel]="passwordLabel"
@@ -147,7 +147,7 @@
         <a href="https://policies.google.com/privacy">Privacy Policy</a> and
         <a href="https://policies.google.com/terms">Terms of Service</a> apply.
       </p>
-      <ng-container *ngIf="isRecaptchaEnabled" [ngSwitch]="studentUser.isRecaptchaInvalid">
+      <ng-container *ngIf="isRecaptchaEnabled" [ngSwitch]="user.isRecaptchaInvalid">
         <mat-error *ngSwitchCase="true" class="recaptchaError" i18n
           >Recaptcha failed. Please reload the page and try again!</mat-error
         >

--- a/src/app/register/register-student-form/register-student-form.component.spec.ts
+++ b/src/app/register/register-student-form/register-student-form.component.spec.ts
@@ -168,7 +168,7 @@ async function createAccount() {
             PASSWORD
           )
         );
-        component.studentUser.isRecaptchaInvalid = true;
+        component.user.isRecaptchaInvalid = true;
         spyOn(recaptchaV3Service, 'execute').and.returnValue(of(''));
         const errorMessage = 'recaptchaResponseInvalid';
         const response: any = helpers.createAccountErrorResponse(errorMessage);

--- a/src/app/register/register-teacher-form/register-teacher-form.component.html
+++ b/src/app/register/register-teacher-form/register-teacher-form.component.html
@@ -115,7 +115,7 @@
           <mat-label i18n>School Level</mat-label>
           <mat-select
             placeholder="School Level"
-            [(value)]="teacherUser.schoolLevel"
+            [(value)]="user.schoolLevel"
             formControlName="schoolLevel"
             required
           >
@@ -141,7 +141,7 @@
           />
         </mat-form-field>
       </p>
-      <div *ngIf="teacherUser.googleUserId == null" formGroupName="passwords">
+      <div *ngIf="user.googleUserId == null" formGroupName="passwords">
         <new-password-and-confirm
           [formGroup]="passwordsFormGroup"
           [passwordLabel]="passwordLabel"
@@ -170,7 +170,7 @@
         <a href="https://policies.google.com/privacy">Privacy Policy</a> and
         <a href="https://policies.google.com/terms">Terms of Service</a> apply.
       </p>
-      <ng-container *ngIf="isRecaptchaEnabled" [ngSwitch]="teacherUser.isRecaptchaInvalid">
+      <ng-container *ngIf="isRecaptchaEnabled" [ngSwitch]="user.isRecaptchaInvalid">
         <mat-error *ngSwitchCase="true" class="center recaptchaError" i18n
           >Recaptcha failed. Please reload the page and try again!</mat-error
         >

--- a/src/app/register/register-teacher-form/register-teacher-form.component.spec.ts
+++ b/src/app/register/register-teacher-form/register-teacher-form.component.spec.ts
@@ -167,7 +167,7 @@ async function createAccount() {
             true
           )
         );
-        component.teacherUser.isRecaptchaInvalid = true;
+        component.user.isRecaptchaInvalid = true;
         spyOn(recaptchaV3Service, 'execute').and.returnValue(of(''));
         const errorMessage = 'recaptchaResponseInvalid';
         const response: any = helpers.createAccountErrorResponse(errorMessage);

--- a/src/app/register/register-teacher-form/register-teacher-form.component.ts
+++ b/src/app/register/register-teacher-form/register-teacher-form.component.ts
@@ -34,8 +34,6 @@ export class RegisterTeacherFormComponent extends RegisterUserFormComponent impl
   );
   isRecaptchaEnabled: boolean = this.configService.isRecaptchaEnabled();
   isSubmitted = false;
-  passwordsFormGroup = this.fb.group({});
-  processing: boolean = false;
   schoolLevels: any[] = [
     { code: 'ELEMENTARY_SCHOOL', label: $localize`Elementary School` },
     { code: 'MIDDLE_SCHOOL', label: $localize`Middle School` },
@@ -43,25 +41,25 @@ export class RegisterTeacherFormComponent extends RegisterUserFormComponent impl
     { code: 'COLLEGE', label: $localize`College` },
     { code: 'OTHER', label: $localize`Other` }
   ];
-  teacherUser: Teacher = new Teacher();
+  user: Teacher = new Teacher();
 
   constructor(
     private changeDetectorRef: ChangeDetectorRef,
     private configService: ConfigService,
-    private fb: FormBuilder,
+    protected fb: FormBuilder,
     private recaptchaV3Service: ReCaptchaV3Service,
     private router: Router,
     private route: ActivatedRoute,
-    private snackBar: MatSnackBar,
+    protected snackBar: MatSnackBar,
     private teacherService: TeacherService,
     private utilService: UtilService
   ) {
-    super();
+    super(fb, snackBar);
   }
 
   ngOnInit(): void {
     this.route.params.subscribe((params) => {
-      this.teacherUser.googleUserId = params['gID'];
+      this.user.googleUserId = params['gID'];
       if (!this.isUsingGoogleId()) {
         this.createTeacherAccountFormGroup.addControl('passwords', this.passwordsFormGroup);
       }
@@ -79,7 +77,7 @@ export class RegisterTeacherFormComponent extends RegisterUserFormComponent impl
   }
 
   private isUsingGoogleId(): boolean {
-    return this.teacherUser.googleUserId != null;
+    return this.user.googleUserId != null;
   }
 
   private setControlFieldValue(name: string, value: string): void {
@@ -91,7 +89,7 @@ export class RegisterTeacherFormComponent extends RegisterUserFormComponent impl
     if (this.createTeacherAccountFormGroup.valid) {
       this.processing = true;
       await this.populateTeacherUser();
-      this.teacherService.registerTeacherAccount(this.teacherUser).subscribe(
+      this.teacherService.registerTeacherAccount(this.user).subscribe(
         (response: any) => {
           this.createAccountSuccess(response);
         },
@@ -110,42 +108,18 @@ export class RegisterTeacherFormComponent extends RegisterUserFormComponent impl
     this.processing = false;
   }
 
-  private createAccountError(error: any): void {
-    const formError: any = {};
-    switch (error.messageCode) {
-      case 'invalidPasswordLength':
-        formError.minlength = true;
-        this.passwordsFormGroup
-          .get(NewPasswordAndConfirmComponent.NEW_PASSWORD_FORM_CONTROL_NAME)
-          .setErrors(formError);
-        break;
-      case 'invalidPasswordPattern':
-        formError.pattern = true;
-        this.passwordsFormGroup
-          .get(NewPasswordAndConfirmComponent.NEW_PASSWORD_FORM_CONTROL_NAME)
-          .setErrors(formError);
-        break;
-      case 'recaptchaResponseInvalid':
-        this.teacherUser['isRecaptchaInvalid'] = true;
-        break;
-      default:
-        this.snackBar.open(this.translateCreateAccountErrorMessageCode(error.messageCode));
-    }
-    this.processing = false;
-  }
-
   private async populateTeacherUser() {
     for (let key of Object.keys(this.createTeacherAccountFormGroup.controls)) {
-      this.teacherUser[key] = this.createTeacherAccountFormGroup.get(key).value;
+      this.user[key] = this.createTeacherAccountFormGroup.get(key).value;
     }
     if (this.isRecaptchaEnabled) {
       const token = await this.recaptchaV3Service.execute('importantAction').toPromise();
-      this.teacherUser['token'] = token;
+      this.user['token'] = token;
     }
     if (!this.isUsingGoogleId()) {
-      this.teacherUser['password'] = this.getPassword();
-      delete this.teacherUser['passwords'];
-      delete this.teacherUser['googleUserId'];
+      this.user['password'] = this.getPassword();
+      delete this.user['passwords'];
+      delete this.user['googleUserId'];
     }
   }
 

--- a/src/app/register/register-user-form/register-user-form.component.ts
+++ b/src/app/register/register-user-form/register-user-form.component.ts
@@ -1,10 +1,44 @@
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { User } from '../../domain/user';
+import { NewPasswordAndConfirmComponent } from '../../password/new-password-and-confirm/new-password-and-confirm.component';
+import { FormBuilder, FormGroup } from '@angular/forms';
+
 export class RegisterUserFormComponent {
-  NAME_REGEX = '^[a-zA-Z]+([ -]?[a-zA-Z]+)*$';
+  protected NAME_REGEX = '^[a-zA-Z]+([ -]?[a-zA-Z]+)*$';
 
-  confirmPasswordLabel: string = $localize`Confirm Password`;
-  passwordLabel: string = $localize`Password`;
+  protected confirmPasswordLabel: string = $localize`Confirm Password`;
+  protected passwordsFormGroup: FormGroup = this.fb.group({});
+  protected passwordLabel: string = $localize`Password`;
+  protected processing: boolean = false;
+  user: User;
 
-  translateCreateAccountErrorMessageCode(messageCode: string) {
+  constructor(protected fb: FormBuilder, protected snackBar: MatSnackBar) {}
+
+  protected createAccountError(error: any): void {
+    const formError: any = {};
+    switch (error.messageCode) {
+      case 'invalidPasswordLength':
+        formError.minlength = true;
+        this.passwordsFormGroup
+          .get(NewPasswordAndConfirmComponent.NEW_PASSWORD_FORM_CONTROL_NAME)
+          .setErrors(formError);
+        break;
+      case 'invalidPasswordPattern':
+        formError.pattern = true;
+        this.passwordsFormGroup
+          .get(NewPasswordAndConfirmComponent.NEW_PASSWORD_FORM_CONTROL_NAME)
+          .setErrors(formError);
+        break;
+      case 'recaptchaResponseInvalid':
+        this.user['isRecaptchaInvalid'] = true;
+        break;
+      default:
+        this.snackBar.open(this.translateCreateAccountErrorMessageCode(error.messageCode));
+    }
+    this.processing = false;
+  }
+
+  private translateCreateAccountErrorMessageCode(messageCode: string): string {
     switch (messageCode) {
       case 'invalidFirstAndLastName':
         return $localize`Error: First Name and Last Name must only contain characters A-Z, a-z, spaces, or dashes and can not start or end with a space or dash`;

--- a/src/app/register/register-user-form/register-user-form.component.ts
+++ b/src/app/register/register-user-form/register-user-form.component.ts
@@ -7,8 +7,8 @@ export class RegisterUserFormComponent {
   protected NAME_REGEX = '^[a-zA-Z]+([ -]?[a-zA-Z]+)*$';
 
   protected confirmPasswordLabel: string = $localize`Confirm Password`;
-  protected passwordsFormGroup: FormGroup = this.fb.group({});
   protected passwordLabel: string = $localize`Password`;
+  protected passwordsFormGroup: FormGroup = this.fb.group({});
   protected processing: boolean = false;
   user: User;
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -2155,7 +2155,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-teacher-form/register-teacher-form.component.ts</context>
-          <context context-type="linenumber">44</context>
+          <context context-type="linenumber">42</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.ts</context>
@@ -7156,7 +7156,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Elementary School</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-teacher-form/register-teacher-form.component.ts</context>
-          <context context-type="linenumber">40</context>
+          <context context-type="linenumber">38</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.ts</context>
@@ -7167,7 +7167,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Middle School</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-teacher-form/register-teacher-form.component.ts</context>
-          <context context-type="linenumber">41</context>
+          <context context-type="linenumber">39</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.ts</context>
@@ -7178,7 +7178,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>High School</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-teacher-form/register-teacher-form.component.ts</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">40</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.ts</context>
@@ -7189,7 +7189,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>College</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-teacher-form/register-teacher-form.component.ts</context>
-          <context context-type="linenumber">43</context>
+          <context context-type="linenumber">41</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.ts</context>
@@ -7207,35 +7207,35 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Confirm Password</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-user-form/register-user-form.component.ts</context>
-          <context context-type="linenumber">4</context>
+          <context context-type="linenumber">9</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1431416938026210429" datatype="html">
         <source>Password</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-user-form/register-user-form.component.ts</context>
-          <context context-type="linenumber">5</context>
+          <context context-type="linenumber">11</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4000970355844798758" datatype="html">
         <source>Error: First Name and Last Name must only contain characters A-Z, a-z, spaces, or dashes and can not start or end with a space or dash</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-user-form/register-user-form.component.ts</context>
-          <context context-type="linenumber">10</context>
+          <context context-type="linenumber">44</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1084197907437634069" datatype="html">
         <source>Error: First Name must only contain characters A-Z, a-z, spaces, or dashes and can not start or end with a space or dash</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-user-form/register-user-form.component.ts</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5970926747435723642" datatype="html">
         <source>Error: Last Name must only contain characters A-Z, a-z, spaces, or dashes and can not start or end with a space or dash</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-user-form/register-user-form.component.ts</context>
-          <context context-type="linenumber">14</context>
+          <context context-type="linenumber">48</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e931f6b80399785ea1647269f43ffeea54327cb6" datatype="html">
@@ -12190,14 +12190,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete the selected item?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">95</context>
+          <context context-type="linenumber">105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1189930234736223663" datatype="html">
         <source>Are you sure you want to delete the <x id="PH" equiv-text="selectedNodeIds.length"/> selected items?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e8fb2ceb6f8d4c3e90a6a688e9024461e67f44f0" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -7251,7 +7251,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Password</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-user-form/register-user-form.component.ts</context>
-          <context context-type="linenumber">11</context>
+          <context context-type="linenumber">10</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4000970355844798758" datatype="html">


### PR DESCRIPTION
## Changes
- Extract ```Register[Student/Teacher]FormComponent.createAccountError()``` to parent ```RegisterUserFormComponent.createAccountError()```
- Clean up surrounding code
   - use ```this.user``` instead of ```this.studentUser``` and ```this.teacherUser``` in the components
   - move ```processing``` and ```passwordsFormGroup``` variables to ```RegisterUserFormComponent```

## Test
- Send an invalid password to the server
   - Set a breakpoint in StudentService.registerStudentAccount() and change the studentUser's password to "1" before it is POST'ed to the server. => verify that RegisterUserFormComponent.createAccountError() is called, and it shows the error on the form
   - Do the same as above with TeacherService.registerTeacherAccount() when registering a new teacher user
- Creating student/teacher accounts without any problems work as before