### PR TITLE
feat(Import Step): Add dedicated choose unit page before choosing step

### DIFF
--- a/src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html
@@ -1,46 +1,45 @@
-<h5 i18n>Choose a location for the imported steps</h5>
-<div style="margin-top: 20px; margin-left: 20px">
-  <div *ngFor="let nodeId of nodeIds" class="project-item">
-    <div
-      id="{{ nodeId }}"
-      [ngClass]="{
-        groupHeader: isGroupNode(nodeId),
-        stepHeader: !isGroupNode(nodeId),
-        branchPathStepHeader: isNodeInAnyBranchPath(nodeId) && !isGroupNode(nodeId)
-      }"
-    >
-      <div fxLayout="row" fxLayoutGap="8px" class="projectItemTitleDiv">
-        <div fxLayout="row" fxLayoutAlign="start center">
-          <node-icon [nodeId]="nodeId" size="18"></node-icon>&nbsp;
-          <p style="display: inline; cursor: pointer">
-            {{ getNodePositionById(nodeId) }}: {{ getNodeTitle(nodeId) }}
-          </p>
-        </div>
-        <button
-          mat-raised-button
-          color="primary"
-          *ngIf="isGroupNode(nodeId)"
-          matTooltip="Insert As First Step"
-          i18n-matTooltip
-          matTooltipPosition="above"
-          (click)="importSelectedNodes(nodeId); $event.stopPropagation()"
-        >
-          <mat-icon>call_received</mat-icon>
-        </button>
-        <button
-          mat-raised-button
-          color="primary"
-          *ngIf="!isGroupNode(nodeId)"
-          matTooltip="Insert After"
-          i18n-matTooltip
-          matTooltipPosition="above"
-          (click)="importSelectedNodes(nodeId); $event.stopPropagation()"
-        >
-          <mat-icon>subdirectory_arrow_left</mat-icon>
-        </button>
+<h5 i18n>Choose a location for the imported steps.</h5>
+<div *ngFor="let nodeId of nodeIds" class="project-item">
+  <div
+    id="{{ nodeId }}"
+    [ngClass]="{
+      'step-header': !isGroupNode(nodeId),
+      'branch-path-step-header': isNodeInAnyBranchPath(nodeId) && !isGroupNode(nodeId)
+    }"
+  >
+    <div fxLayout="row" fxLayoutGap="8px">
+      <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="4px">
+        <node-icon [nodeId]="nodeId" size="18"></node-icon>&nbsp;
+        <span> {{ getNodePositionById(nodeId) }}: {{ getNodeTitle(nodeId) }} </span>
       </div>
+      <button
+        mat-raised-button
+        color="primary"
+        *ngIf="isGroupNode(nodeId)"
+        matTooltip="Insert As First Step"
+        i18n-matTooltip
+        matTooltipPosition="above"
+        (click)="importSelectedNodes(nodeId); $event.stopPropagation()"
+      >
+        <mat-icon>call_received</mat-icon>
+      </button>
+      <button
+        mat-raised-button
+        color="primary"
+        *ngIf="!isGroupNode(nodeId)"
+        matTooltip="Insert After"
+        i18n-matTooltip
+        matTooltipPosition="above"
+        (click)="importSelectedNodes(nodeId); $event.stopPropagation()"
+      >
+        <mat-icon>subdirectory_arrow_left</mat-icon>
+      </button>
     </div>
   </div>
 </div>
-<hr />
-<button mat-button color="primary" routerLink="../.." aria-label="Cancel" i18n>Cancel</button>
+<div class="nav-controls">
+  <mat-divider></mat-divider>
+  <div fxLayout="row" fxLayoutAlign="end center">
+    <button mat-button color="primary" routerLink="../.." aria-label="Cancel" i18n>Cancel</button>
+  </div>
+</div>

--- a/src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.scss
+++ b/src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.scss
@@ -1,23 +1,19 @@
 .project-item {
-  margin-top: 4px;
+  margin-bottom: 4px;
 }
 
 .project-item:hover {
   background-color: #add8e6;
 }
 
-.groupHeader {
-  margin-left: 5px !important;
+.step-header {
+  margin-inline-start: 24px;
 }
 
-.stepHeader {
-  margin-left: 30px !important;
-}
-
-.branchPathStepHeader {
-  margin-left: 55px !important;
+.branch-path-step-header {
+  margin-inline-start: 48px;
 }
 
 .mat-icon {
-  margin: 0px;
+  margin: 0;
 }

--- a/src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.ts
+++ b/src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.ts
@@ -7,7 +7,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'choose-import-step-location',
-  styleUrls: ['choose-import-step-location.component.scss'],
+  styleUrls: ['choose-import-step-location.component.scss', '../import-step.scss'],
   templateUrl: 'choose-import-step-location.component.html'
 })
 export class ChooseImportStepLocationComponent {

--- a/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html
@@ -1,90 +1,65 @@
-<h4 i18n>Import Step(s)</h4>
+<h5 i18n>Choose the step(s) that you want to import, then click next.</h5>
 <br />
-<div i18n>Choose a unit to import from:</div>
-<mat-form-field style="margin-right: 20px; width: 100%">
-  <mat-label i18n>My Units</mat-label>
-  <mat-select
-    [(ngModel)]="importMyProjectId"
-    (selectionChange)="showMyProject()"
-    style="width: 100%"
+<div fxLayout="row wrap" fxLayoutGap="8px">
+  <h4 style="display: inline"><span i18n>Selected unit:</span> {{ project.metadata.title }}</h4>
+  <button
+    mat-raised-button
+    color="primary"
+    (click)="previewProject()"
+    matTooltip="Preview Unit"
+    i18n-matTooltip
+    matTooltipPosition="above"
   >
-    <mat-option *ngFor="let project of myProjectsList" value="{{ project.id }}">
-      {{ project.id + ' - ' + project.name }}
-      <span *ngIf="project.runId != null"> (<span i18n>Run ID</span>: {{ project.runId }})</span>
-    </mat-option>
-  </mat-select>
-</mat-form-field>
-<br />
-<mat-form-field style="margin-right: 20px; width: 100%">
-  <mat-label i18n>Library Units</mat-label>
-  <mat-select
-    [(ngModel)]="importLibraryProjectId"
-    (selectionChange)="showLibraryProject()"
-    style="width: 100%"
-  >
-    <mat-option *ngFor="let project of libraryProjectsList" value="{{ project.id }}">
-      {{ project.id + ' - ' + project.name }}
-    </mat-option>
-  </mat-select>
-</mat-form-field>
-<br />
-<div *ngIf="importProject != null">
-  <div i18n>Choose the step(s) that you want to import, then click next.</div>
-  <br />
-  <div fxLayout="row wrap" fxLayoutGap="8px">
-    <h4 style="display: inline">{{ importProject.metadata.title }}</h4>
+    <mat-icon>visibility</mat-icon>
+  </button>
+</div>
+<div
+  *ngFor="let item of projectIdToOrder"
+  [ngClass]="{
+    groupHeader: item.node.type == 'group',
+    stepHeader: item.node.type != 'group'
+  }"
+>
+  <h6 *ngIf="item.order != 0 && item.node.type == 'group'">
+    {{ item.stepNumber }}: {{ item.node.title }}
+  </h6>
+  <div fxLayout="row wrap" fxLayoutGap="8px" *ngIf="item.order != 0 && item.node.type != 'group'">
+    <mat-checkbox name="item" ngDefaultControl [(ngModel)]="item.checked">
+      <h6 style="display: inline">{{ item.stepNumber }}: {{ item.node.title }}</h6>
+    </mat-checkbox>
     <button
       mat-raised-button
       color="primary"
-      (click)="previewImportProject()"
-      matTooltip="Preview Unit"
+      class="regularButton mat-raised-button mat-primary"
+      style="margin-top: -5"
+      (click)="previewNode(item.node)"
+      aria-label="Preview Step"
+      matTooltip="Preview Step"
       i18n-matTooltip
       matTooltipPosition="above"
     >
       <mat-icon>visibility</mat-icon>
     </button>
   </div>
-  <div
-    *ngFor="let importItem of importProjectIdToOrder"
-    [ngClass]="{
-      groupHeader: importItem.node.type == 'group',
-      stepHeader: importItem.node.type != 'group'
-    }"
-  >
-    <h6 *ngIf="importItem.order != 0 && importItem.node.type == 'group'">
-      {{ importItem.stepNumber }}: {{ importItem.node.title }}
-    </h6>
-    <div
-      fxLayout="row wrap"
-      fxLayoutGap="8px"
-      *ngIf="importItem.order != 0 && importItem.node.type != 'group'"
-    >
-      <mat-checkbox name="importItem" ngDefaultControl [(ngModel)]="importItem.checked">
-        <h6 style="display: inline">{{ importItem.stepNumber }}: {{ importItem.node.title }}</h6>
-      </mat-checkbox>
-      <button
-        mat-raised-button
-        color="primary"
-        class="regularButton mat-raised-button mat-primary"
-        style="margin-top: -5"
-        (click)="previewImportNode(importItem.node)"
-        aria-label="Preview Step"
-        matTooltip="Preview Step"
-        i18n-matTooltip
-        matTooltipPosition="above"
-      >
-        <mat-icon>visibility</mat-icon>
-      </button>
-    </div>
-  </div>
 </div>
 <hr />
 <div class="nav-controls" fxLayout="row" fxLayoutGap="20px" fxLayoutAlign="end center">
+  <button
+    mat-button
+    color="primary"
+    routerLink="../choose-unit"
+    aria-label="Back"
+    i18n-aria-label
+    i18n
+  >
+    Back
+  </button>
+  <span fxFlex></span>
   <button mat-button color="primary" routerLink="../.." aria-label="cancel" i18n>Cancel</button>
   <button
     mat-raised-button
     color="primary"
-    (click)="importSteps()"
+    (click)="goToChooseLocation()"
     [disabled]="getSelectedNodesToImport().length == 0"
     matTooltip="Next"
     i18n-matTooltip

--- a/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html
@@ -1,7 +1,6 @@
-<h5 i18n>Choose the step(s) that you want to import, then click next.</h5>
-<br />
-<div fxLayout="row wrap" fxLayoutGap="8px">
-  <h4 style="display: inline"><span i18n>Selected unit:</span> {{ project.metadata.title }}</h4>
+<h5 i18n>Choose the step(s) that you want to import, then select Next.</h5>
+<p fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="8px">
+  <strong i18n>Selected unit: {{ project.metadata.title }}</strong>
   <button
     mat-raised-button
     color="primary"
@@ -12,7 +11,7 @@
   >
     <mat-icon>visibility</mat-icon>
   </button>
-</div>
+</p>
 <div
   *ngFor="let item of projectIdToOrder"
   [ngClass]="{
@@ -25,12 +24,12 @@
   </h6>
   <div fxLayout="row wrap" fxLayoutGap="8px" *ngIf="item.order != 0 && item.node.type != 'group'">
     <mat-checkbox name="item" ngDefaultControl [(ngModel)]="item.checked">
-      <h6 style="display: inline">{{ item.stepNumber }}: {{ item.node.title }}</h6>
+      <span class="step-title">{{ item.stepNumber }}: {{ item.node.title }}</span>
     </mat-checkbox>
     <button
       mat-raised-button
       color="primary"
-      class="regularButton mat-raised-button mat-primary"
+      class="mat-raised-button mat-primary"
       style="margin-top: -5"
       (click)="previewNode(item.node)"
       aria-label="Preview Step"
@@ -42,31 +41,33 @@
     </button>
   </div>
 </div>
-<hr />
-<div class="nav-controls" fxLayout="row" fxLayoutGap="20px" fxLayoutAlign="end center">
-  <button
-    mat-button
-    color="primary"
-    routerLink="../choose-unit"
-    aria-label="Back"
-    i18n-aria-label
-    i18n
-  >
-    Back
-  </button>
-  <span fxFlex></span>
-  <button mat-button color="primary" routerLink="../.." aria-label="cancel" i18n>Cancel</button>
-  <button
-    mat-raised-button
-    color="primary"
-    (click)="goToChooseLocation()"
-    [disabled]="getSelectedNodesToImport().length == 0"
-    matTooltip="Next"
-    i18n-matTooltip
-    matTooltipPosition="above"
-    aria-label="next"
-    i18n
-  >
-    Next
-  </button>
+<div class="nav-controls">
+  <mat-divider></mat-divider>
+  <div fxLayout="row" fxLayoutGap="16px" fxLayoutAlign="end center">
+    <button
+      mat-button
+      color="primary"
+      routerLink="../choose-unit"
+      aria-label="Back"
+      i18n-aria-label
+      i18n
+    >
+      Back
+    </button>
+    <span fxFlex></span>
+    <button mat-button color="primary" routerLink="../.." aria-label="cancel" i18n>Cancel</button>
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="goToChooseLocation()"
+      [disabled]="getSelectedNodesToImport().length == 0"
+      matTooltip="Next"
+      i18n-matTooltip
+      matTooltipPosition="above"
+      aria-label="next"
+      i18n
+    >
+      Next
+    </button>
+  </div>
 </div>

--- a/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.scss
+++ b/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.scss
@@ -1,14 +1,7 @@
-.stepHeader {
-  margin-top: 4px;
-}
-
-.nav-controls {
-  background-color: white;
-  position: sticky;
-  bottom: 0;
-  padding-bottom: 8px;
-}
-
 .mat-icon {
   margin: 0px;
+}
+
+.step-title {
+  font-weight: 400;
 }

--- a/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.ts
+++ b/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'choose-import-step',
-  styleUrls: ['choose-import-step.component.scss'],
+  styleUrls: ['choose-import-step.component.scss', '../import-step.scss'],
   templateUrl: 'choose-import-step.component.html'
 })
 export class ChooseImportStepComponent {

--- a/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.ts
+++ b/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.ts
@@ -1,6 +1,4 @@
 import { Component } from '@angular/core';
-import { ConfigService } from '../../../../assets/wise5/services/configService';
-import { ProjectLibraryService } from '../../../../assets/wise5/services/projectLibraryService';
 import { TeacherProjectService } from '../../../../assets/wise5/services/teacherProjectService';
 import { ActivatedRoute, Router } from '@angular/router';
 
@@ -10,71 +8,46 @@ import { ActivatedRoute, Router } from '@angular/router';
   templateUrl: 'choose-import-step.component.html'
 })
 export class ChooseImportStepComponent {
-  protected importLibraryProjectId: number;
-  protected importMyProjectId: number;
-  protected importProject: any;
-  private importProjectId: number;
-  protected importProjectIdToOrder: any;
-  private importProjectItems: any[] = [];
-  protected libraryProjectsList: any[];
-  protected myProjectsList: any[];
+  protected project: any;
+  private projectId: number;
+  protected projectIdToOrder: any;
+  private projectItems: any[] = [];
 
   constructor(
-    private configService: ConfigService,
-    private projectLibraryService: ProjectLibraryService,
     private projectService: TeacherProjectService,
     private route: ActivatedRoute,
     private router: Router
   ) {}
 
   ngOnInit() {
-    this.myProjectsList = this.configService.getAuthorableProjects();
-    this.projectLibraryService.getLibraryProjects().then((libraryProjects) => {
-      this.libraryProjectsList = this.projectLibraryService.sortAndFilterUniqueProjects(
-        libraryProjects
-      );
+    this.projectId = history.state.importProjectId;
+    this.projectService.retrieveProjectById(this.projectId).then((projectJSON) => {
+      this.project = projectJSON;
+      const nodeOrderOfProject = this.projectService.getNodeOrderOfProject(this.project);
+      this.projectIdToOrder = Object.values(nodeOrderOfProject.idToOrder);
+      this.projectItems = nodeOrderOfProject.nodes;
     });
   }
 
-  protected showMyProject(): void {
-    this.importLibraryProjectId = null;
-    this.showProject(this.importMyProjectId);
+  protected previewNode(node: any): void {
+    window.open(`${this.project.previewProjectURL}/${node.id}`);
   }
 
-  protected showLibraryProject(): void {
-    this.importMyProjectId = null;
-    this.showProject(this.importLibraryProjectId);
+  protected previewProject(): void {
+    window.open(`${this.project.previewProjectURL}`);
   }
 
-  private showProject(importProjectId: number): void {
-    this.importProjectId = importProjectId;
-    this.projectService.retrieveProjectById(this.importProjectId).then((projectJSON) => {
-      this.importProject = projectJSON;
-      const nodeOrderOfProject = this.projectService.getNodeOrderOfProject(this.importProject);
-      this.importProjectIdToOrder = Object.values(nodeOrderOfProject.idToOrder);
-      this.importProjectItems = nodeOrderOfProject.nodes;
-    });
-  }
-
-  protected previewImportNode(node: any): void {
-    window.open(`${this.importProject.previewProjectURL}/${node.id}`);
-  }
-
-  protected previewImportProject(): void {
-    window.open(`${this.importProject.previewProjectURL}`);
-  }
-
-  protected importSteps(): void {
+  protected goToChooseLocation(): void {
     this.router.navigate(['../choose-location'], {
       relativeTo: this.route,
       state: {
-        importFromProjectId: this.importProjectId,
+        importFromProjectId: this.projectId,
         selectedNodes: this.getSelectedNodesToImport()
       }
     });
   }
 
   protected getSelectedNodesToImport(): any[] {
-    return this.importProjectItems.filter((item) => item.checked).map((item) => item.node);
+    return this.projectItems.filter((item) => item.checked).map((item) => item.node);
   }
 }

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
@@ -1,11 +1,18 @@
 <ng-template #projects let-projects="projects">
-  <div *ngFor="let project of projects" class="projectItem" (click)="chooseProject(project)">
-    {{ project.id + ' - ' + project.name }}
-    <span *ngIf="project.runId != null"> (<span i18n>Run ID</span>: {{ project.runId }})</span>
+  <div class="units" fxLayout="column" fxLayoutAlign="start start" fxLayoutGap="8px">
+    <button
+      *ngFor="let project of projects"
+      mat-stroked-button
+      class="unit"
+      (click)="chooseProject(project)"
+    >
+      {{ project.id + ' - ' + project.name }}
+      <span *ngIf="project.runId != null"> (<span i18n>Run ID</span>: {{ project.runId }})</span>
+    </button>
   </div>
 </ng-template>
 <h5 i18n>Choose a unit from which to import step(s).</h5>
-<mat-tab-group>
+<mat-tab-group mat-stretch-tabs="false">
   <mat-tab label="My Units" i18n-label>
     <ng-container *ngTemplateOutlet="projects; context: { projects: myProjects }"></ng-container
   ></mat-tab>
@@ -15,7 +22,9 @@
     ></ng-container
   ></mat-tab>
 </mat-tab-group>
-<hr />
-<div class="nav-controls" fxLayout="row" fxLayoutGap="20px" fxLayoutAlign="end center">
-  <button mat-button color="primary" routerLink="../.." aria-label="cancel" i18n>Cancel</button>
+<div class="nav-controls">
+  <mat-divider></mat-divider>
+  <div fxLayout="row" fxLayoutGap="16px" fxLayoutAlign="end center">
+    <button mat-button color="primary" routerLink="../.." aria-label="cancel" i18n>Cancel</button>
+  </div>
 </div>

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
@@ -1,0 +1,21 @@
+<ng-template #projects let-projects="projects">
+  <div *ngFor="let project of projects" class="projectItem" (click)="chooseProject(project)">
+    {{ project.id + ' - ' + project.name }}
+    <span *ngIf="project.runId != null"> (<span i18n>Run ID</span>: {{ project.runId }})</span>
+  </div>
+</ng-template>
+<h5 i18n>Choose a unit from which to import step(s).</h5>
+<mat-tab-group>
+  <mat-tab label="My Units" i18n-label>
+    <ng-container *ngTemplateOutlet="projects; context: { projects: myProjects }"></ng-container
+  ></mat-tab>
+  <mat-tab label="Library Units" i18n-label>
+    <ng-container
+      *ngTemplateOutlet="projects; context: { projects: libraryProjects }"
+    ></ng-container
+  ></mat-tab>
+</mat-tab-group>
+<hr />
+<div class="nav-controls" fxLayout="row" fxLayoutGap="20px" fxLayoutAlign="end center">
+  <button mat-button color="primary" routerLink="../.." aria-label="cancel" i18n>Cancel</button>
+</div>

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.scss
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.scss
@@ -1,7 +1,7 @@
-.projectItem {
-  cursor: pointer;
+.units {
+  padding: 16px 0;
 }
 
-.projectItem:hover {
-  background-color:#add8e6;
+.unit {
+  text-transform: none;
 }

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.scss
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.scss
@@ -1,0 +1,7 @@
+.projectItem {
+  cursor: pointer;
+}
+
+.projectItem:hover {
+  background-color:#add8e6;
+}

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.ts
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.ts
@@ -5,7 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'choose-import-unit',
-  styleUrls: ['./choose-import-unit.component.scss'],
+  styleUrls: ['./choose-import-unit.component.scss', '../import-step.scss'],
   templateUrl: './choose-import-unit.component.html'
 })
 export class ChooseImportUnitComponent {

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.ts
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.ts
@@ -1,0 +1,37 @@
+import { Component } from '@angular/core';
+import { ConfigService } from '../../../../assets/wise5/services/configService';
+import { ProjectLibraryService } from '../../../../assets/wise5/services/projectLibraryService';
+import { ActivatedRoute, Router } from '@angular/router';
+
+@Component({
+  selector: 'choose-import-unit',
+  styleUrls: ['./choose-import-unit.component.scss'],
+  templateUrl: './choose-import-unit.component.html'
+})
+export class ChooseImportUnitComponent {
+  protected libraryProjects: any[];
+  protected myProjects: any[];
+
+  constructor(
+    private configService: ConfigService,
+    private projectLibraryService: ProjectLibraryService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.myProjects = this.configService.getAuthorableProjects();
+    this.projectLibraryService.getLibraryProjects().then((libraryProjects) => {
+      this.libraryProjects = this.projectLibraryService.sortAndFilterUniqueProjects(
+        libraryProjects
+      );
+    });
+  }
+
+  protected chooseProject(project: any): void {
+    this.router.navigate(['../choose-step'], {
+      relativeTo: this.route,
+      state: { importProjectId: project.id }
+    });
+  }
+}

--- a/src/app/authoring-tool/import-step/import-step.scss
+++ b/src/app/authoring-tool/import-step/import-step.scss
@@ -1,0 +1,11 @@
+.nav-controls {
+  background-color: white;
+  position: sticky;
+  bottom: 0;
+  padding-bottom: 8px;
+  z-index: 1;
+
+  .mat-divider {
+    margin: 8px 0;
+  }
+}

--- a/src/app/teacher/authoring-routing.module.ts
+++ b/src/app/teacher/authoring-routing.module.ts
@@ -35,6 +35,7 @@ import { ChooseImportComponentComponent } from '../../assets/wise5/authoringTool
 import { ChooseMoveNodeLocationComponent } from '../../assets/wise5/authoringTool/choose-node-location/choose-move-node-location/choose-move-node-location.component';
 import { ChooseCopyNodeLocationComponent } from '../../assets/wise5/authoringTool/choose-node-location/choose-copy-node-location/choose-copy-node-location.component';
 import { ProjectAuthoringParentComponent } from '../../assets/wise5/authoringTool/project-authoring-parent/project-authoring-parent.component';
+import { ChooseImportUnitComponent } from '../authoring-tool/import-step/choose-import-unit/choose-import-unit.component';
 
 const routes: Routes = [
   {
@@ -112,6 +113,10 @@ const routes: Routes = [
               {
                 path: 'choose-step',
                 component: ChooseImportStepComponent
+              },
+              {
+                path: 'choose-unit',
+                component: ChooseImportUnitComponent
               }
             ]
           },

--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -49,6 +49,7 @@ import { InsertNodeInsideButtonComponent } from '../../assets/wise5/authoringToo
 import { NodeIconAndTitleComponent } from '../../assets/wise5/authoringTool/choose-node-location/node-icon-and-title/node-icon-and-title.component';
 import { NodeWithMoveAfterButtonComponent } from '../../assets/wise5/authoringTool/choose-node-location/node-with-move-after-button/node-with-move-after-button.component';
 import { ProjectAuthoringParentComponent } from '../../assets/wise5/authoringTool/project-authoring-parent/project-authoring-parent.component';
+import { ChooseImportUnitComponent } from '../authoring-tool/import-step/choose-import-unit/choose-import-unit.component';
 
 @NgModule({
   declarations: [
@@ -65,6 +66,7 @@ import { ProjectAuthoringParentComponent } from '../../assets/wise5/authoringToo
     ChooseCopyNodeLocationComponent,
     ChooseImportStepComponent,
     ChooseImportStepLocationComponent,
+    ChooseImportUnitComponent,
     ChooseNewComponent,
     ChooseNewNodeLocation,
     ChooseNewNodeTemplate,

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -153,7 +153,7 @@ export class ProjectAuthoringComponent {
   }
 
   protected importStep(): void {
-    this.router.navigate([`/teacher/edit/unit/${this.projectId}/import-step/choose-step`]);
+    this.router.navigate([`/teacher/edit/unit/${this.projectId}/import-step/choose-unit`]);
   }
 
   protected goToAdvancedAuthoring(): void {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -395,7 +395,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">83</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
+          <context context-type="linenumber">20</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
@@ -1413,69 +1417,25 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="64216e7ef99605d9f05614beb1919360ee012177" datatype="html">
-        <source>Import Step(s)</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">1</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1371bc59ef18c928caf36f5d66a7af1af8ce17a2" datatype="html">
-        <source>Choose a unit to import from:</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">3</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="c4058ff063f874b650aca76a5d972f11323bb6fb" datatype="html">
-        <source>My Units</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">5</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library-details.html</context>
-          <context context-type="linenumber">1</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
-          <context context-type="linenumber">6</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-list/project-list.component.html</context>
-          <context context-type="linenumber">55</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="dc834df3c90c7b9021cfa37b2be737c2134249a5" datatype="html">
-        <source>Run ID</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">13</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="325291e71ff2bb75a324c2c02e5deb1ff8600043" datatype="html">
-        <source>Library Units</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">19</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
-          <context context-type="linenumber">23</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="38d584510075ce8ab505c1081beb607c36898b2b" datatype="html">
         <source>Choose the step(s) that you want to import, then click next.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6b5924daf626eefff7575bf77cbe23f1b8116622" datatype="html">
+        <source>Selected unit:</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
+          <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
       <trans-unit id="76176dda9f079e8ab3c78d6975eee76b8b3eddad" datatype="html">
         <source>Preview Unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">40</context>
+          <context context-type="linenumber">9</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
@@ -1494,7 +1454,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Preview Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">37</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
@@ -1517,11 +1477,101 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">48</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="cda31dbd724cf5f4fa7a4274d9120651490c8a8c" datatype="html">
+        <source>Back</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
+          <context context-type="linenumber">51</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/configure-automated-assessment/configure-automated-assessment.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/node-advanced-authoring/node-advanced-authoring.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/ki-cycle-using-oer/ki-cycle-using-oer.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/peer-review-and-revision/peer-review-and-revision.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/self-directed-investigation/self-directed-investigation.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
+          <context context-type="linenumber">381</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
+          <context context-type="linenumber">383</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
+          <context context-type="linenumber">483</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-step-visits/export-step-visits.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1b1b98cf02baa4e4a12eeda340ddcc389ba7d896" datatype="html">
+        <source> Back </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
+          <context context-type="linenumber">54,56</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
+          <context context-type="linenumber">47,49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.html</context>
+          <context context-type="linenumber">46,48</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/configure-automated-assessment/configure-automated-assessment.component.html</context>
+          <context context-type="linenumber">37,39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.html</context>
+          <context context-type="linenumber">20,22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/ki-cycle-using-oer/ki-cycle-using-oer.component.html</context>
+          <context context-type="linenumber">11,13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/peer-review-and-revision/peer-review-and-revision.component.html</context>
+          <context context-type="linenumber">9,11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/self-directed-investigation/self-directed-investigation.component.html</context>
+          <context context-type="linenumber">10,12</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="f732c304c7433e5a83ffcd862c3dce709a0f4982" datatype="html">
         <source>Next</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">89</context>
+          <context context-type="linenumber">64</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
@@ -1556,7 +1606,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source> Next </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">94,96</context>
+          <context context-type="linenumber">69,71</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
@@ -1585,6 +1635,50 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/self-directed-investigation/self-directed-investigation.component.html</context>
           <context context-type="linenumber">24,26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="dc834df3c90c7b9021cfa37b2be737c2134249a5" datatype="html">
+        <source>Run ID</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ceda145a9d260f64412b05c1e9f82a46f4e68cc1" datatype="html">
+        <source>Choose a unit from which to import step(s).</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="c4058ff063f874b650aca76a5d972f11323bb6fb" datatype="html">
+        <source>My Units</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library-details.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-list/project-list.component.html</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="325291e71ff2bb75a324c2c02e5deb1ff8600043" datatype="html">
+        <source>Library Units</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
+          <context context-type="linenumber">23</context>
         </context-group>
       </trans-unit>
       <trans-unit id="041620337eaebda87971d345d05697639dfe78e4" datatype="html">
@@ -9203,88 +9297,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">7</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="cda31dbd724cf5f4fa7a4274d9120651490c8a8c" datatype="html">
-        <source>Back</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
-          <context context-type="linenumber">44</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.html</context>
-          <context context-type="linenumber">43</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/configure-automated-assessment/configure-automated-assessment.component.html</context>
-          <context context-type="linenumber">34</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/node-advanced-authoring/node-advanced-authoring.component.html</context>
-          <context context-type="linenumber">6</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.html</context>
-          <context context-type="linenumber">20</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/ki-cycle-using-oer/ki-cycle-using-oer.component.html</context>
-          <context context-type="linenumber">11</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/peer-review-and-revision/peer-review-and-revision.component.html</context>
-          <context context-type="linenumber">9</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/self-directed-investigation/self-directed-investigation.component.html</context>
-          <context context-type="linenumber">10</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">381</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">383</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">483</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-step-visits/export-step-visits.component.html</context>
-          <context context-type="linenumber">8</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1b1b98cf02baa4e4a12eeda340ddcc389ba7d896" datatype="html">
-        <source> Back </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
-          <context context-type="linenumber">47,49</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.html</context>
-          <context context-type="linenumber">46,48</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/configure-automated-assessment/configure-automated-assessment.component.html</context>
-          <context context-type="linenumber">37,39</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.html</context>
-          <context context-type="linenumber">20,22</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/ki-cycle-using-oer/ki-cycle-using-oer.component.html</context>
-          <context context-type="linenumber">11,13</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/peer-review-and-revision/peer-review-and-revision.component.html</context>
-          <context context-type="linenumber">9,11</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/self-directed-investigation/self-directed-investigation.component.html</context>
-          <context context-type="linenumber">10,12</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="fe47acba6a2b6d343c4568432b800629bb8dd638" datatype="html">
         <source>Choose a location for the new step</source>
         <context-group purpose="location">
@@ -12190,14 +12202,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete the selected item?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">95</context>
+          <context context-type="linenumber">105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1189930234736223663" datatype="html">
         <source>Are you sure you want to delete the <x id="PH" equiv-text="selectedNodeIds.length"/> selected items?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e8fb2ceb6f8d4c3e90a6a688e9024461e67f44f0" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -391,7 +391,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">43</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
@@ -399,7 +399,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">28</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
@@ -1376,8 +1376,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="e8c21747e8604f974b3ed6ecf6089306b7cc0aae" datatype="html">
-        <source>Choose a location for the imported steps</source>
+      <trans-unit id="1cc241602482b371d07a43b1a4c6f0d1c5670b51" datatype="html">
+        <source>Choose a location for the imported steps.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html</context>
           <context context-type="linenumber">1</context>
@@ -1387,7 +1387,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Insert As First Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html</context>
-          <context context-type="linenumber">23</context>
+          <context context-type="linenumber">19</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component.html</context>
@@ -1398,7 +1398,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Insert After</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html</context>
-          <context context-type="linenumber">34</context>
+          <context context-type="linenumber">30</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-choose-location/add-lesson-choose-location.component.html</context>
@@ -1417,25 +1417,25 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="38d584510075ce8ab505c1081beb607c36898b2b" datatype="html">
-        <source>Choose the step(s) that you want to import, then click next.</source>
+      <trans-unit id="aebe90fbb61e57f4a4ea689e1f155a3f58cea25a" datatype="html">
+        <source>Choose the step(s) that you want to import, then select Next.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6b5924daf626eefff7575bf77cbe23f1b8116622" datatype="html">
-        <source>Selected unit:</source>
+      <trans-unit id="2d00759dc177baeb48ce2f3092f5a350caf51b86" datatype="html">
+        <source>Selected unit: <x id="INTERPOLATION" equiv-text="{{ project.metadata.title }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">4</context>
+          <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit>
       <trans-unit id="76176dda9f079e8ab3c78d6975eee76b8b3eddad" datatype="html">
         <source>Preview Unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">9</context>
+          <context context-type="linenumber">8</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
@@ -1454,7 +1454,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Preview Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">37</context>
+          <context context-type="linenumber">36</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
@@ -1532,39 +1532,15 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">8</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1b1b98cf02baa4e4a12eeda340ddcc389ba7d896" datatype="html">
+      <trans-unit id="fd966a55a9d8174e64bf096d0247ba9e1659008e" datatype="html">
         <source> Back </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
           <context context-type="linenumber">54,56</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
-          <context context-type="linenumber">47,49</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.html</context>
-          <context context-type="linenumber">46,48</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/configure-automated-assessment/configure-automated-assessment.component.html</context>
-          <context context-type="linenumber">37,39</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.html</context>
-          <context context-type="linenumber">20,22</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/ki-cycle-using-oer/ki-cycle-using-oer.component.html</context>
-          <context context-type="linenumber">11,13</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/peer-review-and-revision/peer-review-and-revision.component.html</context>
-          <context context-type="linenumber">9,11</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/self-directed-investigation/self-directed-investigation.component.html</context>
-          <context context-type="linenumber">10,12</context>
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
+          <context context-type="linenumber">56,58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f732c304c7433e5a83ffcd862c3dce709a0f4982" datatype="html">
@@ -1602,60 +1578,40 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4d665c6c2c1d69484cfc636b22fd895512246d90" datatype="html">
+      <trans-unit id="c9702419b173fe7ab2aeee4ec1f5857fca1135a1" datatype="html">
         <source> Next </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
           <context context-type="linenumber">69,71</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
-          <context context-type="linenumber">69,71</context>
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
+          <context context-type="linenumber">36,38</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.html</context>
-          <context context-type="linenumber">68,70</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/configure-automated-assessment/configure-automated-assessment.component.html</context>
-          <context context-type="linenumber">44,46</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.html</context>
-          <context context-type="linenumber">34,36</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/ki-cycle-using-oer/ki-cycle-using-oer.component.html</context>
-          <context context-type="linenumber">25,27</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/peer-review-and-revision/peer-review-and-revision.component.html</context>
-          <context context-type="linenumber">23,25</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/self-directed-investigation/self-directed-investigation.component.html</context>
-          <context context-type="linenumber">24,26</context>
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
+          <context context-type="linenumber">70,72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dc834df3c90c7b9021cfa37b2be737c2134249a5" datatype="html">
         <source>Run ID</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">4</context>
+          <context context-type="linenumber">10</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ceda145a9d260f64412b05c1e9f82a46f4e68cc1" datatype="html">
         <source>Choose a unit from which to import step(s).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">7</context>
+          <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c4058ff063f874b650aca76a5d972f11323bb6fb" datatype="html">
         <source>My Units</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">9</context>
+          <context context-type="linenumber">16</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library-details.html</context>
@@ -1674,7 +1630,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Library Units</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">19</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
@@ -9208,17 +9164,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">28,30</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="c9702419b173fe7ab2aeee4ec1f5857fca1135a1" datatype="html">
-        <source> Next </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
-          <context context-type="linenumber">36,38</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">70,72</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="891f639ffcf9d31aea80ea7e8e428a6597b059b3" datatype="html">
         <source>Step Title</source>
         <context-group purpose="location">
@@ -9261,13 +9206,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">49,51</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="fd966a55a9d8174e64bf096d0247ba9e1659008e" datatype="html">
-        <source> Back </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">56,58</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="6009535360963985115" datatype="html">
         <source>New Step</source>
         <context-group purpose="location">
@@ -9295,6 +9233,68 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
           <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1b1b98cf02baa4e4a12eeda340ddcc389ba7d896" datatype="html">
+        <source> Back </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
+          <context context-type="linenumber">47,49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.html</context>
+          <context context-type="linenumber">46,48</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/configure-automated-assessment/configure-automated-assessment.component.html</context>
+          <context context-type="linenumber">37,39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.html</context>
+          <context context-type="linenumber">20,22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/ki-cycle-using-oer/ki-cycle-using-oer.component.html</context>
+          <context context-type="linenumber">11,13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/peer-review-and-revision/peer-review-and-revision.component.html</context>
+          <context context-type="linenumber">9,11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/self-directed-investigation/self-directed-investigation.component.html</context>
+          <context context-type="linenumber">10,12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4d665c6c2c1d69484cfc636b22fd895512246d90" datatype="html">
+        <source> Next </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
+          <context context-type="linenumber">69,71</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.html</context>
+          <context context-type="linenumber">68,70</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/configure-automated-assessment/configure-automated-assessment.component.html</context>
+          <context context-type="linenumber">44,46</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.html</context>
+          <context context-type="linenumber">34,36</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/ki-cycle-using-oer/ki-cycle-using-oer.component.html</context>
+          <context context-type="linenumber">25,27</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/peer-review-and-revision/peer-review-and-revision.component.html</context>
+          <context context-type="linenumber">23,25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/self-directed-investigation/self-directed-investigation.component.html</context>
+          <context context-type="linenumber">24,26</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fe47acba6a2b6d343c4568432b800629bb8dd638" datatype="html">


### PR DESCRIPTION
## Notes
- @breity Please style the pages as you see fit

## Changes
- In AT > Import Step feature, break up the choose unit&step page into two pages: 
   - Choose unit to import from, and 
   - Choose step(s) to import.
- Change the Choose unit UI from a drop-down to a tabbed list (My Units and Library Units), so you can see more units at once.

## Test
- Import steps feature 
   - lets you to choose a unit and steps in different pages
   - works as before 

Closes #1429