### PR TITLE
refactor(EditProfileComponent): reduce duplication

### DIFF
--- a/src/app/common/edit-profile/edit-profile.component.scss
+++ b/src/app/common/edit-profile/edit-profile.component.scss
@@ -1,0 +1,12 @@
+.actions {
+  margin-top: 8px;
+}
+
+.google-icon {
+  height: 1.8em;
+  width: auto;
+}
+
+.unlink {
+  margin: 8px 0;
+}

--- a/src/app/common/edit-profile/edit-profile.component.spec.ts
+++ b/src/app/common/edit-profile/edit-profile.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { EditProfileComponent } from './edit-profile.component';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+
+describe('EditProfileComponent', () => {
+  let component: EditProfileComponent;
+  let fixture: ComponentFixture<EditProfileComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [EditProfileComponent],
+      imports: [MatDialogModule, MatSnackBarModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EditProfileComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/common/edit-profile/edit-profile.component.ts
+++ b/src/app/common/edit-profile/edit-profile.component.ts
@@ -1,0 +1,30 @@
+import { Component } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { UnlinkGoogleAccountConfirmComponent } from '../../modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component';
+
+@Component({
+  selector: 'edit-profile',
+  templateUrl: './edit-profile.component.html',
+  styleUrls: ['./edit-profile.component.scss']
+})
+export class EditProfileComponent {
+  changed: boolean = false;
+
+  constructor(public dialog: MatDialog, public snackBar: MatSnackBar) {}
+
+  handleUpdateProfileResponse(response) {
+    if (response.status === 'success') {
+      this.changed = false;
+      this.snackBar.open($localize`Profile updated.`);
+    } else {
+      this.snackBar.open($localize`An error occurred. Please try again.`);
+    }
+  }
+
+  unlinkGoogleAccount() {
+    this.dialog.open(UnlinkGoogleAccountConfirmComponent, {
+      panelClass: 'dialog-sm'
+    });
+  }
+}

--- a/src/app/domain/profile.constants.ts
+++ b/src/app/domain/profile.constants.ts
@@ -1,0 +1,12 @@
+export const schoolLevels: SchoolLevel[] = [
+  { code: 'ELEMENTARY_SCHOOL', label: $localize`Elementary School` },
+  { code: 'MIDDLE_SCHOOL', label: $localize`Middle School` },
+  { code: 'HIGH_SCHOOL', label: $localize`High School` },
+  { code: 'COLLEGE', label: $localize`College` },
+  { code: 'OTHER', label: $localize`Other` }
+];
+
+export interface SchoolLevel {
+  code: string;
+  label: string;
+}

--- a/src/app/register/register-teacher-form/register-teacher-form.component.ts
+++ b/src/app/register/register-teacher-form/register-teacher-form.component.ts
@@ -10,6 +10,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { ReCaptchaV3Service } from 'ng-recaptcha';
 import { NewPasswordAndConfirmComponent } from '../../password/new-password-and-confirm/new-password-and-confirm.component';
 import { ConfigService } from '../../services/config.service';
+import { SchoolLevel, schoolLevels } from '../../domain/profile.constants';
 
 @Component({
   selector: 'register-teacher-form',
@@ -36,13 +37,7 @@ export class RegisterTeacherFormComponent extends RegisterUserFormComponent impl
   isSubmitted = false;
   passwordsFormGroup = this.fb.group({});
   processing: boolean = false;
-  schoolLevels: any[] = [
-    { code: 'ELEMENTARY_SCHOOL', label: $localize`Elementary School` },
-    { code: 'MIDDLE_SCHOOL', label: $localize`Middle School` },
-    { code: 'HIGH_SCHOOL', label: $localize`High School` },
-    { code: 'COLLEGE', label: $localize`College` },
-    { code: 'OTHER', label: $localize`Other` }
-  ];
+  schoolLevels: SchoolLevel[] = schoolLevels;
   teacherUser: Teacher = new Teacher();
 
   constructor(

--- a/src/app/student/account/edit-profile/edit-profile.component.scss
+++ b/src/app/student/account/edit-profile/edit-profile.component.scss
@@ -6,16 +6,3 @@
 .inputs {
   max-width: breakpoint('sm.min');
 }
-
-.actions {
-  margin-top: 8px;
-}
-
-.google-icon {
-  height: 1.8em;
-  width: auto;
-}
-
-.unlink {
-  margin: 8px 0;
-}

--- a/src/app/student/account/edit-profile/edit-profile.component.spec.ts
+++ b/src/app/student/account/edit-profile/edit-profile.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { EditProfileComponent } from './edit-profile.component';
+import { StudentEditProfileComponent } from './edit-profile.component';
 import { User } from '../../../domain/user';
 import { Observable, BehaviorSubject } from 'rxjs';
 import { UserService } from '../../../services/user.service';
@@ -53,9 +53,9 @@ export class MockStudentService {
   }
 }
 
-describe('EditProfileComponent', () => {
-  let component: EditProfileComponent;
-  let fixture: ComponentFixture<EditProfileComponent>;
+describe('StudentEditProfileComponent', () => {
+  let component: StudentEditProfileComponent;
+  let fixture: ComponentFixture<StudentEditProfileComponent>;
 
   const getSubmitButton = () => {
     return fixture.debugElement.nativeElement.querySelector('button[type="submit"]');
@@ -72,7 +72,7 @@ describe('EditProfileComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [EditProfileComponent],
+      declarations: [StudentEditProfileComponent],
       imports: [
         BrowserAnimationsModule,
         ReactiveFormsModule,
@@ -87,7 +87,7 @@ describe('EditProfileComponent', () => {
       ],
       schemas: [NO_ERRORS_SCHEMA]
     });
-    fixture = TestBed.createComponent(EditProfileComponent);
+    fixture = TestBed.createComponent(StudentEditProfileComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/student/account/edit-profile/edit-profile.component.ts
+++ b/src/app/student/account/edit-profile/edit-profile.component.ts
@@ -7,17 +7,19 @@ import { UserService } from '../../../services/user.service';
 import { StudentService } from '../../student.service';
 import { Subscription } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
-import { UnlinkGoogleAccountConfirmComponent } from '../../../modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component';
+import { EditProfileComponent } from '../../../common/edit-profile/edit-profile.component';
 
 @Component({
-  selector: 'app-edit-profile',
+  selector: 'student-edit-profile',
   templateUrl: './edit-profile.component.html',
-  styleUrls: ['./edit-profile.component.scss']
+  styleUrls: [
+    '../../../common/edit-profile/edit-profile.component.scss',
+    './edit-profile.component.scss'
+  ]
 })
-export class EditProfileComponent {
+export class StudentEditProfileComponent extends EditProfileComponent {
   user: Student;
   languages: object[];
-  changed: boolean = false;
   isSaving: boolean = false;
   isGoogleUser: boolean = false;
   userSubscription: Subscription;
@@ -35,6 +37,7 @@ export class EditProfileComponent {
     public dialog: MatDialog,
     public snackBar: MatSnackBar
   ) {
+    super(dialog, snackBar);
     this.user = <Student>this.getUser().getValue();
     this.setControlFieldValue('firstName', this.user.firstName);
     this.setControlFieldValue('lastName', this.user.lastName);
@@ -85,21 +88,5 @@ export class EditProfileComponent {
 
   getControlFieldValue(fieldName) {
     return this.editProfileFormGroup.get(fieldName).value;
-  }
-
-  handleUpdateProfileResponse(response) {
-    if (response.status === 'success') {
-      this.changed = false;
-      this.snackBar.open($localize`Profile updated.`);
-    } else {
-      this.snackBar.open($localize`An error occurred. Please try again.`);
-    }
-    this.isSaving = false;
-  }
-
-  unlinkGoogleAccount() {
-    this.dialog.open(UnlinkGoogleAccountConfirmComponent, {
-      panelClass: 'dialog-sm'
-    });
   }
 }

--- a/src/app/student/account/edit/edit.component.html
+++ b/src/app/student/account/edit/edit.component.html
@@ -13,7 +13,7 @@
   <mat-tab-group>
     <mat-tab i18n-label label="Account Info">
       <div class="section__tab">
-        <app-edit-profile></app-edit-profile>
+        <student-edit-profile></student-edit-profile>
       </div>
     </mat-tab>
     <mat-tab i18n-label label="Password">

--- a/src/app/student/account/edit/edit.component.spec.ts
+++ b/src/app/student/account/edit/edit.component.spec.ts
@@ -6,20 +6,22 @@ import { Component, NO_ERRORS_SCHEMA } from '@angular/core';
 @Component({ selector: 'app-edit-password', template: '' })
 class EditPasswordComponent {}
 
-@Component({ selector: 'app-edit-profile', template: '' })
-class EditProfileComponent {}
+@Component({ selector: 'student-edit-profile', template: '' })
+class StudentEditProfileComponent {}
 
 describe('EditComponent', () => {
   let component: EditComponent;
   let fixture: ComponentFixture<EditComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [EditComponent],
-      providers: [],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [EditComponent],
+        providers: [],
+        schemas: [NO_ERRORS_SCHEMA]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(EditComponent);

--- a/src/app/student/student.module.ts
+++ b/src/app/student/student.module.ts
@@ -33,7 +33,7 @@ import { StudentRunListItemComponent } from './student-run-list-item/student-run
 import { AuthGuard } from './auth.guard';
 import { AddProjectDialogComponent } from './add-project-dialog/add-project-dialog.component';
 import { EditComponent } from './account/edit/edit.component';
-import { EditProfileComponent } from './account/edit-profile/edit-profile.component';
+import { StudentEditProfileComponent } from './account/edit-profile/edit-profile.component';
 import { TimelineModule } from '../modules/timeline/timeline.module';
 import { TeamSignInDialogComponent } from './team-sign-in-dialog/team-sign-in-dialog.component';
 import { GoogleSignInModule } from '../modules/google-sign-in/google-sign-in.module';
@@ -57,7 +57,7 @@ import { GoogleSignInModule } from '../modules/google-sign-in/google-sign-in.mod
     StudentRunListComponent,
     StudentRunListItemComponent,
     EditComponent,
-    EditProfileComponent,
+    StudentEditProfileComponent,
     TeamSignInDialogComponent
   ],
   providers: [AuthGuard],

--- a/src/app/teacher/account/edit-profile/edit-profile.component.html
+++ b/src/app/teacher/account/edit-profile/edit-profile.component.html
@@ -95,7 +95,7 @@
       <mat-form-field appearance="fill" fxFlex>
         <mat-label i18n>School Level</mat-label>
         <mat-select formControlName="schoolLevel">
-          <mat-option *ngFor="let schoolLevel of schoolLevels" [value]="schoolLevel.id">
+          <mat-option *ngFor="let schoolLevel of schoolLevels" [value]="schoolLevel.code">
             {{ schoolLevel.label }}
           </mat-option>
         </mat-select>

--- a/src/app/teacher/account/edit-profile/edit-profile.component.scss
+++ b/src/app/teacher/account/edit-profile/edit-profile.component.scss
@@ -21,16 +21,3 @@
     }
   }
 }
-
-.actions {
-  margin-top: 8px;
-}
-
-.google-icon {
-  height: 1.8em;
-  width: auto;
-}
-
-.unlink {
-  margin: 8px 0;
-}

--- a/src/app/teacher/account/edit-profile/edit-profile.component.spec.ts
+++ b/src/app/teacher/account/edit-profile/edit-profile.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { EditProfileComponent } from './edit-profile.component';
+import { TeacherEditProfileComponent } from './edit-profile.component';
 import { UserService } from '../../../services/user.service';
 import { Teacher } from '../../../domain/teacher';
 import { Observable, of, BehaviorSubject } from 'rxjs';
@@ -67,9 +67,9 @@ export class MockTeacherService {
   }
 }
 
-describe('EditProfileComponent', () => {
-  let component: EditProfileComponent;
-  let fixture: ComponentFixture<EditProfileComponent>;
+describe('TeacherEditProfileComponent', () => {
+  let component: TeacherEditProfileComponent;
+  let fixture: ComponentFixture<TeacherEditProfileComponent>;
 
   const getSubmitButton = () => {
     return fixture.debugElement.nativeElement.querySelector('button[type="submit"]');
@@ -86,7 +86,7 @@ describe('EditProfileComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [EditProfileComponent],
+      declarations: [TeacherEditProfileComponent],
       imports: [
         BrowserAnimationsModule,
         ReactiveFormsModule,
@@ -101,7 +101,7 @@ describe('EditProfileComponent', () => {
       ],
       schemas: [NO_ERRORS_SCHEMA]
     });
-    fixture = TestBed.createComponent(EditProfileComponent);
+    fixture = TestBed.createComponent(TeacherEditProfileComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/teacher/account/edit-profile/edit-profile.component.ts
+++ b/src/app/teacher/account/edit-profile/edit-profile.component.ts
@@ -7,6 +7,7 @@ import { Teacher } from '../../../domain/teacher';
 import { TeacherService } from '../../teacher.service';
 import { MatDialog } from '@angular/material/dialog';
 import { Subscription } from 'rxjs';
+import { SchoolLevel, schoolLevels } from '../../../domain/profile.constants';
 import { EditProfileComponent } from '../../../common/edit-profile/edit-profile.component';
 
 @Component({
@@ -19,13 +20,7 @@ import { EditProfileComponent } from '../../../common/edit-profile/edit-profile.
 })
 export class TeacherEditProfileComponent extends EditProfileComponent {
   user: Teacher;
-  schoolLevels: any[] = [
-    { id: 'ELEMENTARY_SCHOOL', label: $localize`Elementary School` },
-    { id: 'MIDDLE_SCHOOL', label: $localize`Middle School` },
-    { id: 'HIGH_SCHOOL', label: $localize`High School` },
-    { id: 'COLLEGE', label: $localize`College` },
-    { id: 'OTHER', label: $localize`Other` }
-  ];
+  schoolLevels: SchoolLevel[] = schoolLevels;
   languages: object[];
   isSaving: boolean = false;
   subscriptions: Subscription = new Subscription();

--- a/src/app/teacher/account/edit-profile/edit-profile.component.ts
+++ b/src/app/teacher/account/edit-profile/edit-profile.component.ts
@@ -6,15 +6,18 @@ import { UserService } from '../../../services/user.service';
 import { Teacher } from '../../../domain/teacher';
 import { TeacherService } from '../../teacher.service';
 import { MatDialog } from '@angular/material/dialog';
-import { UnlinkGoogleAccountConfirmComponent } from '../../../modules/shared/unlink-google-account-confirm/unlink-google-account-confirm.component';
 import { Subscription } from 'rxjs';
+import { EditProfileComponent } from '../../../common/edit-profile/edit-profile.component';
 
 @Component({
-  selector: 'app-edit-profile',
+  selector: 'teacher-edit-profile',
   templateUrl: './edit-profile.component.html',
-  styleUrls: ['./edit-profile.component.scss']
+  styleUrls: [
+    '../../../common/edit-profile/edit-profile.component.scss',
+    './edit-profile.component.scss'
+  ]
 })
-export class EditProfileComponent {
+export class TeacherEditProfileComponent extends EditProfileComponent {
   user: Teacher;
   schoolLevels: any[] = [
     { id: 'ELEMENTARY_SCHOOL', label: $localize`Elementary School` },
@@ -24,7 +27,6 @@ export class EditProfileComponent {
     { id: 'OTHER', label: $localize`Other` }
   ];
   languages: object[];
-  changed: boolean = false;
   isSaving: boolean = false;
   subscriptions: Subscription = new Subscription();
 
@@ -48,7 +50,9 @@ export class EditProfileComponent {
     private userService: UserService,
     public dialog: MatDialog,
     public snackBar: MatSnackBar
-  ) {}
+  ) {
+    super(dialog, snackBar);
+  }
 
   getUser() {
     this.subscriptions.add(
@@ -139,20 +143,5 @@ export class EditProfileComponent {
 
   getControlFieldValue(fieldName) {
     return this.editProfileFormGroup.get(fieldName).value;
-  }
-
-  handleUpdateProfileResponse(response) {
-    if (response.status === 'success') {
-      this.changed = false;
-      this.snackBar.open($localize`Profile updated.`);
-    } else {
-      this.snackBar.open($localize`An error occurred. Please try again.`);
-    }
-  }
-
-  unlinkGoogleAccount() {
-    this.dialog.open(UnlinkGoogleAccountConfirmComponent, {
-      panelClass: 'dialog-sm'
-    });
   }
 }

--- a/src/app/teacher/account/edit/edit.component.html
+++ b/src/app/teacher/account/edit/edit.component.html
@@ -13,7 +13,7 @@
   <mat-tab-group>
     <mat-tab i18n-label label="Account Info">
       <div class="section__tab">
-        <app-edit-profile></app-edit-profile>
+        <teacher-edit-profile></teacher-edit-profile>
       </div>
     </mat-tab>
     <mat-tab i18n-label label="Password">

--- a/src/app/teacher/teacher.module.ts
+++ b/src/app/teacher/teacher.module.ts
@@ -32,7 +32,7 @@ import { LibraryModule } from '../modules/library/library.module';
 import { ShareRunDialogComponent } from './share-run-dialog/share-run-dialog.component';
 import { TimelineModule } from '../modules/timeline/timeline.module';
 import { EditComponent } from './account/edit/edit.component';
-import { EditProfileComponent } from './account/edit-profile/edit-profile.component';
+import { TeacherEditProfileComponent } from './account/edit-profile/edit-profile.component';
 import { RunSettingsDialogComponent } from './run-settings-dialog/run-settings-dialog.component';
 import { EditRunWarningDialogComponent } from './edit-run-warning-dialog/edit-run-warning-dialog.component';
 import { ListClassroomCoursesDialogComponent } from './list-classroom-courses-dialog/list-classroom-courses-dialog.component';
@@ -81,7 +81,6 @@ const materialModules = [
     CreateRunDialogComponent,
     DiscourseRecentActivityComponent,
     EditComponent,
-    EditProfileComponent,
     EditRunWarningDialogComponent,
     ListClassroomCoursesDialogComponent,
     RunMenuComponent,
@@ -89,6 +88,7 @@ const materialModules = [
     ShareRunCodeDialogComponent,
     ShareRunDialogComponent,
     TeacherComponent,
+    TeacherEditProfileComponent,
     TeacherHomeComponent,
     TeacherRunListComponent,
     TeacherRunListItemComponent

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1777,6 +1777,28 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">5</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="4967231969832964676" datatype="html">
+        <source>Profile updated.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/common/edit-profile/edit-profile.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7389211279729440739" datatype="html">
+        <source>An error occurred. Please try again.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/common/edit-profile/edit-profile.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.ts</context>
+          <context context-type="linenumber">100</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.ts</context>
+          <context context-type="linenumber">157</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="4c00c8f929591b166c1e22e74a414a4dd42ff00b" datatype="html">
         <source>Thank you for contacting WISE!</source>
         <context-group purpose="location">
@@ -2154,12 +2176,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">140</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/register/register-teacher-form/register-teacher-form.component.ts</context>
-          <context context-type="linenumber">44</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.ts</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="sourcefile">src/app/domain/profile.constants.ts</context>
+          <context context-type="linenumber">6</context>
         </context-group>
       </trans-unit>
       <trans-unit id="862335120638232941" datatype="html">
@@ -2174,6 +2192,34 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
           <context context-type="linenumber">138</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8954371642157143595" datatype="html">
+        <source>Elementary School</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/domain/profile.constants.ts</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4661798863210162530" datatype="html">
+        <source>Middle School</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/domain/profile.constants.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5560057304612443507" datatype="html">
+        <source>High School</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/domain/profile.constants.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1400655560633958921" datatype="html">
+        <source>College</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/domain/profile.constants.ts</context>
+          <context context-type="linenumber">5</context>
         </context-group>
       </trans-unit>
       <trans-unit id="abc0c762d328168e523abf84749240e43593f8df" datatype="html">
@@ -2554,25 +2600,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-username/forgot-teacher-username.component.html</context>
           <context context-type="linenumber">40</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7389211279729440739" datatype="html">
-        <source>An error occurred. Please try again.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.ts</context>
-          <context context-type="linenumber">100</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password-change/forgot-teacher-password-change.component.ts</context>
-          <context context-type="linenumber">157</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/student/account/edit-profile/edit-profile.component.ts</context>
-          <context context-type="linenumber">95</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.ts</context>
-          <context context-type="linenumber">149</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3979fc2476b643d89e8a9f38d1bbc3014c4a4891" datatype="html">
@@ -7152,50 +7179,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">164</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8954371642157143595" datatype="html">
-        <source>Elementary School</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/register/register-teacher-form/register-teacher-form.component.ts</context>
-          <context context-type="linenumber">40</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.ts</context>
-          <context context-type="linenumber">20</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4661798863210162530" datatype="html">
-        <source>Middle School</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/register/register-teacher-form/register-teacher-form.component.ts</context>
-          <context context-type="linenumber">41</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.ts</context>
-          <context context-type="linenumber">21</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="5560057304612443507" datatype="html">
-        <source>High School</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/register/register-teacher-form/register-teacher-form.component.ts</context>
-          <context context-type="linenumber">42</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.ts</context>
-          <context context-type="linenumber">22</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1400655560633958921" datatype="html">
-        <source>College</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/register/register-teacher-form/register-teacher-form.component.ts</context>
-          <context context-type="linenumber">43</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.ts</context>
-          <context context-type="linenumber">23</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="223846e3b440a5bf278a46411d71586ac79cc6ec" datatype="html">
         <source>- or -</source>
         <context-group purpose="location">
@@ -7287,17 +7270,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.html</context>
           <context context-type="linenumber">158</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4967231969832964676" datatype="html">
-        <source>Profile updated.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/student/account/edit-profile/edit-profile.component.ts</context>
-          <context context-type="linenumber">93</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.ts</context>
-          <context context-type="linenumber">147</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a41a1ea741ebed7a4ff655f233fc2d275b9bfa42" datatype="html">
@@ -12190,14 +12162,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete the selected item?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">95</context>
+          <context context-type="linenumber">105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1189930234736223663" datatype="html">
         <source>Are you sure you want to delete the <x id="PH" equiv-text="selectedNodeIds.length"/> selected items?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e8fb2ceb6f8d4c3e90a6a688e9024461e67f44f0" datatype="html">


### PR DESCRIPTION
## Changes
- Extract `EditProfileComponent.handleUpdateProfileResponse()` and `EditProfileComponent.unlinkGoogleAccount()` from teacher and student components to parent `EditProfileComponent`. Rename student and teacher `EditProfileComponent` to `StudentEditProfileComponent` and `TeacherEditProfileComponent`.
- Extract `schoolLevels` from `TeacherEditProfileComponent` and `RegisterTeacherFormComponent` to global constant.

## Test
- Make sure editing student and teacher profiles work as before and toast message is shown when profile is updated.
- Make sure clicking Unlink Google Account button opens the unlink Google account dialog.