### PR TITLE
fix(Manage Students): Student can end up in multiple workgroups

### DIFF
--- a/src/app/services/updateWorkgroupService.ts
+++ b/src/app/services/updateWorkgroupService.ts
@@ -1,21 +1,21 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { ConfigService } from '../../assets/wise5/services/configService';
+import { Observable } from 'rxjs';
 
 @Injectable()
 export class UpdateWorkgroupService {
-  constructor(private ConfigService: ConfigService, private http: HttpClient) {}
+  constructor(private configService: ConfigService, private http: HttpClient) {}
 
   /**
-   * Move student between workgroups, or to/from workgroup and unassigned students
+   * Move student to a workgroup
    * @param userId Student User ID
-   * @param workgroupIdFrom Workgroup ID to move student from. -1 if student is not in a workgroup
-   * @param workgroupIdTo Workgroup ID to move student to. -1 if moving student to unassigned
-   * @param periodId Period ID the student is in.
+   * @param workgroupIdTo Workgroup ID to move student to
+   * @return Observable of move student response
    */
-  moveMember(userId: number, workgroupIdTo: number) {
+  moveMember(userId: number, workgroupIdTo: number): Observable<any> {
     return this.http.post(
-      `/api/teacher/run/${this.ConfigService.getRunId()}/workgroup/move-user/${userId}`,
+      `/api/teacher/run/${this.configService.getRunId()}/workgroup/move-user/${userId}`,
       {
         workgroupIdTo: workgroupIdTo
       }

--- a/src/app/services/updateWorkgroupService.ts
+++ b/src/app/services/updateWorkgroupService.ts
@@ -1,15 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { ConfigService } from '../../assets/wise5/services/configService';
-import { TeacherDataService } from '../../assets/wise5/services/teacherDataService';
 
 @Injectable()
 export class UpdateWorkgroupService {
-  constructor(
-    private ConfigService: ConfigService,
-    private TeacherDataService: TeacherDataService,
-    private http: HttpClient
-  ) {}
+  constructor(private ConfigService: ConfigService, private http: HttpClient) {}
 
   /**
    * Move student between workgroups, or to/from workgroup and unassigned students
@@ -18,18 +13,11 @@ export class UpdateWorkgroupService {
    * @param workgroupIdTo Workgroup ID to move student to. -1 if moving student to unassigned
    * @param periodId Period ID the student is in.
    */
-  moveMember(
-    userId: number,
-    workgroupIdFrom: number = -1,
-    workgroupIdTo: number = -1,
-    periodId: number = this.TeacherDataService.getCurrentPeriodId()
-  ) {
+  moveMember(userId: number, workgroupIdTo: number) {
     return this.http.post(
       `/api/teacher/run/${this.ConfigService.getRunId()}/workgroup/move-user/${userId}`,
       {
-        workgroupIdFrom: workgroupIdFrom,
-        workgroupIdTo: workgroupIdTo,
-        periodId: periodId
+        workgroupIdTo: workgroupIdTo
       }
     );
   }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/add-team-dialog/add-team-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/add-team-dialog/add-team-dialog.component.ts
@@ -74,13 +74,18 @@ export class AddTeamDialogComponent {
         this.period.periodId,
         this.initialTeamMembers.map((member) => member.id)
       )
-      .subscribe((newWorkgroupId: number) => {
-        this.configService.retrieveConfig(
-          `/api/config/classroomMonitor/${this.configService.getRunId()}`
-        );
-        this.snackBar.open($localize`New team ${newWorkgroupId} has been created.`);
-        this.isProcessing = false;
-        this.dialog.closeAll();
+      .subscribe({
+        next: (newWorkgroupId: number) => {
+          this.configService.retrieveConfig(
+            `/api/config/classroomMonitor/${this.configService.getRunId()}`
+          );
+          this.snackBar.open($localize`New Team ${newWorkgroupId} has been created.`);
+          this.isProcessing = false;
+          this.dialog.closeAll();
+        },
+        error: () => {
+          this.snackBar.open($localize`Error: Could not create team.`);
+        }
       });
   }
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
@@ -88,26 +88,26 @@ export class ManageTeamComponent {
 
   private moveUser(event: CdkDragDrop<string[]>): void {
     this.updateWorkgroupService
-      .moveMember(
-        event.item.data.user.id,
-        event.item.data.workgroupId,
-        this.team.workgroupId,
-        this.team.periodId
-      )
-      .subscribe(() => {
-        const previousIndex = event.previousContainer.data.findIndex(
-          (user) => user === event.item.data.user
-        );
-        transferArrayItem(
-          event.previousContainer.data,
-          event.container.data,
-          previousIndex,
-          event.currentIndex
-        );
-        this.configService.retrieveConfig(
-          `/api/config/classroomMonitor/${this.configService.getRunId()}`
-        );
-        this.snackBar.open($localize`Moved student to Team ${this.team.workgroupId}.`);
+      .moveMember(event.item.data.user.id, this.team.workgroupId)
+      .subscribe({
+        next: (workgroupId: number) => {
+          const previousIndex = event.previousContainer.data.findIndex(
+            (user) => user === event.item.data.user
+          );
+          transferArrayItem(
+            event.previousContainer.data,
+            event.container.data,
+            previousIndex,
+            event.currentIndex
+          );
+          this.configService.retrieveConfig(
+            `/api/config/classroomMonitor/${this.configService.getRunId()}`
+          );
+          this.snackBar.open($localize`Moved student to Team ${workgroupId}.`);
+        },
+        error: () => {
+          this.snackBar.open($localize`Error: Could not move student.`);
+        }
       });
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12793,11 +12793,18 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">47,49</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1914329737918937216" datatype="html">
-        <source>New team <x id="PH" equiv-text="newWorkgroupId"/> has been created.</source>
+      <trans-unit id="4783835659219359159" datatype="html">
+        <source>New Team <x id="PH" equiv-text="newWorkgroupId"/> has been created.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/add-team-dialog/add-team-dialog.component.ts</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="545651489407570329" datatype="html">
+        <source>Error: Could not create team.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/add-team-dialog/add-team-dialog.component.ts</context>
+          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6babfd035bd01c83b35e9440bd51b8b3b45e15d6" datatype="html">
@@ -12997,10 +13004,17 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
       </trans-unit>
       <trans-unit id="513458985182639179" datatype="html">
-        <source>Moved student to Team <x id="PH" equiv-text="this.team.workgroupId"/>.</source>
+        <source>Moved student to Team <x id="PH" equiv-text="workgroupId"/>.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts</context>
-          <context context-type="linenumber">110</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="784919496056996013" datatype="html">
+        <source>Error: Could not move student.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts</context>
+          <context context-type="linenumber">109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9b83b532c3f74e3d6e25a6ba749eef54324bea48" datatype="html">


### PR DESCRIPTION
## Changes

- Move student to another workgroup request only sends the to workgroup id now. It no longer sends the from workgroup id or the period id because it no longer needs it. The server will remove the student from all workgroups in the run and figure out the period by looking at the to workgroup.
- Requests to move student or create new workgroup now handles errors from the server

## Test

- Test with https://github.com/WISE-Community/WISE-API/pull/239

Test 1
1. Open the Manage Students view for a run in two different tabs
2. In tab 1 move a student (example aa0101) to another workgroup (example Team 101)
3. In tab 2 move the same student (example aa0101) to another different workgroup (example Team 102)
4. Refresh the page
5. The student aa0101 used to end up in Team 101 and Team 102 but now it should only end up in Team 102

Test 2
1. Open the Manage students view for a run
2. Click "New Team" and add a student (example aa0101) to the new team and click "Create" and then "Proceed". It will say "New Team 103 has been created." but it will not show Team 103. aa0101 will still be in their original team.
3. Drag aa0101 to an existing team (example Team 102)
4. Refresh the page
5. The student aa0101 used to end up in Team 102 and Team 103 but now should only end up in Team 102

Closes #1437