### PR TITLE
fix(Question Bank): Rules do not work with multiple choice multiple answer

### DIFF
--- a/src/assets/wise5/common/constraint/strategies/ChoiceChosenConstraintStrategy.spec.ts
+++ b/src/assets/wise5/common/constraint/strategies/ChoiceChosenConstraintStrategy.spec.ts
@@ -1,0 +1,99 @@
+import { TestBed } from '@angular/core/testing';
+import { StudentDataService } from '../../../services/studentDataService';
+import { ChoiceChosenConstraintStrategy } from './ChoiceChosenConstraintStrategy';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+
+const choiceId1 = 'choice1';
+const choiceId2 = 'choice2';
+const choiceId3 = 'choice3';
+let dataService: StudentDataService;
+let getLatestComponentStateSpy: jasmine.Spy;
+let strategy: ChoiceChosenConstraintStrategy;
+
+const choice1 = { id: choiceId1 };
+const choice2 = { id: choiceId2 };
+const choice3 = { id: choiceId3 };
+const criteria = {
+  params: {
+    nodeId: 'node1',
+    componentId: 'component1',
+    choiceIds: choiceId1
+  }
+};
+
+describe('ChoiceChosenConstraintStrategy', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, StudentTeacherCommonServicesModule]
+    });
+    strategy = new ChoiceChosenConstraintStrategy();
+    dataService = TestBed.inject(StudentDataService);
+    strategy.dataService = dataService;
+    getLatestComponentStateSpy = spyOn(
+      dataService,
+      'getLatestComponentStateByNodeIdAndComponentId'
+    );
+  });
+  evaluate();
+});
+
+function evaluate(): void {
+  describe('evaluate()', () => {
+    noChoicesChosen();
+    oneChoiceChosen();
+    multipleChoicesChosen();
+  });
+}
+
+function noChoicesChosen(): void {
+  describe('no choices are chosen', () => {
+    it('returns false', () => {
+      setStudentChoicesEvaluateAndExpect([], false);
+    });
+  });
+}
+
+function oneChoiceChosen(): void {
+  describe('one choice is chosen', () => {
+    describe('the expected choice is not chosen', () => {
+      it('returns false', () => {
+        setStudentChoicesEvaluateAndExpect([choice2], false);
+      });
+    });
+    describe('the expected choice is chosen', () => {
+      it('returns true', () => {
+        setStudentChoicesEvaluateAndExpect([choice1], true);
+      });
+    });
+  });
+}
+
+function multipleChoicesChosen(): void {
+  describe('multipe choices are chosen', () => {
+    describe('the expected choice is not chosen', () => {
+      it('returns false', () => {
+        setStudentChoicesEvaluateAndExpect([choice2, choice3], false);
+      });
+    });
+    describe('the expected choice is chosen', () => {
+      it('returns true', () => {
+        setStudentChoicesEvaluateAndExpect([choice1, choice2], true);
+      });
+    });
+  });
+}
+
+function setStudentChoicesEvaluateAndExpect(studentChoices: any[], expectedValue: boolean): void {
+  setStudentChoices(studentChoices);
+  expect(strategy.evaluate(criteria)).toEqual(expectedValue);
+}
+
+function setStudentChoices(studentChoices: any[]): void {
+  const componentState = {
+    studentData: {
+      studentChoices: studentChoices
+    }
+  };
+  getLatestComponentStateSpy.and.returnValue(componentState);
+}

--- a/src/assets/wise5/common/constraint/strategies/ChoiceChosenConstraintStrategy.ts
+++ b/src/assets/wise5/common/constraint/strategies/ChoiceChosenConstraintStrategy.ts
@@ -2,11 +2,17 @@ import { AbstractConstraintStrategy } from './AbstractConstraintStrategy';
 
 export class ChoiceChosenConstraintStrategy extends AbstractConstraintStrategy {
   evaluate(criteria: any): boolean {
-    const service = this.componentServiceLookupService.getService('MultipleChoice');
     const latestComponentState = this.dataService.getLatestComponentStateByNodeIdAndComponentId(
       criteria.params.nodeId,
       criteria.params.componentId
     );
-    return latestComponentState != null && service.choiceChosen(criteria, latestComponentState);
+    return latestComponentState != null && this.isChoiceChosen(criteria, latestComponentState);
+  }
+
+  private isChoiceChosen(criteria: any, componentState: any): boolean {
+    const studentChoiceIds = componentState.studentData.studentChoices.map(
+      (choice: any) => choice.id
+    );
+    return studentChoiceIds.includes(criteria.params.choiceIds);
   }
 }

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleExpression.spec.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleExpression.spec.ts
@@ -14,6 +14,16 @@ function getPostfix() {
       expectPostfixExpression('(1 && 2) || (3 && 4)', ['1', '2', '&&', '3', '4', '&&', '||']);
       expectPostfixExpression('!(1 || 2) && 3', ['1', '2', '||', '!', '3', '&&']);
       expectPostfixExpression('(!1 || (2 && 3)) || 4', ['1', '!', '2', '3', '&&', '||', '4', '||']);
+      expectPostfixExpression(
+        'isLowestWorkgroupIdInPeerGroup() && myChoiceChosen("choice1") && myChoiceChosen("choice2")',
+        [
+          'isLowestWorkgroupIdInPeerGroup',
+          'myChoiceChosen("choice1")',
+          '&&',
+          'myChoiceChosen("choice2")',
+          '&&'
+        ]
+      );
     });
   });
 }

--- a/src/assets/wise5/components/common/feedbackRule/FeedbackRuleExpression.ts
+++ b/src/assets/wise5/components/common/feedbackRule/FeedbackRuleExpression.ts
@@ -28,7 +28,7 @@ export class FeedbackRuleExpression {
     return this.text
       .replace(/ /g, '')
       .split(
-        /(hasKIScore\(\d\)|accumulatedIdeaCountEquals\(\d\)|accumulatedIdeaCountLessThan\(\d\)|accumulatedIdeaCountMoreThan\(\d\)|ideaCountEquals\(\S+\)|ideaCountLessThan\(\S+\)|ideaCountMoreThan\(\S+\)|myChoiceChosen\(\S+\)|isSubmitNumber\(\d+\)|&&|\|\||!|\(|\))/g
+        /(hasKIScore\(\d\)|accumulatedIdeaCountEquals\(\d\)|accumulatedIdeaCountLessThan\(\d\)|accumulatedIdeaCountMoreThan\(\d\)|ideaCountEquals\(\S+\)|ideaCountLessThan\(\S+\)|ideaCountMoreThan\(\S+\)|myChoiceChosen\(\S+?\)|isSubmitNumber\(\d+\)|&&|\|\||!|\(|\))/g
       )
       .filter((el) => el !== '');
   }


### PR DESCRIPTION
## Changes

- ChoiceChosenConstraintStrategy now checks if any of the choices the student chose is the one we are looking for
- Fixed an issue where the tokens were not being processed properly when using && and myChoiceChosen

## Test

Test 1
1. Author a Multiple Choice component that is set to "Multiple Answer"
2. Author a Peer Chat with a Question Bank that has rules like these
```
Rule 1 isLowestWorkgroupIdInPeerGroup() && myChoiceChosen("choice1")
Rule 2 isLowestWorkgroupIdInPeerGroup() && myChoiceChosen("choice2")
Rule 3 isLowestWorkgroupIdInPeerGroup() && myChoiceChosen("choice3")
```
3. Preview the unit and choose choice1 and choice2 in the Multiple Choice step and make sure all the correct questions in the Question Bank are shown in the Peer Chat step

Test 2
1. Author a Multiple Choice component that is set to "Multiple Answer"
2. Author a Peer Chat with a Question Bank that has rules like these
```
Rule 1 isLowestWorkgroupIdInPeerGroup() && myChoiceChosen("choice1") && myChoiceChosen("choice2")
Rule 2 isLowestWorkgroupIdInPeerGroup() && myChoiceChosen("choice1")
```
3. Preview the unit and choose choice1 and make sure only the question from Rule 2 is shown in the Peer Chat step. Previously there was a bug where the && was not working properly and it would evaluate Rule 1 as true even if you only chose choice1 and not choice2. Now Rule 1 should only show up if you chose choice1 and choice2.


Closes #1441