### PR TITLE
feat(Import Step): Move to Create New Step Menu

### DIFF
--- a/src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html
@@ -40,8 +40,6 @@
 <div class="nav-controls">
   <mat-divider></mat-divider>
   <div fxLayout="row" fxLayoutAlign="end center">
-    <button mat-button color="primary" routerLink="../../.." aria-label="Cancel" i18n>
-      Cancel
-    </button>
+    <button mat-button color="primary" routerLink="../../.." i18n>Cancel</button>
   </div>
 </div>

--- a/src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html
@@ -40,6 +40,8 @@
 <div class="nav-controls">
   <mat-divider></mat-divider>
   <div fxLayout="row" fxLayoutAlign="end center">
-    <button mat-button color="primary" routerLink="../.." aria-label="Cancel" i18n>Cancel</button>
+    <button mat-button color="primary" routerLink="../../.." aria-label="Cancel" i18n>
+      Cancel
+    </button>
   </div>
 </div>

--- a/src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.ts
+++ b/src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.ts
@@ -39,14 +39,14 @@ export class ChooseImportStepLocationComponent {
           this.projectService.refreshProject();
           if (nodesWithNewNodeIds.length === 1) {
             const newNode = nodesWithNewNodeIds[0];
-            this.router.navigate(['../../node', newNode.id], {
+            this.router.navigate(['../../../node', newNode.id], {
               relativeTo: this.route,
               state: {
                 newComponents: newNode.components
               }
             });
           } else {
-            this.router.navigate(['../..'], { relativeTo: this.route });
+            this.router.navigate(['../../..'], { relativeTo: this.route });
           }
         });
       });

--- a/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html
@@ -55,7 +55,9 @@
       Back
     </button>
     <span fxFlex></span>
-    <button mat-button color="primary" routerLink="../.." aria-label="cancel" i18n>Cancel</button>
+    <button mat-button color="primary" routerLink="../../.." aria-label="cancel" i18n>
+      Cancel
+    </button>
     <button
       mat-raised-button
       color="primary"

--- a/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html
@@ -55,9 +55,7 @@
       Back
     </button>
     <span fxFlex></span>
-    <button mat-button color="primary" routerLink="../../.." aria-label="cancel" i18n>
-      Cancel
-    </button>
+    <button mat-button color="primary" routerLink="../../.." i18n>Cancel</button>
     <button
       mat-raised-button
       color="primary"

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
@@ -25,6 +25,8 @@
 <div class="nav-controls">
   <mat-divider></mat-divider>
   <div fxLayout="row" fxLayoutGap="16px" fxLayoutAlign="end center">
-    <button mat-button color="primary" routerLink="../.." aria-label="cancel" i18n>Cancel</button>
+    <button mat-button color="primary" routerLink="../../.." aria-label="cancel" i18n>
+      Cancel
+    </button>
   </div>
 </div>

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
@@ -25,6 +25,8 @@
 <div class="nav-controls">
   <mat-divider></mat-divider>
   <div fxLayout="row" fxLayoutGap="16px" fxLayoutAlign="end center">
+    <button mat-button color="primary" routerLink="../../choose-template" i18n>Back</button>
+    <span fxFlex></span>
     <button mat-button color="primary" routerLink="../../.." i18n>Cancel</button>
   </div>
 </div>

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
@@ -25,8 +25,6 @@
 <div class="nav-controls">
   <mat-divider></mat-divider>
   <div fxLayout="row" fxLayoutGap="16px" fxLayoutAlign="end center">
-    <button mat-button color="primary" routerLink="../../.." aria-label="cancel" i18n>
-      Cancel
-    </button>
+    <button mat-button color="primary" routerLink="../../.." i18n>Cancel</button>
   </div>
 </div>

--- a/src/app/teacher/authoring-routing.module.ts
+++ b/src/app/teacher/authoring-routing.module.ts
@@ -91,6 +91,23 @@ const routes: Routes = [
                 component: ChooseNewNodeLocation
               },
               {
+                path: 'import-step',
+                children: [
+                  {
+                    path: 'choose-location',
+                    component: ChooseImportStepLocationComponent
+                  },
+                  {
+                    path: 'choose-step',
+                    component: ChooseImportStepComponent
+                  },
+                  {
+                    path: 'choose-unit',
+                    component: ChooseImportUnitComponent
+                  }
+                ]
+              },
+              {
                 path: 'simulation',
                 children: [{ path: 'choose-item', component: ChooseSimulationComponent }]
               }
@@ -103,23 +120,6 @@ const routes: Routes = [
           },
           { path: 'choose-copy-location', component: ChooseCopyNodeLocationComponent },
           { path: 'choose-move-location', component: ChooseMoveNodeLocationComponent },
-          {
-            path: 'import-step',
-            children: [
-              {
-                path: 'choose-location',
-                component: ChooseImportStepLocationComponent
-              },
-              {
-                path: 'choose-step',
-                component: ChooseImportStepComponent
-              },
-              {
-                path: 'choose-unit',
-                component: ChooseImportUnitComponent
-              }
-            ]
-          },
           { path: 'info', component: ProjectInfoAuthoringComponent },
           { path: 'milestones', component: MilestonesAuthoringComponent },
           {

--- a/src/assets/wise5/authoringTool/addNode/NewNodeTemplate.ts
+++ b/src/assets/wise5/authoringTool/addNode/NewNodeTemplate.ts
@@ -1,6 +1,5 @@
 export interface NewNodeTemplate {
   label: string;
-  description: string;
   icon: string;
   route: string;
 }

--- a/src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.html
+++ b/src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.html
@@ -1,4 +1,4 @@
-<h5 i18n>Start from scratch or choose a step template:</h5>
+<h5 i18n>Start from scratch, import from another unit, or choose a step template:</h5>
 <div fxLayout="row wrap" fxLayout.xs="column">
   <div
     class="template"

--- a/src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts
@@ -11,25 +11,21 @@ export class ChooseNewNodeTemplate {
   protected templates: NewNodeTemplate[] = [
     {
       label: $localize`Create Your Own`,
-      description: $localize`Create Your Own Description`,
       icon: 'mode_edit',
       route: 'add-your-own'
     },
     {
-      label: $localize`Import from Another Unit`,
-      description: $localize`Import a step from another unit`,
+      label: $localize`Import From Another Unit`,
       icon: 'system_update_alt',
       route: 'import-step/choose-unit'
     },
     {
       label: $localize`Automated Assessment`,
-      description: $localize`Automated Assessment`,
       icon: 'fact_check',
       route: 'automated-assessment/choose-item'
     },
     {
       label: $localize`Interactive Simulation`,
-      description: $localize`Add an existing interactive simulation`,
       icon: 'video_settings',
       route: 'simulation/choose-item'
     }

--- a/src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts
@@ -16,8 +16,14 @@ export class ChooseNewNodeTemplate {
       route: 'add-your-own'
     },
     {
+      label: $localize`Import from Another Unit`,
+      description: $localize`Import a step from another unit`,
+      icon: 'system_update_alt',
+      route: 'import-step/choose-unit'
+    },
+    {
       label: $localize`Automated Assessment`,
-      description: $localize`Automated Assessment Description`,
+      description: $localize`Automated Assessment`,
       icon: 'fact_check',
       route: 'automated-assessment/choose-item'
     },

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -46,17 +46,6 @@
     <button
       mat-raised-button
       color="primary"
-      (click)="importStep()"
-      [disabled]="stepNodeSelected || groupNodeSelected"
-      matTooltip="Import Step"
-      matTooltipPosition="above"
-      i18n-matTooltip
-    >
-      <mat-icon>system_update_alt</mat-icon>
-    </button>
-    <button
-      mat-raised-button
-      color="primary"
       (click)="chooseLocation(false)"
       [disabled]="!hasSelectedNodes()"
       matTooltip="Move"

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -13,9 +13,9 @@
     <button
       mat-raised-button
       color="primary"
-      (click)="createNewLesson()"
+      (click)="addNewLesson()"
       [disabled]="stepNodeSelected || groupNodeSelected"
-      matTooltip="Create New Lesson"
+      matTooltip="Add New Lesson"
       matTooltipPosition="above"
       i18n-matTooltip
     >
@@ -24,9 +24,9 @@
     <button
       mat-raised-button
       color="primary"
-      (click)="createNewStep()"
+      (click)="addNewStep()"
       [disabled]="stepNodeSelected || groupNodeSelected"
-      matTooltip="Create New Step"
+      matTooltip="Add New Step"
       matTooltipPosition="above"
       i18n-matTooltip
     >

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -152,10 +152,6 @@ export class ProjectAuthoringComponent {
     this.router.navigate([`/teacher/edit/unit/${this.projectId}/structure/choose`]);
   }
 
-  protected importStep(): void {
-    this.router.navigate([`/teacher/edit/unit/${this.projectId}/import-step/choose-unit`]);
-  }
-
   protected goToAdvancedAuthoring(): void {
     this.router.navigate([`/teacher/edit/unit/${this.projectId}/advanced`]);
   }

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -140,11 +140,11 @@ export class ProjectAuthoringComponent {
     this.groupNodeSelected = false;
   }
 
-  protected createNewLesson(): void {
+  protected addNewLesson(): void {
     this.router.navigate([`/teacher/edit/unit/${this.projectId}/add-lesson/configure`]);
   }
 
-  protected createNewStep(): void {
+  protected addNewStep(): void {
     this.router.navigate([`/teacher/edit/unit/${this.projectId}/add-node/choose-template`]);
   }
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9305,50 +9305,25 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">13</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="5366550815577392042" datatype="html">
-        <source>Create Your Own Description</source>
+      <trans-unit id="7152189031040166896" datatype="html">
+        <source>Import From Another Unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts</context>
-          <context context-type="linenumber">14</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6442735221080596866" datatype="html">
-        <source>Import from Another Unit</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts</context>
-          <context context-type="linenumber">19</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8901860174205925726" datatype="html">
-        <source>Import a step from another unit</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8293078288618811295" datatype="html">
         <source>Automated Assessment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts</context>
-          <context context-type="linenumber">25</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">23</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6013229483538709548" datatype="html">
         <source>Interactive Simulation</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts</context>
-          <context context-type="linenumber">31</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3682992588117847800" datatype="html">
-        <source>Add an existing interactive simulation</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9430426ed5a9b22d6dcf57e82af9318742f4b2bc" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -390,18 +390,6 @@
           <context context-type="linenumber">34</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html</context>
-          <context context-type="linenumber">43</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">58</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">28</context>
-        </context-group>
-        <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
           <context context-type="linenumber">14</context>
         </context-group>
@@ -701,7 +689,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">73</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.html</context>
@@ -1417,6 +1405,33 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="da44efc7b658c318651866454d258bbbe57ff21c" datatype="html">
+        <source> Cancel </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html</context>
+          <context context-type="linenumber">43,45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
+          <context context-type="linenumber">58,60</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
+          <context context-type="linenumber">28,30</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
+          <context context-type="linenumber">26,28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
+          <context context-type="linenumber">60,62</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.html</context>
+          <context context-type="linenumber">28,30</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="aebe90fbb61e57f4a4ea689e1f155a3f58cea25a" datatype="html">
         <source>Choose the step(s) that you want to import, then select Next.</source>
         <context-group purpose="location">
@@ -1439,7 +1454,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">106</context>
+          <context context-type="linenumber">95</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/top-bar/top-bar.component.html</context>
@@ -1547,7 +1562,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Next</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">64</context>
+          <context context-type="linenumber">66</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
@@ -1582,7 +1597,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source> Next </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">69,71</context>
+          <context context-type="linenumber">71,73</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
@@ -5390,7 +5405,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">73</context>
+          <context context-type="linenumber">62</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-list/project-list.component.html</context>
@@ -9125,21 +9140,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">20,22</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="da44efc7b658c318651866454d258bbbe57ff21c" datatype="html">
-        <source> Cancel </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
-          <context context-type="linenumber">26,28</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">60,62</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.html</context>
-          <context context-type="linenumber">28,30</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="891f639ffcf9d31aea80ea7e8e428a6597b059b3" datatype="html">
         <source>Step Title</source>
         <context-group purpose="location">
@@ -9280,8 +9280,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8bff5bc1b934165ac00899643ab91eb5320ad557" datatype="html">
-        <source>Start from scratch or choose a step template:</source>
+      <trans-unit id="22d1a7923c6b3db8b9eca074db71d7fda2c76b19" datatype="html">
+        <source>Start from scratch, import from another unit, or choose a step template:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.html</context>
           <context context-type="linenumber">1</context>
@@ -9312,32 +9312,43 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8293078288618811295" datatype="html">
-        <source>Automated Assessment</source>
+      <trans-unit id="6442735221080596866" datatype="html">
+        <source>Import from Another Unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts</context>
           <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2412675100535030076" datatype="html">
-        <source>Automated Assessment Description</source>
+      <trans-unit id="8901860174205925726" datatype="html">
+        <source>Import a step from another unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts</context>
           <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8293078288618811295" datatype="html">
+        <source>Automated Assessment</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts</context>
+          <context context-type="linenumber">26</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6013229483538709548" datatype="html">
         <source>Interactive Simulation</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3682992588117847800" datatype="html">
         <source>Add an existing interactive simulation</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9430426ed5a9b22d6dcf57e82af9318742f4b2bc" datatype="html">
@@ -9688,7 +9699,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">196</context>
+          <context context-type="linenumber">185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a10dba8eb1f22a5f90f90e79b8305963eec3ee38" datatype="html">
@@ -9703,7 +9714,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">265</context>
+          <context context-type="linenumber">254</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0217500199a3e48a7b95762b14b79dad49e76beb" datatype="html">
@@ -9718,7 +9729,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">266</context>
+          <context context-type="linenumber">255</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f951d80b53d5536f79142285e8ba09f190a3c723" datatype="html">
@@ -11474,7 +11485,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">95</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4f26c54d5c3edadf92756d7d3ce466dde1f01e2a" datatype="html">
@@ -12126,18 +12137,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">40</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3538ada3bf07e331bafa52cf68b5862c1670a695" datatype="html">
-        <source>Import Step</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">51</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="57cf305f9bfd681c70dc26e914108d06384ade9f" datatype="html">
         <source>Move</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">62</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2babf1354d25bf42fc198b512e41efe699029adc" datatype="html">
@@ -12146,7 +12150,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
                 }}"/> paths based on <x id="INTERPOLATION_1" equiv-text="{{ getBranchCriteriaDescription(item.key) }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">154,156</context>
+          <context context-type="linenumber">143,145</context>
         </context-group>
       </trans-unit>
       <trans-unit id="30e48681d6264197efea8455adfefd170a75e87f" datatype="html">
@@ -12155,7 +12159,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
                 }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">164,166</context>
+          <context context-type="linenumber">153,155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="352c3d81453aabe6f46a08ce422003e76f85f041" datatype="html">
@@ -12164,14 +12168,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
                 }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">174,176</context>
+          <context context-type="linenumber">163,165</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b3b4847175a6193afa85eb431bbe16d1f04470fa" datatype="html">
         <source>Has Rubric</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">172</context>
         </context-group>
       </trans-unit>
       <trans-unit id="791981839110791639" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12091,15 +12091,15 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">7</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="bcf0ed433ab4782db0764ae24fb015e22520f41f" datatype="html">
-        <source>Create New Lesson</source>
+      <trans-unit id="e5e0c8fd39cb0db7735731e3ae7d2108f430f16e" datatype="html">
+        <source>Add New Lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
           <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="93c7d1ec242f9b1551ee0b4ac7dc133dbeab61cf" datatype="html">
-        <source>Create New Step</source>
+      <trans-unit id="965b71c27ad581bf0f53e7f483505d2898c98a36" datatype="html">
+        <source>Add New Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
           <context context-type="linenumber">29</context>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -390,6 +390,18 @@
           <context context-type="linenumber">34</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
           <context context-type="linenumber">14</context>
         </context-group>
@@ -1405,33 +1417,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="da44efc7b658c318651866454d258bbbe57ff21c" datatype="html">
-        <source> Cancel </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step-location/choose-import-step-location.component.html</context>
-          <context context-type="linenumber">43,45</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">58,60</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">28,30</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
-          <context context-type="linenumber">26,28</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">60,62</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.html</context>
-          <context context-type="linenumber">28,30</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="aebe90fbb61e57f4a4ea689e1f155a3f58cea25a" datatype="html">
         <source>Choose the step(s) that you want to import, then select Next.</source>
         <context-group purpose="location">
@@ -1562,7 +1547,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Next</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">64</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
@@ -1597,7 +1582,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source> Next </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">71,73</context>
+          <context context-type="linenumber">69,71</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
@@ -9138,6 +9123,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
           <context context-type="linenumber">20,22</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="da44efc7b658c318651866454d258bbbe57ff21c" datatype="html">
+        <source> Cancel </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
+          <context context-type="linenumber">26,28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
+          <context context-type="linenumber">60,62</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.html</context>
+          <context context-type="linenumber">28,30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="891f639ffcf9d31aea80ea7e8e428a6597b059b3" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -399,7 +399,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">30</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
@@ -1482,6 +1482,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
           <context context-type="linenumber">51</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
+          <context context-type="linenumber">28</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>


### PR DESCRIPTION
## Notes
- @breity please feel free to style and re-word elements as you see fit
   - For example, should the "Create New Step" button be "Add New Step" in the project-authoring view? 

## Changes
- Move "Import Step" option to "Create New Step" menu (before: "Import Step" was a top-level option in the project-authoring view). This will remove the top-level button in project-authoring view by 1, and make the import step workflow similar to import component flow.

## Test
- "Import Step" option is available through "Add New Step" menu
- "Import Step" workflow works as before, including back/cancel buttons

Closes #1444