### PR TITLE
fix(Project Authoring): Can't go back into node authoring

### DIFF
--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -36,6 +36,7 @@ export class ProjectAuthoringComponent {
   ngOnInit(): void {
     this.projectId = Number(this.route.snapshot.paramMap.get('unitId'));
     this.refreshProject();
+    this.dataService.setCurrentNode(null);
     this.temporarilyHighlightNewNodes(history.state.newNodes);
     this.subscriptions.add(
       this.projectService.refreshProject$.subscribe(() => {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12178,14 +12178,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete the selected item?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">105</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1189930234736223663" datatype="html">
         <source>Are you sure you want to delete the <x id="PH" equiv-text="selectedNodeIds.length"/> selected items?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">106</context>
+          <context context-type="linenumber">107</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e8fb2ceb6f8d4c3e90a6a688e9024461e67f44f0" datatype="html">


### PR DESCRIPTION
## Changes
- Fix issue where you could not return to the node editing for the just-edited node after using the home side-menu icon

## Test
1. Go to step authoring for step 1
2. Exit to project authoring by clicking on the home side-menu icon
3. Go back to step authoring for step 1

This should work. Before, you could not re-open step 1.

Closes #1431 