### PR TITLE
fix(Manage Students): Sometimes does not load any workgroups

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroom-monitor.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroom-monitor.component.ts
@@ -66,6 +66,7 @@ export class ClassroomMonitorComponent implements OnInit {
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
+    this.dataService.clearCurrentPeriod();
   }
 
   private initializeNotebook(): void {

--- a/src/assets/wise5/services/teacherDataService.ts
+++ b/src/assets/wise5/services/teacherDataService.ts
@@ -683,6 +683,10 @@ export class TeacherDataService extends DataService {
     }
   }
 
+  clearCurrentPeriod(): void {
+    this.currentPeriod = null;
+  }
+
   getCurrentPeriod() {
     return this.currentPeriod;
   }


### PR DESCRIPTION
## Changes

Clear current period when leaving Classroom Monitor.

## Test

1. Sign in as a teacher that has at least two runs that have workgroups
2. Load the Manage Students view for the first run by clicking on the "X students" link. You should see workgroups.
3. Click the back button on your browser
4. Load the Manage Students view for the second run by clicking on the "X students" link. The Manage Students view loads and should show the workgroups. It used to not show any workgroups.

Closes #1451