### PR TITLE
refactor(NodeService): Clean up getNextNode() for AT/CM modes

### DIFF
--- a/src/assets/wise5/services/nodeService.ts
+++ b/src/assets/wise5/services/nodeService.ts
@@ -58,7 +58,7 @@ export class NodeService {
       let nextNodeId = null;
       const currentNodeId = currentId ?? this.DataService.getCurrentNodeId();
       if (currentNodeId) {
-        if (['classroomMonitor', 'author'].includes(this.ConfigService.getMode())) {
+        if (['author', 'classroomMonitor'].includes(this.ConfigService.getMode())) {
           const currentNodeOrder = this.ProjectService.getNodeOrderById(currentNodeId);
           if (currentNodeOrder) {
             const nextId = this.ProjectService.getNodeIdByOrder(currentNodeOrder + 1);

--- a/src/assets/wise5/services/nodeService.ts
+++ b/src/assets/wise5/services/nodeService.ts
@@ -53,32 +53,19 @@ export class NodeService {
    * @param currentId (optional)
    * @returns a promise that returns the next node id
    */
-  getNextNodeId(currentId?): Promise<any> {
+  getNextNodeId(currentId?: string): Promise<any> {
     const promise = new Promise((resolve, reject) => {
       let nextNodeId = null;
-      let currentNodeId = null;
-      let mode = this.ConfigService.getMode();
-      if (currentId) {
-        currentNodeId = currentId;
-      } else {
-        let currentNode = null;
-        currentNode = this.DataService.getCurrentNode();
-        if (currentNode) {
-          currentNodeId = currentNode.id;
-        }
-      }
+      const currentNodeId = currentId ?? this.DataService.getCurrentNodeId();
       if (currentNodeId) {
-        if (mode === 'classroomMonitor' || mode === 'author') {
-          let currentNodeOrder = this.ProjectService.getNodeOrderById(currentNodeId);
+        if (['classroomMonitor', 'author'].includes(this.ConfigService.getMode())) {
+          const currentNodeOrder = this.ProjectService.getNodeOrderById(currentNodeId);
           if (currentNodeOrder) {
-            let nextNodeOrder = currentNodeOrder + 1;
-            let nextId = this.ProjectService.getNodeIdByOrder(nextNodeOrder);
+            const nextId = this.ProjectService.getNodeIdByOrder(currentNodeOrder + 1);
             if (nextId) {
-              if (this.ProjectService.isApplicationNode(nextId)) {
-                nextNodeId = nextId;
-              } else if (this.ProjectService.isGroupNode(nextId)) {
-                nextNodeId = this.getNextNodeId(nextId);
-              }
+              nextNodeId = this.ProjectService.isApplicationNode(nextId)
+                ? nextId
+                : this.getNextNodeId(nextId);
             }
           }
           resolve(nextNodeId);


### PR DESCRIPTION
## Changes
- Call ```DataService.getCurrentNodeId()``` to simplify code at the beginning of the function
- Move check for mode closer to where it's actually used
- Use ternary check for application node/group node check
- Change ```let``` to ```const``` where appropriate

## Test
- Going to the next node using the next arrow in the step tools in CM, AT, Student VLE and Preview works as before.