### PR TITLE
fix(Manage Students): Fix UI not updating immediately sometimes

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/add-team-dialog/add-team-dialog.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/add-team-dialog/add-team-dialog.component.spec.ts
@@ -24,7 +24,9 @@ class ConfigServiceStub {
   getAllUsersInPeriod() {
     return [{ name: 'c' }, { name: 'b' }, { name: 'a' }];
   }
-  retrieveConfig() {}
+  retrieveConfig() {
+    return of({});
+  }
 }
 class TeacherDataServiceStub {
   getCurrentPeriodId() {
@@ -33,7 +35,9 @@ class TeacherDataServiceStub {
 }
 class WorkgroupServiceStub {
   isUserInAnyWorkgroup() {}
-  createWorkgroup() {}
+  createWorkgroup() {
+    return of(10);
+  }
 }
 let component: AddTeamDialogComponent;
 let fixture: ComponentFixture<AddTeamDialogComponent>;
@@ -126,8 +130,7 @@ function createTeam() {
     });
     it('should not ask for confirmation when initialMember is not in a workgroup', () => {
       spyOn(workgroupService, 'isUserInAnyWorkgroup').and.returnValue(false);
-      const createWorkgroupSpy = spyOn(workgroupService, 'createWorkgroup').and.returnValue(of(1));
-      spyOn(configService, 'retrieveConfig');
+      const createWorkgroupSpy = spyOn(workgroupService, 'createWorkgroup').and.returnValue(of(10));
       component.createTeam();
       expect(dialogSpy).not.toHaveBeenCalled();
       expect(createWorkgroupSpy).toHaveBeenCalled();

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/add-team-dialog/add-team-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/add-team-dialog/add-team-dialog.component.ts
@@ -76,12 +76,15 @@ export class AddTeamDialogComponent {
       )
       .subscribe({
         next: (newWorkgroupId: number) => {
-          this.configService.retrieveConfig(
-            `/api/config/classroomMonitor/${this.configService.getRunId()}`
-          );
-          this.snackBar.open($localize`New Team ${newWorkgroupId} has been created.`);
-          this.isProcessing = false;
-          this.dialog.closeAll();
+          this.configService
+            .retrieveConfig(`/api/config/classroomMonitor/${this.configService.getRunId()}`)
+            .subscribe({
+              next: () => {
+                this.snackBar.open($localize`New Team ${newWorkgroupId} has been created.`);
+                this.isProcessing = false;
+                this.dialog.closeAll();
+              }
+            });
         },
         error: () => {
           this.snackBar.open($localize`Error: Could not create team.`);

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.spec.ts
@@ -8,6 +8,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ConfigService } from '../../../../services/configService';
 
 import { ChangeTeamPeriodDialogComponent } from './change-team-period-dialog.component';
+import { of } from 'rxjs';
 
 class ConfigServiceStub {
   getPeriods() {
@@ -20,7 +21,7 @@ class ConfigServiceStub {
     return 123;
   }
   retrieveConfig() {
-    return {};
+    return of({});
   }
 }
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/change-team-period-dialog/change-team-period-dialog.component.ts
@@ -44,20 +44,23 @@ export class ChangeTeamPeriodDialogComponent {
         }/change-period`,
         this.selectedPeriod.periodId
       )
-      .subscribe(
-        (response) => {
+      .subscribe({
+        next: () => {
           this.isChangingPeriod = false;
-          this.configService.retrieveConfig(
-            `/api/config/classroomMonitor/${this.configService.getRunId()}`
-          );
-          this.snackBar.open(
-            $localize`Moved Team ${this.team.workgroupId} to Period ${this.selectedPeriod.periodName}.`
-          );
-          this.dialog.closeAll();
+          this.configService
+            .retrieveConfig(`/api/config/classroomMonitor/${this.configService.getRunId()}`)
+            .subscribe({
+              next: () => {
+                this.snackBar.open(
+                  $localize`Moved Team ${this.team.workgroupId} to Period ${this.selectedPeriod.periodName}.`
+                );
+                this.dialog.closeAll();
+              }
+            });
         },
-        (err) => {
+        error: () => {
           this.isChangingPeriod = false;
         }
-      );
+      });
   }
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
@@ -100,10 +100,13 @@ export class ManageTeamComponent {
             previousIndex,
             event.currentIndex
           );
-          this.configService.retrieveConfig(
-            `/api/config/classroomMonitor/${this.configService.getRunId()}`
-          );
-          this.snackBar.open($localize`Moved student to Team ${workgroupId}.`);
+          this.configService
+            .retrieveConfig(`/api/config/classroomMonitor/${this.configService.getRunId()}`)
+            .subscribe({
+              next: () => {
+                this.snackBar.open($localize`Moved student to Team ${workgroupId}.`);
+              }
+            });
         },
         error: () => {
           this.snackBar.open($localize`Error: Could not move student.`);


### PR DESCRIPTION
## Changes

In the Manage Students view, refresh the UI when
- creating a new team
- moving a team to another period
- moving a student to another team

## Test

In the Manage Students view, make sure the UI updates properly when
- creating a new team
- moving a team to another period
- moving a student to another team

Closes #1440