### PR TITLE
refactor(NodeService): Move authoring-specific observables to TeacherNodeService

### DIFF
--- a/src/app/authoring-tool/edit-advanced-component/edit-advanced-component.component.ts
+++ b/src/app/authoring-tool/edit-advanced-component/edit-advanced-component.component.ts
@@ -1,9 +1,9 @@
 import { Directive, Input } from '@angular/core';
 import { ComponentContent } from '../../../assets/wise5/common/ComponentContent';
 import { Component } from '../../../assets/wise5/common/Component';
-import { NodeService } from '../../../assets/wise5/services/nodeService';
 import { NotebookService } from '../../../assets/wise5/services/notebookService';
 import { TeacherProjectService } from '../../../assets/wise5/services/teacherProjectService';
+import { TeacherNodeService } from '../../../assets/wise5/services/teacherNodeService';
 
 @Directive()
 export abstract class EditAdvancedComponentComponent {
@@ -13,7 +13,7 @@ export abstract class EditAdvancedComponentComponent {
   @Input() nodeId: string;
 
   constructor(
-    protected nodeService: NodeService,
+    protected nodeService: TeacherNodeService,
     protected notebookService: NotebookService,
     protected teacherProjectService: TeacherProjectService
   ) {}

--- a/src/assets/wise5/authoringTool/components/AbstractComponentAuthoring.ts
+++ b/src/assets/wise5/authoringTool/components/AbstractComponentAuthoring.ts
@@ -3,8 +3,8 @@ import { Subject, Subscription } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { ProjectAssetService } from '../../../../app/services/projectAssetService';
 import { ConfigService } from '../../services/configService';
-import { NodeService } from '../../services/nodeService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
+import { TeacherNodeService } from '../../services/teacherNodeService';
 
 @Directive()
 export abstract class AbstractComponentAuthoring {
@@ -19,7 +19,7 @@ export abstract class AbstractComponentAuthoring {
 
   constructor(
     protected configService: ConfigService,
-    protected nodeService: NodeService,
+    protected nodeService: TeacherNodeService,
     protected projectAssetService: ProjectAssetService,
     protected projectService: TeacherProjectService
   ) {}

--- a/src/assets/wise5/authoringTool/components/save-starter-state/save-starter-state.component.ts
+++ b/src/assets/wise5/authoringTool/components/save-starter-state/save-starter-state.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit, SimpleChanges } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { NodeService } from '../../../services/nodeService';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 import { Component as WISEComponent } from '../../../common/Component';
 
 @Component({
@@ -12,7 +12,7 @@ export class SaveStarterStateComponent implements OnInit {
   protected isDirty: boolean;
   @Input() private starterState: any;
 
-  constructor(private matDialog: MatDialog, private nodeService: NodeService) {}
+  constructor(private matDialog: MatDialog, private nodeService: TeacherNodeService) {}
 
   ngOnInit(): void {}
 

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
@@ -22,6 +22,7 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 let component: NodeAuthoringComponent;
 let component1: any;
@@ -56,6 +57,7 @@ describe('NodeAuthoringComponent', () => {
         ClassroomStatusService,
         ProjectAssetService,
         TeacherDataService,
+        TeacherNodeService,
         TeacherProjectService,
         TeacherWebSocketService,
         {

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { Subscription, filter } from 'rxjs';
 import { TeacherDataService } from '../../../services/teacherDataService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
-import { NodeService } from '../../../services/nodeService';
 import { ComponentTypeService } from '../../../services/componentTypeService';
 import { ComponentServiceLookupService } from '../../../services/componentServiceLookupService';
 import { Node } from '../../../common/Node';
@@ -15,6 +14,7 @@ import { Component as WiseComponent } from '../../../common/Component';
 import { ChooseNewComponent } from '../../../../../app/authoring-tool/add-component/choose-new-component/choose-new-component.component';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { ActivatedRoute, Router } from '@angular/router';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'node-authoring',
@@ -39,7 +39,7 @@ export class NodeAuthoringComponent implements OnInit {
     private componentServiceLookupService: ComponentServiceLookupService,
     private componentTypeService: ComponentTypeService,
     private dialog: MatDialog,
-    private nodeService: NodeService,
+    private nodeService: TeacherNodeService,
     private projectService: TeacherProjectService,
     private dataService: TeacherDataService,
     private route: ActivatedRoute,

--- a/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.spec.ts
+++ b/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.spec.ts
@@ -11,11 +11,11 @@ import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-comp
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { copy } from '../../../common/object/object';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { MockNodeService } from '../../common/MockNodeService';
 import { AnimationAuthoring } from './animation-authoring.component';
 import { MatDialogModule } from '@angular/material/dialog';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 export class MockConfigService {}
 
@@ -39,7 +39,7 @@ describe('AnimationAuthoring', () => {
       ],
       declarations: [AnimationAuthoring, EditComponentPrompt],
       providers: [
-        { provide: NodeService, useClass: MockNodeService },
+        { provide: TeacherNodeService, useClass: MockNodeService },
         ProjectAssetService,
         TeacherProjectService
       ]

--- a/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.ts
+++ b/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.ts
@@ -7,10 +7,10 @@ import { ProjectAssetService } from '../../../../../app/services/projectAssetSer
 import { AbstractComponentAuthoring } from '../../../authoringTool/components/AbstractComponentAuthoring';
 import { generateRandomKey } from '../../../common/string/string';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { MatDialog } from '@angular/material/dialog';
 import { AssetChooser } from '../../../authoringTool/project-asset-authoring/asset-chooser';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'animation-authoring',
@@ -26,7 +26,7 @@ export class AnimationAuthoring extends AbstractComponentAuthoring {
   constructor(
     protected ConfigService: ConfigService,
     private dialog: MatDialog,
-    protected NodeService: NodeService,
+    protected NodeService: TeacherNodeService,
     protected ProjectAssetService: ProjectAssetService,
     protected ProjectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.spec.ts
+++ b/src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.spec.ts
@@ -11,6 +11,7 @@ import { StudentTeacherCommonServicesModule } from '../../../../../app/student-t
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { AudioOscillatorService } from '../audioOscillatorService';
 import { AudioOscillatorAuthoring } from './audio-oscillator-authoring.component';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 let component: AudioOscillatorAuthoring;
 let fixture: ComponentFixture<AudioOscillatorAuthoring>;
@@ -30,7 +31,7 @@ describe('AudioOscillatorAuthoring', () => {
         StudentTeacherCommonServicesModule
       ],
       declarations: [EditComponentPrompt, AudioOscillatorAuthoring],
-      providers: [ProjectAssetService, TeacherProjectService]
+      providers: [ProjectAssetService, TeacherNodeService, TeacherProjectService]
     });
     fixture = TestBed.createComponent(AudioOscillatorAuthoring);
     component = fixture.componentInstance;

--- a/src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.ts
+++ b/src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.ts
@@ -4,9 +4,9 @@ import { Component } from '@angular/core';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { AbstractComponentAuthoring } from '../../../authoringTool/components/AbstractComponentAuthoring';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { AudioOscillatorService } from '../audioOscillatorService';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'audio-oscillator-authoring',
@@ -23,7 +23,7 @@ export class AudioOscillatorAuthoring extends AbstractComponentAuthoring {
   constructor(
     protected AudioOscillatorService: AudioOscillatorService,
     protected ConfigService: ConfigService,
-    protected NodeService: NodeService,
+    protected NodeService: TeacherNodeService,
     protected ProjectAssetService: ProjectAssetService,
     protected ProjectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/conceptMap/concept-map-authoring/concept-map-authoring.component.ts
+++ b/src/assets/wise5/components/conceptMap/concept-map-authoring/concept-map-authoring.component.ts
@@ -4,12 +4,12 @@ import { Component } from '@angular/core';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { AbstractComponentAuthoring } from '../../../authoringTool/components/AbstractComponentAuthoring';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { ConceptMapService } from '../conceptMapService';
 import { MatDialog } from '@angular/material/dialog';
 import { AssetChooser } from '../../../authoringTool/project-asset-authoring/asset-chooser';
 import { filter } from 'rxjs/operators';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'concept-map-authoring',
@@ -24,7 +24,7 @@ export class ConceptMapAuthoring extends AbstractComponentAuthoring {
     private ConceptMapService: ConceptMapService,
     protected ConfigService: ConfigService,
     private dialog: MatDialog,
-    protected NodeService: NodeService,
+    protected NodeService: TeacherNodeService,
     protected ProjectAssetService: ProjectAssetService,
     protected ProjectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/conceptMap/concept-map-authoring/concept-map-authoring.module.ts
+++ b/src/assets/wise5/components/conceptMap/concept-map-authoring/concept-map-authoring.module.ts
@@ -10,7 +10,6 @@ import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-comp
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { AnnotationService } from '../../../services/annotationService';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { ProjectService } from '../../../services/projectService';
 import { SessionService } from '../../../services/sessionService';
 import { StudentAssetService } from '../../../services/studentAssetService';
@@ -19,6 +18,7 @@ import { TagService } from '../../../services/tagService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { ConceptMapService } from '../conceptMapService';
 import { ConceptMapAuthoring } from './concept-map-authoring.component';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @NgModule({
   declarations: [ConceptMapAuthoring, EditComponentPrompt],
@@ -35,13 +35,13 @@ import { ConceptMapAuthoring } from './concept-map-authoring.component';
     AnnotationService,
     ConceptMapService,
     ConfigService,
-    NodeService,
     ProjectAssetService,
     ProjectService,
     SessionService,
     StudentAssetService,
     StudentDataService,
     TagService,
+    TeacherNodeService,
     TeacherProjectService
   ],
   exports: [ConceptMapAuthoring, EditComponentPrompt]

--- a/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.spec.ts
+++ b/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.spec.ts
@@ -24,6 +24,7 @@ import { NotebookService } from '../../../services/notebookService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { ConceptMapContent } from '../ConceptMapContent';
 import { EditConceptMapAdvancedComponent } from './edit-concept-map-advanced.component';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 let component: EditConceptMapAdvancedComponent;
 let fixture: ComponentFixture<EditConceptMapAdvancedComponent>;
@@ -57,7 +58,7 @@ describe('EditConceptMapAdvancedComponent', () => {
         EditConnectedComponentsAddButtonComponent,
         EditConnectedComponentsComponent
       ],
-      providers: [TeacherProjectService],
+      providers: [TeacherNodeService, TeacherProjectService],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
   });

--- a/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.ts
+++ b/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
 import { EditAdvancedComponentComponent } from '../../../../../app/authoring-tool/edit-advanced-component/edit-advanced-component.component';
-import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { ConceptMapContent } from '../ConceptMapContent';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'edit-concept-map-advanced',
@@ -15,7 +15,7 @@ export class EditConceptMapAdvancedComponent extends EditAdvancedComponentCompon
   allowedConnectedComponentTypes = ['ConceptMap', 'Draw', 'Embedded', 'Graph', 'Label', 'Table'];
 
   constructor(
-    protected nodeService: NodeService,
+    protected nodeService: TeacherNodeService,
     protected notebookService: NotebookService,
     protected projectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.spec.ts
@@ -6,6 +6,7 @@ import { copy } from '../../../common/object/object';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { DialogGuidanceAuthoringComponent } from './dialog-guidance-authoring.component';
 import { DialogGuidanceAuthoringModule } from './dialog-guidance-authoring.module';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 const componentContent = {
   id: 'i64ex48j1z',
@@ -28,7 +29,8 @@ describe('DialogGuidanceAuthoringComponent', () => {
         DialogGuidanceAuthoringModule,
         HttpClientTestingModule,
         StudentTeacherCommonServicesModule
-      ]
+      ],
+      providers: [TeacherNodeService]
     });
     fixture = TestBed.createComponent(DialogGuidanceAuthoringComponent);
     component = fixture.componentInstance;

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.ts
@@ -1,10 +1,10 @@
 import { Component } from '@angular/core';
 import { AbstractComponentAuthoring } from '../../../authoringTool/components/AbstractComponentAuthoring';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { DialogGuidanceService } from '../dialogGuidanceService';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'dialog-guidance-authoring',
@@ -15,7 +15,7 @@ export class DialogGuidanceAuthoringComponent extends AbstractComponentAuthoring
   constructor(
     protected configService: ConfigService,
     private dialogGuidanceService: DialogGuidanceService,
-    protected nodeService: NodeService,
+    protected nodeService: TeacherNodeService,
     protected projectAssetService: ProjectAssetService,
     protected projectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/discussion/discussion-authoring/discussion-authoring.component.ts
+++ b/src/assets/wise5/components/discussion/discussion-authoring/discussion-authoring.component.ts
@@ -4,8 +4,8 @@ import { Component } from '@angular/core';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { AbstractComponentAuthoring } from '../../../authoringTool/components/AbstractComponentAuthoring';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'discussion-authoring',
@@ -15,7 +15,7 @@ import { TeacherProjectService } from '../../../services/teacherProjectService';
 export class DiscussionAuthoring extends AbstractComponentAuthoring {
   constructor(
     protected ConfigService: ConfigService,
-    protected NodeService: NodeService,
+    protected NodeService: TeacherNodeService,
     protected ProjectAssetService: ProjectAssetService,
     protected ProjectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/draw/draw-authoring/draw-authoring.component.ts
+++ b/src/assets/wise5/components/draw/draw-authoring/draw-authoring.component.ts
@@ -10,6 +10,7 @@ import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { AssetChooser } from '../../../authoringTool/project-asset-authoring/asset-chooser';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'draw-authoring',
@@ -48,7 +49,7 @@ export class DrawAuthoring extends AbstractComponentAuthoring {
   constructor(
     protected ConfigService: ConfigService,
     private dialog: MatDialog,
-    protected NodeService: NodeService,
+    protected NodeService: TeacherNodeService,
     protected ProjectAssetService: ProjectAssetService,
     protected ProjectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/draw/draw-authoring/draw-authoring.module.ts
+++ b/src/assets/wise5/components/draw/draw-authoring/draw-authoring.module.ts
@@ -10,7 +10,6 @@ import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-comp
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { AnnotationService } from '../../../services/annotationService';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { ProjectService } from '../../../services/projectService';
 import { SessionService } from '../../../services/sessionService';
 import { StudentAssetService } from '../../../services/studentAssetService';
@@ -19,6 +18,7 @@ import { TagService } from '../../../services/tagService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { DrawService } from '../drawService';
 import { DrawAuthoring } from './draw-authoring.component';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @NgModule({
   declarations: [DrawAuthoring, EditComponentPrompt],
@@ -35,13 +35,13 @@ import { DrawAuthoring } from './draw-authoring.component';
     AnnotationService,
     ConfigService,
     DrawService,
-    NodeService,
     ProjectAssetService,
     ProjectService,
     SessionService,
     StudentAssetService,
     StudentDataService,
     TagService,
+    TeacherNodeService,
     TeacherProjectService
   ],
   exports: [DrawAuthoring, EditComponentPrompt]

--- a/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.spec.ts
+++ b/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.spec.ts
@@ -6,6 +6,7 @@ import { copy } from '../../../common/object/object';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { EmbeddedAuthoring } from './embedded-authoring.component';
 import { EmbeddedAuthoringModule } from './embedded-authoring.module';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 let component: EmbeddedAuthoring;
 let fixture: ComponentFixture<EmbeddedAuthoring>;
@@ -18,7 +19,8 @@ describe('EmbeddedAuthoringComponent', () => {
         EmbeddedAuthoringModule,
         HttpClientTestingModule,
         StudentTeacherCommonServicesModule
-      ]
+      ],
+      providers: [TeacherNodeService]
     });
     fixture = TestBed.createComponent(EmbeddedAuthoring);
     component = fixture.componentInstance;

--- a/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.ts
+++ b/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.ts
@@ -4,12 +4,12 @@ import { Component } from '@angular/core';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { AbstractComponentAuthoring } from '../../../authoringTool/components/AbstractComponentAuthoring';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { EmbeddedService } from '../embeddedService';
 import { MatDialog } from '@angular/material/dialog';
 import { AssetChooser } from '../../../authoringTool/project-asset-authoring/asset-chooser';
 import { filter } from 'rxjs/operators';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'embedded-authoring',
@@ -23,7 +23,7 @@ export class EmbeddedAuthoring extends AbstractComponentAuthoring {
     protected ConfigService: ConfigService,
     private dialog: MatDialog,
     private EmbeddedService: EmbeddedService,
-    protected NodeService: NodeService,
+    protected NodeService: TeacherNodeService,
     protected ProjectAssetService: ProjectAssetService,
     protected ProjectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.spec.ts
+++ b/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.spec.ts
@@ -25,6 +25,7 @@ import { NotebookService } from '../../../services/notebookService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { GraphContent } from '../GraphContent';
 import { EditGraphAdvancedComponent } from './edit-graph-advanced.component';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 let component: EditGraphAdvancedComponent;
 let fixture: ComponentFixture<EditGraphAdvancedComponent>;
@@ -58,7 +59,7 @@ describe('EditGraphAdvancedComponent', () => {
         EditConnectedComponentsComponent,
         EditGraphAdvancedComponent
       ],
-      providers: [TeacherProjectService],
+      providers: [TeacherNodeService, TeacherProjectService],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
   });

--- a/src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.spec.ts
+++ b/src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.spec.ts
@@ -17,6 +17,7 @@ import { StudentTeacherCommonServicesModule } from '../../../../../app/student-t
 import { copy } from '../../../common/object/object';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { GraphAuthoring } from './graph-authoring.component';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 let component: GraphAuthoring;
 let fixture: ComponentFixture<GraphAuthoring>;
@@ -41,7 +42,7 @@ describe('GraphAuthoringComponent', () => {
         StudentTeacherCommonServicesModule
       ],
       declarations: [GraphAuthoring, EditComponentPrompt],
-      providers: [ProjectAssetService, TeacherProjectService]
+      providers: [ProjectAssetService, TeacherNodeService, TeacherProjectService]
     });
     fixture = TestBed.createComponent(GraphAuthoring);
     component = fixture.componentInstance;

--- a/src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.ts
+++ b/src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.ts
@@ -4,13 +4,13 @@ import { Component } from '@angular/core';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { AbstractComponentAuthoring } from '../../../authoringTool/components/AbstractComponentAuthoring';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { GraphService } from '../graphService';
 import { isMultipleYAxes } from '../util';
 import { MatDialog } from '@angular/material/dialog';
 import { AssetChooser } from '../../../authoringTool/project-asset-authoring/asset-chooser';
 import { filter } from 'rxjs/operators';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'graph-authoring',
@@ -134,7 +134,7 @@ export class GraphAuthoring extends AbstractComponentAuthoring {
     protected ConfigService: ConfigService,
     private dialog: MatDialog,
     private GraphService: GraphService,
-    protected NodeService: NodeService,
+    protected NodeService: TeacherNodeService,
     protected ProjectAssetService: ProjectAssetService,
     protected ProjectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/html/html-authoring/html-authoring.component.ts
+++ b/src/assets/wise5/components/html/html-authoring/html-authoring.component.ts
@@ -3,8 +3,8 @@ import { ProjectAssetService } from '../../../../../app/services/projectAssetSer
 import { AbstractComponentAuthoring } from '../../../authoringTool/components/AbstractComponentAuthoring';
 import { insertWiseLinks, replaceWiseLinks } from '../../../common/wise-link/wise-link';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'html-authoring',
@@ -15,9 +15,9 @@ export class HtmlAuthoring extends AbstractComponentAuthoring {
 
   constructor(
     protected configService: ConfigService,
-    protected nodeService: NodeService,
+    protected nodeService: TeacherNodeService,
     protected projectAssetService: ProjectAssetService,
-    protected projectService: TeacherProjectService,
+    protected projectService: TeacherProjectService
   ) {
     super(configService, nodeService, projectAssetService, projectService);
   }

--- a/src/assets/wise5/components/label/label-authoring/label-authoring.component.ts
+++ b/src/assets/wise5/components/label/label-authoring/label-authoring.component.ts
@@ -3,13 +3,13 @@
 import { Component } from '@angular/core';
 import { AbstractComponentAuthoring } from '../../../authoringTool/components/AbstractComponentAuthoring';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter } from 'rxjs/operators';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { MatDialog } from '@angular/material/dialog';
 import { AssetChooser } from '../../../authoringTool/project-asset-authoring/asset-chooser';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'label-authoring',
@@ -23,7 +23,7 @@ export class LabelAuthoring extends AbstractComponentAuthoring {
   constructor(
     protected ConfigService: ConfigService,
     private dialog: MatDialog,
-    protected NodeService: NodeService,
+    protected NodeService: TeacherNodeService,
     protected ProjectAssetService: ProjectAssetService,
     protected ProjectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/match/match-authoring/match-authoring.component.ts
+++ b/src/assets/wise5/components/match/match-authoring/match-authoring.component.ts
@@ -5,11 +5,11 @@ import { ProjectAssetService } from '../../../../../app/services/projectAssetSer
 import { AbstractComponentAuthoring } from '../../../authoringTool/components/AbstractComponentAuthoring';
 import { generateRandomKey } from '../../../common/string/string';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { MatchService } from '../matchService';
 import { MatDialog } from '@angular/material/dialog';
 import { AssetChooser } from '../../../authoringTool/project-asset-authoring/asset-chooser';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'match-authoring',
@@ -24,7 +24,7 @@ export class MatchAuthoring extends AbstractComponentAuthoring {
     protected configService: ConfigService,
     private dialog: MatDialog,
     private matchService: MatchService,
-    protected nodeService: NodeService,
+    protected nodeService: TeacherNodeService,
     protected projectAssetService: ProjectAssetService,
     protected projectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.ts
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.ts
@@ -5,10 +5,10 @@ import { ProjectAssetService } from '../../../../../app/services/projectAssetSer
 import { AbstractComponentAuthoring } from '../../../authoringTool/components/AbstractComponentAuthoring';
 import { generateRandomKey } from '../../../common/string/string';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { MatDialog } from '@angular/material/dialog';
 import { AssetChooser } from '../../../authoringTool/project-asset-authoring/asset-chooser';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'multiple-choice-authoring',
@@ -23,7 +23,7 @@ export class MultipleChoiceAuthoring extends AbstractComponentAuthoring {
   constructor(
     protected ConfigService: ConfigService,
     private dialog: MatDialog,
-    protected NodeService: NodeService,
+    protected NodeService: TeacherNodeService,
     protected ProjectAssetService: ProjectAssetService,
     protected ProjectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
@@ -26,6 +26,7 @@ import { NotebookService } from '../../../services/notebookService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { OpenResponseContent } from '../OpenResponseContent';
 import { EditOpenResponseAdvancedComponent } from './edit-open-response-advanced.component';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 let component: EditOpenResponseAdvancedComponent;
 let fixture: ComponentFixture<EditOpenResponseAdvancedComponent>;
@@ -62,7 +63,7 @@ describe('EditOpenResponseAdvancedComponent', () => {
         EditConnectedComponentsComponent,
         EditOpenResponseAdvancedComponent
       ],
-      providers: [TeacherProjectService],
+      providers: [TeacherNodeService, TeacherProjectService],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
   });

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
@@ -1,10 +1,10 @@
 import { Component } from '@angular/core';
 import { EditAdvancedComponentComponent } from '../../../../../app/authoring-tool/edit-advanced-component/edit-advanced-component.component';
 import { CRaterService } from '../../../services/cRaterService';
-import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { OpenResponseContent } from '../OpenResponseContent';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'edit-open-response-advanced',
@@ -28,7 +28,7 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
 
   constructor(
     protected cRaterService: CRaterService,
-    protected nodeService: NodeService,
+    protected nodeService: TeacherNodeService,
     protected notebookService: NotebookService,
     protected teacherProjectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component.ts
+++ b/src/assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component.ts
@@ -4,9 +4,9 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { AbstractComponentAuthoring } from '../../../authoringTool/components/AbstractComponentAuthoring';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { OutsideURLService } from '../outsideURLService';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'outside-url-authoring',
@@ -45,7 +45,7 @@ export class OutsideUrlAuthoring extends AbstractComponentAuthoring {
 
   constructor(
     protected ConfigService: ConfigService,
-    protected NodeService: NodeService,
+    protected NodeService: TeacherNodeService,
     protected OutsideURLService: OutsideURLService,
     protected ProjectAssetService: ProjectAssetService,
     protected ProjectService: TeacherProjectService

--- a/src/assets/wise5/components/peerChat/edit-peer-chat-advanced-component/edit-peer-chat-advanced-component.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/edit-peer-chat-advanced-component/edit-peer-chat-advanced-component.component.spec.ts
@@ -6,6 +6,7 @@ import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { PeerChatContent } from '../PeerChatContent';
 import { EditPeerChatAdvancedComponentComponent } from './edit-peer-chat-advanced-component.component';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 describe('EditPeerChatAdvancedComponentComponent', () => {
   let component: EditPeerChatAdvancedComponentComponent;
@@ -15,7 +16,7 @@ describe('EditPeerChatAdvancedComponentComponent', () => {
     await TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, MatDialogModule, StudentTeacherCommonServicesModule],
       declarations: [EditPeerChatAdvancedComponentComponent],
-      providers: [TeacherProjectService],
+      providers: [TeacherNodeService, TeacherProjectService],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
   });

--- a/src/assets/wise5/components/peerChat/edit-peer-chat-advanced-component/edit-peer-chat-advanced-component.component.ts
+++ b/src/assets/wise5/components/peerChat/edit-peer-chat-advanced-component/edit-peer-chat-advanced-component.component.ts
@@ -1,8 +1,8 @@
 import { Component } from '@angular/core';
 import { EditAdvancedComponentComponent } from '../../../../../app/authoring-tool/edit-advanced-component/edit-advanced-component.component';
-import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'edit-peer-chat-advanced',
@@ -11,7 +11,7 @@ import { TeacherProjectService } from '../../../services/teacherProjectService';
 })
 export class EditPeerChatAdvancedComponentComponent extends EditAdvancedComponentComponent {
   constructor(
-    protected nodeService: NodeService,
+    protected nodeService: TeacherNodeService,
     protected notebookService: NotebookService,
     protected projectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.spec.ts
@@ -11,7 +11,6 @@ import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-comp
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { copy } from '../../../common/object/object';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { ProjectService } from '../../../services/projectService';
 import { SessionService } from '../../../services/sessionService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
@@ -19,6 +18,7 @@ import { MockNodeService } from '../../common/MockNodeService';
 import { PeerChatAuthoringComponent } from './peer-chat-authoring.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 const componentContent = {
   id: 'qn3savv52r',
@@ -60,7 +60,7 @@ describe('PeerChatAuthoringComponent', () => {
       declarations: [EditComponentPrompt, PeerChatAuthoringComponent],
       providers: [
         ConfigService,
-        { provide: NodeService, useClass: MockNodeService },
+        { provide: TeacherNodeService, useClass: MockNodeService },
         ProjectAssetService,
         ProjectService,
         SessionService,

--- a/src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.ts
@@ -2,9 +2,9 @@ import { Component } from '@angular/core';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { AbstractComponentAuthoring } from '../../../authoringTool/components/AbstractComponentAuthoring';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import peerChatLogicOptions from './peer-chat-logic-options';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'peer-chat-authoring',
@@ -27,7 +27,7 @@ export class PeerChatAuthoringComponent extends AbstractComponentAuthoring {
 
   constructor(
     protected configService: ConfigService,
-    protected nodeService: NodeService,
+    protected nodeService: TeacherNodeService,
     protected projectAssetService: ProjectAssetService,
     protected projectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.spec.ts
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.spec.ts
@@ -14,6 +14,7 @@ import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-comp
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 describe('ShowGroupWorkAuthoringComponent', () => {
   let component: ShowGroupWorkAuthoringComponent;
@@ -35,7 +36,7 @@ describe('ShowGroupWorkAuthoringComponent', () => {
         StudentTeacherCommonServicesModule
       ],
       declarations: [EditComponentPrompt, ShowGroupWorkAuthoringComponent],
-      providers: [ProjectAssetService, TeacherProjectService],
+      providers: [ProjectAssetService, TeacherNodeService, TeacherProjectService],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
   });

--- a/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.ts
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { ShowMyWorkAuthoringComponent } from '../../showMyWork/show-my-work-authoring/show-my-work-authoring.component';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'show-group-work-authoring',
@@ -13,7 +13,7 @@ import { ShowMyWorkAuthoringComponent } from '../../showMyWork/show-my-work-auth
 export class ShowGroupWorkAuthoringComponent extends ShowMyWorkAuthoringComponent {
   constructor(
     protected configService: ConfigService,
-    protected nodeService: NodeService,
+    protected nodeService: TeacherNodeService,
     protected projectAssetService: ProjectAssetService,
     protected projectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/showMyWork/show-my-work-authoring/show-my-work-authoring.component.spec.ts
+++ b/src/assets/wise5/components/showMyWork/show-my-work-authoring/show-my-work-authoring.component.spec.ts
@@ -12,6 +12,7 @@ import { ProjectAssetService } from '../../../../../app/services/projectAssetSer
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { ShowMyWorkAuthoringComponent } from './show-my-work-authoring.component';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 describe('ShowMyWorkAuthoringComponent', () => {
   let component: ShowMyWorkAuthoringComponent;
@@ -43,7 +44,7 @@ describe('ShowMyWorkAuthoringComponent', () => {
         StudentTeacherCommonServicesModule
       ],
       declarations: [EditComponentPrompt, ShowMyWorkAuthoringComponent],
-      providers: [ProjectAssetService, TeacherProjectService]
+      providers: [ProjectAssetService, TeacherNodeService, TeacherProjectService]
     }).compileComponents();
   });
 

--- a/src/assets/wise5/components/showMyWork/show-my-work-authoring/show-my-work-authoring.component.ts
+++ b/src/assets/wise5/components/showMyWork/show-my-work-authoring/show-my-work-authoring.component.ts
@@ -2,8 +2,8 @@ import { Component } from '@angular/core';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { AbstractComponentAuthoring } from '../../../authoringTool/components/AbstractComponentAuthoring';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'show-my-work-authoring',
@@ -30,7 +30,7 @@ export class ShowMyWorkAuthoringComponent extends AbstractComponentAuthoring {
 
   constructor(
     protected configService: ConfigService,
-    protected nodeService: NodeService,
+    protected nodeService: TeacherNodeService,
     protected projectAssetService: ProjectAssetService,
     protected projectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.spec.ts
+++ b/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.spec.ts
@@ -14,10 +14,10 @@ import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-comp
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { copy } from '../../../common/object/object';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { MockNodeService } from '../../common/MockNodeService';
 import { SummaryAuthoring } from './summary-authoring.component';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 export class MockConfigService {}
 
@@ -45,7 +45,7 @@ describe('SummaryAuthoringComponent', () => {
       ],
       declarations: [EditComponentPrompt, SummaryAuthoring],
       providers: [
-        { provide: NodeService, useClass: MockNodeService },
+        { provide: TeacherNodeService, useClass: MockNodeService },
         ProjectAssetService,
         TeacherProjectService
       ]

--- a/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.ts
+++ b/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.ts
@@ -5,10 +5,10 @@ import { ProjectAssetService } from '../../../../../app/services/projectAssetSer
 import { AbstractComponentAuthoring } from '../../../authoringTool/components/AbstractComponentAuthoring';
 import { ComponentServiceLookupService } from '../../../services/componentServiceLookupService';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { MultipleChoiceContent } from '../../multipleChoice/MultipleChoiceContent';
 import { SummaryService } from '../summaryService';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'summary-authoring',
@@ -24,7 +24,7 @@ export class SummaryAuthoring extends AbstractComponentAuthoring {
   constructor(
     private componentServiceLookupService: ComponentServiceLookupService,
     protected ConfigService: ConfigService,
-    protected NodeService: NodeService,
+    protected NodeService: TeacherNodeService,
     protected ProjectAssetService: ProjectAssetService,
     protected ProjectService: TeacherProjectService,
     private SummaryService: SummaryService

--- a/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.spec.ts
+++ b/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.spec.ts
@@ -27,6 +27,7 @@ import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { EditTableConnectedComponentsComponent } from '../edit-table-connected-components/edit-table-connected-components.component';
 import { EditTableAdvancedComponent } from './edit-table-advanced.component';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 let component: EditTableAdvancedComponent;
 let fixture: ComponentFixture<EditTableAdvancedComponent>;
@@ -62,7 +63,7 @@ describe('EditTableAdvancedComponent', () => {
         EditTableAdvancedComponent,
         EditTableConnectedComponentsComponent
       ],
-      providers: [TeacherProjectService],
+      providers: [TeacherNodeService, TeacherProjectService],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
   });

--- a/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.ts
+++ b/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.ts
@@ -1,10 +1,10 @@
 import { Component } from '@angular/core';
 import { EditAdvancedComponentComponent } from '../../../../../app/authoring-tool/edit-advanced-component/edit-advanced-component.component';
 import { CSVToArray } from '../../../common/array/array';
-import { NodeService } from '../../../services/nodeService';
 import { NotebookService } from '../../../services/notebookService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { TableContent } from '../TableContent';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'edit-table-advanced',
@@ -25,7 +25,7 @@ export class EditTableAdvancedComponent extends EditAdvancedComponentComponent {
   importTableMessage: string;
 
   constructor(
-    protected nodeService: NodeService,
+    protected nodeService: TeacherNodeService,
     protected notebookService: NotebookService,
     protected teacherProjectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/components/table/table-authoring/table-authoring.component.ts
+++ b/src/assets/wise5/components/table/table-authoring/table-authoring.component.ts
@@ -6,8 +6,8 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { AbstractComponentAuthoring } from '../../../authoringTool/components/AbstractComponentAuthoring';
 import { ConfigService } from '../../../services/configService';
-import { NodeService } from '../../../services/nodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
   selector: 'table-authoring',
@@ -25,7 +25,7 @@ export class TableAuthoring extends AbstractComponentAuthoring {
 
   constructor(
     protected ConfigService: ConfigService,
-    protected NodeService: NodeService,
+    protected NodeService: TeacherNodeService,
     protected ProjectAssetService: ProjectAssetService,
     protected ProjectService: TeacherProjectService
   ) {

--- a/src/assets/wise5/services/nodeService.ts
+++ b/src/assets/wise5/services/nodeService.ts
@@ -17,12 +17,6 @@ export class NodeService {
   public nodeSubmitClicked$: Observable<any> = this.nodeSubmitClickedSource.asObservable();
   private doneRenderingComponentSource: Subject<any> = new Subject<any>();
   public doneRenderingComponent$ = this.doneRenderingComponentSource.asObservable();
-  private componentShowSubmitButtonValueChangedSource: Subject<any> = new Subject<any>();
-  public componentShowSubmitButtonValueChanged$: Observable<any> = this.componentShowSubmitButtonValueChangedSource.asObservable();
-  private starterStateResponseSource: Subject<any> = new Subject<any>();
-  public starterStateResponse$: Observable<any> = this.starterStateResponseSource.asObservable();
-  private deleteStarterStateSource: Subject<any> = new Subject<any>();
-  public deleteStarterState$: Observable<any> = this.deleteStarterStateSource.asObservable();
 
   constructor(
     protected dialog: MatDialog,
@@ -544,18 +538,6 @@ export class NodeService {
 
   broadcastDoneRenderingComponent(nodeIdAndComponentId: any) {
     this.doneRenderingComponentSource.next(nodeIdAndComponentId);
-  }
-
-  broadcastComponentShowSubmitButtonValueChanged(args: any) {
-    this.componentShowSubmitButtonValueChangedSource.next(args);
-  }
-
-  deleteStarterState(args: any) {
-    this.deleteStarterStateSource.next(args);
-  }
-
-  respondStarterState(args: any) {
-    this.starterStateResponseSource.next(args);
   }
 
   scrollToComponentAndHighlight(componentId: string): void {

--- a/src/assets/wise5/services/teacherNodeService.ts
+++ b/src/assets/wise5/services/teacherNodeService.ts
@@ -1,5 +1,25 @@
 import { Injectable } from '@angular/core';
 import { NodeService } from './nodeService';
+import { Subject, Observable } from 'rxjs';
 
 @Injectable()
-export class TeacherNodeService extends NodeService {}
+export class TeacherNodeService extends NodeService {
+  private componentShowSubmitButtonValueChangedSource: Subject<any> = new Subject<any>();
+  public componentShowSubmitButtonValueChanged$: Observable<any> = this.componentShowSubmitButtonValueChangedSource.asObservable();
+  private deleteStarterStateSource: Subject<any> = new Subject<any>();
+  public deleteStarterState$: Observable<any> = this.deleteStarterStateSource.asObservable();
+  private starterStateResponseSource: Subject<any> = new Subject<any>();
+  public starterStateResponse$: Observable<any> = this.starterStateResponseSource.asObservable();
+
+  broadcastComponentShowSubmitButtonValueChanged(args: any): void {
+    this.componentShowSubmitButtonValueChangedSource.next(args);
+  }
+
+  deleteStarterState(args: any): void {
+    this.deleteStarterStateSource.next(args);
+  }
+
+  respondStarterState(args: any): void {
+    this.starterStateResponseSource.next(args);
+  }
+}

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9589,7 +9589,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroom-monitor.component.ts</context>
-          <context context-type="linenumber">83</context>
+          <context context-type="linenumber">84</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.ts</context>
@@ -9611,7 +9611,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroom-monitor.component.ts</context>
-          <context context-type="linenumber">146</context>
+          <context context-type="linenumber">147</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
@@ -9626,7 +9626,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroom-monitor.component.ts</context>
-          <context context-type="linenumber">147</context>
+          <context context-type="linenumber">148</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
@@ -12613,7 +12613,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Grade by Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroom-monitor.component.ts</context>
-          <context context-type="linenumber">90</context>
+          <context context-type="linenumber">91</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.ts</context>
@@ -12624,7 +12624,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Grade by Team</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroom-monitor.component.ts</context>
-          <context context-type="linenumber">103</context>
+          <context context-type="linenumber">104</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.ts</context>
@@ -12635,7 +12635,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Manage Students</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroom-monitor.component.ts</context>
-          <context context-type="linenumber">110</context>
+          <context context-type="linenumber">111</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.ts</context>
@@ -12646,7 +12646,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Student Notebooks</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroom-monitor.component.ts</context>
-          <context context-type="linenumber">117</context>
+          <context context-type="linenumber">118</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.ts</context>
@@ -12657,7 +12657,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Data Export</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroom-monitor.component.ts</context>
-          <context context-type="linenumber">124</context>
+          <context context-type="linenumber">125</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.ts</context>
@@ -12668,7 +12668,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Error: Data is not being saved! Check your internet connection.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroom-monitor.component.ts</context>
-          <context context-type="linenumber">189</context>
+          <context context-type="linenumber">190</context>
         </context-group>
       </trans-unit>
       <trans-unit id="694e14160d51abf2460c07f4d2592dac127e1f2f" datatype="html">
@@ -17367,7 +17367,7 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
 <x id="PH" equiv-text="this.componentContent.stamps.Stamps[index]"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/draw/draw-authoring/draw-authoring.component.ts</context>
-          <context context-type="linenumber">243</context>
+          <context context-type="linenumber">244</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3ee6d14ea15f70683272c9df8c3aff6457182928" datatype="html">


### PR DESCRIPTION
## Changes
- Move these authoring-specific observables from NodeService to TeacherNodeService
   - componentShowSubmitButtonValueChanged$
   - deleteStarterState$
   - starterStateResponse$
- Update references

## Test
- Authoring works as before, especially:
   - saving/deleting starter state (draw, label, concept map, etc)
   - submit button automatically gets set/unset when cRater is enabled/disabled 
