### PR TITLE
refactor(NodeService): Remove scrollToComponentAndHighlight()

### DIFF
--- a/src/app/services/wiseLinkService.ts
+++ b/src/app/services/wiseLinkService.ts
@@ -3,6 +3,7 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { replaceWiseLinks } from '../../assets/wise5/common/wise-link/wise-link';
 import { NodeService } from '../../assets/wise5/services/nodeService';
 import { StudentDataService } from '../../assets/wise5/services/studentDataService';
+import { scrollToElement, temporarilyHighlightElement } from '../../assets/wise5/common/dom/dom';
 
 @Injectable()
 export class WiseLinkService {
@@ -43,15 +44,26 @@ export class WiseLinkService {
 
   private followLink(nodeId: string, componentId: string): void {
     if (nodeId === this.studentDataService.getCurrentNodeId()) {
-      this.nodeService.scrollToComponentAndHighlight(componentId);
+      this.scrollToComponentAndHighlight(componentId);
     } else {
       this.goToNode(nodeId, componentId);
     }
   }
 
+  private scrollToComponentAndHighlight(componentId: string): void {
+    const elementId = `component_${componentId}`;
+    scrollToElement(elementId);
+    temporarilyHighlightElement(elementId);
+  }
+
   private goToNode(nodeId: string, componentId: string): void {
     if (componentId !== '') {
-      this.nodeService.registerScrollToComponent(componentId);
+      const subscription = this.studentDataService.currentNodeChanged$.subscribe(() => {
+        setTimeout(() => {
+          this.scrollToComponentAndHighlight(componentId);
+          subscription.unsubscribe();
+        }, 500); // timeout attempts to ensure that new node has loaded before scroll+highlight
+      });
     }
     this.nodeService.setCurrentNode(nodeId);
   }

--- a/src/assets/wise5/common/dom/dom.ts
+++ b/src/assets/wise5/common/dom/dom.ts
@@ -32,7 +32,7 @@ export function temporarilyHighlightElement(id: string, duration: number = 1000)
   }, duration);
 }
 
-export function scrollToElement(elementId: string) {
+export function scrollToElement(elementId: string): void {
   $('#content').animate(
     {
       scrollTop: $(`#${elementId}`).prop('offsetTop')

--- a/src/assets/wise5/services/nodeService.ts
+++ b/src/assets/wise5/services/nodeService.ts
@@ -539,28 +539,4 @@ export class NodeService {
   broadcastDoneRenderingComponent(nodeIdAndComponentId: any) {
     this.doneRenderingComponentSource.next(nodeIdAndComponentId);
   }
-
-  scrollToComponentAndHighlight(componentId: string): void {
-    setTimeout(() => {
-      const componentElement = $('#component_' + componentId);
-      const originalBackgroundColor = componentElement.css('backgroundColor');
-      componentElement.css('background-color', '#FFFF9C');
-      $('#content').animate({ scrollTop: componentElement.prop('offsetTop') }, 1000);
-      componentElement.css({
-        transition: 'background-color 3s ease-in-out',
-        'background-color': originalBackgroundColor
-      });
-      setTimeout(() => {
-        // ensures the highlight works for the second time linking to this same step
-        componentElement.css('transition', '');
-      }, 4000);
-    }, 500);
-  }
-
-  registerScrollToComponent(componentId: string): void {
-    const subscription = this.DataService.currentNodeChanged$.subscribe(() => {
-      this.scrollToComponentAndHighlight(componentId);
-      subscription.unsubscribe();
-    });
-  }
 }


### PR DESCRIPTION
## Changes
- Use existing functions in dom.ts instead of NodeService.scrollToComponentAndHighlight(). This only affects the WISE link feature when we need to scroll and highlight a specific component in the same step or in a different step.

## Test
- WISE links work as before, when link is 
   - in the same step
   - in a different step -> should go to new step
   - (regardless of same/different step): to a specific component -> should scroll to component and highlight it