### PR TITLE
refactor(Annotation): Create Annotation class

### DIFF
--- a/src/app/classroom-monitor/component-new-work-badge/component-new-work-badge.component.ts
+++ b/src/app/classroom-monitor/component-new-work-badge/component-new-work-badge.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { AnnotationService } from '../../../assets/wise5/services/annotationService';
 import { TeacherDataService } from '../../../assets/wise5/services/teacherDataService';
+import { Annotation } from '../../../assets/wise5/common/Annotation';
 
 @Component({
   selector: 'component-new-work-badge',
@@ -29,10 +30,8 @@ export class ComponentNewWorkBadgeComponent {
   ngOnInit() {
     this.checkHasNewWork();
     this.annotationSavedToServerSubscription = this.AnnotationService.annotationSavedToServer$.subscribe(
-      ({ annotation }) => {
-        const annotationNodeId = annotation.nodeId;
-        const annotationComponentId = annotation.componentId;
-        if (this.nodeId === annotationNodeId && this.componentId === annotationComponentId) {
+      (annotation: Annotation) => {
+        if (annotation.nodeId === this.nodeId && annotation.componentId === this.componentId) {
           this.checkHasNewWork();
         }
       }

--- a/src/app/classroom-monitor/milestones/milestones.component.ts
+++ b/src/app/classroom-monitor/milestones/milestones.component.ts
@@ -7,6 +7,7 @@ import { AnnotationService } from '../../../assets/wise5/services/annotationServ
 import { MilestoneService } from '../../../assets/wise5/services/milestoneService';
 import { TeacherDataService } from '../../../assets/wise5/services/teacherDataService';
 import { Milestone } from '../../domain/milestone';
+import { Annotation } from '../../../assets/wise5/common/Annotation';
 
 @Component({
   selector: 'milestones',
@@ -62,7 +63,7 @@ export class MilestonesComponent {
 
   private subscribeToAnnotationChanges(): void {
     this.subscriptions.add(
-      this.annotationService.annotationReceived$.subscribe(({ annotation }) => {
+      this.annotationService.annotationReceived$.subscribe((annotation: Annotation) => {
         this.milestones
           .filter(
             (milestone) =>

--- a/src/app/notebook/notebook-report/notebook-report.component.ts
+++ b/src/app/notebook/notebook-report/notebook-report.component.ts
@@ -10,6 +10,7 @@ import {
   insertWiseLinks,
   replaceWiseLinks
 } from '../../../assets/wise5/common/wise-link/wise-link';
+import { Annotation } from '../../../assets/wise5/common/Annotation';
 
 @Component({
   selector: 'notebook-report',
@@ -67,7 +68,7 @@ export class NotebookReportComponent extends NotebookParentComponent {
     this.isAddNoteButtonAvailable = this.isNoteEnabled();
 
     this.subscriptions.add(
-      this.NotebookService.notebookItemAnnotationReceived$.subscribe(({ annotation }: any) => {
+      this.NotebookService.notebookItemAnnotationReceived$.subscribe((annotation: Annotation) => {
         if (annotation.localNotebookItemId === this.reportId) {
           this.hasNewAnnotation = true;
           this.latestAnnotations = this.AnnotationService.getLatestNotebookItemAnnotations(

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-annotations/edit-component-annotations.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-annotations/edit-component-annotations.component.ts
@@ -5,6 +5,7 @@ import { Subscription } from 'rxjs';
 import { AnnotationService } from '../../../services/annotationService';
 import { ConfigService } from '../../../services/configService';
 import { TeacherDataService } from '../../../services/teacherDataService';
+import { Annotation } from '../../../common/Annotation';
 
 @Component({
   selector: 'edit-component-annotations',
@@ -49,11 +50,9 @@ export class EditComponentAnnotationsComponent {
       this.periodId = toUserInfo.periodId;
     }
     this.annotationSavedToServerSubscription = this.AnnotationService.annotationSavedToServer$.subscribe(
-      ({ annotation }) => {
+      (annotation: Annotation) => {
         // TODO: we're watching this here and in the parent component's controller; probably want to optimize!
-        const annotationNodeId = annotation.nodeId;
-        const annotationComponentId = annotation.componentId;
-        if (this.nodeId === annotationNodeId && this.componentId === annotationComponentId) {
+        if (annotation.nodeId === this.nodeId && annotation.componentId === this.componentId) {
           this.processAnnotations();
         }
       }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-grading-view/milestone-grading-view.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-grading-view/milestone-grading-view.component.ts
@@ -10,6 +10,7 @@ import { TeacherDataService } from '../../../../services/teacherDataService';
 import { TeacherPeerGroupService } from '../../../../services/teacherPeerGroupService';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
 import { NodeGradingViewComponent } from '../../nodeGrading/node-grading-view/node-grading-view.component';
+import { Annotation } from '../../../../common/Annotation';
 
 @Component({
   selector: 'milestone-grading-view',
@@ -70,7 +71,7 @@ export class MilestoneGradingViewComponent extends NodeGradingViewComponent {
     super.subscribeToEvents();
     if (this.milestone.report.locations.length > 1) {
       this.subscriptions.add(
-        this.annotationService.annotationReceived$.subscribe(({ annotation }) => {
+        this.annotationService.annotationReceived$.subscribe((annotation: Annotation) => {
           const workgroupId = annotation.toWorkgroupId;
           if (annotation.nodeId === this.firstNodeId && this.workgroupsById[workgroupId]) {
             this.updateWorkgroup(workgroupId);

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading-view/node-grading-view.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading-view/node-grading-view.component.ts
@@ -15,6 +15,7 @@ import { copy } from '../../../../common/object/object';
 import { ShowNodeInfoDialogComponent } from '../../../../../../app/classroom-monitor/show-node-info-dialog/show-node-info-dialog.component';
 import { MatDialog } from '@angular/material/dialog';
 import { MilestoneDetailsDialogComponent } from '../../milestones/milestone-details-dialog/milestone-details-dialog.component';
+import { Annotation } from '../../../../common/Annotation';
 
 @Component({
   selector: 'node-grading-view',
@@ -103,7 +104,7 @@ export class NodeGradingViewComponent implements OnInit {
     );
 
     this.subscriptions.add(
-      this.annotationService.annotationReceived$.subscribe(({ annotation }) => {
+      this.annotationService.annotationReceived$.subscribe((annotation: Annotation) => {
         const workgroupId = annotation.toWorkgroupId;
         if (annotation.nodeId === this.nodeId && this.workgroupsById[workgroupId]) {
           this.updateWorkgroup(workgroupId);

--- a/src/assets/wise5/classroomMonitor/student-grading/student-grading.component.ts
+++ b/src/assets/wise5/classroomMonitor/student-grading/student-grading.component.ts
@@ -8,6 +8,7 @@ import { NotificationService } from '../../services/notificationService';
 import { TeacherDataService } from '../../services/teacherDataService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { ActivatedRoute } from '@angular/router';
+import { Annotation } from '../../common/Annotation';
 
 @Component({
   selector: 'student-grading',
@@ -104,7 +105,7 @@ export class StudentGradingComponent implements OnInit {
 
   private subscribeToAnnotationReceived(): void {
     this.subscriptions.add(
-      this.annotationService.annotationReceived$.subscribe(({ annotation }) => {
+      this.annotationService.annotationReceived$.subscribe((annotation: Annotation) => {
         const workgroupId = annotation.toWorkgroupId;
         const nodeId = annotation.nodeId;
         if (workgroupId === this.workgroupId && this.nodesById[nodeId]) {

--- a/src/assets/wise5/common/Annotation.ts
+++ b/src/assets/wise5/common/Annotation.ts
@@ -1,0 +1,15 @@
+export class Annotation {
+  clientSaveTime: number;
+  componentId: string;
+  data: any;
+  fromWorkgroupId: number;
+  id: number;
+  localNotebookItemId?: number;
+  nodeId: string;
+  notebookItemId: number;
+  periodId: number;
+  serverSaveTime: number;
+  studentWorkId: number;
+  toWorkgroupId: number;
+  type: string;
+}

--- a/src/assets/wise5/components/component-student.component.ts
+++ b/src/assets/wise5/components/component-student.component.ts
@@ -17,6 +17,7 @@ import { StudentAssetRequest } from '../vle/studentAsset/StudentAssetRequest';
 import { ComponentService } from './componentService';
 import { ComponentStateRequest } from './ComponentStateRequest';
 import { ComponentStateWrapper } from './ComponentStateWrapper';
+import { Annotation } from '../common/Annotation';
 
 @Directive()
 export abstract class ComponentStudent {
@@ -119,9 +120,9 @@ export abstract class ComponentStudent {
     this.subscribeToRequestComponentState();
   }
 
-  subscribeToAnnotationSavedToServer() {
+  private subscribeToAnnotationSavedToServer(): void {
     this.subscriptions.add(
-      this.AnnotationService.annotationSavedToServer$.subscribe(({ annotation }) => {
+      this.AnnotationService.annotationSavedToServer$.subscribe((annotation: Annotation) => {
         if (this.isForThisComponent(annotation)) {
           this.latestAnnotations = this.AnnotationService.getLatestComponentAnnotations(
             this.nodeId,

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
@@ -484,9 +484,10 @@ export class OpenResponseStudent extends ComponentStudent {
   }
 
   private getFeedbackText(rule: FeedbackRule): string {
-    const annotationsForFeedbackRule = this.AnnotationService.annotations.filter((annotation) => {
-      return this.isForThisComponent(annotation) && annotation.data.feedbackRuleId === rule.id;
-    });
+    const annotationsForFeedbackRule = this.AnnotationService.getAnnotations().filter(
+      (annotation) =>
+        this.isForThisComponent(annotation) && annotation.data.feedbackRuleId === rule.id
+    );
     return rule.feedback[annotationsForFeedbackRule.length % rule.feedback.length];
   }
 

--- a/src/assets/wise5/services/annotationService.ts
+++ b/src/assets/wise5/services/annotationService.ts
@@ -7,15 +7,16 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable, Subject } from 'rxjs';
 import { isMatchingPeriods } from '../common/period/period';
 import { generateRandomKey } from '../common/string/string';
+import { Annotation } from '../common/Annotation';
 
 @Injectable()
 export class AnnotationService {
-  annotations: any = [];
+  annotations: Annotation[] = [];
   dummyAnnotationId: number = 1; // used in preview mode when we simulate saving of annotation
-  private annotationSavedToServerSource: Subject<any> = new Subject<any>();
-  public annotationSavedToServer$: Observable<any> = this.annotationSavedToServerSource.asObservable();
-  private annotationReceivedSource: Subject<any> = new Subject<any>();
-  public annotationReceived$: Observable<any> = this.annotationReceivedSource.asObservable();
+  private annotationSavedToServerSource: Subject<Annotation> = new Subject<Annotation>();
+  public annotationSavedToServer$: Observable<Annotation> = this.annotationSavedToServerSource.asObservable();
+  private annotationReceivedSource: Subject<Annotation> = new Subject<Annotation>();
+  public annotationReceived$: Observable<Annotation> = this.annotationReceivedSource.asObservable();
 
   constructor(
     private http: HttpClient,
@@ -23,7 +24,7 @@ export class AnnotationService {
     private ProjectService: ProjectService
   ) {}
 
-  getAnnotations() {
+  getAnnotations(): Annotation[] {
     return this.annotations;
   }
 
@@ -197,7 +198,7 @@ export class AnnotationService {
               localAnnotation.serverSaveTime = savedAnnotation.serverSaveTime;
               //localAnnotation.requestToken = null; // requestToken is no longer needed.
 
-              this.broadcastAnnotationSavedToServer({ annotation: localAnnotation });
+              this.broadcastAnnotationSavedToServer(localAnnotation);
               break;
             } else if (
               localAnnotation.requestToken != null &&
@@ -221,7 +222,7 @@ export class AnnotationService {
                 this.dummyAnnotationId++;
               }
 
-              this.broadcastAnnotationSavedToServer({ annotation: localAnnotation });
+              this.broadcastAnnotationSavedToServer(localAnnotation);
               break;
             }
           }
@@ -798,11 +799,11 @@ export class AnnotationService {
     return null;
   }
 
-  broadcastAnnotationSavedToServer(args: any) {
-    this.annotationSavedToServerSource.next(args);
+  broadcastAnnotationSavedToServer(annotation: Annotation): void {
+    this.annotationSavedToServerSource.next(annotation);
   }
 
-  broadcastAnnotationReceived(args: any) {
-    this.annotationReceivedSource.next(args);
+  broadcastAnnotationReceived(annotation: Annotation): void {
+    this.annotationReceivedSource.next(annotation);
   }
 }

--- a/src/assets/wise5/services/notebookService.ts
+++ b/src/assets/wise5/services/notebookService.ts
@@ -8,6 +8,7 @@ import { StudentAssetService } from './studentAssetService';
 import { Subject } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { EditNotebookItemDialogComponent } from '../themes/default/notebook/edit-notebook-item-dialog/edit-notebook-item-dialog.component';
+import { Annotation } from '../common/Annotation';
 
 @Injectable()
 export class NotebookService {
@@ -52,7 +53,7 @@ export class NotebookService {
   reports = [];
   publicNotebookItems = {};
   notebooksByWorkgroup = {};
-  private notebookItemAnnotationReceivedSource: Subject<any> = new Subject<any>();
+  private notebookItemAnnotationReceivedSource: Subject<Annotation> = new Subject<Annotation>();
   public notebookItemAnnotationReceived$ = this.notebookItemAnnotationReceivedSource.asObservable();
   private notebookItemChosenSource: Subject<any> = new Subject<any>();
   public notebookItemChosen$ = this.notebookItemChosenSource.asObservable();
@@ -77,7 +78,7 @@ export class NotebookService {
     private StudentAssetService: StudentAssetService
   ) {}
 
-  broadcastNotebookItemAnnotationReceived(annotation: any) {
+  broadcastNotebookItemAnnotationReceived(annotation: Annotation) {
     this.notebookItemAnnotationReceivedSource.next(annotation);
   }
 

--- a/src/assets/wise5/services/studentDataService.ts
+++ b/src/assets/wise5/services/studentDataService.ts
@@ -491,7 +491,7 @@ export class StudentDataService extends DataService {
           this.setRemoteIdIntoLocalId(savedAnnotation, localAnnotation);
           this.setRemoteServerSaveTimeIntoLocalServerSaveTime(savedAnnotation, localAnnotation);
           this.clearRequestToken(localAnnotation);
-          this.AnnotationService.broadcastAnnotationSavedToServer({ annotation: localAnnotation });
+          this.AnnotationService.broadcastAnnotationSavedToServer(localAnnotation);
           break;
         }
       }

--- a/src/assets/wise5/services/studentWebSocketService.ts
+++ b/src/assets/wise5/services/studentWebSocketService.ts
@@ -10,6 +10,7 @@ import { Message } from '@stomp/stompjs';
 import { NotebookService } from './notebookService';
 import { StompService } from './stompService';
 import { ConfigService } from './configService';
+import { Annotation } from '../common/Annotation';
 
 @Injectable()
 export class StudentWebSocketService {
@@ -36,8 +37,7 @@ export class StudentWebSocketService {
         const studentWork = JSON.parse(body.content);
         this.StudentDataService.broadcastStudentWorkReceived(studentWork);
       } else if (body.type === 'annotation') {
-        const annotation = JSON.parse(body.content);
-        this.AnnotationService.broadcastAnnotationReceived({ annotation: annotation });
+        this.AnnotationService.broadcastAnnotationReceived(JSON.parse(body.content));
       } else if (body.type === 'goToNode') {
         this.goToStep(body.content);
       } else if (body.type === 'node') {
@@ -54,9 +54,9 @@ export class StudentWebSocketService {
     this.stompService.workgroupMessage$.subscribe((message: Message) => {
       const body = JSON.parse(message.body);
       if (body.type === 'annotation') {
-        const annotationData = JSON.parse(body.content);
-        this.AnnotationService.addOrUpdateAnnotation(annotationData);
-        this.handleAnnotationReceived(annotationData);
+        const annotation = JSON.parse(body.content);
+        this.AnnotationService.addOrUpdateAnnotation(annotation);
+        this.handleAnnotationReceived(annotation);
       } else if (body.type === 'tagsToWorkgroup') {
         const tags = JSON.parse(body.content);
         this.TagService.setTags(tags);
@@ -72,12 +72,12 @@ export class StudentWebSocketService {
     });
   }
 
-  handleAnnotationReceived(annotation: any): void {
+  private handleAnnotationReceived(annotation: Annotation): void {
     this.StudentDataService.studentData.annotations.push(annotation);
     if (annotation.notebookItemId) {
-      this.notebookService.broadcastNotebookItemAnnotationReceived({ annotation: annotation });
+      this.notebookService.broadcastNotebookItemAnnotationReceived(annotation);
     } else {
-      this.AnnotationService.broadcastAnnotationReceived({ annotation: annotation });
+      this.AnnotationService.broadcastAnnotationReceived(annotation);
     }
   }
 

--- a/src/assets/wise5/services/teacherDataService.ts
+++ b/src/assets/wise5/services/teacherDataService.ts
@@ -13,6 +13,7 @@ import { compressToEncodedURIComponent } from 'lz-string';
 import { isMatchingPeriods } from '../common/period/period';
 import { getIntersectOfArrays } from '../common/array/array';
 import { serverSaveTimeComparator } from '../common/object/object';
+import { Annotation } from '../common/Annotation';
 
 @Injectable()
 export class TeacherDataService extends DataService {
@@ -50,11 +51,11 @@ export class TeacherDataService extends DataService {
   }
 
   subscribeToEvents() {
-    this.AnnotationService.annotationSavedToServer$.subscribe(({ annotation }) => {
+    this.AnnotationService.annotationSavedToServer$.subscribe((annotation: Annotation) => {
       this.handleAnnotationReceived(annotation);
     });
 
-    this.TeacherWebSocketService.newAnnotationReceived$.subscribe(({ annotation }) => {
+    this.TeacherWebSocketService.newAnnotationReceived$.subscribe((annotation: Annotation) => {
       this.handleAnnotationReceived(annotation);
     });
 
@@ -70,7 +71,7 @@ export class TeacherDataService extends DataService {
     });
   }
 
-  handleAnnotationReceived(annotation) {
+  private handleAnnotationReceived(annotation: Annotation): void {
     this.studentData.annotations.push(annotation);
     const toWorkgroupId = annotation.toWorkgroupId;
     if (this.studentData.annotationsToWorkgroupId[toWorkgroupId] == null) {
@@ -83,7 +84,7 @@ export class TeacherDataService extends DataService {
     }
     this.studentData.annotationsByNodeId[nodeId].push(annotation);
     this.AnnotationService.setAnnotations(this.studentData.annotations);
-    this.AnnotationService.broadcastAnnotationReceived({ annotation: annotation });
+    this.AnnotationService.broadcastAnnotationReceived(annotation);
   }
 
   saveEvent(context, nodeId, componentId, componentType, category, event, data) {

--- a/src/assets/wise5/services/teacherWebSocketService.ts
+++ b/src/assets/wise5/services/teacherWebSocketService.ts
@@ -8,13 +8,14 @@ import { Observable, Subject } from 'rxjs';
 import { AchievementService } from './achievementService';
 import { RxStomp } from '@stomp/rx-stomp';
 import { Message } from '@stomp/stompjs';
+import { Annotation } from '../common/Annotation';
 
 @Injectable()
 export class TeacherWebSocketService {
   runId: number;
   rxStomp: RxStomp;
-  private newAnnotationReceivedSource: Subject<any> = new Subject<any>();
-  public newAnnotationReceived$: Observable<any> = this.newAnnotationReceivedSource.asObservable();
+  private newAnnotationReceivedSource: Subject<Annotation> = new Subject<Annotation>();
+  public newAnnotationReceived$: Observable<Annotation> = this.newAnnotationReceivedSource.asObservable();
   private newStudentWorkReceivedSource: Subject<any> = new Subject<any>();
   public newStudentWorkReceived$: Observable<any> = this.newStudentWorkReceivedSource.asObservable();
 
@@ -55,8 +56,7 @@ export class TeacherWebSocketService {
         const achievement = JSON.parse(body.content);
         this.AchievementService.broadcastNewStudentAchievement(achievement);
       } else if (body.type === 'annotation') {
-        const annotationData = JSON.parse(body.content);
-        this.broadcastNewAnnotationReceived({ annotation: annotationData });
+        this.broadcastNewAnnotationReceived(JSON.parse(body.content));
       }
     });
   }
@@ -65,8 +65,8 @@ export class TeacherWebSocketService {
     this.newStudentWorkReceivedSource.next(args);
   }
 
-  broadcastNewAnnotationReceived(args: any) {
-    this.newAnnotationReceivedSource.next(args);
+  broadcastNewAnnotationReceived(annotation: Annotation): void {
+    this.newAnnotationReceivedSource.next(annotation);
   }
 
   subscribeToTeacherWorkgroupTopic() {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1714,7 +1714,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>New</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/classroom-monitor/component-new-work-badge/component-new-work-badge.component.ts</context>
-          <context context-type="linenumber">8</context>
+          <context context-type="linenumber">9</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/classroom-monitor/step-info/step-info.component.html</context>
@@ -13605,7 +13605,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherDataService.ts</context>
-          <context context-type="linenumber">635</context>
+          <context context-type="linenumber">636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6933068701447776492" datatype="html">
@@ -20852,7 +20852,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Notebook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
-          <context context-type="linenumber">17</context>
+          <context context-type="linenumber">18</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
@@ -20863,7 +20863,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>note</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">31</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
@@ -20878,7 +20878,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">32</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
@@ -20893,14 +20893,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Manage Notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1444501656744347415" datatype="html">
         <source>report</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">43</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
@@ -20911,7 +20911,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>reports</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
-          <context context-type="linenumber">43</context>
+          <context context-type="linenumber">44</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
@@ -20922,7 +20922,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Report</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
-          <context context-type="linenumber">44</context>
+          <context context-type="linenumber">45</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>


### PR DESCRIPTION
## Changes
- Create Annotation class and type variables as Annotation instead of ```any``` on some (not all yet) variables where appropriate
- Remove extra wrapper { annotation: annotation } that is sent around in observables and pass in Annotation directly
- Add private modifiers and function return types
- Fix yoda expressions and remove unnecessary code

## Test
- These annotations are sent, retrieved and displayed correctly as before:
   - Teacher -> Student annotations (score, comments)
   - Student -> Teacher annotations (C-rater auto-score values in node/student grading views)
   - C-rater auto-feedback text for students