### PR TITLE
refactor(AnnotationService): getLatestScoreAnnotation()

### DIFF
--- a/src/app/classroom-monitor/component-new-work-badge/component-new-work-badge.component.ts
+++ b/src/app/classroom-monitor/component-new-work-badge/component-new-work-badge.component.ts
@@ -62,7 +62,7 @@ export class ComponentNewWorkBadgeComponent {
       }
       let latestTeacherScore = null;
       if (latestAnnotations && latestAnnotations.score) {
-        if (latestAnnotations.score !== 'autoScore') {
+        if (latestAnnotations.score.type !== 'autoScore') {
           latestTeacherScore = latestAnnotations.score;
         }
       }

--- a/src/app/services/annotationService.spec.ts
+++ b/src/app/services/annotationService.spec.ts
@@ -66,7 +66,7 @@ function getLatestScoreAnnotation() {
 function getLatestScoreAnnotation_NoMatch_ReturnNull() {
   describe('no matching annotation is found', () => {
     it('returns null', () => {
-      expect(service.getLatestScoreAnnotation('nodeX', 'componentX', 10, 'any')).toBeUndefined();
+      expect(service.getLatestScoreAnnotation('nodeX', 'componentX', 10, 'any')).toBeNull();
     });
   });
 }

--- a/src/app/services/annotationService.spec.ts
+++ b/src/app/services/annotationService.spec.ts
@@ -5,27 +5,41 @@ import { AnnotationService } from '../../assets/wise5/services/annotationService
 import { ProjectService } from '../../assets/wise5/services/projectService';
 import { StudentTeacherCommonServicesModule } from '../student-teacher-common-services.module';
 import demoProjectJSON_import from './sampleData/curriculum/Demo.project.json';
+import { Annotation } from '../../assets/wise5/common/Annotation';
 
 let service: AnnotationService;
 let projectService: ProjectService;
 let demoProjectJSON: any;
 
-const annotations = [
-  {
-    toWorkgroupId: 1,
-    type: 'score',
-    nodeId: 'node2',
-    componentId: '7edwu1p29b',
-    data: { value: 1 }
-  },
-  {
-    toWorkgroupId: 1,
-    type: 'autoScore',
-    nodeId: 'node3',
-    componentId: '0sef5ya2wj',
-    data: { value: 2 }
-  }
-];
+const annotation1 = {
+  toWorkgroupId: 1,
+  type: 'score',
+  nodeId: 'node2',
+  componentId: '7edwu1p29b',
+  data: { value: 1 }
+};
+const annotation2 = {
+  toWorkgroupId: 1,
+  type: 'comment',
+  nodeId: 'node2',
+  componentId: '7edwu1p29b',
+  data: { value: 'Nice job!' }
+};
+const annotation3 = {
+  toWorkgroupId: 1,
+  type: 'autoScore',
+  nodeId: 'node3',
+  componentId: '0sef5ya2wj',
+  data: { value: 2 }
+};
+const annotation4 = {
+  toWorkgroupId: 1,
+  type: 'autoScore',
+  nodeId: 'node2',
+  componentId: '7edwu1p29b',
+  data: { value: 5 }
+};
+const annotations = [annotation1, annotation2, annotation3, annotation4];
 
 describe('AnnotationService', () => {
   beforeEach(() => {
@@ -33,12 +47,39 @@ describe('AnnotationService', () => {
       imports: [HttpClientTestingModule, StudentTeacherCommonServicesModule]
     });
     service = TestBed.inject(AnnotationService);
+    service.annotations = annotations as Annotation[];
     projectService = TestBed.inject(ProjectService);
     demoProjectJSON = copy(demoProjectJSON_import);
     projectService.setProject(demoProjectJSON);
   });
+  getLatestScoreAnnotation();
   getTotalScore();
 });
+
+function getLatestScoreAnnotation() {
+  describe('getLatestScoreAnnotation()', () => {
+    getLatestScoreAnnotation_NoMatch_ReturnNull();
+    getLatestScoreAnnotation_MultipleMatches_ReturnLatestAnnotation();
+  });
+}
+
+function getLatestScoreAnnotation_NoMatch_ReturnNull() {
+  describe('no matching annotation is found', () => {
+    it('returns null', () => {
+      expect(service.getLatestScoreAnnotation('nodeX', 'componentX', 10, 'any')).toBeUndefined();
+    });
+  });
+}
+
+function getLatestScoreAnnotation_MultipleMatches_ReturnLatestAnnotation() {
+  describe('multiple annotations are found', () => {
+    it('returns latest annotation', () => {
+      expect(service.getLatestScoreAnnotation('node2', '7edwu1p29b', 1, 'any')).toEqual(
+        annotation4 as Annotation
+      );
+    });
+  });
+}
 
 function getTotalScore() {
   describe('getTotalScore()', () => {
@@ -57,7 +98,7 @@ function getTotalScore_noAnnotationForWorkgroup_return0() {
 
 function getTotalScore_returnSumScoresAutoScoresForWorkgroup() {
   it('should return sum of annotation scores and autoscores for workgroup', () => {
-    expect(service.getTotalScore(annotations)).toEqual(3);
+    expect(service.getTotalScore(annotations)).toEqual(7);
   });
 }
 
@@ -73,6 +114,6 @@ function getTotalScore_omitInActiveNodes() {
 function getTotalScore_omitExcludFromTotalScoreNodes() {
   it('should omit scores for nodes marked as excludeFromTotalScore', () => {
     projectService.getComponent('node3', '0sef5ya2wj').excludeFromTotalScore = true;
-    expect(service.getTotalScore(annotations)).toEqual(1);
+    expect(service.getTotalScore(annotations)).toEqual(5);
   });
 }

--- a/src/app/services/studentPeerGroupService.spec.ts
+++ b/src/app/services/studentPeerGroupService.spec.ts
@@ -11,11 +11,12 @@ import { ProjectService } from '../../assets/wise5/services/projectService';
 import { StudentDataService } from '../../assets/wise5/services/studentDataService';
 import { StudentPeerGroupService } from '../../assets/wise5/services/studentPeerGroupService';
 import { StudentTeacherCommonServicesModule } from '../student-teacher-common-services.module';
+import { Annotation } from '../../assets/wise5/common/Annotation';
 
 let annotationService: AnnotationService;
 const componentId1 = 'component1';
 let configService: ConfigService;
-const dummyAnnotation = { id: 200, data: {} };
+const dummyAnnotation = { id: 200, data: {} } as Annotation;
 const dummyStudentData = { id: 100, studentData: {} };
 let http: HttpClient;
 const nodeId1 = 'node1';

--- a/src/assets/wise5/common/constraint/strategies/ScoreConstraintStrategy.spec.ts
+++ b/src/assets/wise5/common/constraint/strategies/ScoreConstraintStrategy.spec.ts
@@ -5,6 +5,7 @@ import { AnnotationService } from '../../../services/annotationService';
 import { ConfigService } from '../../../services/configService';
 import { StudentDataService } from '../../../services/studentDataService';
 import { ScoreConstraintStrategy } from './ScoreConstraintStrategy';
+import { Annotation } from '../../Annotation';
 
 let annotationService: AnnotationService;
 let configService: ConfigService;
@@ -47,7 +48,7 @@ function evaluate() {
 
 function expectEvaluate(criteria: any, score: number, expected: boolean): void {
   spyOn(configService, 'getWorkgroupId').and.returnValue(1);
-  spyOn(annotationService, 'getLatestScoreAnnotation').and.returnValue({});
+  spyOn(annotationService, 'getLatestScoreAnnotation').and.returnValue({} as Annotation);
   spyOn(annotationService, 'getScoreValueFromScoreAnnotation').and.returnValue(score);
   expect(strategy.evaluate(criteria)).toEqual(expected);
 }

--- a/src/assets/wise5/services/annotationService.ts
+++ b/src/assets/wise5/services/annotationService.ts
@@ -536,15 +536,17 @@ export class AnnotationService {
     workgroupId: number,
     scoreType: 'score' | 'autoScore' | 'any' = 'any'
   ): Annotation {
-    return this.getAnnotations()
-      .filter(
-        (annotation) =>
-          annotation.nodeId == nodeId &&
-          annotation.componentId == componentId &&
-          annotation.toWorkgroupId == workgroupId &&
-          this.matchesScoreType(annotation, scoreType)
-      )
-      .at(-1);
+    return (
+      this.getAnnotations()
+        .filter(
+          (annotation) =>
+            annotation.nodeId == nodeId &&
+            annotation.componentId == componentId &&
+            annotation.toWorkgroupId == workgroupId &&
+            this.matchesScoreType(annotation, scoreType)
+        )
+        .at(-1) || null
+    );
   }
 
   private matchesScoreType(
@@ -552,8 +554,8 @@ export class AnnotationService {
     scoreType: 'score' | 'autoScore' | 'any'
   ): boolean {
     return (
-      ['autoScore', 'score'].includes(annotation.type) &&
-      (scoreType === 'any' || annotation.type === scoreType)
+      (scoreType === 'any' && ['autoScore', 'score'].includes(annotation.type)) ||
+      annotation.type === scoreType
     );
   }
 


### PR DESCRIPTION
## Changes
- Simplify function using ```Array.filter()``` and ```Array.at()```
- Function now returns ```undefined``` instead of ```null``` if there is no latest score or auto-score
- Add private modifiers, param types and function return types
- Update references
- Add basic tests

## Test
- Teacher score and auto-score annotations appear correctly as before in 
   - Grading by step
   - Grade by team
   - Milestone report -> Student Work
   - Student VLE component scores from teacher and auto-scores from CRater