### PR TITLE
feat(Export): Include Question Used column in Peer Chat export

### DIFF
--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/PeerChatComponentDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/PeerChatComponentDataExportStrategy.ts
@@ -51,41 +51,34 @@ export class PeerChatComponentDataExportStrategy extends AbstractDataExportStrat
   private generateComponentHeaderRow(component: any, columnNameToNumber: any): string[] {
     const headerRow = this.defaultColumnNames.map((columnName: string) => columnName);
     const componentStates = this.teacherDataService.getComponentStatesByComponentId(component.id);
-    this.insertPromptColumnIfNecessary(headerRow, component);
-    this.insertPrePromptColumnIfNecessary(headerRow, component);
-    this.insertDynamicPromptColumnIfNecessary(headerRow, component);
-    this.insertPostPromptColumnIfNecessary(headerRow, component);
-    this.insertQuestionColumnsIfNecessary(headerRow, componentStates);
-    this.insertQuestionUsedColumnIfNecessary(headerRow, component);
+    this.insertPromptColumns(headerRow, component);
+    this.insertQuestionColumns(headerRow, component, componentStates);
     this.populateColumnNameMappings(headerRow, columnNameToNumber);
     return headerRow;
   }
 
-  private insertPromptColumnIfNecessary(headerRow: string[], component: any): void {
+  private insertPromptColumns(headerRow: string[], component: any): void {
     if (!this.hasDynamicPrompt(component)) {
       this.insertBeforeResponseColumn(headerRow, 'Prompt');
     }
-  }
-
-  private insertPrePromptColumnIfNecessary(headerRow: string[], component: any): void {
     if (this.hasPrePrompt(component)) {
       this.insertBeforeResponseColumn(headerRow, 'Pre Prompt');
     }
-  }
-
-  private insertDynamicPromptColumnIfNecessary(headerRow: string[], component: any): void {
     if (this.hasDynamicPrompt(component)) {
       this.insertBeforeResponseColumn(headerRow, 'Dynamic Prompt');
     }
-  }
-
-  private insertPostPromptColumnIfNecessary(headerRow: string[], component: any): void {
     if (this.hasPostPrompt(component)) {
       this.insertBeforeResponseColumn(headerRow, 'Post Prompt');
     }
   }
 
-  private insertQuestionUsedColumnIfNecessary(headerRow: string[], component: any): void {
+  private insertQuestionColumns(headerRow: string[], component: any, componentStates: any[]): void {
+    const maxQuestions = this.getMaxQuestionBankCount(componentStates);
+    if (maxQuestions > 0) {
+      for (let q = 0; q < maxQuestions; q++) {
+        headerRow.splice(headerRow.indexOf('Response'), 0, `Question ${q + 1}`);
+      }
+    }
     if (this.isClickToAddEnabled(component)) {
       this.insertBeforeResponseColumn(headerRow, 'Question Used');
     }
@@ -113,15 +106,6 @@ export class PeerChatComponentDataExportStrategy extends AbstractDataExportStrat
 
   private isClickToAddEnabled(component: any): boolean {
     return component.questionBank?.clickToAddEnabled;
-  }
-
-  private insertQuestionColumnsIfNecessary(headerRow: string[], componentStates: any[]): void {
-    const maxQuestions = this.getMaxQuestionBankCount(componentStates);
-    if (maxQuestions > 0) {
-      for (let q = 0; q < maxQuestions; q++) {
-        headerRow.splice(headerRow.indexOf('Response'), 0, `Question ${q + 1}`);
-      }
-    }
   }
 
   private getMaxQuestionBankCount(componentStates: any[]): number {

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/PeerChatComponentDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/PeerChatComponentDataExportStrategy.ts
@@ -93,7 +93,7 @@ export class PeerChatComponentDataExportStrategy extends AbstractDataExportStrat
 
   private hasPrePrompt(component: any): boolean {
     const prePrompt = component.dynamicPrompt?.prePrompt;
-    return prePrompt != null && prePrompt !== '';
+    return this.hasDynamicPrompt(component) && prePrompt != null && prePrompt !== '';
   }
 
   private hasDynamicPrompt(component: any): boolean {
@@ -102,7 +102,7 @@ export class PeerChatComponentDataExportStrategy extends AbstractDataExportStrat
 
   private hasPostPrompt(component: any): boolean {
     const postPrompt = component.dynamicPrompt?.postPrompt;
-    return postPrompt != null && postPrompt !== '';
+    return this.hasDynamicPrompt(component) && postPrompt != null && postPrompt !== '';
   }
 
   private isClickToAddEnabled(component: any): boolean {
@@ -254,19 +254,7 @@ export class PeerChatComponentDataExportStrategy extends AbstractDataExportStrat
       'Client Timestamp',
       millisecondsToDateTime(componentState.clientSaveTime)
     );
-    this.setColumnValue(row, columnNameToNumber, 'Pre Prompt', component.dynamicPrompt?.prePrompt);
-    this.setColumnValue(
-      row,
-      columnNameToNumber,
-      'Dynamic Prompt',
-      componentState.studentData.dynamicPrompt?.prompt
-    );
-    this.setColumnValue(
-      row,
-      columnNameToNumber,
-      'Post Prompt',
-      component.dynamicPrompt?.postPrompt
-    );
+    this.setDynamicPrompts(row, columnNameToNumber, component, componentState);
     if (componentState.studentData.questionBank != null) {
       this.setQuestions(row, columnNameToNumber, componentState);
     }
@@ -279,6 +267,38 @@ export class PeerChatComponentDataExportStrategy extends AbstractDataExportStrat
       );
     }
     this.setColumnValue(row, columnNameToNumber, 'Response', componentState.studentData.response);
+  }
+
+  private setDynamicPrompts(
+    row: any,
+    columnNameToNumber: any,
+    component: any,
+    componentState: any
+  ): void {
+    if (this.hasPrePrompt(component)) {
+      this.setColumnValue(
+        row,
+        columnNameToNumber,
+        'Pre Prompt',
+        component.dynamicPrompt?.prePrompt
+      );
+    }
+    if (this.hasDynamicPrompt(component)) {
+      this.setColumnValue(
+        row,
+        columnNameToNumber,
+        'Dynamic Prompt',
+        componentState.studentData.dynamicPrompt?.prompt
+      );
+    }
+    if (this.hasPostPrompt(component)) {
+      this.setColumnValue(
+        row,
+        columnNameToNumber,
+        'Post Prompt',
+        component.dynamicPrompt?.postPrompt
+      );
+    }
   }
 
   private setQuestions(row: any[], columnNameToNumber: any, componentState: any): void {

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/PeerChatComponentDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/PeerChatComponentDataExportStrategy.ts
@@ -76,10 +76,10 @@ export class PeerChatComponentDataExportStrategy extends AbstractDataExportStrat
     const maxQuestions = this.getMaxQuestionBankCount(componentStates);
     if (maxQuestions > 0) {
       for (let q = 0; q < maxQuestions; q++) {
-        headerRow.splice(headerRow.indexOf('Response'), 0, `Question ${q + 1}`);
+        this.insertBeforeResponseColumn(headerRow, `Question ${q + 1}`);
       }
     }
-    if (this.isClickToAddEnabled(component)) {
+    if (this.isClickToUseEnabled(component)) {
       this.insertBeforeResponseColumn(headerRow, 'Question Used');
     }
   }
@@ -104,8 +104,8 @@ export class PeerChatComponentDataExportStrategy extends AbstractDataExportStrat
     return value != null && value !== '';
   }
 
-  private isClickToAddEnabled(component: any): boolean {
-    return component.questionBank?.clickToAddEnabled;
+  private isClickToUseEnabled(component: any): boolean {
+    return component.questionBank?.clickToUseEnabled;
   }
 
   private getMaxQuestionBankCount(componentStates: any[]): number {
@@ -248,7 +248,7 @@ export class PeerChatComponentDataExportStrategy extends AbstractDataExportStrat
     if (componentState.studentData.questionBank != null) {
       this.setQuestions(row, columnNameToNumber, componentState);
     }
-    if (this.isClickToAddEnabled(component)) {
+    if (this.isClickToUseEnabled(component)) {
       this.setColumnValue(
         row,
         columnNameToNumber,

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/PeerChatComponentDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/PeerChatComponentDataExportStrategy.ts
@@ -63,37 +63,40 @@ export class PeerChatComponentDataExportStrategy extends AbstractDataExportStrat
 
   private insertPromptColumnIfNecessary(headerRow: string[], component: any): void {
     if (!this.hasDynamicPrompt(component)) {
-      headerRow.splice(headerRow.indexOf('Response'), 0, 'Prompt');
+      this.insertBeforeResponseColumn(headerRow, 'Prompt');
     }
   }
 
   private insertPrePromptColumnIfNecessary(headerRow: string[], component: any): void {
     if (this.hasPrePrompt(component)) {
-      headerRow.splice(headerRow.indexOf('Response'), 0, 'Pre Prompt');
+      this.insertBeforeResponseColumn(headerRow, 'Pre Prompt');
     }
   }
 
   private insertDynamicPromptColumnIfNecessary(headerRow: string[], component: any): void {
     if (this.hasDynamicPrompt(component)) {
-      headerRow.splice(headerRow.indexOf('Response'), 0, 'Dynamic Prompt');
+      this.insertBeforeResponseColumn(headerRow, 'Dynamic Prompt');
     }
   }
 
   private insertPostPromptColumnIfNecessary(headerRow: string[], component: any): void {
     if (this.hasPostPrompt(component)) {
-      headerRow.splice(headerRow.indexOf('Response'), 0, 'Post Prompt');
+      this.insertBeforeResponseColumn(headerRow, 'Post Prompt');
     }
   }
 
   private insertQuestionUsedColumnIfNecessary(headerRow: string[], component: any): void {
     if (this.isClickToAddEnabled(component)) {
-      headerRow.splice(headerRow.indexOf('Response'), 0, 'Question Used');
+      this.insertBeforeResponseColumn(headerRow, 'Question Used');
     }
   }
 
+  private insertBeforeResponseColumn(headerRow: string[], columnName: string): void {
+    headerRow.splice(headerRow.indexOf('Response'), 0, columnName);
+  }
+
   private hasPrePrompt(component: any): boolean {
-    const prePrompt = component.dynamicPrompt?.prePrompt;
-    return this.hasDynamicPrompt(component) && prePrompt != null && prePrompt !== '';
+    return this.hasDynamicPrompt(component) && this.hasValue(component.dynamicPrompt?.prePrompt);
   }
 
   private hasDynamicPrompt(component: any): boolean {
@@ -101,8 +104,11 @@ export class PeerChatComponentDataExportStrategy extends AbstractDataExportStrat
   }
 
   private hasPostPrompt(component: any): boolean {
-    const postPrompt = component.dynamicPrompt?.postPrompt;
-    return this.hasDynamicPrompt(component) && postPrompt != null && postPrompt !== '';
+    return this.hasDynamicPrompt(component) && this.hasValue(component.dynamicPrompt?.postPrompt);
+  }
+
+  private hasValue(value: any): boolean {
+    return value != null && value !== '';
   }
 
   private isClickToAddEnabled(component: any): boolean {


### PR DESCRIPTION
## Changes

- If "Student can select questions to use in Peer Chat" is enabled, include "Question Used" column in the export
- Now only show either "Prompt" or "Dynamic Prompt" column, not both. Previously we would show both.

## Test

- If "Student can select questions to use in Peer Chat" is enabled, show the "Question Used" column
- If a student used a question for their response, make sure it shows the question they used in the "Question Used" column
- If dynamic prompt is enabled, make sure the "Dynamic Prompt" column shows up and the "Prompt" column does not
- If dynamic prompt is not enabled, make sure the "Prompt" column shows up and the "Dynamic Prompt" column does not

Closes #1482