### PR TITLE
refactor(DiscussionShowWorkComponent): Extract common function to show/hide posts

### DIFF
--- a/src/assets/wise5/components/discussion/discussion-show-work/discussion-show-work.component.html
+++ b/src/assets/wise5/components/discussion/discussion-show-work/discussion-show-work.component.html
@@ -5,8 +5,8 @@
       [response]="componentState"
       [numReplies]="componentState.replies.length"
       [mode]="'grading'"
-      (deleteButtonClicked)="deleteButtonClicked($event)"
-      (undoDeleteButtonClicked)="undoDeleteButtonClicked($event)"
+      (deleteButtonClicked)="hidePost($event)"
+      (undoDeleteButtonClicked)="showPost($event)"
       [isDisabled]="true"
       class="post"
     >

--- a/src/assets/wise5/components/discussion/discussion-show-work/discussion-show-work.component.ts
+++ b/src/assets/wise5/components/discussion/discussion-show-work/discussion-show-work.component.ts
@@ -107,37 +107,8 @@ export class DiscussionShowWorkComponent extends ComponentShowWorkDirective {
    * the class from seeing the post.
    * @param componentState the student component state the teacher wants to delete.
    */
-  deleteButtonClicked(componentState: any): void {
-    const toWorkgroupId = componentState.workgroupId;
-    const userInfo = this.ConfigService.getUserInfoByWorkgroupId(toWorkgroupId);
-    const periodId = userInfo.periodId;
-    const teacherUserInfo = this.ConfigService.getMyUserInfo();
-    const fromWorkgroupId = teacherUserInfo.workgroupId;
-    const runId = this.ConfigService.getRunId();
-    const nodeId = this.nodeId;
-    const componentId = this.componentId;
-    const studentWorkId = componentState.id;
-    const data = {
-      action: 'Delete'
-    };
-    const annotation = this.AnnotationService.createInappropriateFlagAnnotation(
-      runId,
-      periodId,
-      nodeId,
-      componentId,
-      fromWorkgroupId,
-      toWorkgroupId,
-      studentWorkId,
-      data
-    );
-    this.AnnotationService.saveAnnotation(annotation).then(() => {
-      const componentStates = this.TeacherDiscussionService.getPostsAssociatedWithComponentIdsAndWorkgroupId(
-        this.getGradingComponentIds(),
-        this.workgroupId
-      );
-      const annotations = this.getInappropriateFlagAnnotationsByComponentStates(componentStates);
-      this.setClassResponses(componentStates, annotations);
-    });
+  protected hidePost(componentState: any): void {
+    this.flagPost(componentState, 'Delete');
   }
 
   /**
@@ -146,7 +117,11 @@ export class DiscussionShowWorkComponent extends ComponentShowWorkDirective {
    * This will make the post visible to the students.
    * @param componentState the student component state the teacher wants to show again.
    */
-  undoDeleteButtonClicked(componentState: any): any {
+  protected showPost(componentState: any): void {
+    this.flagPost(componentState, 'Undo Delete');
+  }
+
+  private flagPost(componentState: any, action: 'Delete' | 'Undo Delete'): void {
     const toWorkgroupId = componentState.workgroupId;
     const userInfo = this.ConfigService.getUserInfoByWorkgroupId(toWorkgroupId);
     const periodId = userInfo.periodId;
@@ -157,7 +132,7 @@ export class DiscussionShowWorkComponent extends ComponentShowWorkDirective {
     const componentId = this.componentId;
     const studentWorkId = componentState.id;
     const data = {
-      action: 'Undo Delete'
+      action: action
     };
     const annotation = this.AnnotationService.createInappropriateFlagAnnotation(
       runId,


### PR DESCRIPTION
## Changes
- Extract common code to ```flagPost()``` function to handle hiding/showing posts
- Rename functions to ```hidePost()``` and ```showPost()``` and add private/protected modifiers

## Test
- In the CM, the teacher can show/hide comments in the discussion component as before, and it is reflected in the student's view