### PR TITLE
fix(Authoring): Recovery view does not load when project is broken

### DIFF
--- a/src/app/services/projectService.spec.ts
+++ b/src/app/services/projectService.spec.ts
@@ -43,7 +43,6 @@ describe('ProjectService', () => {
   shouldReplaceAssetPathsInHtmlComponentContent();
   shouldNotReplaceAssetPathsInHtmlComponentContent();
   shouldRetrieveProjectWhenConfigProjectURLIsValid();
-  shouldNotRetrieveProjectWhenConfigProjectURLIsUndefined();
   shouldGetDefaultThemePath();
   shouldReturnTheStartNodeOfTheProject();
   shouldReturnTheNodeByNodeId();
@@ -154,15 +153,6 @@ function shouldRetrieveProjectWhenConfigProjectURLIsValid() {
       expect(response).toEqual(scootersProjectJSON);
     });
     http.expectOne(projectURL);
-  });
-}
-
-function shouldNotRetrieveProjectWhenConfigProjectURLIsUndefined() {
-  it('should not retrieve project when Config.projectURL is undefined', () => {
-    spyOn(configService, 'getConfigParam').and.returnValue(null);
-    const project = service.retrieveProject();
-    expect(configService.getConfigParam).toHaveBeenCalledWith('projectURL');
-    expect(project).toBeNull();
   });
 }
 

--- a/src/app/teacher/authoring-routing.module.ts
+++ b/src/app/teacher/authoring-routing.module.ts
@@ -38,6 +38,7 @@ import { ProjectAuthoringParentComponent } from '../../assets/wise5/authoringToo
 import { ChooseImportUnitComponent } from '../authoring-tool/import-step/choose-import-unit/choose-import-unit.component';
 import { NodeAuthoringParentComponent } from '../../assets/wise5/authoringTool/node/node-authoring-parent/node-authoring-parent.component';
 import { AddLessonChooseTemplateComponent } from '../../assets/wise5/authoringTool/addLesson/add-lesson-choose-template/add-lesson-choose-template.component';
+import { RecoveryAuthoringProjectResolver } from './recovery-authoring-project.resolver';
 
 const routes: Routes = [
   {
@@ -46,8 +47,13 @@ const routes: Routes = [
     resolve: { config: AuthoringConfigResolver },
     children: [
       { path: 'home', component: ProjectListComponent },
-
       { path: 'new-unit', component: AddProjectComponent },
+      {
+        path: 'unit/:unitId/recovery',
+        component: ProjectAuthoringParentComponent,
+        resolve: { project: RecoveryAuthoringProjectResolver },
+        children: [{ path: '', component: RecoveryAuthoringComponent }]
+      },
       {
         path: 'unit/:unitId',
         component: ProjectAuthoringParentComponent,
@@ -165,8 +171,7 @@ const routes: Routes = [
               }
             ]
           },
-          { path: 'notebook', component: NotebookAuthoringComponent },
-          { path: 'recovery', component: RecoveryAuthoringComponent }
+          { path: 'notebook', component: NotebookAuthoringComponent }
         ]
       }
     ]

--- a/src/app/teacher/authoring-routing.module.ts
+++ b/src/app/teacher/authoring-routing.module.ts
@@ -49,10 +49,9 @@ const routes: Routes = [
       { path: 'home', component: ProjectListComponent },
       { path: 'new-unit', component: AddProjectComponent },
       {
-        path: 'unit/:unitId/recovery',
-        component: ProjectAuthoringParentComponent,
-        resolve: { project: RecoveryAuthoringProjectResolver },
-        children: [{ path: '', component: RecoveryAuthoringComponent }]
+        path: 'recovery/:unitId',
+        component: RecoveryAuthoringComponent,
+        resolve: { project: RecoveryAuthoringProjectResolver }
       },
       {
         path: 'unit/:unitId',

--- a/src/app/teacher/recovery-authoring-project.resolver.ts
+++ b/src/app/teacher/recovery-authoring-project.resolver.ts
@@ -1,0 +1,16 @@
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
+import { Observable, switchMap } from 'rxjs';
+import { ProjectService } from '../../assets/wise5/services/projectService';
+import { ConfigService } from '../../assets/wise5/services/configService';
+
+export const RecoveryAuthoringProjectResolver: ResolveFn<any> = (
+  route: ActivatedRouteSnapshot,
+  state: RouterStateSnapshot,
+  configService: ConfigService = inject(ConfigService),
+  projectService: ProjectService = inject(ProjectService)
+): Observable<any> => {
+  return configService
+    .retrieveConfig(`/api/author/config/${route.params['unitId']}`)
+    .pipe(switchMap(() => projectService.retrieveProjectWithoutParsing()));
+};

--- a/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html
+++ b/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html
@@ -1,49 +1,60 @@
-<div class="save-bar" fxLayout="row" fxLayoutAlign="space-between center">
-  <div fxLayoutGap="20px">
-    <button mat-raised-button color="primary" (click)="save()" [disabled]="!saveButtonEnabled" i18n>
-      Save
-    </button>
-    <button mat-raised-button color="primary" routerLink=".." i18n>Go to Authoring View</button>
-  </div>
-  <div fxLayout="row">
-    <div *ngIf="jsonIsValid" class="valid" i18n>JSON Valid</div>
-    <div *ngIf="!jsonIsValid" class="invalid" i18n>JSON Invalid</div>
-    <div *ngIf="globalMessage != null">
-      <div class="component__actions__info md-caption global-message">
-        {{ globalMessage.text }} {{ globalMessage.time | date: 'medium' }}
+<div class="body">
+  <h4 class="view-title" i18n>Recovery View</h4>
+  <div class="save-bar" fxLayout="row" fxLayoutAlign="space-between center">
+    <div fxLayoutGap="20px">
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="save()"
+        [disabled]="!saveButtonEnabled"
+        i18n
+      >
+        Save
+      </button>
+      <button mat-raised-button color="primary" routerLink="../../unit/{{ unitId }}" i18n>
+        Go to Authoring View
+      </button>
+    </div>
+    <div fxLayout="row">
+      <div *ngIf="jsonValid" class="valid" i18n>JSON Valid</div>
+      <div *ngIf="!jsonValid" class="invalid" i18n>JSON Invalid</div>
+      <div *ngIf="globalMessage != null">
+        <div class="component__actions__info md-caption global-message">
+          {{ globalMessage.text }} {{ globalMessage.time | date: 'medium' }}
+        </div>
       </div>
     </div>
   </div>
-</div>
-<div class="warning-div" i18n>
-  Warning: Modifying the JSON may break the project. Please make a backup copy of the JSON before
-  you modify it.
-</div>
-<div *ngIf="badNodes.length > 0" class="potential-problems-div">
-  <div class="potential-problems-header" i18n>Potential Problems</div>
-  <div *ngFor="let badNode of badNodes" class="bad-node">
-    <div class="node-id">{{ badNode.nodeId }}</div>
-    <div *ngIf="badNode.referencedIdsThatDoNotExist.length > 0" i18n>
-      This group references the node ID but the node does not exist:
-      {{ badNode.referencedIdsThatDoNotExist }}
-    </div>
-    <div *ngIf="badNode.referencedIdsThatAreDuplicated.length > 0" i18n>
-      This group references the same node ID multiple times:
-      {{ badNode.referencedIdsThatAreDuplicated }}
-    </div>
-    <div *ngIf="badNode.hasTransitionToNull" i18n>This node has a transition to null</div>
+  <div class="warning-div" i18n>
+    Warning: Modifying the JSON may break the project. Please make a backup copy of the JSON before
+    you modify it.
   </div>
-</div>
-<div>
-  <mat-form-field fxFlex appearance="outline">
-    <mat-label i18n>Edit Unit JSON</mat-label>
-    <textarea
-      class="mat-body-2"
-      matInput
-      cdkTextareaAutosize
-      [(ngModel)]="projectJSONString"
-      (ngModelChange)="projectJSONChanged()"
-    >
-    </textarea>
-  </mat-form-field>
+  <div *ngIf="badNodes.length > 0" class="potential-problems-div">
+    <div class="potential-problems-header" i18n>Potential Problems</div>
+    <div *ngFor="let badNode of badNodes" class="bad-node">
+      <div class="node-id">{{ badNode.nodeId }}</div>
+      <div *ngIf="badNode.referencedIdsThatDoNotExist.length > 0" i18n>
+        This group references the node ID but the node does not exist:
+        {{ badNode.referencedIdsThatDoNotExist }}
+      </div>
+      <div *ngIf="badNode.referencedIdsThatAreDuplicated.length > 0" i18n>
+        This group references the same node ID multiple times:
+        {{ badNode.referencedIdsThatAreDuplicated }}
+      </div>
+      <div *ngIf="badNode.hasTransitionToNull" i18n>This node has a transition to null</div>
+    </div>
+  </div>
+  <div>
+    <mat-form-field fxFlex appearance="outline">
+      <mat-label i18n>Edit Unit JSON</mat-label>
+      <textarea
+        class="mat-body-2"
+        matInput
+        cdkTextareaAutosize
+        [(ngModel)]="projectJSONString"
+        (ngModelChange)="projectJSONChanged()"
+      >
+      </textarea>
+    </mat-form-field>
+  </div>
 </div>

--- a/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.scss
+++ b/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.scss
@@ -1,15 +1,5 @@
-.main-box {
-  position: relative;
-  padding: 16px !important;
-}
-
-.top-div {
-  background-color: white;
-  position: sticky;
-  top: 0px;
-  z-index: 2;
-  padding-top: 4px;
-  padding-bottom: 4px;
+.body {
+  padding: 0px 32px;
 }
 
 .save-bar {
@@ -22,6 +12,10 @@
 
 .invalid {
   color: red;
+}
+
+.view-title {
+  margin-bottom: 20px;
 }
 
 .warning-div {

--- a/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.scss
+++ b/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.scss
@@ -42,7 +42,7 @@
   border: 1px solid red;
   border-radius: 8px;
   padding: 8px;
-  margin-bottom: 4px;
+  margin-bottom: 20px;
 }
 
 .node-id {

--- a/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.spec.ts
@@ -7,6 +7,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { RecoveryAuthoringComponent } from './recovery-authoring.component';
+import { ActivatedRoute, RouterModule } from '@angular/router';
 
 class MockTeacherProjectService {
   project = {
@@ -46,9 +47,13 @@ describe('RecoveryAuthoringComponent', () => {
         HttpClientTestingModule,
         MatDialogModule,
         MatInputModule,
+        RouterModule,
         StudentTeacherCommonServicesModule
       ],
-      providers: [{ provide: TeacherProjectService, useClass: MockTeacherProjectService }]
+      providers: [
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '1' } } } },
+        { provide: TeacherProjectService, useClass: MockTeacherProjectService }
+      ]
     }).compileComponents();
   });
 
@@ -81,7 +86,7 @@ function detectJSONValidity() {
 
 function setJSONAndExpect(json: string, jsonIsValid: boolean, saveButtonEnabled: boolean) {
   setProjectJSONStringAndTriggerChange(json);
-  expect(component.jsonIsValid).toEqual(jsonIsValid);
+  expect(component.jsonValid).toEqual(jsonIsValid);
   expect(component.saveButtonEnabled).toEqual(saveButtonEnabled);
 }
 

--- a/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.ts
@@ -4,6 +4,7 @@ import { NotificationService } from '../../services/notificationService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { NodeRecoveryAnalysis } from '../../../../app/domain/nodeRecoveryAnalysis';
 import { isValidJSONString } from '../../common/string/string';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'recovery-authoring',
@@ -13,17 +14,20 @@ import { isValidJSONString } from '../../common/string/string';
 export class RecoveryAuthoringComponent implements OnInit {
   badNodes: NodeRecoveryAnalysis[] = [];
   protected globalMessage: any;
-  jsonIsValid: boolean;
+  jsonValid: boolean;
   projectJSONString: string;
   saveButtonEnabled: boolean = false;
   private subscriptions: Subscription = new Subscription();
+  protected unitId: string;
 
   constructor(
+    private route: ActivatedRoute,
     private notificationService: NotificationService,
     private projectService: TeacherProjectService
   ) {}
 
   ngOnInit(): void {
+    this.unitId = this.route.snapshot.paramMap.get('unitId');
     this.projectJSONString = JSON.stringify(this.projectService.project, null, 4);
     this.checkProjectJSONValidity();
     this.subscribeToGlobalMessage();
@@ -36,14 +40,14 @@ export class RecoveryAuthoringComponent implements OnInit {
 
   projectJSONChanged(): void {
     this.checkProjectJSONValidity();
-    this.saveButtonEnabled = this.jsonIsValid;
-    if (this.jsonIsValid) {
+    this.saveButtonEnabled = this.jsonValid;
+    if (this.jsonValid) {
       this.checkNodes();
     }
   }
 
   private checkProjectJSONValidity(): void {
-    this.jsonIsValid = isValidJSONString(this.projectJSONString);
+    this.jsonValid = isValidJSONString(this.projectJSONString);
   }
 
   private subscribeToGlobalMessage(): void {

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -772,23 +772,29 @@ export class ProjectService {
    * Retrieves the project JSON from Config.projectURL and returns it.
    * If Config.projectURL is undefined, returns null.
    */
-  retrieveProject(parseProject: boolean = true): any {
-    let projectURL = this.configService.getConfigParam('projectURL');
-    if (projectURL == null) {
-      return null;
-    }
-    const headers = new HttpHeaders().set('cache-control', 'no-cache');
-    return this.http.get(projectURL, { headers: headers }).pipe(
+  retrieveProject(): Observable<any> {
+    return this.makeProjectRequest().pipe(
       tap((projectJSON: any) => {
-        if (parseProject) {
-          this.setProject(projectJSON);
-        } else {
-          this.project = projectJSON;
-          this.metadata = projectJSON.metadata;
-        }
+        this.setProject(projectJSON);
         return projectJSON;
       })
     );
+  }
+
+  retrieveProjectWithoutParsing(): Observable<any> {
+    return this.makeProjectRequest().pipe(
+      tap((projectJSON: any) => {
+        this.project = projectJSON;
+        this.metadata = projectJSON.metadata;
+        return projectJSON;
+      })
+    );
+  }
+
+  private makeProjectRequest(): Observable<any> {
+    const projectURL = this.configService.getConfigParam('projectURL');
+    const headers = new HttpHeaders().set('cache-control', 'no-cache');
+    return this.http.get(projectURL, { headers: headers });
   }
 
   getThemePath(): string {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -6351,6 +6351,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">72,74</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
+          <context context-type="linenumber">11,13</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/themes/default/notebook/edit-notebook-item-dialog/edit-notebook-item-dialog.component.html</context>
           <context context-type="linenumber">80,82</context>
         </context-group>
@@ -9478,7 +9482,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9203b05eb7515e937cc5e5d8cbc8a03195bb2d7f" datatype="html">
@@ -12281,68 +12285,67 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">96</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2a62a59d9424e9e869061ebf3e8f8b8f95411571" datatype="html">
-        <source> Save </source>
+      <trans-unit id="da5a512c617db2028ac96bac14b200a4bbc381d4" datatype="html">
+        <source>Recovery View</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
-          <context context-type="linenumber">3,5</context>
+          <context context-type="linenumber">2</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="d248762832ad761d68ef47c207a41b0d017f73dc" datatype="html">
-        <source>Go to Authoring View</source>
+      <trans-unit id="2d7827cfe4d0ae4813b39caa8b57acc610e0649e" datatype="html">
+        <source> Go to Authoring View </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
-          <context context-type="linenumber">6</context>
+          <context context-type="linenumber">14,16</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e1cb0d996371ebffafe43d0b31533c5abc1df249" datatype="html">
         <source>JSON Valid</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
-          <context context-type="linenumber">9</context>
+          <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e2dfb6ef44ed682083e2134c987104526aee896d" datatype="html">
         <source>JSON Invalid</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
-          <context context-type="linenumber">10</context>
+          <context context-type="linenumber">20</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="cb2bfc10eb1169d6e2c6ead8c9813283576f1e58" datatype="html">
-        <source> Warning: Modifying the JSON may break the project. Please make a backup copy of the JSON before you modify it.
-</source>
+      <trans-unit id="dd31d9374bba1e354dafc011fcfe8eae11d9dfe0" datatype="html">
+        <source> Warning: Modifying the JSON may break the project. Please make a backup copy of the JSON before you modify it. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
-          <context context-type="linenumber">18,21</context>
+          <context context-type="linenumber">28,31</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5f462e9a8a700a6c7bf878514a1ff79ef71431f7" datatype="html">
         <source>Potential Problems</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
-          <context context-type="linenumber">23</context>
+          <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="b2d91091db1b8cd31b8a6c29eae33be7e16d1788" datatype="html">
+      <trans-unit id="9af5a41d1ad467cd8dcf483170b09aab746727b5" datatype="html">
         <source> This group references the node ID but the node does not exist: <x id="INTERPOLATION" equiv-text="{{ badNode.referencedIdsThatDoNotExist }}"/> </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
-          <context context-type="linenumber">26,29</context>
+          <context context-type="linenumber">36,39</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="eebb4509e6a5470fd71a7933d5d65b3664c1fa05" datatype="html">
+      <trans-unit id="953cf03917b428312a6ce5b151886334c1c465e9" datatype="html">
         <source> This group references the same node ID multiple times: <x id="INTERPOLATION" equiv-text="{{ badNode.referencedIdsThatAreDuplicated }}"/> </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
-          <context context-type="linenumber">30,33</context>
+          <context context-type="linenumber">40,43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="96d19c7b193e83ea80c75c0696ab059d43008164" datatype="html">
         <source>This node has a transition to null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
-          <context context-type="linenumber">34</context>
+          <context context-type="linenumber">44</context>
         </context-group>
       </trans-unit>
       <trans-unit id="92328333ea9c72926ca7c631e9e1c0f081cbf565" datatype="html">
@@ -20898,112 +20901,112 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Complete &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1174</context>
+          <context context-type="linenumber">1180</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4750375498606149231" datatype="html">
         <source>Visit &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1180</context>
+          <context context-type="linenumber">1186</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6126058561630526429" datatype="html">
         <source>Correctly answer &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1186</context>
+          <context context-type="linenumber">1192</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7085241847460263487" datatype="html">
         <source>Obtain a score of &lt;b&gt;<x id="PH" equiv-text="scoresString"/>&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1201</context>
+          <context context-type="linenumber">1207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5469027549306748048" datatype="html">
         <source>You must choose &quot;<x id="PH" equiv-text="choiceText"/>&quot; on &quot;<x id="PH_1" equiv-text="nodeTitle"/>&quot;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1209</context>
+          <context context-type="linenumber">1215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6293177000168372990" datatype="html">
         <source>Submit &lt;b&gt;<x id="PH" equiv-text="requiredSubmitCount"/>&lt;/b&gt; time on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1221</context>
+          <context context-type="linenumber">1227</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4693324974790890133" datatype="html">
         <source>Submit &lt;b&gt;<x id="PH" equiv-text="requiredSubmitCount"/>&lt;/b&gt; times on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1223</context>
+          <context context-type="linenumber">1229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8416169412912074869" datatype="html">
         <source>Take the branch path from &lt;b&gt;<x id="PH" equiv-text="fromNodeTitle"/>&lt;/b&gt; to &lt;b&gt;<x id="PH_1" equiv-text="toNodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1230</context>
+          <context context-type="linenumber">1236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8087029188038414167" datatype="html">
         <source>Write &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfWords"/>&lt;/b&gt; words on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1236</context>
+          <context context-type="linenumber">1242</context>
         </context-group>
       </trans-unit>
       <trans-unit id="22049568725715518" datatype="html">
         <source>&quot;<x id="PH" equiv-text="nodeTitle"/>&quot; is visible</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1242</context>
+          <context context-type="linenumber">1248</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5023130174506669799" datatype="html">
         <source>&quot;<x id="PH" equiv-text="nodeTitle"/>&quot; is visitable</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1248</context>
+          <context context-type="linenumber">1254</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1185133360670447094" datatype="html">
         <source>Add &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfNotes"/>&lt;/b&gt; note on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1255</context>
+          <context context-type="linenumber">1261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5985921753090789216" datatype="html">
         <source>Add &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfNotes"/>&lt;/b&gt; notes on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1257</context>
+          <context context-type="linenumber">1263</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4560070803879446782" datatype="html">
         <source>You must fill in &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfFilledRows"/>&lt;/b&gt; row in the &lt;b&gt;Table&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1264</context>
+          <context context-type="linenumber">1270</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2804292280751903227" datatype="html">
         <source>You must fill in &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfFilledRows"/>&lt;/b&gt; rows in the &lt;b&gt;Table&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1266</context>
+          <context context-type="linenumber">1272</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4171523921205906508" datatype="html">
         <source>Wait for your teacher to unlock the item</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1269</context>
+          <context context-type="linenumber">1275</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8770055323459972095" datatype="html">


### PR DESCRIPTION
## Changes

- Added specific route for the recovery view with its own resolver
- Removed null check for projectURL because I couldn't find where this would occur

## Test

- Make sure recovery view works when the project is broken. You can break a project by adding a non-existing step node id to the ids array of a group node.
- Make sure projects load normally in the VLE, Authoring, Classroom Monitor

Closes #1488