### PR TITLE
refactor(Classroom Monitor): Clean up getStudentProjectCompletion()

### DIFF
--- a/src/assets/wise5/classroomMonitor/student-grading/student-grading.component.ts
+++ b/src/assets/wise5/classroomMonitor/student-grading/student-grading.component.ts
@@ -70,8 +70,7 @@ export class StudentGradingComponent implements OnInit {
     this.maxScore = maxScore ? maxScore : 0;
     this.totalScore = this.dataService.getTotalScoreByWorkgroupId(this.workgroupId);
     this.projectCompletion = this.classroomStatusService.getStudentProjectCompletion(
-      this.workgroupId,
-      true
+      this.workgroupId
     );
     this.nodeIds = this.projectService.getFlattenedProjectAsNodeIds();
     this.setNodesById();

--- a/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts
+++ b/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts
@@ -73,7 +73,7 @@ export class StudentProgressComponent implements OnInit {
 
   private updateTeam(workgroupId: number): void {
     const location = this.getCurrentNodeForWorkgroupId(workgroupId);
-    const completion = this.getStudentProjectCompletion(workgroupId);
+    const completion = this.classroomStatusService.getStudentProjectCompletion(workgroupId);
     const score = this.getStudentTotalScore(workgroupId);
     let maxScore = this.classroomStatusService.getMaxScoreForWorkgroupId(workgroupId);
     maxScore = maxScore ? maxScore : 0;
@@ -93,15 +93,6 @@ export class StudentProgressComponent implements OnInit {
     return this.classroomStatusService.getCurrentNodePositionAndNodeTitleForWorkgroupId(
       workgroupId
     );
-  }
-
-  /**
-   * Get project completion data for the given workgroup (only include nodes with student work)
-   * @param workgroupId the workgroup id
-   * @return object with completed, total, and percent completed (integer between 0 and 100)
-   */
-  private getStudentProjectCompletion(workgroupId: number): any {
-    return this.classroomStatusService.getStudentProjectCompletion(workgroupId);
   }
 
   private getStudentTotalScore(workgroupId: number): number {

--- a/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts
+++ b/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts
@@ -53,7 +53,9 @@ export class StudentProgressComponent implements OnInit {
 
   private initializeStudents(): void {
     this.teams = [];
-    const workgroups = this.configService.getClassmateUserInfos();
+    const workgroups = this.configService
+      .getClassmateUserInfos()
+      .filter((workgroup: any) => workgroup.workgroupId != null);
     for (const workgroup of workgroups) {
       const workgroupId = workgroup.workgroupId;
       const displayNames = this.configService.getDisplayUsernamesByWorkgroupId(workgroupId);
@@ -99,7 +101,7 @@ export class StudentProgressComponent implements OnInit {
    * @return object with completed, total, and percent completed (integer between 0 and 100)
    */
   private getStudentProjectCompletion(workgroupId: number): any {
-    return this.classroomStatusService.getStudentProjectCompletion(workgroupId, true);
+    return this.classroomStatusService.getStudentProjectCompletion(workgroupId);
   }
 
   private getStudentTotalScore(workgroupId: number): number {

--- a/src/assets/wise5/common/ProjectCompletion.ts
+++ b/src/assets/wise5/common/ProjectCompletion.ts
@@ -1,0 +1,5 @@
+export class ProjectCompletion {
+  completedItems: number;
+  completionPct: number;
+  totalItems: number;
+}

--- a/src/assets/wise5/services/classroomStatusService.ts
+++ b/src/assets/wise5/services/classroomStatusService.ts
@@ -65,19 +65,6 @@ export class ClassroomStatusService {
     return null;
   }
 
-  getStudentStatusForWorkgroupId0(workgroupId: number): any {
-    const studentStatuses = this.getStudentStatuses();
-    for (let tempStudentStatus of studentStatuses) {
-      if (tempStudentStatus != null) {
-        const tempWorkgroupId = tempStudentStatus.workgroupId;
-        if (workgroupId === tempWorkgroupId) {
-          return tempStudentStatus;
-        }
-      }
-    }
-    return null;
-  }
-
   getStudentStatusForWorkgroupId(workgroupId: number): any {
     return (
       this.getStudentStatuses().find(


### PR DESCRIPTION
## Changes

- Cleaned up getStudentProjectCompletion()
- When initializing students, only look at workgroups that have a workgroup id
- Removed getWorkgroupIdsOnNode() function which was no longer used

## Test

- Make sure the Grade By Team view (where it shows all the workgroups) works and shows the unit completion for the workgroups
- Make sure the workgroup grading view (where it shows just one workgroup) works and shows the completion percentage