### PR TITLE
fix(Classroom Monitor): Null pointer when exiting workgroup grading view

### DIFF
--- a/src/assets/wise5/classroomMonitor/student-grading/student-grading.component.ts
+++ b/src/assets/wise5/classroomMonitor/student-grading/student-grading.component.ts
@@ -134,7 +134,7 @@ export class StudentGradingComponent implements OnInit {
   private subscribeToCurrentWorkgroupChanged(): void {
     this.subscriptions.add(
       this.dataService.currentWorkgroupChanged$
-        .pipe(filter((workgroup) => workgroup != null))
+        .pipe(filter(({ currentWorkgroup }) => currentWorkgroup != null))
         .subscribe(({ currentWorkgroup }) => {
           const workgroupId = currentWorkgroup.workgroupId;
           if (this.workgroupId !== workgroupId) {


### PR DESCRIPTION
## Changes

Properly filter out null workgroup when changing views.

## Test

1. Open a run in the Classroom Monitor
2. Go to the Grade by Team view
3. Click on a team
4. Go to any other view like Grade by Step or Manage Students
5. The error below used to show up in the console but now it should not

```
teacherDataService.ts:683 ERROR TypeError: Cannot read properties of null (reading 'workgroupId')
    at Object.next (student-grading.component.ts:139:48)
```

Closes #1492