### PR TITLE
refactor(NodeService): Clean up getPrevNodeId() for AT/CM modes

### DIFF
--- a/src/assets/wise5/services/nodeService.ts
+++ b/src/assets/wise5/services/nodeService.ts
@@ -88,33 +88,18 @@ export class NodeService {
    * Get the previous node in the project sequence
    * @param currentId (optional)
    */
-  getPrevNodeId(currentId?) {
+  getPrevNodeId(currentId?: string): string {
     let prevNodeId = null;
-    let currentNodeId = null;
-    const mode = this.ConfigService.getMode();
-    if (currentId) {
-      currentNodeId = currentId;
-    } else {
-      let currentNode = null;
-      currentNode = this.DataService.getCurrentNode();
-      if (currentNode) {
-        currentNodeId = currentNode.id;
-      }
-    }
+    const currentNodeId = currentId ?? this.DataService.getCurrentNodeId();
     if (currentNodeId) {
-      if (['classroomMonitor', 'author'].includes(mode)) {
-        let currentNodeOrder = this.ProjectService.getNodeOrderById(currentNodeId);
+      if (['author', 'classroomMonitor'].includes(this.ConfigService.getMode())) {
+        const currentNodeOrder = this.ProjectService.getNodeOrderById(currentNodeId);
         if (currentNodeOrder) {
-          let prevNodeOrder = currentNodeOrder - 1;
-          let prevId = this.ProjectService.getNodeIdByOrder(prevNodeOrder);
+          const prevId = this.ProjectService.getNodeIdByOrder(currentNodeOrder - 1);
           if (prevId) {
-            if (this.ProjectService.isApplicationNode(prevId)) {
-              // node is a step, so set it as the next node
-              prevNodeId = prevId;
-            } else if (this.ProjectService.isGroupNode(prevId)) {
-              // node is an activity, so get next nodeId
-              prevNodeId = this.getPrevNodeId(prevId);
-            }
+            prevNodeId = this.ProjectService.isApplicationNode(prevId)
+              ? prevId
+              : this.getPrevNodeId(prevId);
           }
         }
       } else {


### PR DESCRIPTION
## Changes
- Call ```DataService.getCurrentNodeId()``` to simplify code at the beginning of the function
- Move check for mode closer to where it's actually used
- Use ternary check for application node/group node check
- Change ```let``` to ```const``` where appropriate

## Test
- Going to the previous node using the prev arrow in the step tools in CM, AT, Student VLE and Preview works as before.