### PR TITLE
refactor(AnnotationService): Move getAllLatestScoreAnnotations() to MilestoneReportService

### DIFF
--- a/src/assets/wise5/services/annotationService.ts
+++ b/src/assets/wise5/services/annotationService.ts
@@ -640,26 +640,6 @@ export class AnnotationService {
     return this.annotations.filter((annotation) => annotation.studentWorkId === studentWorkId);
   }
 
-  getAllLatestScoreAnnotations(nodeId, componentId, periodId) {
-    const workgroupIdsFound = {};
-    const latestScoreAnnotations = [];
-    for (let a = this.annotations.length - 1; a >= 0; a--) {
-      const annotation = this.annotations[a];
-      const workgroupId = annotation.toWorkgroupId;
-      if (
-        workgroupIdsFound[workgroupId] == null &&
-        nodeId === annotation.nodeId &&
-        componentId === annotation.componentId &&
-        (periodId === -1 || periodId === annotation.periodId) &&
-        ('score' === annotation.type || 'autoScore' === annotation.type)
-      ) {
-        workgroupIdsFound[workgroupId] = annotation;
-        latestScoreAnnotations.push(annotation);
-      }
-    }
-    return latestScoreAnnotations;
-  }
-
   broadcastAnnotationSavedToServer(annotation: Annotation): void {
     this.annotationSavedToServerSource.next(annotation);
   }


### PR DESCRIPTION
## Changes
- Move AnnotationService.getAllLatestScoreAnnotations() to MilestoneReportService, the only place it's used
- Rewrite the function using filter() and reduceRight()
- Add function param and return types and make function private

## Test
- Milestone TAP report chooses and displays the correct report template as before