### PR TITLE
refactor(NodeService): Remove currentNodeHasTransitionLogic()

### DIFF
--- a/src/assets/wise5/services/nodeService.ts
+++ b/src/assets/wise5/services/nodeService.ts
@@ -297,17 +297,6 @@ export class NodeService {
     return availableTransitions;
   }
 
-  currentNodeHasTransitionLogic() {
-    const currentNode: any = this.DataService.getCurrentNode();
-    if (currentNode != null) {
-      const transitionLogic = currentNode.transitionLogic;
-      if (transitionLogic != null) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   /**
    * Evaluate the transition logic for the current node and create branch
    * path taken events if necessary.

--- a/src/assets/wise5/vle/node/node.component.ts
+++ b/src/assets/wise5/vle/node/node.component.ts
@@ -151,10 +151,7 @@ export class NodeComponent implements OnInit {
     this.dirtySubmitComponentIds = [];
     this.updateComponentVisibility();
 
-    if (
-      this.nodeService.currentNodeHasTransitionLogic() &&
-      this.nodeService.evaluateTransitionLogicOn('enterNode')
-    ) {
+    if (this.nodeService.evaluateTransitionLogicOn('enterNode')) {
       this.nodeService.evaluateTransitionLogic();
     }
 
@@ -204,10 +201,7 @@ export class NodeComponent implements OnInit {
   ngOnDestroy() {
     this.stopAutoSaveInterval();
     this.nodeUnloaded(this.node.id);
-    if (
-      this.nodeService.currentNodeHasTransitionLogic() &&
-      this.nodeService.evaluateTransitionLogicOn('exitNode')
-    ) {
+    if (this.nodeService.evaluateTransitionLogicOn('exitNode')) {
       this.nodeService.evaluateTransitionLogic();
     }
     this.subscriptions.unsubscribe();
@@ -286,23 +280,21 @@ export class NodeComponent implements OnInit {
         .saveToServer(componentStates, componentEvents, componentAnnotations)
         .then((savedStudentDataResponse) => {
           if (savedStudentDataResponse) {
-            if (this.nodeService.currentNodeHasTransitionLogic()) {
-              if (this.nodeService.evaluateTransitionLogicOn('studentDataChanged')) {
-                this.nodeService.evaluateTransitionLogic();
-              }
-              if (this.nodeService.evaluateTransitionLogicOn('scoreChanged')) {
-                if (componentAnnotations != null && componentAnnotations.length > 0) {
-                  let evaluateTransitionLogic = false;
-                  for (const componentAnnotation of componentAnnotations) {
-                    if (componentAnnotation != null) {
-                      if (componentAnnotation.type === 'autoScore') {
-                        evaluateTransitionLogic = true;
-                      }
+            if (this.nodeService.evaluateTransitionLogicOn('studentDataChanged')) {
+              this.nodeService.evaluateTransitionLogic();
+            }
+            if (this.nodeService.evaluateTransitionLogicOn('scoreChanged')) {
+              if (componentAnnotations != null && componentAnnotations.length > 0) {
+                let evaluateTransitionLogic = false;
+                for (const componentAnnotation of componentAnnotations) {
+                  if (componentAnnotation != null) {
+                    if (componentAnnotation.type === 'autoScore') {
+                      evaluateTransitionLogic = true;
                     }
                   }
-                  if (evaluateTransitionLogic) {
-                    this.nodeService.evaluateTransitionLogic();
-                  }
+                }
+                if (evaluateTransitionLogic) {
+                  this.nodeService.evaluateTransitionLogic();
                 }
               }
             }


### PR DESCRIPTION
## Changes
- Remove calls to NodeService.currentNodeHasTransitionLogic() and the function itself. This is because every node should have a transition logic field. If it doesn't, it's a problem with the unit and the behavior is unknown.

## Test
- Units load and work as before in student VLE and preview

