### PR TITLE
fix(Classroom Monitor): Grade by Step expand lesson console error

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/node-progress-view/node-progress-view.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/node-progress-view/node-progress-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
 import { TeacherDataService } from '../../../../services/teacherDataService';
 import { Subscription } from 'rxjs';
@@ -20,6 +20,7 @@ export class NodeProgressViewComponent implements OnInit {
   private subscriptions: Subscription = new Subscription();
 
   constructor(
+    private changeDetectorRef: ChangeDetectorRef,
     private configService: ConfigService,
     private dialog: MatDialog,
     private projectService: TeacherProjectService,
@@ -38,6 +39,10 @@ export class NodeProgressViewComponent implements OnInit {
     if (!this.isShowingNodeGradingView()) {
       this.saveNodeProgressViewDisplayedEvent();
     }
+  }
+
+  ngAfterViewChecked(): void {
+    this.changeDetectorRef.detectChanges();
   }
 
   private subscribeToCurrentNodeChanged(): void {


### PR DESCRIPTION
## Changes

Added call to changeDetectorRef.detectChanges() like we do in other components to prevent ExpressionChangedAfterItHasBeenCheckedError from occurring.

## Test

1. Open the Classroom Monitor for a run
2. Go to the Grade By Step view
3. Click on a lesson to expand it. You should not see the error below in the console.

```
ERROR Error: NG0100: ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked. Previous value: 'false'. Current value: 'true'. Find more at https://angular.io/errors/NG0100
    at throwErrorIfNoChangesMode (core.mjs:8515:11)
    at bindingUpdated (core.mjs:12843:17)
    at pureFunction1Internal (core.mjs:20614:12)
    at Module.ɵɵpureFunction1 (core.mjs:20411:12)
    at NodeProgressViewComponent_div_0_nav_item_5_Template (node-progress-view.component.html:14:11)
```

Closes #1500