### PR TITLE
refactor(NodeService): Move evaluateTransitionLogicOn() to Node

### DIFF
--- a/src/assets/wise5/common/Node.ts
+++ b/src/assets/wise5/common/Node.ts
@@ -47,6 +47,10 @@ export class Node {
     return this.type === 'group';
   }
 
+  isEvaluateTransitionLogicOn(event: string): boolean {
+    return this.getTransitionLogic().whenToChoosePath === event;
+  }
+
   getNodeIdComponentIds(): any {
     return this.components.map((component) => {
       return { nodeId: this.id, componentId: component.id };

--- a/src/assets/wise5/common/TransitionLogic.ts
+++ b/src/assets/wise5/common/TransitionLogic.ts
@@ -4,4 +4,5 @@ export interface TransitionLogic {
   canChangePath?: boolean;
   howToChooseAmongAvailablePaths?: string;
   transitions: Transition[];
+  whenToChoosePath?: string;
 }

--- a/src/assets/wise5/services/nodeService.ts
+++ b/src/assets/wise5/services/nodeService.ts
@@ -361,18 +361,6 @@ export class NodeService {
     this.DataService.saveVLEEvent(nodeId, componentId, componentType, category, event, eventData);
   }
 
-  evaluateTransitionLogicOn(event) {
-    const currentNode: any = this.DataService.getCurrentNode();
-    if (currentNode != null) {
-      const transitionLogic = currentNode.transitionLogic;
-      const whenToChoosePath = transitionLogic.whenToChoosePath;
-      if (event === whenToChoosePath) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   /**
    * Get the transition result for a node
    * @param nodeId the the node id

--- a/src/assets/wise5/vle/node/node.component.ts
+++ b/src/assets/wise5/vle/node/node.component.ts
@@ -151,7 +151,7 @@ export class NodeComponent implements OnInit {
     this.dirtySubmitComponentIds = [];
     this.updateComponentVisibility();
 
-    if (this.nodeService.evaluateTransitionLogicOn('enterNode')) {
+    if (this.node.isEvaluateTransitionLogicOn('enterNode')) {
       this.nodeService.evaluateTransitionLogic();
     }
 
@@ -201,7 +201,7 @@ export class NodeComponent implements OnInit {
   ngOnDestroy() {
     this.stopAutoSaveInterval();
     this.nodeUnloaded(this.node.id);
-    if (this.nodeService.evaluateTransitionLogicOn('exitNode')) {
+    if (this.node.isEvaluateTransitionLogicOn('exitNode')) {
       this.nodeService.evaluateTransitionLogic();
     }
     this.subscriptions.unsubscribe();
@@ -280,10 +280,10 @@ export class NodeComponent implements OnInit {
         .saveToServer(componentStates, componentEvents, componentAnnotations)
         .then((savedStudentDataResponse) => {
           if (savedStudentDataResponse) {
-            if (this.nodeService.evaluateTransitionLogicOn('studentDataChanged')) {
+            if (this.node.isEvaluateTransitionLogicOn('studentDataChanged')) {
               this.nodeService.evaluateTransitionLogic();
             }
-            if (this.nodeService.evaluateTransitionLogicOn('scoreChanged')) {
+            if (this.node.isEvaluateTransitionLogicOn('scoreChanged')) {
               if (componentAnnotations != null && componentAnnotations.length > 0) {
                 let evaluateTransitionLogic = false;
                 for (const componentAnnotation of componentAnnotations) {


### PR DESCRIPTION
## Changes
- Move NodeService.evaluateTransitionLogicOn() to Node.isEvaluateTransitionLogicOn()
- Clean up isEvaluateTransitionLogicOn()
   - Remove null-check (this function was always called when there was a currentNode)
   - Reduce return statement from 2 to 1
   - Add function param and return types

## Test
- Evaluating transition logic on events work as before, e.g.,
   - Node is authored to choose a branch path when student chooses a choice
   - Node is authored to randomly choose a branch path when student enters node 
   - Node is authored with a "Get a specific score on a component" requirement before moving to the next path