### PR TITLE
fix(Site): Search shows two x buttons

### DIFF
--- a/src/app/modules/shared/search-bar/search-bar.component.html
+++ b/src/app/modules/shared/search-bar/search-bar.component.html
@@ -1,7 +1,7 @@
 <mat-form-field class="search-bar" appearance="fill">
   <mat-label>{{ placeholderText }}</mat-label>
   <mat-icon matPrefix>search</mat-icon>
-  <input matInput type="search" [formControl]="searchField" />
+  <input matInput [formControl]="searchField" />
   <button
     mat-icon-button
     matSuffix


### PR DESCRIPTION
## Changes

Removed type="search" from the search input to get rid of the extra x button.

## Test

Make sure the search still works in these locations
- Teacher Run Search
- Teacher Unit Library Search
- Student Run Search

Enter some text in the search input and only the white x button should appear. Previously two x buttons would appear like in the screenshot below.

![Screenshot 2023-11-01 152039](https://github.com/WISE-Community/WISE-Client/assets/1036509/058a9c48-eb40-4b2d-a900-f4efcab4b876)

Closes #1405