### PR TITLE
fix(Authoring): Concurrent authors message not updating on log out

### DIFF
--- a/src/assets/wise5/authoringTool/concurrent-authors-message/concurrent-authors-message.component.spec.ts
+++ b/src/assets/wise5/authoringTool/concurrent-authors-message/concurrent-authors-message.component.spec.ts
@@ -4,6 +4,8 @@ import { ConfigService } from '../../services/configService';
 import { By } from '@angular/platform-browser';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { of } from 'rxjs';
+import { SessionService } from '../../services/sessionService';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 class MockConfigService {
   getMyUsername(): string {
@@ -22,8 +24,10 @@ describe('ConcurrentAuthorsMessageComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ConcurrentAuthorsMessageComponent],
+      imports: [HttpClientTestingModule],
       providers: [
         { provide: ConfigService, useClass: MockConfigService },
+        SessionService,
         { provide: TeacherProjectService, useClass: MockTeacherProjectService }
       ]
     });

--- a/src/assets/wise5/authoringTool/concurrent-authors-message/concurrent-authors-message.component.ts
+++ b/src/assets/wise5/authoringTool/concurrent-authors-message/concurrent-authors-message.component.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '../../services/configService';
 import { RxStomp } from '@stomp/rx-stomp';
 import { Message } from '@stomp/stompjs';
 import { TeacherProjectService } from '../../services/teacherProjectService';
+import { SessionService } from '../../services/sessionService';
 
 @Component({
   selector: 'concurrent-authors-message',
@@ -14,7 +15,11 @@ export class ConcurrentAuthorsMessageComponent {
   @Input() private projectId: number;
   private rxStomp: RxStomp = new RxStomp();
 
-  constructor(private configService: ConfigService, private projectService: TeacherProjectService) {
+  constructor(
+    private configService: ConfigService,
+    private projectService: TeacherProjectService,
+    private sessionService: SessionService
+  ) {
     this.myUsername = this.configService.getMyUsername();
     this.rxStomp.configure({
       brokerURL: this.configService.getWebSocketURL()
@@ -27,6 +32,7 @@ export class ConcurrentAuthorsMessageComponent {
       this.projectService.notifyAuthorProjectBegin(this.projectId);
     });
     this.subscribeToCurrentAuthors();
+    this.subscribeToSessionExit();
   }
 
   private subscribeToCurrentAuthors(): void {
@@ -38,6 +44,12 @@ export class ConcurrentAuthorsMessageComponent {
               ', '
             )}. Be careful not to overwrite each other's work!`
           : '';
+    });
+  }
+
+  private subscribeToSessionExit(): void {
+    this.sessionService.exit$.subscribe(() => {
+      this.projectService.notifyAuthorProjectEnd();
     });
   }
 

--- a/src/assets/wise5/services/sessionService.ts
+++ b/src/assets/wise5/services/sessionService.ts
@@ -50,6 +50,7 @@ export class SessionService {
   }
 
   logOut() {
+    this.broadcastExit();
     this.http.get(this.configService.getSessionLogOutURL()).subscribe(() => {
       window.location.href = '/';
     });


### PR DESCRIPTION
## Changes
- When the user logs out, send the author project end message to remove their name from the concurrent authors

## Test
1. Sign in as two teachers that are authoring the same project
2. Make sure the concurrent authors message updates when one teacher
- Refreshes the page
- Clicks the "Go Home" button and then the browser back button
- Clicks the "Sign Out" button

Closes #1423
