### PR TITLE
fix(Table): Don't truncate overflow Tabulator cell content

### DIFF
--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.scss
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.scss
@@ -18,6 +18,7 @@
     background-color: #ffffff;
     min-height: 44px; // temporary hack to fix height for some rows with empty cell values; TODO: investigate and fix
     border-bottom: 1px solid #dddddd;
+    white-space: normal;
     
     &.tabulator-frozen {
       background-color: #ffffff;


### PR DESCRIPTION
## Changes
Tabulator cells with content longer than the width of the cell no longer truncate the cell text.

Previous behavior:
![Screenshot 2023-11-13 at 8 52 04 PM](https://github.com/WISE-Community/WISE-Client/assets/297450/2d5c6c5d-c76f-46f0-914e-1f78409f9f75)

New behavior:
![Screenshot 2023-11-13 at 8 52 42 PM](https://github.com/WISE-Community/WISE-Client/assets/297450/1e52f32d-a261-4483-aa06-d394367578e0)

## Test
- Author a Table component with some long text in the cells.
- Ensure that all the content in the cells with long text is visible and the row height adjusts to accommodate (text wraps to new lines when necessary).
