### PR TITLE
fix(Student): Add teammate already in another team error message

### DIFF
--- a/src/app/student/team-sign-in-dialog/team-sign-in-dialog.component.scss
+++ b/src/app/student/team-sign-in-dialog/team-sign-in-dialog.component.scss
@@ -9,3 +9,7 @@
 .login-btn {
   height: 51px;
 }
+
+.mat-icon {
+  margin: 0px;
+}

--- a/src/app/student/team-sign-in-dialog/team-sign-in-dialog.component.ts
+++ b/src/app/student/team-sign-in-dialog/team-sign-in-dialog.component.ts
@@ -103,7 +103,7 @@ export class TeamSignInDialogComponent implements OnInit {
                   this.run.workgroupId = canBeAddedToWorkgroupResponse.workgroupId;
                 }
               } else if (
-                canBeAddedToWorkgroupResponse.workgroupMembers.length ===
+                canBeAddedToWorkgroupResponse.workgroupMembers?.length ===
                 this.run.maxStudentsPerTeam
               ) {
                 alert(


### PR DESCRIPTION
## Changes
- Added null check for field that is not returned when the user is already in another team.
- Fixed sign in check button icon alignment

## Test
- Test with https://github.com/WISE-Community/WISE-API/pull/246
- Make sure these scenarios still work using a run that allows multiple students per team
  - Student A is in a workgroup and Student B is in a different workgroup. Student A is signed in. When you try to add Student B to the workgroup it should say "Student B is already on another team".
  - Student A is not in a workgroup and Student B is not in a workgroup. Student A is signed in. When you try to add Student B to the workgroup it should work.
  - Student A is in a workgroup and Student B is not in a workgroup. Student A is signed in. When you try to add Student B to the workgroup it should work.
  - Student A is in a workgroup and Student B is not in a workgroup. Student B is signed in. When you try to add Student A to the workgroup it should work.

Closes #929
