### PR TITLE
refactor(Grading): Clean up UpdateWorkgroup()

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-grading-view/milestone-grading-view.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-grading-view/milestone-grading-view.component.ts
@@ -147,8 +147,8 @@ export class MilestoneGradingViewComponent extends NodeGradingViewComponent {
     this.saveMilestoneWorkgroupItemViewedEvent(workgroupId, value);
   }
 
-  updateWorkgroup(workgroupId: number, init = false): void {
-    super.updateWorkgroup(workgroupId, init);
+  protected updateWorkgroup(workgroupId: number): void {
+    super.updateWorkgroup(workgroupId);
     const workgroup = this.workgroupsById[workgroupId];
     workgroup.score = this.getScoreByWorkgroupId(workgroupId);
     if (this.milestone.report.locations.length > 1) {
@@ -160,9 +160,7 @@ export class MilestoneGradingViewComponent extends NodeGradingViewComponent {
       );
       workgroup.changeInScore = this.getChangeInScore(workgroup.initialScore, workgroup.score);
     }
-    if (!init) {
-      this.workgroupsById[workgroupId] = copy(workgroup);
-    }
+    this.workgroupsById[workgroupId] = copy(workgroup);
   }
 
   private getChangeInScore(initialScore: number, revisedScore: number): number {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading-view/node-grading-view.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading-view/node-grading-view.component.ts
@@ -153,7 +153,7 @@ export class NodeGradingViewComponent implements OnInit {
       const workgroupId = workgroup.workgroupId;
       this.workgroupsById[workgroupId] = workgroup;
       this.workVisibilityById[workgroupId] = false;
-      this.updateWorkgroup(workgroupId, true);
+      this.updateWorkgroup(workgroupId);
     }
   }
 
@@ -240,9 +240,8 @@ export class NodeGradingViewComponent implements OnInit {
    * Update statuses, scores, notifications, etc. for a workgroup object. Also check if we need to
    * hide student names because logged-in user does not have the right permissions
    * @param workgroupID a workgroup ID number
-   * @param init Boolean whether we're in controller initialization or not
    */
-  protected updateWorkgroup(workgroupId: number, init = false): void {
+  protected updateWorkgroup(workgroupId: number): void {
     const workgroup = this.workgroupsById[workgroupId];
     const alertNotifications = this.notificationService.getAlertNotifications({
       nodeId: this.nodeId,

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13556,7 +13556,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherDataService.ts</context>
-          <context context-type="linenumber">604</context>
+          <context context-type="linenumber">575</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6933068701447776492" datatype="html">
@@ -13910,14 +13910,14 @@ Are you sure you want to proceed?</source>
         <source> Team has not saved any work </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.html</context>
-          <context context-type="linenumber">16,18</context>
+          <context context-type="linenumber">22,24</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1a68048cfcd964c630f4316c43db20f0b8e3a80d" datatype="html">
         <source>See revisions</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.html</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9b7565e0b46708f16f29b8b055bc32b758f30834" datatype="html">


### PR DESCRIPTION
## Changes
- Remove init parameter to the updateWorkgroup() functions in NodeGradingView and MilestoneGradingView. This parameter did not seem to be used in any meaningful way. Perhaps it was a remnant from AngularJS times?

## Test
- 

Closes #
