### PR TITLE
refactor(NodeComponent): Remove getComponentStatePromiseFromService()

### DIFF
--- a/src/assets/wise5/vle/node/node.component.ts
+++ b/src/assets/wise5/vle/node/node.component.ts
@@ -373,26 +373,11 @@ export class NodeComponent implements OnInit {
     const componentStatePromises = [];
     for (const component of components) {
       componentStatePromises.push(
-        this.getComponentStatePromiseFromService(this.node.id, component.id, isAutoSave, isSubmit)
+        this.getComponentStatePromise(this.node.id, component.id, isAutoSave, isSubmit)
       );
       this.componentService.requestComponentState(this.node.id, component.id, isSubmit);
     }
     return componentStatePromises;
-  }
-
-  private getComponentStatePromiseFromService(
-    nodeId: string,
-    componentId: string,
-    isAutoSave: boolean = false,
-    isSubmit: boolean = false
-  ): Promise<any> {
-    const componentStatePromise = this.getComponentStatePromise(
-      nodeId,
-      componentId,
-      isAutoSave,
-      isSubmit
-    );
-    return componentStatePromise;
   }
 
   private getComponentStatePromise(
@@ -404,9 +389,10 @@ export class NodeComponent implements OnInit {
     return new Promise((resolve) => {
       this.componentService.sendComponentStateSource$
         .pipe(
-          filter((data: any) => {
-            return data.nodeId === nodeId && data.componentId === componentId;
-          }),
+          filter(
+            (data: ComponentStateWrapper) =>
+              data.nodeId === nodeId && data.componentId === componentId
+          ),
           take(1)
         )
         .toPromise()


### PR DESCRIPTION
## Changes
- Remove getComponentStatePromiseFromService() intermediate function and call getComponentStatePromise() directly
- Inside filter() function
   - Type data as ```ComponentStateWrapper``` instead of ```any```
   - Remove ```return``` and brackets (```{}```) 

## Test
- In student VLE, saving student work (component states) work as before