### PR TITLE
refactor(NodeComponent): createComponentStatesResponseHandler()

### DIFF
--- a/src/assets/wise5/vle/node/node.component.ts
+++ b/src/assets/wise5/vle/node/node.component.ts
@@ -279,20 +279,11 @@ export class NodeComponent implements OnInit {
             if (this.node.isEvaluateTransitionLogicOn('studentDataChanged')) {
               this.nodeService.evaluateTransitionLogic();
             }
-            if (this.node.isEvaluateTransitionLogicOn('scoreChanged')) {
-              if (componentAnnotations != null && componentAnnotations.length > 0) {
-                let evaluateTransitionLogic = false;
-                for (const componentAnnotation of componentAnnotations) {
-                  if (componentAnnotation != null) {
-                    if (componentAnnotation.type === 'autoScore') {
-                      evaluateTransitionLogic = true;
-                    }
-                  }
-                }
-                if (evaluateTransitionLogic) {
-                  this.nodeService.evaluateTransitionLogic();
-                }
-              }
+            if (
+              this.node.isEvaluateTransitionLogicOn('scoreChanged') &&
+              componentAnnotations.some((annotation) => annotation.type === 'autoScore')
+            ) {
+              this.nodeService.evaluateTransitionLogic();
             }
             const studentWorkList = savedStudentDataResponse.studentWorkList;
             if (!componentId && studentWorkList && studentWorkList.length) {

--- a/src/assets/wise5/vle/node/node.component.ts
+++ b/src/assets/wise5/vle/node/node.component.ts
@@ -266,18 +266,14 @@ export class NodeComponent implements OnInit {
   }
 
   private createComponentStatesResponseHandler(isAutoSave, componentId = null, isSubmit = null) {
-    return (componentStatesFromComponents) => {
-      const {
-        componentStates,
-        componentEvents,
-        componentAnnotations
-      } = this.getDataArraysToSaveFromComponentStates(componentStatesFromComponents);
+    return (componentStates) => {
+      const componentAnnotations = this.getAnnotationsFromComponentStates(componentStates);
       componentStates.forEach((componentState: any) => {
         this.injectAdditionalComponentStateFields(componentState, isAutoSave, isSubmit);
         this.notifyConnectedParts(componentId, componentState);
       });
       return this.studentDataService
-        .saveToServer(componentStates, componentEvents, componentAnnotations)
+        .saveToServer(componentStates, [], componentAnnotations)
         .then((savedStudentDataResponse) => {
           if (savedStudentDataResponse) {
             if (this.node.isEvaluateTransitionLogicOn('studentDataChanged')) {
@@ -310,14 +306,6 @@ export class NodeComponent implements OnInit {
           }
           return savedStudentDataResponse;
         });
-    };
-  }
-
-  private getDataArraysToSaveFromComponentStates(componentStates: any[]): any {
-    return {
-      componentStates: componentStates,
-      componentEvents: [],
-      componentAnnotations: this.getAnnotationsFromComponentStates(componentStates)
     };
   }
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -14360,49 +14360,49 @@ Are you sure you want to proceed?</source>
         <source>Correctness column key: 0 = Incorrect, 1 = Correct, 2 = Correct bucket but wrong position</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">138</context>
+          <context context-type="linenumber">140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7865202073915909645" datatype="html">
         <source>One Workgroup Per Row</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">161</context>
+          <context context-type="linenumber">163</context>
         </context-group>
       </trans-unit>
       <trans-unit id="789970879723970594" datatype="html">
         <source>Latest Student Work</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">163</context>
+          <context context-type="linenumber">165</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6593306077428507515" datatype="html">
         <source>All Student Work</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">165</context>
+          <context context-type="linenumber">167</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5729418620241283277" datatype="html">
         <source>Events</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">167</context>
+          <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
       <trans-unit id="347166173746466674" datatype="html">
         <source>Raw Data</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">169</context>
+          <context context-type="linenumber">171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="456492495567778711" datatype="html">
         <source>Downloading Export</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">2220</context>
+          <context context-type="linenumber">2022</context>
         </context-group>
       </trans-unit>
       <trans-unit id="18a393cd6211a7e1f51159db6b49637ee7c61490" datatype="html">


### PR DESCRIPTION
## Changes
- Remove getDataArraysToSaveFromComponentStates() and set variables directly
- Clean up logic when translation logic should be evaluated using ```some()```

## Test
- Branching based on auto-score c-rater item (e.g. score 1 => branch 1, score 2 => branch 2, etc) works as before.
- Saving component state works as before