### PR TITLE
refactor(StudentStatusService): Clean up code

### DIFF
--- a/src/app/services/studentStatusService.spec.ts
+++ b/src/app/services/studentStatusService.spec.ts
@@ -56,7 +56,7 @@ function retrieveStudentStatus() {
 function retrieveStudentStatus_Preview_SetNewStatus() {
   it('should retrieve empty student status when in preview', () => {
     setIsPreview(true);
-    expectStudentStatusToBeUndefined();
+    expectNewStudentStatus();
     service.retrieveStudentStatus();
     expect(service.getStudentStatus()).toEqual(new StudentStatus());
   });
@@ -65,7 +65,7 @@ function retrieveStudentStatus_Preview_SetNewStatus() {
 function retrieveStudentStatus_ReceiveNull_SetNewStatus() {
   it('should retrieve student status and receive null', () => {
     setIsPreview(false);
-    expectStudentStatusToBeUndefined();
+    expectNewStudentStatus();
     const httpGetSpy = spyOn(http, 'get').and.returnValue(of(null));
     service.retrieveStudentStatus();
     expect(httpGetSpy).toHaveBeenCalled();
@@ -76,7 +76,7 @@ function retrieveStudentStatus_ReceiveNull_SetNewStatus() {
 function retrieveStudentStatus_ReceiveStudentStatus_SetStudentStatus() {
   it('should retrieve student status and receive a student status', () => {
     setIsPreview(false);
-    expectStudentStatusToBeUndefined();
+    expectNewStudentStatus();
     const studentStatus = new StudentStatus({ computerAvatarId: 'robot1' });
     const studentStatusWrapper = createStudentStatusWrapper(studentStatus);
     const httpGetSpy = spyOn(http, 'get').and.returnValue(of(studentStatusWrapper));
@@ -105,9 +105,7 @@ function saveStudentStatus_nodeStatusChanged_PostStudentStatus() {
     const httpPostSpy = spyOn(http, 'post').and.callFake((url: string, body: any) => {
       return of({} as any);
     });
-    const studentStatus = new StudentStatus();
-    studentStatus.computerAvatarId = computerAvatarId;
-    service.studentStatus = studentStatus;
+    service.setComputerAvatarId(computerAvatarId);
     studentDataService.broadcastNodeStatusesChanged();
     const studentStatusJSON = {
       runId: runId,
@@ -136,8 +134,8 @@ function setIsRunActive(value: boolean) {
   spyOn(TestBed.inject(ConfigService), 'isRunActive').and.returnValue(value);
 }
 
-function expectStudentStatusToBeUndefined() {
-  expect(service.studentStatus).toBeUndefined();
+function expectNewStudentStatus() {
+  expect(service.getStudentStatus()).toEqual(new StudentStatus());
 }
 
 function createStudentStatusWrapper(studentStatus: StudentStatus): any {

--- a/src/app/services/studentStatusService.spec.ts
+++ b/src/app/services/studentStatusService.spec.ts
@@ -47,23 +47,13 @@ describe('StudentStatusService', () => {
 
 function retrieveStudentStatus() {
   describe('retrieveStudentStatus()', () => {
-    retrieveStudentStatus_Preview_SetNewStatus();
     retrieveStudentStatus_ReceiveNull_SetNewStatus();
     retrieveStudentStatus_ReceiveStudentStatus_SetStudentStatus();
   });
 }
 
-function retrieveStudentStatus_Preview_SetNewStatus() {
-  it('should retrieve empty student status when in preview', () => {
-    setIsPreview(true);
-    expectNewStudentStatus();
-    service.retrieveStudentStatus();
-    expect(service.getStudentStatus()).toEqual(new StudentStatus());
-  });
-}
-
 function retrieveStudentStatus_ReceiveNull_SetNewStatus() {
-  it('should retrieve student status and receive null', () => {
+  it('should retrieve new student status when backend returns null', () => {
     setIsPreview(false);
     expectNewStudentStatus();
     const httpGetSpy = spyOn(http, 'get').and.returnValue(of(null));

--- a/src/assets/wise5/services/initializeVLEService.ts
+++ b/src/assets/wise5/services/initializeVLEService.ts
@@ -57,7 +57,6 @@ export class InitializeVLEService {
 
   async initializePreview(unitId: string) {
     this.configService.retrieveConfig(`/api/config/preview/${unitId}`).subscribe(async () => {
-      this.studentStatusService.retrieveStudentStatus();
       await this.projectService.retrieveProject().subscribe(async () => {
         this.studentDataService.retrieveStudentData();
         this.studentDataService.retrieveRunStatus();

--- a/src/assets/wise5/services/studentStatusService.ts
+++ b/src/assets/wise5/services/studentStatusService.ts
@@ -9,7 +9,7 @@ import { StudentDataService } from './studentDataService';
 
 @Injectable()
 export class StudentStatusService {
-  studentStatus: StudentStatus;
+  private studentStatus: StudentStatus = new StudentStatus();
 
   constructor(
     private http: HttpClient,
@@ -24,19 +24,15 @@ export class StudentStatusService {
   }
 
   retrieveStudentStatus(): any {
-    if (this.configService.isPreview()) {
-      this.setStudentStatus(new StudentStatus());
-    } else {
-      return this.http
-        .get(`/api/studentStatus/${this.configService.getWorkgroupId()}`)
-        .subscribe((studentStatus: any) => {
-          if (studentStatus == null) {
-            this.setStudentStatus(new StudentStatus());
-          } else {
-            this.setStudentStatus(new StudentStatus(JSON.parse(studentStatus.status)));
-          }
-        });
-    }
+    return this.http
+      .get(`/api/studentStatus/${this.configService.getWorkgroupId()}`)
+      .subscribe((studentStatus: any) => {
+        if (studentStatus == null) {
+          this.setStudentStatus(new StudentStatus());
+        } else {
+          this.setStudentStatus(new StudentStatus(JSON.parse(studentStatus.status)));
+        }
+      });
   }
 
   private setStudentStatus(studentStatus: StudentStatus): void {

--- a/src/assets/wise5/services/studentStatusService.ts
+++ b/src/assets/wise5/services/studentStatusService.ts
@@ -27,16 +27,11 @@ export class StudentStatusService {
     return this.http
       .get(`/api/studentStatus/${this.configService.getWorkgroupId()}`)
       .subscribe((studentStatus: any) => {
-        if (studentStatus == null) {
-          this.setStudentStatus(new StudentStatus());
-        } else {
-          this.setStudentStatus(new StudentStatus(JSON.parse(studentStatus.status)));
-        }
+        this.studentStatus =
+          studentStatus == null
+            ? new StudentStatus()
+            : new StudentStatus(JSON.parse(studentStatus.status));
       });
-  }
-
-  private setStudentStatus(studentStatus: StudentStatus): void {
-    this.studentStatus = studentStatus;
   }
 
   getStudentStatus(): StudentStatus {
@@ -68,7 +63,7 @@ export class StudentStatusService {
       if (computerAvatarId != null) {
         studentStatusJSON.computerAvatarId = computerAvatarId;
       }
-      this.setStudentStatus(studentStatusJSON);
+      this.studentStatus = studentStatusJSON;
       const studentStatusParams = {
         runId: runId,
         periodId: periodId,

--- a/src/assets/wise5/services/studentStatusService.ts
+++ b/src/assets/wise5/services/studentStatusService.ts
@@ -19,7 +19,9 @@ export class StudentStatusService {
     private studentDataService: StudentDataService
   ) {
     studentDataService.nodeStatusesChanged$.subscribe(() => {
-      this.saveStudentStatus();
+      if (!this.configService.isPreview() && this.configService.isRunActive()) {
+        this.saveStudentStatus();
+      }
     });
   }
 
@@ -46,42 +48,30 @@ export class StudentStatusService {
     return this.studentStatus.computerAvatarId;
   }
 
-  private saveStudentStatus() {
-    if (!this.configService.isPreview() && this.configService.isRunActive()) {
-      const runId = this.configService.getRunId();
-      const periodId = this.configService.getPeriodId();
-      const workgroupId = this.configService.getWorkgroupId();
-      const studentStatusJSON: StudentStatus = {
-        runId: runId,
-        periodId: periodId,
-        workgroupId: workgroupId,
-        currentNodeId: this.studentDataService.getCurrentNodeId(),
-        nodeStatuses: this.nodeStatusService.getNodeStatuses(),
-        projectCompletion: this.getProjectCompletion()
-      };
-      const computerAvatarId = this.getComputerAvatarId();
-      if (computerAvatarId != null) {
-        studentStatusJSON.computerAvatarId = computerAvatarId;
-      }
-      this.studentStatus = studentStatusJSON;
-      const studentStatusParams = {
-        runId: runId,
-        periodId: periodId,
-        workgroupId: workgroupId,
-        status: JSON.stringify(studentStatusJSON)
-      };
-      return this.http
-        .post(this.configService.getStudentStatusURL(), studentStatusParams)
-        .toPromise()
-        .then(
-          (result) => {
-            return true;
-          },
-          (result) => {
-            return false;
-          }
-        );
+  private saveStudentStatus(): void {
+    const runId = this.configService.getRunId();
+    const periodId = this.configService.getPeriodId();
+    const workgroupId = this.configService.getWorkgroupId();
+    const studentStatusJSON: StudentStatus = {
+      runId: runId,
+      periodId: periodId,
+      workgroupId: workgroupId,
+      currentNodeId: this.studentDataService.getCurrentNodeId(),
+      nodeStatuses: this.nodeStatusService.getNodeStatuses(),
+      projectCompletion: this.getProjectCompletion()
+    };
+    const computerAvatarId = this.getComputerAvatarId();
+    if (computerAvatarId != null) {
+      studentStatusJSON.computerAvatarId = computerAvatarId;
     }
+    this.studentStatus = studentStatusJSON;
+    const studentStatusParams = {
+      runId: runId,
+      periodId: periodId,
+      workgroupId: workgroupId,
+      status: JSON.stringify(studentStatusJSON)
+    };
+    this.http.post(this.configService.getStudentStatusURL(), studentStatusParams).subscribe();
   }
 
   private getProjectCompletion(): NodeProgress {


### PR DESCRIPTION
## Changes
- Don't call retrieveStudentStatus() if preview mode. Start with an empty StudentStatus instead.
- Remove setStudentStatus() and set field directly
- Make studentStatus field private.
- Only call saveStudentStatus() in student mode. Do mode check before function is called.
- Change saveStudentStatus() return type to void

## Test
- Student status retrieval/saving works as before in student mode
   - project completion saves 
- Student status works as before in preview mode
   - does not retrieve or save student status (as before) 