### PR TITLE
refactor(NodeAuthoring): Componentize EditComponentAdvancedButton

### DIFF
--- a/src/app/teacher/component-authoring.module.ts
+++ b/src/app/teacher/component-authoring.module.ts
@@ -83,6 +83,7 @@ import { EditComponentAdvancedComponent } from '../authoring-tool/edit-component
 import { ComponentAuthoringComponent } from '../../assets/wise5/authoringTool/components/component-authoring.component';
 import { WiseTinymceEditorModule } from '../../assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.module';
 import { WiseLinkAuthoringDialogComponent } from '../../assets/wise5/authoringTool/wise-link-authoring-dialog/wise-link-authoring-dialog.component';
+import { EditComponentAdvancedButtonComponent } from '../../assets/wise5/authoringTool/components/edit-component-advanced-button/edit-component-advanced-button.component';
 
 @NgModule({
   declarations: [
@@ -99,6 +100,7 @@ import { WiseLinkAuthoringDialogComponent } from '../../assets/wise5/authoringTo
     EditAnimationAdvancedComponent,
     EditAudioOscillatorAdvancedComponent,
     EditCommonAdvancedComponent,
+    EditComponentAdvancedButtonComponent,
     EditComponentAdvancedComponent,
     EditComponentAddToNotebookButtonComponent,
     EditComponentConstraintsComponent,
@@ -185,6 +187,7 @@ import { WiseLinkAuthoringDialogComponent } from '../../assets/wise5/authoringTo
     EditAudioOscillatorAdvancedComponent,
     EditCommonAdvancedComponent,
     EditComponentAddToNotebookButtonComponent,
+    EditComponentAdvancedButtonComponent,
     EditComponentConstraintsComponent,
     EditComponentDefaultFeedback,
     EditComponentExcludeFromTotalScoreComponent,

--- a/src/assets/wise5/authoringTool/components/edit-component-advanced-button/edit-component-advanced-button.component.html
+++ b/src/assets/wise5/authoringTool/components/edit-component-advanced-button/edit-component-advanced-button.component.html
@@ -1,0 +1,10 @@
+<button
+  mat-icon-button
+  color="primary"
+  (click)="showComponentAdvancedAuthoring($event)"
+  matTooltip="Advanced"
+  matTooltipPosition="above"
+  i18n-matTooltip
+>
+  <mat-icon>build</mat-icon>
+</button>

--- a/src/assets/wise5/authoringTool/components/edit-component-advanced-button/edit-component-advanced-button.component.ts
+++ b/src/assets/wise5/authoringTool/components/edit-component-advanced-button/edit-component-advanced-button.component.ts
@@ -1,0 +1,24 @@
+import { Component, Input } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { ComponentContent } from '../../../common/ComponentContent';
+import { EditComponentAdvancedComponent } from '../../../../../app/authoring-tool/edit-component-advanced/edit-component-advanced.component';
+import { Component as WiseComponent } from '../../../common/Component';
+
+@Component({
+  selector: 'edit-component-advanced-button',
+  templateUrl: 'edit-component-advanced-button.component.html'
+})
+export class EditComponentAdvancedButtonComponent {
+  @Input() componentContent: ComponentContent;
+  @Input() nodeId: string;
+
+  constructor(private dialog: MatDialog) {}
+
+  protected showComponentAdvancedAuthoring(event: Event): void {
+    event.stopPropagation();
+    this.dialog.open(EditComponentAdvancedComponent, {
+      data: new WiseComponent(this.componentContent, this.nodeId),
+      width: '80%'
+    });
+  }
+}

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
@@ -181,17 +181,11 @@
               matTooltipPosition="above"
               i18n-matTooltip
             ></div>
-            <button
+            <edit-component-advanced-button
               *ngIf="componentsToExpanded[component.id]"
-              mat-icon-button
-              color="primary"
-              (click)="showComponentAdvancedAuthoring(component, $event)"
-              matTooltip="Advanced"
-              matTooltipPosition="above"
-              i18n-matTooltip
-            >
-              <mat-icon>build</mat-icon>
-            </button>
+              [componentContent]="component"
+              [nodeId]="nodeId"
+            ></edit-component-advanced-button>
             <preview-component-button
               class="dynamic-component-button"
               [ngClass]="{

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
@@ -9,8 +9,6 @@ import { ComponentContent } from '../../../common/ComponentContent';
 import { temporarilyHighlightElement } from '../../../common/dom/dom';
 import { MatDialog } from '@angular/material/dialog';
 import { ConfigService } from '../../../../wise5/services/configService';
-import { EditComponentAdvancedComponent } from '../../../../../app/authoring-tool/edit-component-advanced/edit-component-advanced.component';
-import { Component as WiseComponent } from '../../../common/Component';
 import { ChooseNewComponent } from '../../../../../app/authoring-tool/add-component/choose-new-component/choose-new-component.component';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -308,14 +306,6 @@ export class NodeAuthoringComponent implements OnInit {
 
   protected getComponentTypeLabel(componentType: string): string {
     return this.componentTypeService.getComponentTypeLabel(componentType);
-  }
-
-  protected showComponentAdvancedAuthoring(componentContent: ComponentContent, event: any): void {
-    event.stopPropagation();
-    this.dialog.open(EditComponentAdvancedComponent, {
-      data: new WiseComponent(componentContent, this.nodeId),
-      width: '80%'
-    });
   }
 
   protected updateIsAnyComponentSelected(): void {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9816,6 +9816,17 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="bc2e854e111ecf2bd7db170da5e3c2ed08181d88" datatype="html">
+        <source>Advanced</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/components/edit-component-advanced-button/edit-component-advanced-button.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="929954f6e28805c5a7c03aac44c9e48cad2ab3e3" datatype="html">
         <source>Preview Component</source>
         <context-group purpose="location">
@@ -11509,17 +11520,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">242</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="bc2e854e111ecf2bd7db170da5e3c2ed08181d88" datatype="html">
-        <source>Advanced</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">21</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">189</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="90c4e4785a98ff9c710d707d8e079c584fb9af48" datatype="html">
         <source>Back to unit</source>
         <context-group purpose="location">
@@ -11608,14 +11608,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Copy Component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">211</context>
+          <context context-type="linenumber">205</context>
         </context-group>
       </trans-unit>
       <trans-unit id="46c242cc262ba3a868dfd6bd37f555c1ada6877c" datatype="html">
         <source>Delete Component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">225</context>
+          <context context-type="linenumber">219</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7035134055292483273" datatype="html">
@@ -11623,7 +11623,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">251</context>
+          <context context-type="linenumber">249</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5170405945214763287" datatype="html">
@@ -11631,7 +11631,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">252</context>
+          <context context-type="linenumber">250</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bb39841df2c03f771748c1f986e615bffa7f2593" datatype="html">


### PR DESCRIPTION
## Changes
- Extract EditComponentAdvancedButton from NodeAuthoring into a new component
   - With this change, launching the EditComponentAdvanced dialog will no longer be NodeAuthoringComponent's responsibility 

## Test
- Edit Component Advanced button works as before
   - It should appear only when the component authoring view is expanded
   - Clicking on the button should launch the edit component advanced dialog
   - Clicking on the button should not collapse the component authoring view 