### PR TITLE
refactor(NodeAuthoring): Convert componentsToChecked to signal

### DIFF
--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
@@ -71,7 +71,7 @@
     <ng-container
       *ngTemplateOutlet="addComponentButtonTemplate; context: { componentId: null }"
     ></ng-container>
-    <div *ngIf="isAnyComponentSelected">
+    <div *ngIf="isAnyComponentSelected()">
       <button
         mat-icon-button
         color="primary"
@@ -163,9 +163,9 @@
             >
             <mat-checkbox
               color="primary"
-              [(ngModel)]="componentsToChecked[component.id]"
-              (change)="updateIsAnyComponentSelected()"
-              (click)="componentCheckboxClicked($event)"
+              [(ngModel)]="componentsToChecked()[component.id]"
+              (change)="componentCheckboxChanged(component.id, $event.checked)"
+              (click)="$event.stopPropagation()"
               aria-label="Select component"
               i18n-aria-label
             >

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
@@ -161,10 +161,14 @@ function deleteComponents() {
         `Are you sure you want to delete these components?\n1. OpenResponse\n3. Match`
       );
       expect(component.components).toEqual([component2]);
-      expect(component.componentsToChecked[component1.id]).toBeUndefined();
-      expect(component.componentsToChecked[component3.id]).toBeUndefined();
+      expect(expectCheckboxValue(component1.id)).toBeFalsy();
+      expect(expectCheckboxValue(component3.id)).toBeFalsy();
     });
   });
+}
+
+function expectCheckboxValue(componentId: string): void {
+  return fixture.debugElement.query(By.css(`#${componentId} mat-checkbox`)).nativeElement.checked;
 }
 
 function clickComponentCheckbox(componentId: string): void {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -11623,7 +11623,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">249</context>
+          <context context-type="linenumber">245</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5170405945214763287" datatype="html">
@@ -11631,7 +11631,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">250</context>
+          <context context-type="linenumber">246</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bb39841df2c03f771748c1f986e615bffa7f2593" datatype="html">


### PR DESCRIPTION
## Changes
- Convert componentsToChecked and isAnyComponentSelected fields to signals and make them protected
- Update tests

## Test (in node authoring)
- checking/unchecking a component checkbox shows/hides the contextual buttons (move, copy, delete)
   - as long as one component is checked, the contextual buttons should show 
- move/copy/delete single/multiple components work as before using contextual buttons and component-specific buttons

