### PR TITLE
fix(Graph Authoring): Set categorical graph data point to default to 0

### DIFF
--- a/src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.ts
+++ b/src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.ts
@@ -247,7 +247,7 @@ export class GraphAuthoring extends AbstractComponentAuthoring {
       ) {
         series.data.push([]);
       } else if (this.componentContent.xAxis.type === 'categories') {
-        series.data.push(null);
+        series.data.push(0);
       }
     }
     this.componentChanged();


### PR DESCRIPTION
## Changes
When a categorical graph data point is added, it now defaults to 0 instead of null.

## Test
1. Open a unit in the Authoring Tool
2. Create a Graph step
3. Set the Plot Type to Column Plot
4. Scroll down to the Data Points and add a data point. The value should default to 0 instead of null.

Closes #1538