### PR TITLE
fix(Graph Authoring): Set connected component series number default to 0

### DIFF
--- a/src/assets/wise5/components/graph/edit-graph-connected-components/edit-graph-connected-components.component.ts
+++ b/src/assets/wise5/components/graph/edit-graph-connected-components/edit-graph-connected-components.component.ts
@@ -16,7 +16,7 @@ export class EditGraphConnectedComponentsComponent extends EditConnectedComponen
     if (connectedComponent.seriesNumbers == null) {
       connectedComponent.seriesNumbers = [];
     }
-    connectedComponent.seriesNumbers.push(null);
+    connectedComponent.seriesNumbers.push(0);
     this.connectedComponentChanged();
   }
 


### PR DESCRIPTION
## Changes
When a Graph has an Embedded connected component and a series number is added, the series number defaults to 0 instead of null.

## Test
1. Open a unit in the Authoring Tool
2. Create an Embedded step
3. Create a Graph step
4. Open the Graph step
5. Open the Graph advanced popup
6. Add a Connected Component
7. Set the Connected Component step to the Embedded step
8. Add a Series Number. The value defaults to null but it should default to 0.

Closes #1540
