### PR TITLE
refactor(NodeAuthoring): Extract AddComponentButtonComponent

### DIFF
--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -56,9 +56,11 @@ import { ComponentTypeButtonComponent } from '../../assets/wise5/authoringTool/c
 import { ComponentInfoDialogComponent } from '../../assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component';
 import { ComponentTypeSelectorComponent } from '../../assets/wise5/authoringTool/components/component-type-selector/component-type-selector.component';
 import { EditNodeTitleComponent } from '../../assets/wise5/authoringTool/node/edit-node-title/edit-node-title.component';
+import { AddComponentButtonComponent } from '../../assets/wise5/authoringTool/node/add-component-button/add-component-button.component';
 
 @NgModule({
   declarations: [
+    AddComponentButtonComponent,
     AddLessonChooseLocationComponent,
     AddLessonChooseTemplateComponent,
     AddLessonConfigureComponent,

--- a/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.html
+++ b/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.html
@@ -1,0 +1,10 @@
+<button
+  mat-icon-button
+  color="primary"
+  matTooltip="Add a new component"
+  i18n-matTooltip
+  matTooltipPosition="above"
+  (click)="addComponent()"
+>
+  <mat-icon>add_circle</mat-icon>
+</button>

--- a/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AddComponentButtonComponent } from './add-component-button.component';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatIconModule } from '@angular/material/icon';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { ChooseNewComponent } from '../../../../../app/authoring-tool/add-component/choose-new-component/choose-new-component.component';
+import { of } from 'rxjs';
+import { Node } from '../../../common/Node';
+
+class MockTeacherProjectService {
+  createComponent() {}
+  saveProject() {}
+}
+let loader: HarnessLoader;
+describe('AddComponentButtonComponent', () => {
+  let component: AddComponentButtonComponent;
+  let fixture: ComponentFixture<AddComponentButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AddComponentButtonComponent],
+      imports: [MatDialogModule, MatIconModule, RouterTestingModule],
+      providers: [{ provide: TeacherProjectService, useClass: MockTeacherProjectService }]
+    });
+    fixture = TestBed.createComponent(AddComponentButtonComponent);
+    component = fixture.componentInstance;
+    component.node = { id: 'node1' } as Node;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  });
+
+  describe('clicking on the button', () => {
+    it('shows add component dialog, create selected component, and save project', async () => {
+      const dialogSpy = spyOn(TestBed.inject(MatDialog), 'open').and.returnValue({
+        afterClosed: () => of({ action: 'create', componentType: 'OpenResponse' })
+      } as any);
+      const projectService = TestBed.inject(TeacherProjectService);
+      const createComponentSpy = spyOn(projectService, 'createComponent');
+      const saveProjectSpy = spyOn(projectService, 'saveProject');
+      await (await loader.getHarness(MatButtonHarness)).click();
+      expect(dialogSpy).toHaveBeenCalledWith(ChooseNewComponent, {
+        data: null,
+        width: '80%'
+      });
+      expect(createComponentSpy).toHaveBeenCalled();
+      expect(saveProjectSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.ts
+++ b/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.ts
@@ -1,0 +1,52 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { MatDialog } from '@angular/material/dialog';
+import { ChooseNewComponent } from '../../../../../app/authoring-tool/add-component/choose-new-component/choose-new-component.component';
+import { filter } from 'rxjs';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Node } from '../../../common/Node';
+
+@Component({
+  selector: 'add-component-button',
+  templateUrl: './add-component-button.component.html'
+})
+export class AddComponentButtonComponent {
+  @Input() insertAfterComponentId: string = null;
+  @Input() node: Node;
+  @Output() newComponentsEvent: EventEmitter<any> = new EventEmitter<any>();
+
+  constructor(
+    private dialog: MatDialog,
+    private projectService: TeacherProjectService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {}
+
+  protected addComponent(): void {
+    this.dialog
+      .open(ChooseNewComponent, {
+        data: this.insertAfterComponentId,
+        width: '80%'
+      })
+      .afterClosed()
+      .pipe(filter((componentType) => componentType != null))
+      .subscribe(({ action, componentType }) => {
+        if (action === 'import') {
+          this.router.navigate(['import-component/choose-component'], {
+            relativeTo: this.route,
+            state: {
+              insertAfterComponentId: this.insertAfterComponentId
+            }
+          });
+        } else {
+          const component = this.projectService.createComponent(
+            this.node.id,
+            componentType,
+            this.insertAfterComponentId
+          );
+          this.projectService.saveProject();
+          this.newComponentsEvent.emit([component]);
+        }
+      });
+  }
+}

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
@@ -37,18 +37,6 @@
       <mat-icon>close</mat-icon>
     </button>
   </div>
-  <ng-template #addComponentButtonTemplate let-componentId="componentId">
-    <button
-      mat-icon-button
-      color="primary"
-      matTooltip="Add a new component"
-      i18n-matTooltip
-      matTooltipPosition="above"
-      (click)="addComponent(componentId)"
-    >
-      <mat-icon>add_circle</mat-icon>
-    </button>
-  </ng-template>
   <div
     *ngIf="!isGroupNode"
     class="components-header"
@@ -57,9 +45,10 @@
     fxLayoutGap="4px"
   >
     <h5 i18n>Components</h5>
-    <ng-container
-      *ngTemplateOutlet="addComponentButtonTemplate; context: { componentId: null }"
-    ></ng-container>
+    <add-component-button
+      [node]="node"
+      (newComponentsEvent)="highlightNewComponentsAndThenShowComponentAuthoring($event)"
+    ></add-component-button>
     <div *ngIf="isAnyComponentSelected()">
       <button
         mat-icon-button
@@ -227,11 +216,12 @@
             [componentContent]="component"
           ></component-authoring-component>
         </div>
-        <div class="add-component">
-          <ng-container
-            *ngTemplateOutlet="addComponentButtonTemplate; context: { componentId: component.id }"
-          ></ng-container>
-        </div>
+        <add-component-button
+          class="add-component"
+          [insertAfterComponentId]="component.id"
+          [node]="node"
+          (newComponentsEvent)="highlightNewComponentsAndThenShowComponentAuthoring($event)"
+        ></add-component-button>
       </div>
     </div>
   </div>

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
@@ -4,7 +4,6 @@ import { NodeAuthoringComponent } from './node-authoring.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
-import { MatDialogModule } from '@angular/material/dialog';
 import { TeacherDataService } from '../../../services/teacherDataService';
 import { TeacherWebSocketService } from '../../../services/teacherWebSocketService';
 import { ClassroomStatusService } from '../../../services/classroomStatusService';
@@ -24,6 +23,7 @@ import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
 import { TeacherNodeService } from '../../../services/teacherNodeService';
 import { EditNodeTitleComponent } from '../edit-node-title/edit-node-title.component';
+import { AddComponentButtonComponent } from '../add-component-button/add-component-button.component';
 
 let component: NodeAuthoringComponent;
 let component1: any;
@@ -39,7 +39,12 @@ let teacherProjectService: TeacherProjectService;
 describe('NodeAuthoringComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [EditNodeTitleComponent, NodeAuthoringComponent, TeacherNodeIconComponent],
+      declarations: [
+        AddComponentButtonComponent,
+        EditNodeTitleComponent,
+        NodeAuthoringComponent,
+        TeacherNodeIconComponent
+      ],
       imports: [
         BrowserAnimationsModule,
         ComponentAuthoringModule,
@@ -47,7 +52,6 @@ describe('NodeAuthoringComponent', () => {
         FormsModule,
         HttpClientTestingModule,
         MatCheckboxModule,
-        MatDialogModule,
         MatIconModule,
         MatInputModule,
         PreviewComponentModule,

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit, Signal, WritableSignal, computed, signal } from '@angular/core';
-import { Subscription, filter } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { TeacherDataService } from '../../../services/teacherDataService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { ComponentTypeService } from '../../../services/componentTypeService';
@@ -7,9 +7,7 @@ import { ComponentServiceLookupService } from '../../../services/componentServic
 import { Node } from '../../../common/Node';
 import { ComponentContent } from '../../../common/ComponentContent';
 import { temporarilyHighlightElement } from '../../../common/dom/dom';
-import { MatDialog } from '@angular/material/dialog';
 import { ConfigService } from '../../../../wise5/services/configService';
-import { ChooseNewComponent } from '../../../../../app/authoring-tool/add-component/choose-new-component/choose-new-component.component';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TeacherNodeService } from '../../../services/teacherNodeService';
@@ -37,7 +35,6 @@ export class NodeAuthoringComponent implements OnInit {
     private configService: ConfigService,
     private componentServiceLookupService: ComponentServiceLookupService,
     private componentTypeService: ComponentTypeService,
-    private dialog: MatDialog,
     private nodeService: TeacherNodeService,
     private projectService: TeacherProjectService,
     private dataService: TeacherDataService,
@@ -120,34 +117,6 @@ export class NodeAuthoringComponent implements OnInit {
   protected close(): void {
     this.dataService.setCurrentNode(null);
     this.scrollToTopOfPage();
-  }
-
-  protected addComponent(insertAfterComponentId: string): void {
-    const dialogRef = this.dialog.open(ChooseNewComponent, {
-      data: insertAfterComponentId,
-      width: '80%'
-    });
-    dialogRef
-      .afterClosed()
-      .pipe(filter((componentType) => componentType != null))
-      .subscribe(({ action, componentType }) => {
-        if (action === 'import') {
-          this.router.navigate(['import-component/choose-component'], {
-            relativeTo: this.route,
-            state: {
-              insertAfterComponentId: insertAfterComponentId
-            }
-          });
-        } else {
-          const component = this.projectService.createComponent(
-            this.nodeId,
-            componentType,
-            insertAfterComponentId
-          );
-          this.projectService.saveProject();
-          this.highlightNewComponentsAndThenShowComponentAuthoring([component]);
-        }
-      });
   }
 
   protected hideAllComponentSaveButtons(): void {
@@ -276,7 +245,7 @@ export class NodeAuthoringComponent implements OnInit {
    * @param newComponents an array of the new components we have just added
    * @param expandComponents expand component(s)' authoring views after highlighting
    */
-  private highlightNewComponentsAndThenShowComponentAuthoring(
+  protected highlightNewComponentsAndThenShowComponentAuthoring(
     newComponents: any = [],
     expandComponents: boolean = true
   ): void {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1172,7 +1172,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">149</context>
+          <context context-type="linenumber">138</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.html</context>
@@ -10897,6 +10897,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">443</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="2998257cb98e73a3cfaf686ef9c2bbbf618f6fb0" datatype="html">
+        <source>Add a new component</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="95a6b174bcdc9e77421358825217263add8e6bd8" datatype="html">
         <source>Create Branch</source>
         <context-group purpose="location">
@@ -11515,95 +11522,88 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2998257cb98e73a3cfaf686ef9c2bbbf618f6fb0" datatype="html">
-        <source>Add a new component</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">44</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="16f48e8858552177f3da7a0ccf2449b2522ebe14" datatype="html">
         <source>Components</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">59</context>
+          <context context-type="linenumber">47</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7c5b499b46f7ab611026c2e07b19d8d70e51853a" datatype="html">
         <source>Move Components</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">68</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="835ab9ba787d9e73a77b6f723e200ca24a5808a9" datatype="html">
         <source>Copy Components</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">78</context>
+          <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="646e338d93a6cafb1c27766c746ce8f2fde3c2a6" datatype="html">
         <source>Delete Components</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">88</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="67145eb769f4fe04e8b9f3c24d4452cf18ac196b" datatype="html">
         <source> + Expand All </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">103,105</context>
+          <context context-type="linenumber">92,94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="22137335ce02968992f1f2fb73c630e68be673cb" datatype="html">
         <source> - Collapse All </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">112,114</context>
+          <context context-type="linenumber">101,103</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1944eaae32b2002e6f552fd9c1f5a113c412ad25" datatype="html">
         <source>This step does not have any components. Click the + button to add a component.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">119</context>
+          <context context-type="linenumber">108</context>
         </context-group>
       </trans-unit>
       <trans-unit id="534f4fefca77da56b8b0ea6fb63ff18bae415a92" datatype="html">
         <source>Toggle component authoring</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">141</context>
+          <context context-type="linenumber">130</context>
         </context-group>
       </trans-unit>
       <trans-unit id="11cd90245b41b1506efabdcea69d3c5c0964a432" datatype="html">
         <source>Select component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">158</context>
+          <context context-type="linenumber">147</context>
         </context-group>
       </trans-unit>
       <trans-unit id="47f8ae23f1be55b30a01abc41c7ca4b770f5d1b2" datatype="html">
         <source>Click to expand/collapse</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">169</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6e04c490706ecafe8e0c842513b700e165d97bc2" datatype="html">
         <source>Copy Component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">194</context>
+          <context context-type="linenumber">183</context>
         </context-group>
       </trans-unit>
       <trans-unit id="46c242cc262ba3a868dfd6bd37f555c1ada6877c" datatype="html">
         <source>Delete Component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">208</context>
+          <context context-type="linenumber">197</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7035134055292483273" datatype="html">
@@ -11611,7 +11611,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">245</context>
+          <context context-type="linenumber">214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5170405945214763287" datatype="html">
@@ -11619,7 +11619,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">246</context>
+          <context context-type="linenumber">215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bb39841df2c03f771748c1f986e615bffa7f2593" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -2762,7 +2762,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password/forgot-teacher-password.component.ts</context>
-          <context context-type="linenumber">91</context>
+          <context context-type="linenumber">90</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6244139ed5734258736685c4d638b4fac1b04bbb" datatype="html">
@@ -2841,7 +2841,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password/forgot-teacher-password.component.ts</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c83b838d845690bcb897f775f53b5316535306dc" datatype="html">
@@ -3314,14 +3314,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>You have submitted an invalid verification code too many times. For security reasons, we will lock the ability to change your password for 10 minutes. After 10 minutes, you can try again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password/forgot-teacher-password.component.ts</context>
-          <context context-type="linenumber">85</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="243316711119938992" datatype="html">
         <source>The server has encountered an error and was unable to send you an email. Please try again. If the error continues to occur, please contact us.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password/forgot-teacher-password.component.ts</context>
-          <context context-type="linenumber">88</context>
+          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5c112eccf2cd10cf48736fb8fd2c18c1788b6bb9" datatype="html">


### PR DESCRIPTION
## Changes
- Extract AddComponentButtonComponent from NodeAuthoring component and template. This reduces NodeAuthoringComponent's responsibility.
   - AddComponent dialog is now launched from AddComponentButtonComponent instead of NodeAuthoringComponent
   - Result from AddComponent dialog (chosen component type or chosen import component(s)) is now saved by AddComponentButtonComponent and sent back to NodeAuthoring via newComponentsEvent output
- Add tests for AddComponentButtonComponent

## Test (in Node Authoring)
- Add new component(s) and import component(s) work as before
   - insert as the first component of the node
   - insert after an existing component