### PR TITLE
fix(Table): Properly calculate row heights after build

### DIFF
--- a/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
+++ b/src/assets/wise5/components/table/tabulator-table/tabulator-table.component.ts
@@ -78,6 +78,7 @@ export class TabulatorTableComponent implements OnChanges, AfterViewInit {
         this.setupRowSelection();
       }
       this.setupSorting();
+      this.table.setSort();
       this.ready.emit();
     });
     this.tableContainer.nativeElement.appendChild(this.tableEl);


### PR DESCRIPTION
## Changes
Properly calculates Tabulator row heights for certain table components when the table is built.

[Production example](https://wise.berkeley.edu/preview/unit/41025/node223) where row heights are not properly sized:
![Screenshot 2023-11-29 at 11 24 19 AM](https://github.com/WISE-Community/WISE-Client/assets/297450/972bf010-e031-47cc-a4e8-ed35f178b438)

With this fix, example table renders like this:
![Screenshot 2023-11-29 at 11 26 38 AM](https://github.com/WISE-Community/WISE-Client/assets/297450/881ecce9-0b07-45fa-ba80-cb6048226b11)


## Test
Make sure Table component row heights are properly calculated and Table components work as before.
