### PR TITLE
feat(Edit Project Info): Multiple languages setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@angular/platform-browser": "^16.2.9",
         "@angular/platform-browser-dynamic": "^16.2.9",
         "@angular/router": "^16.2.9",
+        "@ng-select/ng-select": "^11.2.0",
         "@ng-web-apis/common": "^2.0.1",
         "@ng-web-apis/intersection-observer": "^3.0.0",
         "@stomp/rx-stomp": "^1.1.4",
@@ -5059,6 +5060,23 @@
         "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
         "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@ng-select/ng-select": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@ng-select/ng-select/-/ng-select-11.2.0.tgz",
+      "integrity": "sha512-lTyw93kFdKGecp9eKmOP0PQSCaAJS8DCt4D60ns055+ixvRSp2fuXAuJUvn1e3gAsvpZor37osmYlOJ4LYwYIA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 16",
+        "npm": ">= 8"
+      },
+      "peerDependencies": {
+        "@angular/common": "^16.0.0",
+        "@angular/core": "^16.0.0",
+        "@angular/forms": "^16.0.0"
       }
     },
     "node_modules/@ng-web-apis/common": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@angular/platform-browser": "^16.2.9",
     "@angular/platform-browser-dynamic": "^16.2.9",
     "@angular/router": "^16.2.9",
+    "@ng-select/ng-select": "^11.2.0",
     "@ng-web-apis/common": "^2.0.1",
     "@ng-web-apis/intersection-observer": "^3.0.0",
     "@stomp/rx-stomp": "^1.1.4",

--- a/src/app/domain/localeToLanguage.ts
+++ b/src/app/domain/localeToLanguage.ts
@@ -1,12 +1,12 @@
 export const localeToLanguage: { [locale: string]: string } = {
-  en_US: $localize`English`,
-  es: $localize`Spanish`,
-  de: $localize`German`,
-  ja: $localize`Japanese`,
-  it: $localize`Italian`,
-  ko: $localize`Korean`,
-  nl: $localize`Dutch (Netherlands)`,
-  vi: $localize`Vietnamese`,
   zh_CN: $localize`Chinese (Simplified)`,
-  zh_TW: $localize`Chinese (Traditional)`
+  zh_TW: $localize`Chinese (Traditional)`,
+  nl: $localize`Dutch`,
+  en_US: $localize`English`,
+  de: $localize`German`,
+  it: $localize`Italian`,
+  ja: $localize`Japanese`,
+  ko: $localize`Korean`,
+  es: $localize`Spanish`,
+  vi: $localize`Vietnamese`
 };

--- a/src/app/domain/localeToLanguage.ts
+++ b/src/app/domain/localeToLanguage.ts
@@ -1,6 +1,12 @@
-export const localeToLanguage = {
+export const localeToLanguage: { [locale: string]: string } = {
   en_US: $localize`English`,
   es: $localize`Spanish`,
+  de: $localize`German`,
   ja: $localize`Japanese`,
-  it: $localize`Italian`
+  it: $localize`Italian`,
+  ko: $localize`Korean`,
+  nl: $localize`Dutch (Netherlands)`,
+  vi: $localize`Vietnamese`,
+  zh_CN: $localize`Chinese (Simplified)`,
+  zh_TW: $localize`Chinese (Traditional)`
 };

--- a/src/app/domain/projectLocale.ts
+++ b/src/app/domain/projectLocale.ts
@@ -9,6 +9,10 @@ export class ProjectLocale {
     this.locale = locale;
   }
 
+  getAvailableLanguages(): Language[] {
+    return [this.getDefaultLanguage()].concat(this.getSupportedLanguages());
+  }
+
   getDefaultLanguage(): Language {
     return { language: localeToLanguage[this.locale.default], locale: this.locale.default };
   }

--- a/src/app/domain/projectLocale.ts
+++ b/src/app/domain/projectLocale.ts
@@ -1,32 +1,39 @@
 import { Language } from './language';
 import { localeToLanguage } from './localeToLanguage';
 
-const defaultLocales = {
-  default: 'en_US',
-  supported: []
-};
+const defaultProjectLocale = { default: 'en_US', supported: [] };
 export class ProjectLocale {
-  private default: string;
-  private supported: string[];
+  private locale: { default: string; supported: string[] };
 
-  constructor(locales: any = defaultLocales) {
-    this.default = locales.default;
-    this.supported = locales.supported;
+  constructor(locale: any = defaultProjectLocale) {
+    this.locale = locale;
+  }
+
+  getDefaultLanguage(): Language {
+    return { language: localeToLanguage[this.locale.default], locale: this.locale.default };
+  }
+
+  setDefaultLocale(locale: string): void {
+    this.locale.default = locale;
   }
 
   getSupportedLanguages(): Language[] {
-    return this.supported.map((locale) => ({
+    return this.locale.supported.map((locale) => ({
       language: localeToLanguage[locale],
       locale: locale
     }));
   }
 
+  setSupportedLanguages(languages: Language[]): void {
+    this.locale.supported = languages.map((language) => language.locale);
+  }
+
   private hasLocale(locale: string): boolean {
-    return this.supported.includes(locale);
+    return this.locale.supported.includes(locale);
   }
 
   hasTranslations(): boolean {
-    return this.supported.length > 1;
+    return this.locale.supported.length > 1;
   }
 
   hasTranslationsToApply(locale: string): boolean {
@@ -34,6 +41,6 @@ export class ProjectLocale {
   }
 
   isDefaultLocale(locale: string): boolean {
-    return this.default === locale;
+    return this.locale.default === locale;
   }
 }

--- a/src/app/domain/projectLocale.ts
+++ b/src/app/domain/projectLocale.ts
@@ -39,7 +39,7 @@ export class ProjectLocale {
   }
 
   hasTranslations(): boolean {
-    return this.locale.supported.length > 1;
+    return this.locale.supported.length > 0;
   }
 
   hasTranslationsToApply(locale: string): boolean {

--- a/src/app/domain/projectLocale.ts
+++ b/src/app/domain/projectLocale.ts
@@ -1,11 +1,10 @@
 import { Language } from './language';
 import { localeToLanguage } from './localeToLanguage';
 
-const defaultProjectLocale = { default: 'en_US', supported: [] };
 export class ProjectLocale {
   private locale: { default: string; supported: string[] };
 
-  constructor(locale: any = defaultProjectLocale) {
+  constructor(locale: any) {
     this.locale = locale;
   }
 

--- a/src/app/domain/projectLocale.ts
+++ b/src/app/domain/projectLocale.ts
@@ -19,6 +19,9 @@ export class ProjectLocale {
 
   setDefaultLocale(locale: string): void {
     this.locale.default = locale;
+    this.locale.supported = this.locale.supported.filter(
+      (supportedLocale) => supportedLocale != locale
+    );
   }
 
   getSupportedLanguages(): Language[] {

--- a/src/app/services/sampleData/curriculum/TeacherProjectServiceSpec.project.json
+++ b/src/app/services/sampleData/curriculum/TeacherProjectServiceSpec.project.json
@@ -1,6 +1,7 @@
 {
   "startGroupId": "group0",
   "startNodeId": "node1",
+  "metadata": {},
   "nodes": [
     {
       "id": "group0",

--- a/src/app/services/translateProjectService.spec.ts
+++ b/src/app/services/translateProjectService.spec.ts
@@ -28,7 +28,9 @@ describe('TranslateProjectService', () => {
   describe('translate()', () => {
     describe('has no translations to apply', () => {
       beforeEach(() => {
-        spyOn(projectService, 'getLocale').and.returnValue(new ProjectLocale());
+        spyOn(projectService, 'getLocale').and.returnValue(
+          new ProjectLocale({ default: 'en_US', supported: [] })
+        );
       });
       it('should keep original project in tact', () => {
         service.translate().then(() => {

--- a/src/app/services/translateProjectService.spec.ts
+++ b/src/app/services/translateProjectService.spec.ts
@@ -31,7 +31,7 @@ describe('TranslateProjectService', () => {
         spyOn(projectService, 'getLocale').and.returnValue(new ProjectLocale());
       });
       it('should keep original project in tact', () => {
-        service.translate().subscribe(() => {
+        service.translate().then(() => {
           expect(projectService.getProjectTitle()).toEqual('Demo Project');
         });
       });
@@ -44,7 +44,7 @@ describe('TranslateProjectService', () => {
         spyOn(configService, 'getConfigParam').and.returnValue('/123/project.json');
       });
       it('should retrieve translation mapping file and translate project', () => {
-        service.translate('es').subscribe(() => {
+        service.translate('es').then(() => {
           expect(projectService.getProjectTitle()).toEqual('Proyecto de demostración');
         });
         http

--- a/src/app/student/project-language-chooser/project-language-chooser.component.spec.ts
+++ b/src/app/student/project-language-chooser/project-language-chooser.component.spec.ts
@@ -5,11 +5,15 @@ import { StudentTeacherCommonServicesModule } from '../../student-teacher-common
 import { ProjectService } from '../../../assets/wise5/services/projectService';
 import { ProjectLocale } from '../../domain/projectLocale';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatSelectHarness } from '@angular/material/select/testing';
 
 let projectService: ProjectService;
 describe('ProjectLanguageChooserComponent', () => {
   let component: ProjectLanguageChooserComponent;
   let fixture: ComponentFixture<ProjectLanguageChooserComponent>;
+  let loader: HarnessLoader;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -24,13 +28,23 @@ describe('ProjectLanguageChooserComponent', () => {
   });
 
   beforeEach(() => {
-    spyOn(projectService, 'getLocale').and.returnValue(new ProjectLocale());
+    spyOn(projectService, 'getLocale').and.returnValue(
+      new ProjectLocale({ default: 'en_US', supported: ['ja', 'es'] })
+    );
     fixture = TestBed.createComponent(ProjectLanguageChooserComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('shows available languages', async () => {
+    const selects = await loader.getAllHarnesses(MatSelectHarness);
+    const selectComponent = selects[0];
+    await selectComponent.open();
+    const options = await selectComponent.getOptions();
+    expect(options.length).toEqual(3);
+    expect(await options[0].getText()).toMatch('English');
+    expect(await options[1].getText()).toMatch('Japanese');
+    expect(await options[2].getText()).toMatch('Spanish');
   });
 });

--- a/src/app/student/project-language-chooser/project-language-chooser.component.ts
+++ b/src/app/student/project-language-chooser/project-language-chooser.component.ts
@@ -24,7 +24,7 @@ export class ProjectLanguageChooserComponent implements OnInit {
 
   ngOnInit(): void {
     const unitLocale = this.projectService.getLocale();
-    this.availableLanguages = unitLocale.getSupportedLanguages();
+    this.availableLanguages = unitLocale.getAvailableLanguages();
     this.selectedLanguage = this.availableLanguages.find((language) =>
       unitLocale.isDefaultLocale(language.locale)
     );

--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { NgSelectModule } from '@ng-select/ng-select';
 import { AddYourOwnNode } from '../../assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component';
 import { ChooseNewNodeLocation } from '../../assets/wise5/authoringTool/addNode/choose-new-node-location/choose-new-node-location.component';
 import { ChooseNewNodeTemplate } from '../../assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component';
@@ -56,6 +57,7 @@ import { ComponentTypeButtonComponent } from '../../assets/wise5/authoringTool/c
 import { ComponentInfoDialogComponent } from '../../assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component';
 import { ComponentTypeSelectorComponent } from '../../assets/wise5/authoringTool/components/component-type-selector/component-type-selector.component';
 import { EditNodeTitleComponent } from '../../assets/wise5/authoringTool/node/edit-node-title/edit-node-title.component';
+import { EditProjectLanguageSettingComponent } from '../../assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component';
 
 @NgModule({
   declarations: [
@@ -85,6 +87,7 @@ import { EditNodeTitleComponent } from '../../assets/wise5/authoringTool/node/ed
     ConcurrentAuthorsMessageComponent,
     ConfigureAutomatedAssessmentComponent,
     EditNodeTitleComponent,
+    EditProjectLanguageSettingComponent,
     InsertNodeAfterButtonComponent,
     InsertNodeInsideButtonComponent,
     MilestonesAuthoringComponent,
@@ -111,6 +114,7 @@ import { EditNodeTitleComponent } from '../../assets/wise5/authoringTool/node/ed
     MatBadgeModule,
     MatChipsModule,
     ImportComponentModule,
+    NgSelectModule,
     NodeAdvancedAuthoringModule,
     PreviewComponentModule,
     ProjectAssetAuthoringModule,

--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html
@@ -52,7 +52,10 @@
       (ngModelChange)="metadataChanged.next()"
     />
   </mat-form-field>
-  <ng-container *ngIf="metadataField.type === 'radio'">
+  <edit-project-language-setting
+    *ngIf="metadataField.name === 'Language'"
+  ></edit-project-language-setting>
+  <ng-container *ngIf="metadataField.type === 'radio' && metadataField.name !== 'Language'">
     <label class="bold">{{ metadataField.name }}:</label>
     <mat-radio-group class="radio-group margin-bottom-20" fxLayout="column">
       <ng-container *ngFor="let choice of metadataField.choices">

--- a/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.html
+++ b/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.html
@@ -13,6 +13,7 @@
   [items]="availableLanguages"
   bindLabel="language"
   [(ngModel)]="supportedLanguages"
+  [closeOnSelect]="false"
   [multiple]="true"
   (change)="updateSupportedLanguages()"
 >

--- a/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.html
+++ b/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.html
@@ -1,0 +1,19 @@
+<h3 i18n>Language</h3>
+<span i18n>Default language:</span>
+<ng-select
+  [items]="availableLanguages"
+  bindLabel="language"
+  [(ngModel)]="defaultLanguage"
+  [clearable]="false"
+  (change)="updateDefaultLanguage()"
+>
+</ng-select>
+<span i18n>Additional languages:</span>
+<ng-select
+  [items]="availableLanguages"
+  bindLabel="language"
+  [(ngModel)]="supportedLanguages"
+  [multiple]="true"
+  (change)="updateSupportedLanguages()"
+>
+</ng-select>

--- a/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.spec.ts
@@ -21,7 +21,9 @@ describe('EditProjectLanguageSettingComponent', () => {
     });
     fixture = TestBed.createComponent(EditProjectLanguageSettingComponent);
     component = fixture.componentInstance;
-    spyOn(TestBed.inject(TeacherProjectService), 'getLocale').and.returnValue(new ProjectLocale());
+    spyOn(TestBed.inject(TeacherProjectService), 'getLocale').and.returnValue(
+      new ProjectLocale({ default: 'en_US', supported: [] })
+    );
     fixture.detectChanges();
   });
 

--- a/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.spec.ts
@@ -1,0 +1,31 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NgSelectModule } from '@ng-select/ng-select';
+import { EditProjectLanguageSettingComponent } from './edit-project-language-setting.component';
+import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { ProjectLocale } from '../../../../../app/domain/projectLocale';
+import { FormsModule } from '@angular/forms';
+
+class MockTeacherProjectService {
+  getLocale() {}
+  saveProject() {}
+}
+describe('EditProjectLanguageSettingComponent', () => {
+  let component: EditProjectLanguageSettingComponent;
+  let fixture: ComponentFixture<EditProjectLanguageSettingComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [EditProjectLanguageSettingComponent],
+      imports: [FormsModule, NgSelectModule],
+      providers: [{ provide: TeacherProjectService, useClass: MockTeacherProjectService }]
+    });
+    fixture = TestBed.createComponent(EditProjectLanguageSettingComponent);
+    component = fixture.componentInstance;
+    spyOn(TestBed.inject(TeacherProjectService), 'getLocale').and.returnValue(new ProjectLocale());
+    fixture.detectChanges();
+  });
+
+  it('creates', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.ts
+++ b/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.ts
@@ -9,9 +9,7 @@ import { localeToLanguage } from '../../../../../app/domain/localeToLanguage';
   templateUrl: './edit-project-language-setting.component.html'
 })
 export class EditProjectLanguageSettingComponent {
-  protected availableLanguages: Language[] = Object.entries(
-    localeToLanguage
-  ).map(([locale, language]) => ({ locale: locale, language: language }));
+  protected availableLanguages: Language[];
   protected defaultLanguage: Language;
   private projectLocale: ProjectLocale;
   protected supportedLanguages: Language[];
@@ -19,18 +17,30 @@ export class EditProjectLanguageSettingComponent {
   constructor(private projectService: TeacherProjectService) {}
 
   ngOnInit(): void {
+    this.updateModel();
+  }
+
+  private updateModel(): void {
     this.projectLocale = this.projectService.getLocale();
     this.defaultLanguage = this.projectLocale.getDefaultLanguage();
     this.supportedLanguages = this.projectLocale.getSupportedLanguages();
+    this.availableLanguages = Object.entries(localeToLanguage)
+      .map(([locale, language]) => ({
+        locale: locale,
+        language: language
+      }))
+      .filter((language) => language.locale != this.defaultLanguage.locale);
   }
 
   protected updateDefaultLanguage(): void {
     this.projectLocale.setDefaultLocale(this.defaultLanguage.locale);
     this.projectService.saveProject();
+    this.updateModel();
   }
 
   protected updateSupportedLanguages(): void {
     this.projectLocale.setSupportedLanguages(this.supportedLanguages);
     this.projectService.saveProject();
+    this.updateModel();
   }
 }

--- a/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.ts
+++ b/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.ts
@@ -1,0 +1,36 @@
+import { Component } from '@angular/core';
+import { Language } from '../../../../../app/domain/language';
+import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { ProjectLocale } from '../../../../../app/domain/projectLocale';
+import { localeToLanguage } from '../../../../../app/domain/localeToLanguage';
+
+@Component({
+  selector: 'edit-project-language-setting',
+  templateUrl: './edit-project-language-setting.component.html'
+})
+export class EditProjectLanguageSettingComponent {
+  protected availableLanguages: Language[] = Object.entries(
+    localeToLanguage
+  ).map(([locale, language]) => ({ locale: locale, language: language }));
+  protected defaultLanguage: Language;
+  private projectLocale: ProjectLocale;
+  protected supportedLanguages: Language[];
+
+  constructor(private projectService: TeacherProjectService) {}
+
+  ngOnInit(): void {
+    this.projectLocale = this.projectService.getLocale();
+    this.defaultLanguage = this.projectLocale.getDefaultLanguage();
+    this.supportedLanguages = this.projectLocale.getSupportedLanguages();
+  }
+
+  protected updateDefaultLanguage(): void {
+    this.projectLocale.setDefaultLocale(this.defaultLanguage.locale);
+    this.projectService.saveProject();
+  }
+
+  protected updateSupportedLanguages(): void {
+    this.projectLocale.setSupportedLanguages(this.supportedLanguages);
+    this.projectService.saveProject();
+  }
+}

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -237,6 +237,10 @@ export class ProjectService {
   instantiateDefaults(): void {
     this.project.nodes = this.project.nodes ? this.project.nodes : [];
     this.project.inactiveNodes = this.project.inactiveNodes ? this.project.inactiveNodes : [];
+    this.project.metadata.locale = this.project.metadata.locale ?? {
+      default: 'en_US',
+      supported: []
+    };
   }
 
   private calculateNodeOrderOfProject(): void {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -21228,112 +21228,112 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Complete &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1192</context>
+          <context context-type="linenumber">1196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4750375498606149231" datatype="html">
         <source>Visit &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1198</context>
+          <context context-type="linenumber">1202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6126058561630526429" datatype="html">
         <source>Correctly answer &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1204</context>
+          <context context-type="linenumber">1208</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7085241847460263487" datatype="html">
         <source>Obtain a score of &lt;b&gt;<x id="PH" equiv-text="scoresString"/>&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1219</context>
+          <context context-type="linenumber">1223</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5469027549306748048" datatype="html">
         <source>You must choose &quot;<x id="PH" equiv-text="choiceText"/>&quot; on &quot;<x id="PH_1" equiv-text="nodeTitle"/>&quot;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1227</context>
+          <context context-type="linenumber">1231</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6293177000168372990" datatype="html">
         <source>Submit &lt;b&gt;<x id="PH" equiv-text="requiredSubmitCount"/>&lt;/b&gt; time on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1239</context>
+          <context context-type="linenumber">1243</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4693324974790890133" datatype="html">
         <source>Submit &lt;b&gt;<x id="PH" equiv-text="requiredSubmitCount"/>&lt;/b&gt; times on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1241</context>
+          <context context-type="linenumber">1245</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8416169412912074869" datatype="html">
         <source>Take the branch path from &lt;b&gt;<x id="PH" equiv-text="fromNodeTitle"/>&lt;/b&gt; to &lt;b&gt;<x id="PH_1" equiv-text="toNodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1248</context>
+          <context context-type="linenumber">1252</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8087029188038414167" datatype="html">
         <source>Write &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfWords"/>&lt;/b&gt; words on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1254</context>
+          <context context-type="linenumber">1258</context>
         </context-group>
       </trans-unit>
       <trans-unit id="22049568725715518" datatype="html">
         <source>&quot;<x id="PH" equiv-text="nodeTitle"/>&quot; is visible</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1260</context>
+          <context context-type="linenumber">1264</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5023130174506669799" datatype="html">
         <source>&quot;<x id="PH" equiv-text="nodeTitle"/>&quot; is visitable</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1266</context>
+          <context context-type="linenumber">1270</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1185133360670447094" datatype="html">
         <source>Add &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfNotes"/>&lt;/b&gt; note on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1273</context>
+          <context context-type="linenumber">1277</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5985921753090789216" datatype="html">
         <source>Add &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfNotes"/>&lt;/b&gt; notes on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1275</context>
+          <context context-type="linenumber">1279</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4560070803879446782" datatype="html">
         <source>You must fill in &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfFilledRows"/>&lt;/b&gt; row in the &lt;b&gt;Table&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1282</context>
+          <context context-type="linenumber">1286</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2804292280751903227" datatype="html">
         <source>You must fill in &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfFilledRows"/>&lt;/b&gt; rows in the &lt;b&gt;Table&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1284</context>
+          <context context-type="linenumber">1288</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4171523921205906508" datatype="html">
         <source>Wait for your teacher to unlock the item</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1287</context>
+          <context context-type="linenumber">1291</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8770055323459972095" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -2265,71 +2265,71 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">138</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="5866254605255506989" datatype="html">
-        <source>English</source>
+      <trans-unit id="511208907501917679" datatype="html">
+        <source>Chinese (Simplified)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
           <context context-type="linenumber">2</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="5190825892106392539" datatype="html">
-        <source>Spanish</source>
+      <trans-unit id="4303868626158306518" datatype="html">
+        <source>Chinese (Traditional)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
           <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3071065188816255493" datatype="html">
+        <source>Dutch</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5866254605255506989" datatype="html">
+        <source>English</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
+          <context context-type="linenumber">5</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1858110241312746425" datatype="html">
         <source>German</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
-          <context context-type="linenumber">4</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6924606686202701860" datatype="html">
-        <source>Japanese</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
-          <context context-type="linenumber">5</context>
+          <context context-type="linenumber">6</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2935232983274991580" datatype="html">
         <source>Italian</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
-          <context context-type="linenumber">6</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6924606686202701860" datatype="html">
+        <source>Japanese</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
+          <context context-type="linenumber">8</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6145439649200570157" datatype="html">
         <source>Korean</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
-          <context context-type="linenumber">7</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1134844588409242643" datatype="html">
-        <source>Dutch (Netherlands)</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
-          <context context-type="linenumber">8</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3611216939636790848" datatype="html">
-        <source>Vietnamese</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
           <context context-type="linenumber">9</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="511208907501917679" datatype="html">
-        <source>Chinese (Simplified)</source>
+      <trans-unit id="5190825892106392539" datatype="html">
+        <source>Spanish</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
           <context context-type="linenumber">10</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4303868626158306518" datatype="html">
-        <source>Chinese (Traditional)</source>
+      <trans-unit id="3611216939636790848" datatype="html">
+        <source>Vietnamese</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
           <context context-type="linenumber">11</context>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -2279,18 +2279,60 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1858110241312746425" datatype="html">
+        <source>German</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="6924606686202701860" datatype="html">
         <source>Japanese</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
-          <context context-type="linenumber">4</context>
+          <context context-type="linenumber">5</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2935232983274991580" datatype="html">
         <source>Italian</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
-          <context context-type="linenumber">5</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6145439649200570157" datatype="html">
+        <source>Korean</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1134844588409242643" datatype="html">
+        <source>Dutch (Netherlands)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3611216939636790848" datatype="html">
+        <source>Vietnamese</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="511208907501917679" datatype="html">
+        <source>Chinese (Simplified)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4303868626158306518" datatype="html">
+        <source>Chinese (Traditional)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/domain/localeToLanguage.ts</context>
+          <context context-type="linenumber">11</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8954371642157143595" datatype="html">
@@ -2790,7 +2832,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password/forgot-teacher-password.component.ts</context>
-          <context context-type="linenumber">91</context>
+          <context context-type="linenumber">90</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6244139ed5734258736685c4d638b4fac1b04bbb" datatype="html">
@@ -2869,7 +2911,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password/forgot-teacher-password.component.ts</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c83b838d845690bcb897f775f53b5316535306dc" datatype="html">
@@ -3342,14 +3384,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>You have submitted an invalid verification code too many times. For security reasons, we will lock the ability to change your password for 10 minutes. After 10 minutes, you can try again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password/forgot-teacher-password.component.ts</context>
-          <context context-type="linenumber">85</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="243316711119938992" datatype="html">
         <source>The server has encountered an error and was unable to send you an email. Please try again. If the error continues to occur, please contact us.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password/forgot-teacher-password.component.ts</context>
-          <context context-type="linenumber">88</context>
+          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5c112eccf2cd10cf48736fb8fd2c18c1788b6bb9" datatype="html">
@@ -7391,6 +7433,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.html</context>
           <context context-type="linenumber">109</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.html</context>
+          <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cabad35c321f1c28ef7c11f848cd458bb934e304" datatype="html">
@@ -12266,6 +12312,20 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
           <context context-type="linenumber">22,24</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="d5633c7ffb5d36eebe0dbe84efa93a1e95713391" datatype="html">
+        <source>Default language:</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="a4822ae93998e191f2bed67a380af96f2b5e63bb" datatype="html">
+        <source>Additional languages:</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.html</context>
+          <context context-type="linenumber">11</context>
         </context-group>
       </trans-unit>
       <trans-unit id="abf24af7ad0fd7ffecdad3210051c47589373d68" datatype="html">

--- a/src/style/styles.scss
+++ b/src/style/styles.scss
@@ -63,6 +63,7 @@
 @import 'themes/dark';
 @import 'themes/author';
 @import 'themes/monitor';
+@import "~@ng-select/ng-select/themes/material.theme.css";
 
 // TODO: remove/merge after upgrading apps to Angular
 @import 'themes/apps';


### PR DESCRIPTION
## Notes
- Don't worry about styling for this PR- we can do that in a separate branch. 

## Changes
- Create EditProjectLanguageSettingComponent to allow authors to specify default language and add/delete supported languages for the project.

## Test (in Unit Authoring > Info view)
- default language 
   - displays previously-chosen value
      - for units without a default language (e.g., older units), it should show "English"
   - can be changed, and saves immediately upon change
   - must always have 1 default language (i.e., can't be empty) 
- supported languages 
   - displays previously-chosen value
      - for units without a default language (e.g., older units), it should show empty
   - can be changed (add/delete languages), and saves immediately upon change  

## Test (in unit preview and student VLE views)
- Supported languages options appear in the "Language" dropdown at the top-right corner of the page
