### PR TITLE
feature(VLE): Add support for custom unit styles

### DIFF
--- a/src/assets/wise5/vle/vle.component.html
+++ b/src/assets/wise5/vle/vle.component.html
@@ -1,6 +1,6 @@
 <link rel="stylesheet" href="/assets/wise5/themes/default/style/angular-material.css" />
 <link rel="stylesheet" href="/assets/wise5/themes/default/style/vle.css" />
-<style ng-bind-html="projectStyle"></style>
+<link rel="stylesheet" [href]="projectStylePath" />
 <mat-drawer-container [hasBackdrop]="false" *ngIf="initialized">
   <mat-drawer #drawer mode="over" position="end" (keydown.escape)="closeNotes()">
     <notebook-notes [config]="notebookConfig"></notebook-notes>

--- a/src/assets/wise5/vle/vle.component.html
+++ b/src/assets/wise5/vle/vle.component.html
@@ -1,6 +1,6 @@
 <link rel="stylesheet" href="/assets/wise5/themes/default/style/angular-material.css" />
 <link rel="stylesheet" href="/assets/wise5/themes/default/style/vle.css" />
-<link rel="stylesheet" [href]="projectStylePath" />
+<link rel="stylesheet" [href]="projectStylePath | safeUrl" />
 <mat-drawer-container [hasBackdrop]="false" *ngIf="initialized">
   <mat-drawer #drawer mode="over" position="end" (keydown.escape)="closeNotes()">
     <notebook-notes [config]="notebookConfig"></notebook-notes>

--- a/src/assets/wise5/vle/vle.component.spec.ts
+++ b/src/assets/wise5/vle/vle.component.spec.ts
@@ -36,7 +36,7 @@ let fixture: ComponentFixture<VLEComponent>;
 const node1Id: string = 'node1';
 let saveVLEEventSpy: jasmine.Spy;
 
-fdescribe('VLEComponent', () => {
+describe('VLEComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [

--- a/src/assets/wise5/vle/vle.component.spec.ts
+++ b/src/assets/wise5/vle/vle.component.spec.ts
@@ -29,13 +29,14 @@ import { InitializeVLEService } from '../services/initializeVLEService';
 import { StudentTeacherCommonServicesModule } from '../../../app/student-teacher-common-services.module';
 import { PauseScreenService } from '../services/pauseScreenService';
 import { StudentNotificationService } from '../services/studentNotificationService';
+import { SafeUrl } from '../../../assets/wise5/directives/safeUrl/safe-url.pipe';
 
 let component: VLEComponent;
 let fixture: ComponentFixture<VLEComponent>;
 const node1Id: string = 'node1';
 let saveVLEEventSpy: jasmine.Spy;
 
-describe('VLEComponent', () => {
+fdescribe('VLEComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
@@ -60,6 +61,7 @@ describe('VLEComponent', () => {
         NodeIconComponent,
         NodeStatusIcon,
         NotebookNotesComponent,
+        SafeUrl,
         StepToolsComponent,
         StudentAccountMenuComponent,
         TopBarComponent,
@@ -76,7 +78,6 @@ describe('VLEComponent', () => {
 
   beforeEach(() => {
     const vleProjectService = TestBed.inject(VLEProjectService);
-    spyOn(vleProjectService, 'getStyle').and.returnValue(null);
     spyOn(vleProjectService, 'getProjectScript').and.returnValue(null);
     const notebookService = TestBed.inject(NotebookService);
     spyOn(notebookService, 'isNotebookEnabled').and.returnValue(false);

--- a/src/assets/wise5/vle/vle.component.ts
+++ b/src/assets/wise5/vle/vle.component.ts
@@ -14,6 +14,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { WiseLinkService } from '../../../app/services/wiseLinkService';
 import { convertToPNGFile } from '../common/canvas/canvas';
 import { NodeStatusService } from '../services/nodeStatusService';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
 @Component({
   selector: 'vle',
@@ -31,7 +32,7 @@ export class VLEComponent implements AfterViewInit {
   notebookConfig: any;
   notesEnabled: boolean = false;
   notesVisible: boolean = false;
-  projectStyle: string;
+  projectStylePath: SafeResourceUrl;
   reportEnabled: boolean = false;
   reportFullscreen: boolean = false;
   runEndedAndLocked: boolean;
@@ -49,6 +50,7 @@ export class VLEComponent implements AfterViewInit {
     private projectService: VLEProjectService,
     private route: ActivatedRoute,
     private router: Router,
+    private sanitizer: DomSanitizer,
     private sessionService: SessionService,
     private studentDataService: StudentDataService,
     private wiseLinkService: WiseLinkService
@@ -69,7 +71,9 @@ export class VLEComponent implements AfterViewInit {
       this.projectService.project.theme === 'tab'
         ? this.tabbedVLETemplate
         : this.defaultVLETemplate;
-    this.projectStyle = this.projectService.getStyle();
+    this.projectStylePath = this.sanitizer.bypassSecurityTrustResourceUrl(
+      this.configService.getProjectAssetsDirectoryPath() + '/project_styles.css'
+    );
     if (this.notebookService.isNotebookEnabled()) {
       this.notebookConfig = this.notebookService.getStudentNotebookConfig();
       this.notesEnabled = this.notebookConfig.itemTypes.note.enabled;

--- a/src/assets/wise5/vle/vle.component.ts
+++ b/src/assets/wise5/vle/vle.component.ts
@@ -50,7 +50,6 @@ export class VLEComponent implements AfterViewInit {
     private projectService: VLEProjectService,
     private route: ActivatedRoute,
     private router: Router,
-    private sanitizer: DomSanitizer,
     private sessionService: SessionService,
     private studentDataService: StudentDataService,
     private wiseLinkService: WiseLinkService
@@ -71,9 +70,8 @@ export class VLEComponent implements AfterViewInit {
       this.projectService.project.theme === 'tab'
         ? this.tabbedVLETemplate
         : this.defaultVLETemplate;
-    this.projectStylePath = this.sanitizer.bypassSecurityTrustResourceUrl(
-      this.configService.getProjectAssetsDirectoryPath() + '/project_styles.css'
-    );
+    this.projectStylePath =
+      this.configService.getProjectAssetsDirectoryPath() + '/project_styles.css';
     if (this.notebookService.isNotebookEnabled()) {
       this.notebookConfig = this.notebookService.getStudentNotebookConfig();
       this.notesEnabled = this.notebookConfig.itemTypes.note.enabled;

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9605,7 +9605,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">146</context>
+          <context context-type="linenumber">150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="537022937435161177" datatype="html">
@@ -9620,7 +9620,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">147</context>
+          <context context-type="linenumber">151</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3407061818321766940" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9605,7 +9605,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">148</context>
         </context-group>
       </trans-unit>
       <trans-unit id="537022937435161177" datatype="html">
@@ -9620,7 +9620,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/vle.component.ts</context>
-          <context context-type="linenumber">151</context>
+          <context context-type="linenumber">149</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3407061818321766940" datatype="html">


### PR DESCRIPTION
## Changes
- Adds support for custom unit styles via a `project_styles.css` file in the project assets directory.

Previously, we supported custom css via a `style` value in the project.json, but that was broken after converting from AngularJS -> Angular. This implementation uses a separate CSS file, which is easier to edit/manage. For now, only trusted authors can upload CSS files to a project's assets. This is good for security, since we need to bypass the Angular sanitizer to load the file. In the future, we'll add a custom CSS option to the authoring tool that will dynamically create and update the file so that authors don't need to upload the file, but can create rules using the authoring interface.

## Test
- Add a `project_styles.css` file with some rules to the project assets folder for a unit.
- Verify that the custom styles are applied to when previewing the unit and viewing as a student.