### PR TITLE
Multiple languages: Change i18nId string to i18n object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "@babel/core": "^7.17.9",
         "@babel/preset-env": "^7.16.11",
         "@ngtools/webpack": "^16.2.6",
+        "@semantic-release/exec": "^6.0.3",
         "@semantic-release/github": "^8.0.4",
         "@types/dom-mediacapture-record": "^1.0.11",
         "@types/jasmine": "^4.3.1",
@@ -5569,6 +5570,150 @@
       "dev": true,
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/@semantic-release/exec": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-6.0.3.tgz",
+      "integrity": "sha512-bxAq8vLOw76aV89vxxICecEa8jfaWwYITw6X74zzlO0mc/Bgieqx9kBRz9z96pHectiTAtsCwsQcUyLYWnp3VQ==",
+      "dev": true,
+      "dependencies": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^5.0.0",
+        "lodash": "^4.17.4",
+        "parse-json": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@semantic-release/github": {
@@ -19236,7 +19381,6 @@
     },
     "node_modules/npm/node_modules/@colors/colors": {
       "version": "1.5.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -19247,7 +19391,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19265,7 +19408,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -19278,14 +19420,12 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -19303,7 +19443,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -19319,14 +19458,12 @@
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "2.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19343,7 +19480,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/agent/node_modules/agent-base": {
       "version": "7.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -19356,7 +19492,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/agent/node_modules/http-proxy-agent": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -19370,7 +19505,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/agent/node_modules/https-proxy-agent": {
       "version": "7.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -19384,7 +19518,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/agent/node_modules/socks-proxy-agent": {
       "version": "8.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -19399,7 +19532,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "7.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19447,7 +19579,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "8.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19467,7 +19598,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/disparity-colors": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19480,7 +19610,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "3.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19493,7 +19622,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/git": {
       "version": "5.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19513,7 +19641,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19530,7 +19657,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "3.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19546,7 +19672,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19562,7 +19687,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19572,7 +19696,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19582,7 +19705,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19601,7 +19723,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19614,7 +19735,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/query": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19627,7 +19747,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "7.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19644,7 +19763,6 @@
     },
     "node_modules/npm/node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -19655,7 +19773,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/bundle": {
       "version": "2.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -19668,7 +19785,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
       "version": "0.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -19678,7 +19794,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
       "version": "2.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -19693,7 +19808,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
       "version": "2.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -19707,7 +19821,6 @@
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -19717,7 +19830,6 @@
     },
     "node_modules/npm/node_modules/@tufjs/models": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -19731,7 +19843,6 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19741,7 +19852,6 @@
     },
     "node_modules/npm/node_modules/abort-controller": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -19754,7 +19864,6 @@
     },
     "node_modules/npm/node_modules/aggregate-error": {
       "version": "3.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -19768,7 +19877,6 @@
     },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -19778,7 +19886,6 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -19794,21 +19901,18 @@
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
       "version": "4.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19822,14 +19926,12 @@
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/base64-js": {
       "version": "1.5.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -19850,7 +19952,6 @@
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "4.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19866,7 +19967,6 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "2.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -19876,7 +19976,6 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -19886,7 +19985,6 @@
     },
     "node_modules/npm/node_modules/buffer": {
       "version": "6.0.3",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -19911,7 +20009,6 @@
     },
     "node_modules/npm/node_modules/builtins": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -19921,7 +20018,6 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "18.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19945,7 +20041,6 @@
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "5.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -19958,7 +20053,6 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -19968,7 +20062,6 @@
     },
     "node_modules/npm/node_modules/ci-info": {
       "version": "3.9.0",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -19984,7 +20077,6 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "peer": true,
@@ -19997,7 +20089,6 @@
     },
     "node_modules/npm/node_modules/clean-stack": {
       "version": "2.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20007,7 +20098,6 @@
     },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20021,7 +20111,6 @@
     },
     "node_modules/npm/node_modules/cli-table3": {
       "version": "0.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20037,7 +20126,6 @@
     },
     "node_modules/npm/node_modules/clone": {
       "version": "1.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20047,7 +20135,6 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "6.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20057,7 +20144,6 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20070,14 +20156,12 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/color-support": {
       "version": "1.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20087,7 +20171,6 @@
     },
     "node_modules/npm/node_modules/columnify": {
       "version": "1.6.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20101,21 +20184,18 @@
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true
     },
     "node_modules/npm/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true
     },
     "node_modules/npm/node_modules/cross-spawn": {
       "version": "7.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20130,7 +20210,6 @@
     },
     "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20146,7 +20225,6 @@
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20159,7 +20237,6 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.3.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20177,14 +20254,12 @@
     },
     "node_modules/npm/node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/defaults": {
       "version": "1.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20197,14 +20272,12 @@
     },
     "node_modules/npm/node_modules/delegates": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/diff": {
       "version": "5.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -20214,21 +20287,18 @@
     },
     "node_modules/npm/node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -20239,7 +20309,6 @@
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20249,14 +20318,12 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/event-target-shim": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20266,7 +20333,6 @@
     },
     "node_modules/npm/node_modules/events": {
       "version": "3.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20276,14 +20342,12 @@
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20293,7 +20357,6 @@
     },
     "node_modules/npm/node_modules/foreground-child": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20310,7 +20373,6 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "3.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20323,14 +20385,12 @@
     },
     "node_modules/npm/node_modules/function-bind": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/gauge": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20350,7 +20410,6 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "10.3.10",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20373,14 +20432,12 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true
     },
     "node_modules/npm/node_modules/has": {
       "version": "1.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20393,14 +20450,12 @@
     },
     "node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "7.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20413,14 +20468,12 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "peer": true
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -20434,7 +20487,6 @@
     },
     "node_modules/npm/node_modules/ieee754": {
       "version": "1.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -20455,7 +20507,6 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "6.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20468,7 +20519,6 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20478,7 +20528,6 @@
     },
     "node_modules/npm/node_modules/indent-string": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20488,7 +20537,6 @@
     },
     "node_modules/npm/node_modules/ini": {
       "version": "4.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20498,7 +20546,6 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20517,14 +20564,12 @@
     },
     "node_modules/npm/node_modules/ip": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20534,7 +20579,6 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "4.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "peer": true,
@@ -20547,7 +20591,6 @@
     },
     "node_modules/npm/node_modules/is-core-module": {
       "version": "2.13.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20560,7 +20603,6 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20570,21 +20612,18 @@
     },
     "node_modules/npm/node_modules/is-lambda": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true
     },
     "node_modules/npm/node_modules/jackspeak": {
       "version": "2.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "peer": true,
@@ -20603,7 +20642,6 @@
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20613,7 +20651,6 @@
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20623,7 +20660,6 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
-      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -20633,21 +20669,18 @@
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "8.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20661,7 +20694,6 @@
     },
     "node_modules/npm/node_modules/libnpmdiff": {
       "version": "6.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20682,7 +20714,6 @@
     },
     "node_modules/npm/node_modules/libnpmexec": {
       "version": "7.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20705,7 +20736,6 @@
     },
     "node_modules/npm/node_modules/libnpmfund": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20718,7 +20748,6 @@
     },
     "node_modules/npm/node_modules/libnpmhook": {
       "version": "10.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20732,7 +20761,6 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20746,7 +20774,6 @@
     },
     "node_modules/npm/node_modules/libnpmpack": {
       "version": "6.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20762,7 +20789,6 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "9.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20782,7 +20808,6 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20795,7 +20820,6 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20809,7 +20833,6 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20826,7 +20849,6 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "10.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20836,7 +20858,6 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "13.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20859,7 +20880,6 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "9.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20875,7 +20895,6 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "7.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20885,7 +20904,6 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20898,7 +20916,6 @@
     },
     "node_modules/npm/node_modules/minipass-collect/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20911,7 +20928,6 @@
     },
     "node_modules/npm/node_modules/minipass-fetch": {
       "version": "3.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20929,7 +20945,6 @@
     },
     "node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20942,7 +20957,6 @@
     },
     "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20955,7 +20969,6 @@
     },
     "node_modules/npm/node_modules/minipass-json-stream": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -20966,7 +20979,6 @@
     },
     "node_modules/npm/node_modules/minipass-json-stream/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20979,7 +20991,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -20992,7 +21003,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21005,7 +21015,6 @@
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21018,7 +21027,6 @@
     },
     "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21031,7 +21039,6 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21045,7 +21052,6 @@
     },
     "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21058,7 +21064,6 @@
     },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21071,14 +21076,12 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21088,7 +21091,6 @@
     },
     "node_modules/npm/node_modules/negotiator": {
       "version": "0.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21098,7 +21100,6 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "10.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21123,7 +21124,6 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "7.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21139,7 +21139,6 @@
     },
     "node_modules/npm/node_modules/normalize-package-data": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "peer": true,
@@ -21155,7 +21154,6 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21165,7 +21163,6 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21178,7 +21175,6 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "6.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "peer": true,
@@ -21191,7 +21187,6 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21201,7 +21196,6 @@
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "11.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21217,7 +21211,6 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "8.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21230,7 +21223,6 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "9.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21246,7 +21238,6 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "9.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21260,7 +21251,6 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "16.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21279,7 +21269,6 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "peer": true,
@@ -21289,7 +21278,6 @@
     },
     "node_modules/npm/node_modules/npmlog": {
       "version": "7.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21305,7 +21293,6 @@
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21321,7 +21308,6 @@
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "17.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21354,7 +21340,6 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21369,7 +21354,6 @@
     },
     "node_modules/npm/node_modules/path-key": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21379,7 +21363,6 @@
     },
     "node_modules/npm/node_modules/path-scurry": {
       "version": "1.10.1",
-      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "peer": true,
@@ -21396,7 +21379,6 @@
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
       "version": "6.0.13",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21410,7 +21392,6 @@
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21420,7 +21401,6 @@
     },
     "node_modules/npm/node_modules/process": {
       "version": "0.11.10",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21430,7 +21410,6 @@
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21440,7 +21419,6 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21450,14 +21428,12 @@
     },
     "node_modules/npm/node_modules/promise-inflight": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21471,7 +21447,6 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21484,7 +21459,6 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
-      "dev": true,
       "inBundle": true,
       "peer": true,
       "bin": {
@@ -21493,7 +21467,6 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "2.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21506,7 +21479,6 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21516,7 +21488,6 @@
     },
     "node_modules/npm/node_modules/read-package-json": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21532,7 +21503,6 @@
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
       "version": "3.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21546,7 +21516,6 @@
     },
     "node_modules/npm/node_modules/readable-stream": {
       "version": "4.4.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21563,7 +21532,6 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21573,7 +21541,6 @@
     },
     "node_modules/npm/node_modules/safe-buffer": {
       "version": "5.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -21594,7 +21561,6 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -21602,7 +21568,6 @@
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.5.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21618,7 +21583,6 @@
     },
     "node_modules/npm/node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21631,14 +21595,12 @@
     },
     "node_modules/npm/node_modules/set-blocking": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true
     },
     "node_modules/npm/node_modules/shebang-command": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21651,7 +21613,6 @@
     },
     "node_modules/npm/node_modules/shebang-regex": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21661,7 +21622,6 @@
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "4.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21674,7 +21634,6 @@
     },
     "node_modules/npm/node_modules/sigstore": {
       "version": "2.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -21690,7 +21649,6 @@
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21701,7 +21659,6 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.7.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21716,7 +21673,6 @@
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -21727,14 +21683,12 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0",
       "peer": true
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21745,14 +21699,12 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.16",
-      "dev": true,
       "inBundle": true,
       "license": "CC0-1.0",
       "peer": true
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "10.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21765,7 +21717,6 @@
     },
     "node_modules/npm/node_modules/string_decoder": {
       "version": "1.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21775,7 +21726,6 @@
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21791,7 +21741,6 @@
     "node_modules/npm/node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21806,7 +21755,6 @@
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21820,7 +21768,6 @@
     "node_modules/npm/node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21833,7 +21780,6 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "9.4.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21846,7 +21792,6 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "6.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21864,7 +21809,6 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21877,7 +21821,6 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21890,7 +21833,6 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21900,21 +21842,18 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21924,7 +21863,6 @@
     },
     "node_modules/npm/node_modules/tuf-js": {
       "version": "2.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -21939,7 +21877,6 @@
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21952,7 +21889,6 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21965,14 +21901,12 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -21983,7 +21917,6 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -21996,14 +21929,12 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true
     },
     "node_modules/npm/node_modules/wcwidth": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -22013,7 +21944,6 @@
     },
     "node_modules/npm/node_modules/which": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -22029,7 +21959,6 @@
     },
     "node_modules/npm/node_modules/which/node_modules/isexe": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -22039,7 +21968,6 @@
     },
     "node_modules/npm/node_modules/wide-align": {
       "version": "1.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -22049,7 +21977,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -22068,7 +21995,6 @@
     "node_modules/npm/node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -22086,7 +22012,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -22099,7 +22024,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "6.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -22112,14 +22036,12 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -22137,7 +22059,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -22153,7 +22074,6 @@
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -22167,7 +22087,6 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@babel/core": "^7.17.9",
     "@babel/preset-env": "^7.16.11",
     "@ngtools/webpack": "^16.2.6",
+    "@semantic-release/exec": "^6.0.3",
     "@semantic-release/github": "^8.0.4",
     "@types/dom-mediacapture-record": "^1.0.11",
     "@types/jasmine": "^4.3.1",
@@ -169,10 +170,19 @@
         }
       ],
       [
+        "@semantic-release/exec",
+        {
+          "prepareCmd": "cd dist; tar -czf en-US.tar.gz en-US"
+        }
+      ],
+      [
         "@semantic-release/github",
         {
           "assets": [
-            { "path": "dist/en-US/**", "label": "English build" }
+            {
+              "path": "dist/en-US.tar.gz",
+              "label": "English build"
+            }
           ]
         }
       ]

--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -56,9 +56,11 @@ import { ComponentTypeButtonComponent } from '../../assets/wise5/authoringTool/c
 import { ComponentInfoDialogComponent } from '../../assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component';
 import { ComponentTypeSelectorComponent } from '../../assets/wise5/authoringTool/components/component-type-selector/component-type-selector.component';
 import { EditNodeTitleComponent } from '../../assets/wise5/authoringTool/node/edit-node-title/edit-node-title.component';
+import { AddComponentButtonComponent } from '../../assets/wise5/authoringTool/node/add-component-button/add-component-button.component';
 
 @NgModule({
   declarations: [
+    AddComponentButtonComponent,
     AddLessonChooseLocationComponent,
     AddLessonChooseTemplateComponent,
     AddLessonConfigureComponent,

--- a/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.html
+++ b/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.html
@@ -1,0 +1,10 @@
+<button
+  mat-icon-button
+  color="primary"
+  matTooltip="Add a new component"
+  i18n-matTooltip
+  matTooltipPosition="above"
+  (click)="addComponent()"
+>
+  <mat-icon>add_circle</mat-icon>
+</button>

--- a/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AddComponentButtonComponent } from './add-component-button.component';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatIconModule } from '@angular/material/icon';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { ChooseNewComponent } from '../../../../../app/authoring-tool/add-component/choose-new-component/choose-new-component.component';
+import { of } from 'rxjs';
+import { Node } from '../../../common/Node';
+
+class MockTeacherProjectService {
+  createComponent() {}
+  saveProject() {}
+}
+let loader: HarnessLoader;
+describe('AddComponentButtonComponent', () => {
+  let component: AddComponentButtonComponent;
+  let fixture: ComponentFixture<AddComponentButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AddComponentButtonComponent],
+      imports: [MatDialogModule, MatIconModule, RouterTestingModule],
+      providers: [{ provide: TeacherProjectService, useClass: MockTeacherProjectService }]
+    });
+    fixture = TestBed.createComponent(AddComponentButtonComponent);
+    component = fixture.componentInstance;
+    component.node = { id: 'node1' } as Node;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  });
+
+  describe('clicking on the button', () => {
+    it('shows add component dialog, create selected component, and save project', async () => {
+      const dialogSpy = spyOn(TestBed.inject(MatDialog), 'open').and.returnValue({
+        afterClosed: () => of({ action: 'create', componentType: 'OpenResponse' })
+      } as any);
+      const projectService = TestBed.inject(TeacherProjectService);
+      const createComponentSpy = spyOn(projectService, 'createComponent');
+      const saveProjectSpy = spyOn(projectService, 'saveProject');
+      await (await loader.getHarness(MatButtonHarness)).click();
+      expect(dialogSpy).toHaveBeenCalledWith(ChooseNewComponent, {
+        data: null,
+        width: '80%'
+      });
+      expect(createComponentSpy).toHaveBeenCalled();
+      expect(saveProjectSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.ts
+++ b/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.ts
@@ -1,0 +1,52 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { MatDialog } from '@angular/material/dialog';
+import { ChooseNewComponent } from '../../../../../app/authoring-tool/add-component/choose-new-component/choose-new-component.component';
+import { filter } from 'rxjs';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Node } from '../../../common/Node';
+
+@Component({
+  selector: 'add-component-button',
+  templateUrl: './add-component-button.component.html'
+})
+export class AddComponentButtonComponent {
+  @Input() insertAfterComponentId: string = null;
+  @Input() node: Node;
+  @Output() newComponentsEvent: EventEmitter<any> = new EventEmitter<any>();
+
+  constructor(
+    private dialog: MatDialog,
+    private projectService: TeacherProjectService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {}
+
+  protected addComponent(): void {
+    this.dialog
+      .open(ChooseNewComponent, {
+        data: this.insertAfterComponentId,
+        width: '80%'
+      })
+      .afterClosed()
+      .pipe(filter((componentType) => componentType != null))
+      .subscribe(({ action, componentType }) => {
+        if (action === 'import') {
+          this.router.navigate(['import-component/choose-component'], {
+            relativeTo: this.route,
+            state: {
+              insertAfterComponentId: this.insertAfterComponentId
+            }
+          });
+        } else {
+          const component = this.projectService.createComponent(
+            this.node.id,
+            componentType,
+            this.insertAfterComponentId
+          );
+          this.projectService.saveProject();
+          this.newComponentsEvent.emit([component]);
+        }
+      });
+  }
+}

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
@@ -37,18 +37,6 @@
       <mat-icon>close</mat-icon>
     </button>
   </div>
-  <ng-template #addComponentButtonTemplate let-componentId="componentId">
-    <button
-      mat-icon-button
-      color="primary"
-      matTooltip="Add a new component"
-      i18n-matTooltip
-      matTooltipPosition="above"
-      (click)="addComponent(componentId)"
-    >
-      <mat-icon>add_circle</mat-icon>
-    </button>
-  </ng-template>
   <div
     *ngIf="!isGroupNode"
     class="components-header"
@@ -57,9 +45,10 @@
     fxLayoutGap="4px"
   >
     <h5 i18n>Components</h5>
-    <ng-container
-      *ngTemplateOutlet="addComponentButtonTemplate; context: { componentId: null }"
-    ></ng-container>
+    <add-component-button
+      [node]="node"
+      (newComponentsEvent)="highlightNewComponentsAndThenShowComponentAuthoring($event)"
+    ></add-component-button>
     <div *ngIf="isAnyComponentSelected()">
       <button
         mat-icon-button
@@ -227,11 +216,12 @@
             [componentContent]="component"
           ></component-authoring-component>
         </div>
-        <div class="add-component">
-          <ng-container
-            *ngTemplateOutlet="addComponentButtonTemplate; context: { componentId: component.id }"
-          ></ng-container>
-        </div>
+        <add-component-button
+          class="add-component"
+          [insertAfterComponentId]="component.id"
+          [node]="node"
+          (newComponentsEvent)="highlightNewComponentsAndThenShowComponentAuthoring($event)"
+        ></add-component-button>
       </div>
     </div>
   </div>

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
@@ -4,7 +4,6 @@ import { NodeAuthoringComponent } from './node-authoring.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
-import { MatDialogModule } from '@angular/material/dialog';
 import { TeacherDataService } from '../../../services/teacherDataService';
 import { TeacherWebSocketService } from '../../../services/teacherWebSocketService';
 import { ClassroomStatusService } from '../../../services/classroomStatusService';
@@ -24,6 +23,7 @@ import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
 import { TeacherNodeService } from '../../../services/teacherNodeService';
 import { EditNodeTitleComponent } from '../edit-node-title/edit-node-title.component';
+import { AddComponentButtonComponent } from '../add-component-button/add-component-button.component';
 
 let component: NodeAuthoringComponent;
 let component1: any;
@@ -39,7 +39,12 @@ let teacherProjectService: TeacherProjectService;
 describe('NodeAuthoringComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [EditNodeTitleComponent, NodeAuthoringComponent, TeacherNodeIconComponent],
+      declarations: [
+        AddComponentButtonComponent,
+        EditNodeTitleComponent,
+        NodeAuthoringComponent,
+        TeacherNodeIconComponent
+      ],
       imports: [
         BrowserAnimationsModule,
         ComponentAuthoringModule,
@@ -47,7 +52,6 @@ describe('NodeAuthoringComponent', () => {
         FormsModule,
         HttpClientTestingModule,
         MatCheckboxModule,
-        MatDialogModule,
         MatIconModule,
         MatInputModule,
         PreviewComponentModule,

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit, Signal, WritableSignal, computed, signal } from '@angular/core';
-import { Subscription, filter } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { TeacherDataService } from '../../../services/teacherDataService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { ComponentTypeService } from '../../../services/componentTypeService';
@@ -7,9 +7,7 @@ import { ComponentServiceLookupService } from '../../../services/componentServic
 import { Node } from '../../../common/Node';
 import { ComponentContent } from '../../../common/ComponentContent';
 import { temporarilyHighlightElement } from '../../../common/dom/dom';
-import { MatDialog } from '@angular/material/dialog';
 import { ConfigService } from '../../../../wise5/services/configService';
-import { ChooseNewComponent } from '../../../../../app/authoring-tool/add-component/choose-new-component/choose-new-component.component';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TeacherNodeService } from '../../../services/teacherNodeService';
@@ -37,7 +35,6 @@ export class NodeAuthoringComponent implements OnInit {
     private configService: ConfigService,
     private componentServiceLookupService: ComponentServiceLookupService,
     private componentTypeService: ComponentTypeService,
-    private dialog: MatDialog,
     private nodeService: TeacherNodeService,
     private projectService: TeacherProjectService,
     private dataService: TeacherDataService,
@@ -120,34 +117,6 @@ export class NodeAuthoringComponent implements OnInit {
   protected close(): void {
     this.dataService.setCurrentNode(null);
     this.scrollToTopOfPage();
-  }
-
-  protected addComponent(insertAfterComponentId: string): void {
-    const dialogRef = this.dialog.open(ChooseNewComponent, {
-      data: insertAfterComponentId,
-      width: '80%'
-    });
-    dialogRef
-      .afterClosed()
-      .pipe(filter((componentType) => componentType != null))
-      .subscribe(({ action, componentType }) => {
-        if (action === 'import') {
-          this.router.navigate(['import-component/choose-component'], {
-            relativeTo: this.route,
-            state: {
-              insertAfterComponentId: insertAfterComponentId
-            }
-          });
-        } else {
-          const component = this.projectService.createComponent(
-            this.nodeId,
-            componentType,
-            insertAfterComponentId
-          );
-          this.projectService.saveProject();
-          this.highlightNewComponentsAndThenShowComponentAuthoring([component]);
-        }
-      });
   }
 
   protected hideAllComponentSaveButtons(): void {
@@ -276,7 +245,7 @@ export class NodeAuthoringComponent implements OnInit {
    * @param newComponents an array of the new components we have just added
    * @param expandComponents expand component(s)' authoring views after highlighting
    */
-  private highlightNewComponentsAndThenShowComponentAuthoring(
+  protected highlightNewComponentsAndThenShowComponentAuthoring(
     newComponents: any = [],
     expandComponents: boolean = true
   ): void {

--- a/src/assets/wise5/services/translateProjectService.ts
+++ b/src/assets/wise5/services/translateProjectService.ts
@@ -38,7 +38,9 @@ export class TranslateProjectService {
   }
 
   private getTranslationMappingURL(locale: string): string {
-    return this.configService.getConfigParam('projectURL').replace('.json', `.${locale}.json`);
+    return this.configService
+      .getConfigParam('projectURL')
+      .replace('project.json', `translations.${locale}.json`);
   }
 
   private applyTranslations(projectElement: any, translations: any): void {

--- a/src/assets/wise5/services/translateProjectService.ts
+++ b/src/assets/wise5/services/translateProjectService.ts
@@ -43,12 +43,12 @@ export class TranslateProjectService {
 
   private applyTranslations(projectElement: any, translations: any): void {
     Object.keys(projectElement)
-      .filter((key) => key.endsWith('.i18nId'))
+      .filter((key) => key.endsWith('.i18n'))
       .forEach((key) => {
-        const translationKey = projectElement[key];
+        const translationKey = projectElement[key].id;
         if (translations[translationKey]) {
-          const keyWithoutI18NId = key.substring(0, key.lastIndexOf('.i18nId'));
-          projectElement[keyWithoutI18NId] = translations[translationKey];
+          const keyWithoutI18NId = key.substring(0, key.lastIndexOf('.i18n'));
+          projectElement[keyWithoutI18NId] = translations[translationKey].value;
         }
       });
     Object.values(projectElement).forEach((value) => {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1172,7 +1172,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">149</context>
+          <context context-type="linenumber">138</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.html</context>
@@ -2762,7 +2762,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password/forgot-teacher-password.component.ts</context>
-          <context context-type="linenumber">91</context>
+          <context context-type="linenumber">90</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6244139ed5734258736685c4d638b4fac1b04bbb" datatype="html">
@@ -2841,7 +2841,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password/forgot-teacher-password.component.ts</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c83b838d845690bcb897f775f53b5316535306dc" datatype="html">
@@ -3314,14 +3314,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>You have submitted an invalid verification code too many times. For security reasons, we will lock the ability to change your password for 10 minutes. After 10 minutes, you can try again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password/forgot-teacher-password.component.ts</context>
-          <context context-type="linenumber">85</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="243316711119938992" datatype="html">
         <source>The server has encountered an error and was unable to send you an email. Please try again. If the error continues to occur, please contact us.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-password/forgot-teacher-password.component.ts</context>
-          <context context-type="linenumber">88</context>
+          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5c112eccf2cd10cf48736fb8fd2c18c1788b6bb9" datatype="html">
@@ -10897,6 +10897,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">443</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="2998257cb98e73a3cfaf686ef9c2bbbf618f6fb0" datatype="html">
+        <source>Add a new component</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="95a6b174bcdc9e77421358825217263add8e6bd8" datatype="html">
         <source>Create Branch</source>
         <context-group purpose="location">
@@ -11515,95 +11522,88 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2998257cb98e73a3cfaf686ef9c2bbbf618f6fb0" datatype="html">
-        <source>Add a new component</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">44</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="16f48e8858552177f3da7a0ccf2449b2522ebe14" datatype="html">
         <source>Components</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">59</context>
+          <context context-type="linenumber">47</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7c5b499b46f7ab611026c2e07b19d8d70e51853a" datatype="html">
         <source>Move Components</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">68</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="835ab9ba787d9e73a77b6f723e200ca24a5808a9" datatype="html">
         <source>Copy Components</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">78</context>
+          <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="646e338d93a6cafb1c27766c746ce8f2fde3c2a6" datatype="html">
         <source>Delete Components</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">88</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="67145eb769f4fe04e8b9f3c24d4452cf18ac196b" datatype="html">
         <source> + Expand All </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">103,105</context>
+          <context context-type="linenumber">92,94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="22137335ce02968992f1f2fb73c630e68be673cb" datatype="html">
         <source> - Collapse All </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">112,114</context>
+          <context context-type="linenumber">101,103</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1944eaae32b2002e6f552fd9c1f5a113c412ad25" datatype="html">
         <source>This step does not have any components. Click the + button to add a component.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">119</context>
+          <context context-type="linenumber">108</context>
         </context-group>
       </trans-unit>
       <trans-unit id="534f4fefca77da56b8b0ea6fb63ff18bae415a92" datatype="html">
         <source>Toggle component authoring</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">141</context>
+          <context context-type="linenumber">130</context>
         </context-group>
       </trans-unit>
       <trans-unit id="11cd90245b41b1506efabdcea69d3c5c0964a432" datatype="html">
         <source>Select component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">158</context>
+          <context context-type="linenumber">147</context>
         </context-group>
       </trans-unit>
       <trans-unit id="47f8ae23f1be55b30a01abc41c7ca4b770f5d1b2" datatype="html">
         <source>Click to expand/collapse</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">169</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6e04c490706ecafe8e0c842513b700e165d97bc2" datatype="html">
         <source>Copy Component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">194</context>
+          <context context-type="linenumber">183</context>
         </context-group>
       </trans-unit>
       <trans-unit id="46c242cc262ba3a868dfd6bd37f555c1ada6877c" datatype="html">
         <source>Delete Component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">208</context>
+          <context context-type="linenumber">197</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7035134055292483273" datatype="html">
@@ -11611,7 +11611,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">245</context>
+          <context context-type="linenumber">214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5170405945214763287" datatype="html">
@@ -11619,7 +11619,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">246</context>
+          <context context-type="linenumber">215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bb39841df2c03f771748c1f986e615bffa7f2593" datatype="html">


### PR DESCRIPTION
## Notes
- This will merge to the https://github.com/WISE-Community/WISE-Client/issues/1513 feature branch (not to the develop branch)
- The only file that changed is TranslateProjectService. Others are merge commits that for some reason still show up as being changed, even though the feature branch already contain those commits. I'm not quite sure how this happened.
- Don't worry about styles in this PR

## Changes
- Change ```i18nId: string``` to ```i18n: { id: string, modified: number }``` in project.json. This will allow us to compare modified times of the original and translation strings and offer better translation support in the future.
- Rename translation files from ```project.[locale].json``` to ```translations.[locale].json```

## Test Prep
0. (Optional) make a backup of the project that has translations, in case you need to review other "Multiple Language..." PR's using the old i18n format and want to easily switch project versions
1. In ```project.json```, change instances of
```
   "some_key.i18nId": "abc123",
```
to
```
   "some_key.i18n": { "id": "abc123", "modified": 123 },
```
2. Rename ```project.[locale].json``` to ```translations.[locale].json``` for all supported locales for the unit
3. In ```translations.[locale].json```, change instances of
```
   "abc123": "[translated text]",
```
to
```
   "abc123": {"value": "[translated text]", "modified": 345 },
```

## Test
- Switching between translations work as before. While logged in as a student or previewing a unit, test that:
   - Languages drop-down appears only if the unit has at least 1 supported locale
   - Switching between the language options immediately translates elements of the page that have translations
      - Test everywhere: unit plan, step select drop down, unit title
      - Elements that don't have translations appear in default locale
      - You can switch back to default locale