### PR TITLE
refactor(NodeAuthoring): Extract CopyComponentButtonComponent

### DIFF
--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -57,6 +57,7 @@ import { ComponentInfoDialogComponent } from '../../assets/wise5/authoringTool/c
 import { ComponentTypeSelectorComponent } from '../../assets/wise5/authoringTool/components/component-type-selector/component-type-selector.component';
 import { EditNodeTitleComponent } from '../../assets/wise5/authoringTool/node/edit-node-title/edit-node-title.component';
 import { AddComponentButtonComponent } from '../../assets/wise5/authoringTool/node/add-component-button/add-component-button.component';
+import { CopyComponentButtonComponent } from '../../assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component';
 
 @NgModule({
   declarations: [
@@ -86,6 +87,7 @@ import { AddComponentButtonComponent } from '../../assets/wise5/authoringTool/no
     ComponentTypeSelectorComponent,
     ConcurrentAuthorsMessageComponent,
     ConfigureAutomatedAssessmentComponent,
+    CopyComponentButtonComponent,
     EditNodeTitleComponent,
     InsertNodeAfterButtonComponent,
     InsertNodeInsideButtonComponent,

--- a/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.html
+++ b/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.html
@@ -1,0 +1,10 @@
+<button
+  mat-icon-button
+  color="primary"
+  (click)="copy($event)"
+  matTooltip="Copy Component"
+  matTooltipPosition="above"
+  i18n-matTooltip
+>
+  <mat-icon>content_copy</mat-icon>
+</button>

--- a/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CopyComponentButtonComponent } from './copy-component-button.component';
+import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { MatIconModule } from '@angular/material/icon';
+
+class MockTeacherProjectService {}
+describe('CopyComponentButtonComponent', () => {
+  let component: CopyComponentButtonComponent;
+  let fixture: ComponentFixture<CopyComponentButtonComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [CopyComponentButtonComponent],
+      imports: [MatIconModule],
+      providers: [{ provide: TeacherProjectService, useClass: MockTeacherProjectService }]
+    });
+    fixture = TestBed.createComponent(CopyComponentButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.ts
+++ b/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.ts
@@ -1,0 +1,22 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { Node } from '../../../common/Node';
+
+@Component({
+  selector: 'copy-component-button',
+  templateUrl: './copy-component-button.component.html'
+})
+export class CopyComponentButtonComponent {
+  @Input() componentId: string;
+  @Output() newComponentEvent = new EventEmitter<any[]>();
+  @Input() node: Node;
+
+  constructor(private projectService: TeacherProjectService) {}
+
+  protected copy(event: Event): void {
+    event.stopPropagation();
+    const newComponents = this.node.copyComponents([this.componentId], this.componentId);
+    this.projectService.saveProject();
+    this.newComponentEvent.emit(newComponents);
+  }
+}

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
@@ -172,20 +172,15 @@
               [nodeId]="nodeId"
               [componentId]="component.id"
             ></preview-component-button>
-            <button
-              mat-icon-button
-              color="primary"
+            <copy-component-button
               class="dynamic-component-button"
               [ngClass]="{
                 'show-dynamic-component-button': componentsToExpanded[component.id]
               }"
-              (click)="copyComponent($event, component)"
-              matTooltip="Copy Component"
-              matTooltipPosition="above"
-              i18n-matTooltip
-            >
-              <mat-icon>content_copy</mat-icon>
-            </button>
+              [node]="node"
+              [componentId]="component.id"
+              (newComponentEvent)="highlightNewComponentsAndThenShowComponentAuthoring($event)"
+            ></copy-component-button>
             <button
               mat-icon-button
               color="primary"

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
@@ -24,6 +24,7 @@ import { of } from 'rxjs';
 import { TeacherNodeService } from '../../../services/teacherNodeService';
 import { EditNodeTitleComponent } from '../edit-node-title/edit-node-title.component';
 import { AddComponentButtonComponent } from '../add-component-button/add-component-button.component';
+import { CopyComponentButtonComponent } from '../copy-component-button/copy-component-button.component';
 
 let component: NodeAuthoringComponent;
 let component1: any;
@@ -41,6 +42,7 @@ describe('NodeAuthoringComponent', () => {
     await TestBed.configureTestingModule({
       declarations: [
         AddComponentButtonComponent,
+        CopyComponentButtonComponent,
         EditNodeTitleComponent,
         NodeAuthoringComponent,
         TeacherNodeIconComponent

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
@@ -177,13 +177,6 @@ export class NodeAuthoringComponent implements OnInit {
     });
   }
 
-  protected copyComponent(event: any, component: ComponentContent): void {
-    event.stopPropagation();
-    const newComponents = this.node.copyComponents([component.id], component.id);
-    this.projectService.saveProject();
-    this.highlightNewComponentsAndThenShowComponentAuthoring(newComponents);
-  }
-
   protected deleteComponents(): void {
     this.scrollToTopOfPage();
     if (this.confirmDeleteComponent(this.getSelectedComponentNumbersAndTypes())) {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -11474,6 +11474,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="6e04c490706ecafe8e0c842513b700e165d97bc2" datatype="html">
+        <source>Copy Component</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="af141a4234919a32d9752f13097c6ed98fca668a" datatype="html">
         <source>Step Title <x id="INTERPOLATION" equiv-text="{{ nodePosition }}"/>:</source>
         <context-group purpose="location">
@@ -11592,18 +11599,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6e04c490706ecafe8e0c842513b700e165d97bc2" datatype="html">
-        <source>Copy Component</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">183</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="46c242cc262ba3a868dfd6bd37f555c1ada6877c" datatype="html">
         <source>Delete Component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">192</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7035134055292483273" datatype="html">
@@ -11611,7 +11611,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">214</context>
+          <context context-type="linenumber">207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5170405945214763287" datatype="html">
@@ -11619,7 +11619,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">215</context>
+          <context context-type="linenumber">208</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bb39841df2c03f771748c1f986e615bffa7f2593" datatype="html">


### PR DESCRIPTION
## Changes
- Extract CopyComponentButtonComponent from NodeAuthoring component and template. This reduces NodeAuthoringComponent's responsibility.
   - Changes are saved by CopyComponentButtonComponent and the new component is sent back to NodeAuthoring via newComponentEvent output so that it can be expanded and highlighted in the view

## Test (in Node Authoring)
- Copy component button (button on the component block, not the contextual copy button that appears when you check a component) works as before. It should copy the component, place it below the original, expand and highlight it