### PR TITLE
refactor(TeacherProjectService): Extract getUniqueAuthors to Array.ts

### DIFF
--- a/src/app/services/teacherProjectService.spec.ts
+++ b/src/app/services/teacherProjectService.spec.ts
@@ -65,7 +65,6 @@ describe('TeacherProjectService', () => {
   shouldBeAbleToInsertAGroupNodeInsideAGroupNode();
   shouldNotBeAbleToInsertAStepNodeInsideAStepNode();
   getComponentPosition();
-  getUniqueAuthors();
   addCurrentUserToAuthors_CM_shouldAddUserInfo();
   getNodeIds();
   getInactiveNodeIds();
@@ -483,66 +482,6 @@ function getComponentPosition() {
     expect(componentExists).toEqual(0);
     const componentExists2 = service.getComponentPosition('node9', 'mnzx68ix8h');
     expect(componentExists2).toEqual(1);
-  });
-}
-
-function getUniqueAuthors() {
-  describe('getUniqueAuthors', () => {
-    it('should get unique authors when there are no authors', () => {
-      const authors = [];
-      const uniqueAuthors = service.getUniqueAuthors(authors);
-      expect(uniqueAuthors.length).toEqual(0);
-    });
-
-    it('should get unique authors when there is one author', () => {
-      const authors = [{ id: 1, firstName: 'a', lastName: 'a' }];
-      const uniqueAuthors = service.getUniqueAuthors(authors);
-      expect(uniqueAuthors.length).toEqual(1);
-      expect(uniqueAuthors[0].id).toEqual(1);
-      expect(uniqueAuthors[0].firstName).toEqual('a');
-      expect(uniqueAuthors[0].lastName).toEqual('a');
-    });
-
-    it('should get unique authors when there are multiple duplicates', () => {
-      const authors = [
-        { id: 1, firstName: 'a', lastName: 'a' },
-        { id: 2, firstName: 'b', lastName: 'b' },
-        { id: 1, firstName: 'a', lastName: 'a' },
-        { id: 3, firstName: 'c', lastName: 'c' },
-        { id: 3, firstName: 'c', lastName: 'c' },
-        { id: 1, firstName: 'a', lastName: 'a' }
-      ];
-      const uniqueAuthors = service.getUniqueAuthors(authors);
-      expect(uniqueAuthors.length).toEqual(3);
-      expect(uniqueAuthors[0].id).toEqual(1);
-      expect(uniqueAuthors[0].firstName).toEqual('a');
-      expect(uniqueAuthors[0].lastName).toEqual('a');
-      expect(uniqueAuthors[1].id).toEqual(2);
-      expect(uniqueAuthors[1].firstName).toEqual('b');
-      expect(uniqueAuthors[1].lastName).toEqual('b');
-      expect(uniqueAuthors[2].id).toEqual(3);
-      expect(uniqueAuthors[2].firstName).toEqual('c');
-      expect(uniqueAuthors[2].lastName).toEqual('c');
-    });
-
-    it('should get unique authors when there are no duplicates', () => {
-      const authors = [
-        { id: 1, firstName: 'a', lastName: 'a' },
-        { id: 2, firstName: 'b', lastName: 'b' },
-        { id: 3, firstName: 'c', lastName: 'c' }
-      ];
-      const uniqueAuthors = service.getUniqueAuthors(authors);
-      expect(uniqueAuthors.length).toEqual(3);
-      expect(uniqueAuthors[0].id).toEqual(1);
-      expect(uniqueAuthors[0].firstName).toEqual('a');
-      expect(uniqueAuthors[0].lastName).toEqual('a');
-      expect(uniqueAuthors[1].id).toEqual(2);
-      expect(uniqueAuthors[1].firstName).toEqual('b');
-      expect(uniqueAuthors[1].lastName).toEqual('b');
-      expect(uniqueAuthors[2].id).toEqual(3);
-      expect(uniqueAuthors[2].firstName).toEqual('c');
-      expect(uniqueAuthors[2].lastName).toEqual('c');
-    });
   });
 }
 

--- a/src/assets/wise5/authoringTool/node/advanced/general/node-advanced-general-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/advanced/general/node-advanced-general-authoring.component.ts
@@ -18,6 +18,6 @@ export class NodeAdvancedGeneralAuthoringComponent implements OnInit {
   }
 
   protected saveProject(): void {
-    return this.projectService.saveProject();
+    this.projectService.saveProject();
   }
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/grading-edit-component-max-score/grading-edit-component-max-score.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/grading-edit-component-max-score/grading-edit-component-max-score.component.spec.ts
@@ -23,7 +23,7 @@ describe('GradingEditComponentMaxScoreComponent', () => {
     projectService = TestBed.inject(TeacherProjectService);
     fixture = TestBed.createComponent(GradingEditComponentMaxScoreComponent);
     component = fixture.componentInstance;
-    saveProjectSpy = spyOn(projectService, 'saveProject').and.callFake(() => {});
+    saveProjectSpy = spyOn(projectService, 'saveProject').and.callFake(() => new Promise(() => {}));
     setMaxScoreForComponentSpy = spyOn(
       projectService,
       'setMaxScoreForComponent'

--- a/src/assets/wise5/common/array/array.spec.ts
+++ b/src/assets/wise5/common/array/array.spec.ts
@@ -1,4 +1,4 @@
-import { arraysContainSameValues, CSVToArray } from './array';
+import { arraysContainSameValues, CSVToArray, reduceByUniqueId } from './array';
 import csvArraySample from './arraySample';
 import { getIntersectOfArrays } from './array';
 
@@ -59,5 +59,38 @@ describe('arraysContainSameValues()', () => {
   it('should return false when arrays have different values', () => {
     expect(arraysContainSameValues(['a'], [])).toBeFalse();
     expect(arraysContainSameValues(['a', 'b'], ['a'])).toBeFalse();
+  });
+});
+
+describe('reduceByUniqueId', () => {
+  it('should get empty array when input is empty array', () => {
+    const objArr = [];
+    const result = reduceByUniqueId(objArr);
+    expect(result.length).toEqual(0);
+  });
+
+  it('should get one object when there is one object in input array', () => {
+    const objArr = [{ id: 1 }];
+    const result = reduceByUniqueId(objArr);
+    expect(result.length).toEqual(1);
+    expect(result[0].id).toEqual(1);
+  });
+
+  it('should get unique objects when there are multiple duplicates', () => {
+    const objArr = [{ id: 1 }, { id: 2 }, { id: 1 }, { id: 3 }, { id: 3 }, { id: 1 }];
+    const result = reduceByUniqueId(objArr);
+    expect(result.length).toEqual(3);
+    expect(result[0].id).toEqual(1);
+    expect(result[1].id).toEqual(2);
+    expect(result[2].id).toEqual(3);
+  });
+
+  it('should get original array when there are no duplicates', () => {
+    const objArr = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const result = reduceByUniqueId(objArr);
+    expect(result.length).toEqual(3);
+    expect(result[0].id).toEqual(1);
+    expect(result[1].id).toEqual(2);
+    expect(result[2].id).toEqual(3);
   });
 });

--- a/src/assets/wise5/common/array/array.ts
+++ b/src/assets/wise5/common/array/array.ts
@@ -83,3 +83,15 @@ export function arraysContainSameValues(array1: string[], array2: string[]): boo
   array2Copy.sort();
   return JSON.stringify(array1Copy) === JSON.stringify(array2Copy);
 }
+
+export function reduceByUniqueId(objArr: any[]): any[] {
+  const idToObj = {};
+  const result = [];
+  for (const obj of objArr) {
+    if (idToObj[obj.id] == null) {
+      result.push(obj);
+      idToObj[obj.id] = obj;
+    }
+  }
+  return result;
+}

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -10,6 +10,7 @@ import { PathService } from './pathService';
 import { copy } from '../common/object/object';
 import { generateRandomKey } from '../common/string/string';
 import { branchPathBackgroundColors } from '../common/color/color';
+import { reduceByUniqueId } from '../common/array/array';
 
 @Injectable()
 export class TeacherProjectService extends ProjectService {
@@ -991,14 +992,14 @@ export class TeacherProjectService extends ProjectService {
    * Saves the project to Config.saveProjectURL and returns commit history promise.
    * if Config.saveProjectURL or Config.projectId are undefined, does not save and returns null
    */
-  saveProject(): any {
+  saveProject(): Promise<any> {
     if (!this.configService.getConfigParam('canEditProject')) {
       this.broadcastNotAllowedToEditThisProject();
       return null;
     }
     this.broadcastSavingProject();
     this.cleanupBeforeSave();
-    this.project.metadata.authors = this.getUniqueAuthors(
+    this.project.metadata.authors = reduceByUniqueId(
       this.addCurrentUserToAuthors(this.getAuthors())
     );
     return this.http
@@ -1009,7 +1010,7 @@ export class TeacherProjectService extends ProjectService {
       });
   }
 
-  getAuthors(): any[] {
+  private getAuthors(): any[] {
     return this.project.metadata.authors ? this.project.metadata.authors : [];
   }
 
@@ -1025,18 +1026,6 @@ export class TeacherProjectService extends ProjectService {
     }
     authors.push(userInfo);
     return authors;
-  }
-
-  getUniqueAuthors(authors = []): any[] {
-    const idToAuthor = {};
-    const uniqueAuthors = [];
-    for (const author of authors) {
-      if (idToAuthor[author.id] == null) {
-        uniqueAuthors.push(author);
-        idToAuthor[author.id] = author;
-      }
-    }
-    return uniqueAuthors;
   }
 
   handleSaveProjectResponse(response: any): any {
@@ -3066,7 +3055,7 @@ export class TeacherProjectService extends ProjectService {
     return a.order - b.order;
   }
 
-  broadcastSavingProject() {
+  private broadcastSavingProject(): void {
     this.savingProjectSource.next();
   }
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -21021,7 +21021,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">94</context>
+          <context context-type="linenumber">95</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7975589013595125523" datatype="html">
@@ -21032,11 +21032,11 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">106</context>
+          <context context-type="linenumber">107</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">148</context>
+          <context context-type="linenumber">149</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5946383547512220582" datatype="html">
@@ -21047,11 +21047,11 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">107</context>
+          <context context-type="linenumber">108</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">149</context>
+          <context context-type="linenumber">150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3177789104763917185" datatype="html">
@@ -21069,7 +21069,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">116</context>
+          <context context-type="linenumber">117</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6590475405017990661" datatype="html">
@@ -21080,7 +21080,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">117</context>
+          <context context-type="linenumber">118</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7008439939460403347" datatype="html">
@@ -21091,7 +21091,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">118</context>
+          <context context-type="linenumber">119</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4200122564420479235" datatype="html">
@@ -21308,145 +21308,145 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>First Lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">54</context>
+          <context context-type="linenumber">55</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2017855920890197640" datatype="html">
         <source>First Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">73</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8104421162933956065" datatype="html">
         <source>Notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">108</context>
+          <context context-type="linenumber">109</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">151</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5668531960608480573" datatype="html">
         <source>Final Report</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">125</context>
+          <context context-type="linenumber">126</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8604167983715964004" datatype="html">
         <source>Final summary report of what you learned in this unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">126</context>
+          <context context-type="linenumber">127</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4419148705442508208" datatype="html">
         <source>Use this space to write your final report using evidence from your notebook.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">127</context>
+          <context context-type="linenumber">128</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2128364009265696768" datatype="html">
         <source>&lt;h3&gt;This is a heading&lt;/h3&gt;&lt;p&gt;This is a paragraph.&lt;/p&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">128</context>
+          <context context-type="linenumber">129</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3712572360135341203" datatype="html">
         <source>Teacher Notebook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">136</context>
+          <context context-type="linenumber">137</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3422550137142657635" datatype="html">
         <source>teacher notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">158</context>
+          <context context-type="linenumber">159</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">159</context>
+          <context context-type="linenumber">160</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2558301014879118031" datatype="html">
         <source>Teacher Notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">160</context>
+          <context context-type="linenumber">161</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">167</context>
+          <context context-type="linenumber">168</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2841850575512700640" datatype="html">
         <source>Notes for the teacher as they&apos;re running the WISE unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">168</context>
+          <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4383493915104232758" datatype="html">
         <source>Use this space to take notes for this unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">169</context>
+          <context context-type="linenumber">170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8373748870534083811" datatype="html">
         <source>&lt;p&gt;Use this space to take notes for this unit&lt;/p&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">170</context>
+          <context context-type="linenumber">171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4358283284933461426" datatype="html">
         <source>All steps after this one will not be visitable until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">942</context>
+          <context context-type="linenumber">943</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5548702737138673668" datatype="html">
         <source>All steps after this one will not be visible until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">945</context>
+          <context context-type="linenumber">946</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3112051127445790513" datatype="html">
         <source>All other steps will not be visitable until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">948</context>
+          <context context-type="linenumber">949</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2264443134334419091" datatype="html">
         <source>All other steps will not be visible until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">951</context>
+          <context context-type="linenumber">952</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6819040711904864999" datatype="html">
         <source>This step will not be visitable until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">954</context>
+          <context context-type="linenumber">955</context>
         </context-group>
       </trans-unit>
       <trans-unit id="816962217622004346" datatype="html">
         <source>This step will not be visible until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">957</context>
+          <context context-type="linenumber">958</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846fecebb7756c6127955bc2c08d2111dce64c3c" datatype="html">


### PR DESCRIPTION
## Notes
- Looks like CC's analysis is hanging atm. But it's probably safe to proceed with review.
 
## Changes
- Move ```TeacherProjectService.getUniqueAuthors()``` to ```Array.reduceByUniqueId()```. This function didn't have to be in ```TeacherProjectService```, because it didn't touch any of the class's other fields/functions.
- Clean up accompanying test. We only care about unique id's in the resulting array, so I removed checks for other fields in the object like firstname and lastname.
- Add private modifier to ```getAuthors()``` and ```broadcastSavingProject()```

## Test
- Upon saving changes in the AT, the project's ```medata.authors``` field only contains unique authors