### PR TITLE
fix(Discussion): Limit student post length

### DIFF
--- a/src/assets/wise5/components/discussion/class-response/class-response.component.html
+++ b/src/assets/wise5/components/discussion/class-response/class-response.component.html
@@ -169,6 +169,7 @@
       aria-label="Add Comment"
       i18n-aria-label
       cdkTextareaAutosize
+      maxlength="10000"
     >
     </textarea>
   </div>

--- a/src/assets/wise5/components/discussion/class-response/class-response.component.scss
+++ b/src/assets/wise5/components/discussion/class-response/class-response.component.scss
@@ -14,6 +14,7 @@
 
   .post {
     margin-top: 16px;
+    overflow-wrap: break-word;
   }
 
   .attachment {
@@ -34,6 +35,7 @@
 
   .comment {
     padding-bottom: 16px;
+    overflow-wrap: break-word;
   }
 
   .mat-mdc-list-base .mat-mdc-list-item {

--- a/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.html
+++ b/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.html
@@ -37,6 +37,7 @@
             (focus)="focus = true"
             (blur)="focus = false"
             cdkTextareaAutosize
+            maxlength="10000"
           >
           </textarea>
         </mat-form-field>


### PR DESCRIPTION
## Changes
- Limit the Discussion student post length to 10000 characters
- Set overflow wrap to break word. Previously if the student posted a long string of characters without a space, the post would only display on one line and run off to the right and off the page. This means you could only see about 200 characters of the text before it ran off the page. Now the text should wrap even if it does not have any spaces.

## Test
- As a student, go to a Discussion component and try to post a string that contains a lot of characters (like 1 million) and does not have any spaces. If you do this, the text should automatically be truncated to 10000 characters and you should be able to submit it and everything should work in regards to viewing the post and reloading the post when you leave and come back to the step.

Closes #1554