### PR TITLE
refactor(NodeAuthoring): highlightAndExpandComponents()

### DIFF
--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
@@ -47,7 +47,7 @@
     <h5 i18n>Components</h5>
     <add-component-button
       [node]="node"
-      (newComponentsEvent)="highlightNewComponentsAndThenShowComponentAuthoring($event)"
+      (newComponentsEvent)="highlightAndExpandComponents($event)"
     ></add-component-button>
     <div *ngIf="isAnyComponentSelected()">
       <button
@@ -179,7 +179,7 @@
               }"
               [node]="node"
               [componentId]="component.id"
-              (newComponentEvent)="highlightNewComponentsAndThenShowComponentAuthoring($event)"
+              (newComponentEvent)="highlightAndExpandComponents($event)"
             ></copy-component-button>
             <button
               mat-icon-button
@@ -215,7 +215,7 @@
           class="add-component"
           [insertAfterComponentId]="component.id"
           [node]="node"
-          (newComponentsEvent)="highlightNewComponentsAndThenShowComponentAuthoring($event)"
+          (newComponentsEvent)="highlightAndExpandComponents($event)"
         ></add-component-button>
       </div>
     </div>

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
@@ -6,7 +6,7 @@ import { ComponentTypeService } from '../../../services/componentTypeService';
 import { ComponentServiceLookupService } from '../../../services/componentServiceLookupService';
 import { Node } from '../../../common/Node';
 import { ComponentContent } from '../../../common/ComponentContent';
-import { temporarilyHighlightElement } from '../../../common/dom/dom';
+import { scrollToTopOfPage, temporarilyHighlightElement } from '../../../common/dom/dom';
 import { ConfigService } from '../../../../wise5/services/configService';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -61,7 +61,7 @@ export class NodeAuthoringComponent implements OnInit {
     if (history.state.newComponents && history.state.newComponents.length > 0) {
       this.highlightAndExpandComponents(history.state.newComponents);
     } else {
-      this.scrollToTopOfPage();
+      scrollToTopOfPage();
     }
   }
 
@@ -114,7 +114,7 @@ export class NodeAuthoringComponent implements OnInit {
 
   protected close(): void {
     this.dataService.setCurrentNode(null);
-    this.scrollToTopOfPage();
+    scrollToTopOfPage();
   }
 
   protected hideAllComponentSaveButtons(): void {
@@ -176,7 +176,7 @@ export class NodeAuthoringComponent implements OnInit {
   }
 
   protected deleteComponents(): void {
-    this.scrollToTopOfPage();
+    scrollToTopOfPage();
     if (this.confirmDeleteComponent(this.getSelectedComponentNumbersAndTypes())) {
       const componentIdAndTypes = this.getSelectedComponents()
         .map((component) => this.node.deleteComponent(component.id))
@@ -249,10 +249,6 @@ export class NodeAuthoringComponent implements OnInit {
         }
       }
     }, 100);
-  }
-
-  private scrollToTopOfPage(): void {
-    document.getElementById('top').scrollIntoView();
   }
 
   protected getComponentTypeLabel(componentType: string): string {

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
@@ -243,9 +243,9 @@ export class NodeAuthoringComponent implements OnInit {
       if (components.length > 0) {
         const componentElement = $('#' + components[0].id);
         $('#content').scrollTop(componentElement.offset().top - 200);
-        for (const newComponent of components) {
-          temporarilyHighlightElement(newComponent.id);
-          this.componentsToExpanded[newComponent.id] = true;
+        for (const component of components) {
+          temporarilyHighlightElement(component.id);
+          this.componentsToExpanded[component.id] = true;
         }
       }
     }, 100);

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
@@ -61,7 +61,7 @@ export class NodeAuthoringComponent implements OnInit {
     this.componentsToExpanded = {};
 
     if (history.state.newComponents && history.state.newComponents.length > 0) {
-      this.highlightNewComponentsAndThenShowComponentAuthoring(history.state.newComponents);
+      this.highlightAndExpandComponents(history.state.newComponents);
     } else {
       this.scrollToTopOfPage();
     }
@@ -233,25 +233,21 @@ export class NodeAuthoringComponent implements OnInit {
   }
 
   /**
-   * Temporarily highlight the new components and then show the component
+   * Temporarily highlight the specified components and show the component
    * authoring views. Used to bring user's attention to new changes.
-   * @param newComponents an array of the new components we have just added
-   * @param expandComponents expand component(s)' authoring views after highlighting
+   * @param components an array of components to highlight and expand
    */
-  protected highlightNewComponentsAndThenShowComponentAuthoring(
-    newComponents: any = [],
-    expandComponents: boolean = true
-  ): void {
+  protected highlightAndExpandComponents(components: any = []): void {
     this.componentsToChecked.set({});
 
     // wait for the UI to update and then scroll to the first new component
     setTimeout(() => {
-      if (newComponents.length > 0) {
-        const componentElement = $('#' + newComponents[0].id);
+      if (components.length > 0) {
+        const componentElement = $('#' + components[0].id);
         $('#content').scrollTop(componentElement.offset().top - 200);
-        for (const newComponent of newComponents) {
+        for (const newComponent of components) {
           temporarilyHighlightElement(newComponent.id);
-          this.componentsToExpanded[newComponent.id] = expandComponents;
+          this.componentsToExpanded[newComponent.id] = true;
         }
       }
     }, 100);

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
@@ -28,7 +28,6 @@ export class NodeAuthoringComponent implements OnInit {
   node: Node;
   nodeJson: any;
   @Input() nodeId?: string;
-  nodePosition: any;
   subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -55,7 +54,6 @@ export class NodeAuthoringComponent implements OnInit {
     this.node = this.projectService.getNode(this.nodeId);
     this.isGroupNode = this.projectService.isGroupNode(this.nodeId);
     this.nodeJson = this.projectService.getNodeById(this.nodeId);
-    this.nodePosition = this.projectService.getNodePositionById(this.nodeId);
     this.components = this.projectService.getComponents(this.nodeId);
     this.componentsToChecked.set({});
     this.componentsToExpanded = {};

--- a/src/assets/wise5/authoringTool/project-list/project-list.component.ts
+++ b/src/assets/wise5/authoringTool/project-list/project-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { temporarilyHighlightElement } from '../../common/dom/dom';
+import { scrollToTopOfPage, temporarilyHighlightElement } from '../../common/dom/dom';
 import { ConfigService } from '../../services/configService';
 import { CopyProjectService } from '../../services/copyProjectService';
 import { MatDialog } from '@angular/material/dialog';
@@ -43,7 +43,7 @@ export class ProjectListComponent implements OnInit {
       this.showMessageInModalDialog($localize`Copying Unit...`);
       this.copyProjectService.copyProject(projectId).subscribe({
         next: (project: any) => {
-          this.scrollToTopOfPage();
+          scrollToTopOfPage();
           this.highlightNewProject(project.id);
         },
         error: () => {
@@ -77,10 +77,6 @@ export class ProjectListComponent implements OnInit {
         });
       })
     );
-  }
-
-  private scrollToTopOfPage(): void {
-    document.getElementById('top').scrollIntoView();
   }
 
   private showMessageInModalDialog(message: string): void {

--- a/src/assets/wise5/common/dom/dom.ts
+++ b/src/assets/wise5/common/dom/dom.ts
@@ -40,3 +40,7 @@ export function scrollToElement(elementId: string): void {
     1000
   );
 }
+
+export function scrollToTopOfPage(): void {
+  document.getElementById('top').scrollIntoView();
+}

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -11611,7 +11611,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">207</context>
+          <context context-type="linenumber">205</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5170405945214763287" datatype="html">
@@ -11619,7 +11619,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">208</context>
+          <context context-type="linenumber">206</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bb39841df2c03f771748c1f986e615bffa7f2593" datatype="html">
@@ -12309,7 +12309,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Loading Unit...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-list/project-list.component.ts</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="da5a512c617db2028ac96bac14b200a4bbc381d4" datatype="html">


### PR DESCRIPTION
## Changes
- Clean up ```highlightNewComponentsAndThenShowComponentAuthoring()``` by choosing a shorter name, and removing unused ```expandComponents``` second parameter (which was always ```true```)
- Remove unused ```nodePosition``` variable
- Move duplicate ```scrollToTopOfPage()``` to dom.ts

## Test
- In node authoring, adding new component(s) by copying/importing/adding new component highlights and expands the new component(s) as before

## Note
- ```scrollToTopOfPage()``` is used in ProjectListComponent, but doesn't seem to be working in develop branch atm. The newly-copied unit should appear, but right now you don't see any changes reflected on the page. I'll write up a separate issue to fix this issue