### PR TITLE
refactor(TeacherProjectService): Move getBranchLetter to OneWorkgroupPerRowDataExportStrategy

### DIFF
--- a/src/app/services/teacherProjectService.spec.ts
+++ b/src/app/services/teacherProjectService.spec.ts
@@ -47,7 +47,6 @@ describe('TeacherProjectService', () => {
   testDeleteTransition();
   testGetNodeIdAfter();
   testCreateNodeAfter();
-  shouldGetTheBranchLetter();
   lockNode();
   unlockNode();
   getNextAvailableNodeId();
@@ -201,24 +200,6 @@ function testCreateNodeAfter() {
       expect(newNode.transitionLogic.transitions[0].to).toEqual('node20');
       expect(service.getNodeIdAfter('node19')).toEqual('node1000');
     });
-  });
-}
-
-function shouldGetTheBranchLetter() {
-  it('should get the branch letter', () => {
-    service.setProject(teacherProjectJSON);
-    let branchLetter = service.getBranchLetter('node1');
-    expect(branchLetter).toEqual(null);
-    branchLetter = service.getBranchLetter('node2');
-    expect(branchLetter).toEqual('A');
-    branchLetter = service.getBranchLetter('node3');
-    expect(branchLetter).toEqual('A');
-    branchLetter = service.getBranchLetter('node4');
-    expect(branchLetter).toEqual('B');
-    branchLetter = service.getBranchLetter('node5');
-    expect(branchLetter).toEqual('B');
-    branchLetter = service.getBranchLetter('node6');
-    expect(branchLetter).toEqual(null);
   });
 }
 

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/OneWorkgroupPerRowDataExportStrategy.spec.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/OneWorkgroupPerRowDataExportStrategy.spec.ts
@@ -1,0 +1,20 @@
+import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { OneWorkgroupPerRowDataExportStrategy } from './OneWorkgroupPerRowDataExportStrategy';
+
+const strategy = new OneWorkgroupPerRowDataExportStrategy();
+class MockProjectService {
+  getNodePositionById(nodeId: string): string {
+    return { node1: '1.1', node2: '1.2A', node3: '1.2B' }[nodeId];
+  }
+}
+describe('OneWorkgroupPerRowDataExportStrategy', () => {
+  describe('getBranchLetter()', () => {
+    it('gets the branch letter', () => {
+      strategy.projectService = new MockProjectService() as TeacherProjectService;
+      expect(strategy.getBranchLetter('node1')).toEqual(null);
+      expect(strategy.getBranchLetter('node2')).toEqual('A');
+      expect(strategy.getBranchLetter('node3')).toEqual('B');
+      expect(strategy.getBranchLetter('node4')).toEqual(null);
+    });
+  });
+});

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/OneWorkgroupPerRowDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/OneWorkgroupPerRowDataExportStrategy.ts
@@ -222,7 +222,7 @@ export class OneWorkgroupPerRowDataExportStrategy extends AbstractDataExportStra
                 }
               }
               if (this.controller.includeBranchPathTaken) {
-                var branchLetter = this.projectService.getBranchLetter(toNodeId);
+                var branchLetter = this.getBranchLetter(toNodeId);
                 if (stepTitle != null) {
                   workgroupRow[columnIdToColumnIndex[nodeId + '-branchPathTaken']] = branchLetter;
                 } else {
@@ -247,6 +247,21 @@ export class OneWorkgroupPerRowDataExportStrategy extends AbstractDataExportStra
       this.controller.generateCSVFile(rows, fileName);
       this.controller.hideDownloadingExportMessage();
     });
+  }
+
+  /**
+   * Get the branch letter in the node position string if the node is in a branch path
+   * @param nodeId the node id we want the branch letter for
+   * @return the branch letter in the node position if the node is in a branch path
+   */
+  getBranchLetter(nodeId: string): string {
+    const nodePosition = this.projectService.getNodePositionById(nodeId);
+    const branchLetterRegex = /.*([A-Z])/;
+    const match = branchLetterRegex.exec(nodePosition);
+    if (match != null) {
+      return match[1];
+    }
+    return null;
   }
 
   /**

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -870,21 +870,6 @@ export class TeacherProjectService extends ProjectService {
     return this.configService.getConfigParam('simulationProjectId') || -1;
   }
 
-  /**
-   * Get the branch letter in the node position string if the node is in a branch path
-   * @param nodeId the node id we want the branch letter for
-   * @return the branch letter in the node position if the node is in a branch path
-   */
-  getBranchLetter(nodeId) {
-    const nodePosition = this.getNodePositionById(nodeId);
-    const branchLetterRegex = /.*([A-Z])/;
-    const match = branchLetterRegex.exec(nodePosition);
-    if (match != null) {
-      return match[1];
-    }
-    return null;
-  }
-
   componentChanged(): void {
     this.componentChangedSource.next();
   }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -21411,42 +21411,42 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>All steps after this one will not be visitable until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">943</context>
+          <context context-type="linenumber">928</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5548702737138673668" datatype="html">
         <source>All steps after this one will not be visible until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">946</context>
+          <context context-type="linenumber">931</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3112051127445790513" datatype="html">
         <source>All other steps will not be visitable until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">949</context>
+          <context context-type="linenumber">934</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2264443134334419091" datatype="html">
         <source>All other steps will not be visible until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">952</context>
+          <context context-type="linenumber">937</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6819040711904864999" datatype="html">
         <source>This step will not be visitable until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">955</context>
+          <context context-type="linenumber">940</context>
         </context-group>
       </trans-unit>
       <trans-unit id="816962217622004346" datatype="html">
         <source>This step will not be visible until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">958</context>
+          <context context-type="linenumber">943</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846fecebb7756c6127955bc2c08d2111dce64c3c" datatype="html">


### PR DESCRIPTION
## Changes
- Move ```TeacherProjectService.getBranchLetter()``` to ```OneWorkgroupPerRowDataExportStrategy.getBranchLetter()```. ```OneWorkgroupPerRowDataExportStrategy``` was the only class that was calling this function.

## Test
- Export "One Workgroup per Row" for a run with a branch. Verify that the export has a "Branch Path Taken" column with the correct value