### PR TITLE
feat(Classroom Monitor): Add save indicator for comments and scores

### DIFF
--- a/src/app/teacher/grading-common.module.ts
+++ b/src/app/teacher/grading-common.module.ts
@@ -14,6 +14,7 @@ import { StudentTeacherCommonModule } from '../student-teacher-common.module';
 import { ComponentGradingModule } from './component-grading.module';
 import { StatusIconComponent } from '../classroom-monitor/status-icon/status-icon.component';
 import { NavItemProgressComponent } from '../classroom-monitor/nav-item-progress/nav-item-progress.component';
+import { SaveIndicatorComponent } from '../../assets/wise5/common/save-indicator/save-indicator.component';
 
 @NgModule({
   imports: [ComponentGradingModule, IntersectionObserverModule, StudentTeacherCommonModule],
@@ -23,6 +24,7 @@ import { NavItemProgressComponent } from '../classroom-monitor/nav-item-progress
     EditComponentScoreComponent,
     GradingEditComponentMaxScoreComponent,
     NavItemProgressComponent,
+    SaveIndicatorComponent,
     StatusIconComponent,
     WorkgroupComponentGradingComponent,
     WorkgroupInfoComponent,
@@ -39,6 +41,7 @@ import { NavItemProgressComponent } from '../classroom-monitor/nav-item-progress
     GradingEditComponentMaxScoreComponent,
     IntersectionObserverModule,
     NavItemProgressComponent,
+    SaveIndicatorComponent,
     StatusIconComponent,
     WorkgroupComponentGradingComponent,
     WorkgroupInfoComponent,

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.spec.ts
@@ -3,25 +3,24 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AnnotationService } from '../../../services/annotationService';
 import { EditComponentCommentComponent } from './edit-component-comment.component';
+import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { MatDialogModule } from '@angular/material/dialog';
+import { NotificationService } from '../../../services/notificationService';
 
-class MockAnnotationService {
-  createAnnotation() {}
-  saveAnnotation() {}
-}
-
-let annotationService;
+let annotationService: AnnotationService;
 let component: EditComponentCommentComponent;
 let fixture: ComponentFixture<EditComponentCommentComponent>;
+let notificationService: NotificationService;
 
 describe('EditComponentCommentComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       declarations: [EditComponentCommentComponent],
-      providers: [{ provide: AnnotationService, useClass: MockAnnotationService }],
+      imports: [HttpClientTestingModule, MatDialogModule, StudentTeacherCommonServicesModule],
       schemas: [NO_ERRORS_SCHEMA]
     });
     annotationService = TestBed.inject(AnnotationService);
+    notificationService = TestBed.inject(NotificationService);
     fixture = TestBed.createComponent(EditComponentCommentComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -31,17 +30,40 @@ describe('EditComponentCommentComponent', () => {
 
 function saveComment() {
   describe('saveComment()', () => {
-    it('should create and save annotation', () => {
-      const createAnnotationSpy = spyOn(
-        annotationService,
-        'createAnnotation'
-      ).and.callFake(() => {});
-      const saveAnnotationSpy = spyOn(annotationService, 'saveAnnotation').and.callFake(() => {
-        return new Promise(() => {});
+    it('creates and saves annotation', async () => {
+      const commentText = 'Good job.';
+      const annotation = createAnnotation(commentText);
+      const createAnnotationSpy = spyOn(annotationService, 'createAnnotation').and.callFake(() => {
+        return annotation;
       });
-      component.saveComment();
+      const saveAnnotationSpy = spyOn(annotationService, 'saveAnnotation').and.returnValue(
+        Promise.resolve()
+      );
+      const notificationShowSavedMessageSpy = spyOn(notificationService, 'showSavedMessage');
+      component.saveComment(commentText);
       expect(createAnnotationSpy).toHaveBeenCalled();
-      expect(saveAnnotationSpy).toHaveBeenCalled();
+      expect(saveAnnotationSpy).toHaveBeenCalledWith(annotation);
+      fixture.whenStable().then(() => {
+        expect(notificationShowSavedMessageSpy).toHaveBeenCalledWith('Saved Comment');
+      });
     });
   });
+}
+
+function createAnnotation(value: string): any {
+  return {
+    id: null,
+    runId: null,
+    periodId: null,
+    fromWorkgroupId: null,
+    toWorkgroupId: null,
+    nodeId: null,
+    componentId: null,
+    studentWorkId: null,
+    localNotebookItemId: null,
+    notebookItemId: null,
+    type: 'comment',
+    data: { value: value },
+    clientSaveTime: null
+  };
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.spec.ts
@@ -44,7 +44,7 @@ function saveComment() {
       expect(createAnnotationSpy).toHaveBeenCalled();
       expect(saveAnnotationSpy).toHaveBeenCalledWith(annotation);
       fixture.whenStable().then(() => {
-        expect(notificationShowSavedMessageSpy).toHaveBeenCalledWith('Saved Comment');
+        expect(notificationShowSavedMessageSpy).toHaveBeenCalledWith('Saved comment');
       });
     });
   });

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.ts
@@ -71,7 +71,7 @@ export class EditComponentCommentComponent {
     );
     this.annotationService.saveAnnotation(annotation).then(() => {
       this.setIsDirty(false);
-      this.notificationService.showSavedMessage($localize`Saved Comment`);
+      this.notificationService.showSavedMessage($localize`Saved comment`);
     });
   }
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from '@angular/core';
 import { Subject, Subscription } from 'rxjs';
 import { debounceTime, distinctUntilChanged, tap } from 'rxjs/operators';
 import { AnnotationService } from '../../../services/annotationService';
+import { NotificationService } from '../../../services/notificationService';
 
 @Component({
   selector: 'edit-component-comment',
@@ -23,31 +24,37 @@ export class EditComponentCommentComponent {
   isDirty: boolean;
   subscriptions: Subscription = new Subscription();
 
-  constructor(private AnnotationService: AnnotationService) {}
+  constructor(
+    private annotationService: AnnotationService,
+    private notificationService: NotificationService
+  ) {}
 
   ngOnInit() {
     this.subscriptions.add(
       this.commentChanged
         .pipe(
-          tap(() => this.setIsDirty(true)),
-          debounceTime(5000),
-          distinctUntilChanged()
+          debounceTime(1000),
+          distinctUntilChanged(),
+          tap(() => {
+            this.setIsDirty(true);
+            this.notificationService.showSavingMessage();
+          })
         )
         .subscribe(() => {
-          this.saveComment();
+          this.saveComment(this.comment);
         })
     );
   }
 
   ngOnDestroy() {
     if (this.isDirty) {
-      this.saveComment();
+      this.saveComment(this.comment);
     }
     this.subscriptions.unsubscribe();
   }
 
-  saveComment() {
-    const annotation = this.AnnotationService.createAnnotation(
+  saveComment(comment: string): void {
+    const annotation = this.annotationService.createAnnotation(
       null,
       this.runId,
       this.periodId,
@@ -59,10 +66,13 @@ export class EditComponentCommentComponent {
       null,
       null,
       'comment',
-      { value: this.comment },
+      { value: comment },
       new Date().getTime()
     );
-    this.AnnotationService.saveAnnotation(annotation).then(() => this.setIsDirty(false));
+    this.annotationService.saveAnnotation(annotation).then(() => {
+      this.setIsDirty(false);
+      this.notificationService.showSavedMessage($localize`Saved Comment`);
+    });
   }
 
   setIsDirty(isDirty: boolean) {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.spec.ts
@@ -67,7 +67,7 @@ function saveScore() {
       expect(createAnnotationSpy).toHaveBeenCalled();
       expect(saveAnnotationSpy).toHaveBeenCalledWith(annotation);
       fixture.whenStable().then(() => {
-        expect(notificationShowSavedMessageSpy).toHaveBeenCalledWith('Saved Score');
+        expect(notificationShowSavedMessageSpy).toHaveBeenCalledWith('Saved score');
       });
     });
   });

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.spec.ts
@@ -3,25 +3,24 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AnnotationService } from '../../../services/annotationService';
 import { EditComponentScoreComponent } from './edit-component-score.component';
+import { MatDialogModule } from '@angular/material/dialog';
+import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { NotificationService } from '../../../services/notificationService';
 
-class MockAnnotationService {
-  createAnnotation() {}
-  saveAnnotation() {}
-}
-
-let annotationService;
+let annotationService: AnnotationService;
 let component: EditComponentScoreComponent;
 let fixture: ComponentFixture<EditComponentScoreComponent>;
+let notificationService: NotificationService;
 
 describe('EditComponentScoreComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       declarations: [EditComponentScoreComponent],
-      providers: [{ provide: AnnotationService, useClass: MockAnnotationService }],
+      imports: [HttpClientTestingModule, MatDialogModule, StudentTeacherCommonServicesModule],
       schemas: [NO_ERRORS_SCHEMA]
     });
     annotationService = TestBed.inject(AnnotationService);
+    notificationService = TestBed.inject(NotificationService);
     fixture = TestBed.createComponent(EditComponentScoreComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -38,14 +37,14 @@ function ngOnInit() {
 }
 
 function ngOnInit_latestAnnotationNull_SetScoreTo0() {
-  it('should set score to 0 when latestAnnotationScore is not set', () => {
+  it('sets score to 0 when latestAnnotationScore is not set', () => {
     component.ngOnInit();
     expect(component.score).toEqual(0);
   });
 }
 
 function ngOnInit_latestAnnotationSet_SetScoreFromAnnotation() {
-  it('should set score to latestAnnotation.score', () => {
+  it('sets score to latestAnnotation.score', () => {
     component.latestAnnotationScore = { data: { value: 5 } };
     component.ngOnInit();
     expect(component.score).toEqual(5);
@@ -54,15 +53,40 @@ function ngOnInit_latestAnnotationSet_SetScoreFromAnnotation() {
 
 function saveScore() {
   describe('saveScore()', () => {
-    it('should create and save annotation', () => {
-      const createAnnotationSpy = spyOn(
-        annotationService,
-        'createAnnotation'
-      ).and.callFake(() => {});
-      const saveAnnotationSpy = spyOn(annotationService, 'saveAnnotation').and.callFake(() => {});
-      component.saveScore(5);
+    it('creates and saves annotation', async () => {
+      const score = 5;
+      const annotation = createAnnotation(score);
+      const createAnnotationSpy = spyOn(annotationService, 'createAnnotation').and.callFake(() => {
+        return annotation;
+      });
+      const saveAnnotationSpy = spyOn(annotationService, 'saveAnnotation').and.callFake(() =>
+        Promise.resolve()
+      );
+      const notificationShowSavedMessageSpy = spyOn(notificationService, 'showSavedMessage');
+      component.saveScore(score);
       expect(createAnnotationSpy).toHaveBeenCalled();
-      expect(saveAnnotationSpy).toHaveBeenCalled();
+      expect(saveAnnotationSpy).toHaveBeenCalledWith(annotation);
+      fixture.whenStable().then(() => {
+        expect(notificationShowSavedMessageSpy).toHaveBeenCalledWith('Saved Score');
+      });
     });
   });
+}
+
+function createAnnotation(value: number): any {
+  return {
+    id: null,
+    runId: null,
+    periodId: null,
+    fromWorkgroupId: null,
+    toWorkgroupId: null,
+    nodeId: null,
+    componentId: null,
+    studentWorkId: null,
+    localNotebookItemId: null,
+    notebookItemId: null,
+    type: 'score',
+    data: { value: value },
+    clientSaveTime: null
+  };
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.ts
@@ -62,7 +62,7 @@ export class EditComponentScoreComponent {
       new Date().getTime()
     );
     this.annotationService.saveAnnotation(annotation).then(() => {
-      this.notificationService.showSavedMessage($localize`Saved Score`);
+      this.notificationService.showSavedMessage($localize`Saved score`);
     });
   }
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.ts
@@ -2,6 +2,7 @@ import { Component, ElementRef, Input, ViewChild } from '@angular/core';
 import { Subject, Subscription } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { AnnotationService } from '../../../services/annotationService';
+import { NotificationService } from '../../../services/notificationService';
 
 @Component({
   selector: 'edit-component-score',
@@ -24,13 +25,17 @@ export class EditComponentScoreComponent {
   scoreChanged: Subject<number> = new Subject<number>();
   subscriptions: Subscription = new Subscription();
 
-  constructor(private AnnotationService: AnnotationService) {}
+  constructor(
+    private annotationService: AnnotationService,
+    private notificationService: NotificationService
+  ) {}
 
   ngOnInit() {
     this.isAutoScore = this.latestAnnotationScore?.type === 'autoScore';
     this.score = this.latestAnnotationScore?.data.value ?? 0;
     this.subscriptions.add(
       this.scoreChanged.pipe(debounceTime(1000), distinctUntilChanged()).subscribe((newScore) => {
+        this.notificationService.showSavingMessage();
         this.saveScore(newScore);
       })
     );
@@ -40,8 +45,8 @@ export class EditComponentScoreComponent {
     this.subscriptions.unsubscribe();
   }
 
-  saveScore(score: number) {
-    const annotation = this.AnnotationService.createAnnotation(
+  saveScore(score: number): void {
+    const annotation = this.annotationService.createAnnotation(
       null,
       this.runId,
       this.periodId,
@@ -56,7 +61,9 @@ export class EditComponentScoreComponent {
       { value: score },
       new Date().getTime()
     );
-    this.AnnotationService.saveAnnotation(annotation);
+    this.annotationService.saveAnnotation(annotation).then(() => {
+      this.notificationService.showSavedMessage($localize`Saved Score`);
+    });
   }
 
   focusScoreInput() {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.html
@@ -16,7 +16,7 @@
     <student-grading-tools *ngIf="showTeamTools" [workgroupId]="workgroupId">
     </student-grading-tools>
     <span fxFlex></span>
-    <save-indicator class="save-indicator"></save-indicator>
+    <save-indicator></save-indicator>
     <select-period *ngIf="showPeriodSelect"></select-period>
   </div>
 </mat-toolbar>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.html
@@ -16,6 +16,7 @@
     <student-grading-tools *ngIf="showTeamTools" [workgroupId]="workgroupId">
     </student-grading-tools>
     <span fxFlex></span>
+    <save-indicator class="save-indicator"></save-indicator>
     <select-period *ngIf="showPeriodSelect"></select-period>
   </div>
 </mat-toolbar>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.scss
@@ -10,6 +10,6 @@
   width: 100%;
 }
 
-.save-indicator {
-  margin-right: 20px;
+save-indicator {
+  margin: 0 16px;
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.scss
@@ -9,3 +9,7 @@
   padding: 0 4px;
   width: 100%;
 }
+
+.save-indicator {
+  margin-right: 20px;
+}

--- a/src/assets/wise5/common/save-indicator/save-indicator.component.html
+++ b/src/assets/wise5/common/save-indicator/save-indicator.component.html
@@ -1,7 +1,6 @@
 <div fxLayout="row wrap" fxLayoutAlign="start center">
   <mat-spinner
     *ngIf="globalMessage.isProgressIndicatorVisible"
-    class="spinner"
     [mode]="'indeterminate'"
     [diameter]="24"
   >

--- a/src/assets/wise5/common/save-indicator/save-indicator.component.html
+++ b/src/assets/wise5/common/save-indicator/save-indicator.component.html
@@ -1,0 +1,12 @@
+<div fxLayout="row wrap" fxLayoutAlign="start center">
+  <mat-spinner
+    *ngIf="globalMessage.isProgressIndicatorVisible"
+    class="spinner"
+    [mode]="'indeterminate'"
+    [diameter]="24"
+  >
+  </mat-spinner>
+  <span *ngIf="globalMessage.text" class="component__actions__info mat-small global-message">
+    {{ globalMessage.text }} {{ globalMessage.time | date: 'medium' }}
+  </span>
+</div>

--- a/src/assets/wise5/common/save-indicator/save-indicator.component.spec.ts
+++ b/src/assets/wise5/common/save-indicator/save-indicator.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SaveIndicatorComponent } from './save-indicator.component';
+import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { MatDialogModule } from '@angular/material/dialog';
+
+describe('SaveIndicatorComponent', () => {
+  let component: SaveIndicatorComponent;
+  let fixture: ComponentFixture<SaveIndicatorComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [SaveIndicatorComponent],
+      imports: [HttpClientTestingModule, MatDialogModule, StudentTeacherCommonServicesModule]
+    });
+    fixture = TestBed.createComponent(SaveIndicatorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/assets/wise5/common/save-indicator/save-indicator.component.ts
+++ b/src/assets/wise5/common/save-indicator/save-indicator.component.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit } from '@angular/core';
+import { NotificationService } from '../../services/notificationService';
+import { Subscription } from 'rxjs';
+
+@Component({
+  selector: 'save-indicator',
+  templateUrl: './save-indicator.component.html',
+  styleUrls: ['./save-indicator.component.scss']
+})
+export class SaveIndicatorComponent implements OnInit {
+  protected globalMessage: any = {};
+  private subscriptions: Subscription = new Subscription();
+
+  constructor(private notificationService: NotificationService) {}
+
+  ngOnInit(): void {
+    this.subscriptions.add(
+      this.notificationService.setGlobalMessage$.subscribe(({ globalMessage }) => {
+        this.globalMessage = globalMessage;
+      })
+    );
+  }
+}

--- a/src/assets/wise5/common/save-indicator/save-indicator.component.ts
+++ b/src/assets/wise5/common/save-indicator/save-indicator.component.ts
@@ -20,4 +20,8 @@ export class SaveIndicatorComponent implements OnInit {
       })
     );
   }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
 }

--- a/src/assets/wise5/services/notificationService.ts
+++ b/src/assets/wise5/services/notificationService.ts
@@ -485,14 +485,6 @@ export class NotificationService {
     });
   }
 
-  /*
-   * @param message The message to show.
-   * @param timeout The amount of time to wait in milliseconds before changing the message from
-   * 'Saving...' to 'Saved' assuming showSavingMessage() was previously called. We do this to make
-   * sure the 'Saving...' message is visible long enough for the user to notice otherwise it might
-   * switch too fast from 'Saving...' to 'Saved'. If we don't perform the wait, it will always say
-   * 'Saved' and the author might wonder whether anything was ever saved.
-   */
   showSavedMessage(message: string, timeout: number = 500): void {
     setTimeout(() => {
       this.broadcastSetGlobalMessage({

--- a/src/assets/wise5/services/notificationService.ts
+++ b/src/assets/wise5/services/notificationService.ts
@@ -474,4 +474,34 @@ export class NotificationService {
   broadcastViewCurrentAmbientNotification(args: any) {
     this.viewCurrentAmbientNotificationSource.next(args);
   }
+
+  showSavingMessage(): void {
+    this.broadcastSetGlobalMessage({
+      globalMessage: {
+        text: $localize`Saving...`,
+        isProgressIndicatorVisible: true,
+        time: null
+      }
+    });
+  }
+
+  /*
+   * @param message The message to show.
+   * @param timeout The amount of time to wait in milliseconds before changing the message from
+   * 'Saving...' to 'Saved' assuming showSavingMessage() was previously called. We do this to make
+   * sure the 'Saving...' message is visible long enough for the user to notice otherwise it might
+   * switch too fast from 'Saving...' to 'Saved'. If we don't perform the wait, it will always say
+   * 'Saved' and the author might wonder whether anything was ever saved.
+   */
+  showSavedMessage(message: string, timeout: number = 500): void {
+    setTimeout(() => {
+      this.broadcastSetGlobalMessage({
+        globalMessage: {
+          text: message,
+          isProgressIndicatorVisible: false,
+          time: new Date().getTime()
+        }
+      });
+    }, timeout);
+  }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9629,6 +9629,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/assets/wise5/authoringTool/authoring-tool.component.ts</context>
           <context context-type="linenumber">138</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/services/notificationService.ts</context>
+          <context context-type="linenumber">481</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="6333335057236774263" datatype="html">
         <source>Saved</source>
@@ -12652,6 +12656,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">6</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1043824604272788384" datatype="html">
+        <source>Saved Comment</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.ts</context>
+          <context context-type="linenumber">74</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="2471906abf7baa724640a079ab3d084a78462ba2" datatype="html">
         <source>Auto Score</source>
         <context-group purpose="location">
@@ -12671,6 +12682,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.html</context>
           <context context-type="linenumber">9</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3896680733357333416" datatype="html">
+        <source>Saved Score</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.ts</context>
+          <context context-type="linenumber">65</context>
         </context-group>
       </trans-unit>
       <trans-unit id="463ae7be19d173ab727deebd0ba59925ab12390d" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12656,8 +12656,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">6</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1043824604272788384" datatype="html">
-        <source>Saved Comment</source>
+      <trans-unit id="4288751301092959187" datatype="html">
+        <source>Saved comment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.ts</context>
           <context context-type="linenumber">74</context>
@@ -12684,8 +12684,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">9</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3896680733357333416" datatype="html">
-        <source>Saved Score</source>
+      <trans-unit id="6225667577278887616" datatype="html">
+        <source>Saved score</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-score/edit-component-score.component.ts</context>
           <context context-type="linenumber">65</context>


### PR DESCRIPTION
@breity Can you fix the styling when the save message is displayed and the browser window is really narrow. Right now when that happens you can't see the Period drop down.

## Changes
- Created SaveIndicatorComponent
- Added save indicator to the Classroom Monitor tool bar at the top
- Show save message when comment is saved
- Show save message when score is saved
- Reduced comment debounce time from 5 seconds to 1 second to be more responsive and prevent potential comment loss

## Test
- Save a comment and make sure the save message appears
- Save a score and make sure the save message appears

Closes #218