### PR TITLE
feat(Component Info): Allow multiple examples per component type

### DIFF
--- a/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html
+++ b/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html
@@ -11,7 +11,7 @@
   <p class="description">{{ description }}</p>
   <mat-divider></mat-divider>
   <h3 i18n>Example:</h3>
-  <div class="example app-background">
+  <mat-card appearance="outlined">
     <preview-component
       *ngIf="previewComponents.length === 1"
       [component]="previewComponents[0]"
@@ -24,7 +24,7 @@
         <preview-component [component]="component"></preview-component>
       </mat-tab>
     </mat-tab-group>
-  </div>
+  </mat-card>
 </mat-dialog-content>
 <mat-dialog-actions fxLayoutAlign="end">
   <button mat-button mat-dialog-close cdkFocusRegionstart i18n>Close</button>

--- a/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html
+++ b/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html
@@ -10,7 +10,18 @@
   <h3 i18n>Description</h3>
   <p class="description">{{ description }}</p>
   <h3 i18n>Example</h3>
-  <preview-component [component]="component"> </preview-component>
+  <preview-component
+    *ngIf="previewComponents.length === 1"
+    [component]="previewComponents[0]"
+  ></preview-component>
+  <mat-tab-group *ngIf="previewComponents.length > 1">
+    <mat-tab
+      *ngFor="let component of previewComponents; index as i"
+      [label]="previewExamples[i].label"
+    >
+      <preview-component [component]="component"></preview-component>
+    </mat-tab>
+  </mat-tab-group>
 </mat-dialog-content>
 <mat-dialog-actions fxLayoutAlign="end">
   <button mat-button mat-dialog-close cdkFocusRegionstart i18n>Close</button>

--- a/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html
+++ b/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html
@@ -1,4 +1,4 @@
-<div class="component-info-top-bar" fxLayoutAlign="start center">
+<div fxLayoutAlign="start center">
   <h2 mat-dialog-title i18n>Component Info</h2>
   <div fxFlex></div>
   <component-type-selector
@@ -6,22 +6,25 @@
     (componentTypeSelectedEvent)="displayComponent($event)"
   ></component-type-selector>
 </div>
-<mat-dialog-content>
-  <h3 i18n>Description</h3>
+<mat-dialog-content class="dialog-content-scroll">
+  <h3 i18n>Description:</h3>
   <p class="description">{{ description }}</p>
-  <h3 i18n>Example</h3>
-  <preview-component
-    *ngIf="previewComponents.length === 1"
-    [component]="previewComponents[0]"
-  ></preview-component>
-  <mat-tab-group *ngIf="previewComponents.length > 1">
-    <mat-tab
-      *ngFor="let component of previewComponents; index as i"
-      [label]="previewExamples[i].label"
-    >
-      <preview-component [component]="component"></preview-component>
-    </mat-tab>
-  </mat-tab-group>
+  <mat-divider></mat-divider>
+  <h3 i18n>Example:</h3>
+  <div class="example app-background">
+    <preview-component
+      *ngIf="previewComponents.length === 1"
+      [component]="previewComponents[0]"
+    ></preview-component>
+    <mat-tab-group *ngIf="previewComponents.length > 1" mat-stretch-tabs="false">
+      <mat-tab
+        *ngFor="let component of previewComponents; index as i"
+        [label]="previewExamples[i].label"
+      >
+        <preview-component [component]="component"></preview-component>
+      </mat-tab>
+    </mat-tab-group>
+  </div>
 </mat-dialog-content>
 <mat-dialog-actions fxLayoutAlign="end">
   <button mat-button mat-dialog-close cdkFocusRegionstart i18n>Close</button>

--- a/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.scss
+++ b/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.scss
@@ -1,7 +1,3 @@
 component-type-selector {
   padding: 0 8px;
 }
-
-.example {
-  padding: 1px 0;
-}

--- a/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.scss
+++ b/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.scss
@@ -1,17 +1,7 @@
-@use '@angular/material' as mat;
-@import
-  'style/abstracts/variables',
-  'style/abstracts/functions',
-  'style/base/typography';
-
-.component-info-top-bar {
-  padding: 12px 6px;
+component-type-selector {
+  padding: 0 8px;
 }
 
-.description {
-  padding: 0px 24px;
-}
-
-.mat-mdc-dialog-content {
-  margin: 0px 24px;
+.example {
+  padding: 1px 0;
 }

--- a/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.spec.ts
+++ b/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.spec.ts
@@ -20,6 +20,7 @@ import { MultipleChoiceInfo } from '../../../components/multipleChoice/MultipleC
 import { OutsideUrlInfo } from '../../../components/outsideURL/OutsideUrlInfo';
 import { OpenResponseInfo } from '../../../components/openResponse/OpenResponseInfo';
 import { ComponentInfo } from '../../../components/ComponentInfo';
+import { MatCardModule } from '@angular/material/card';
 
 let component: ComponentInfoDialogComponent;
 let fixture: ComponentFixture<ComponentInfoDialogComponent>;
@@ -40,6 +41,7 @@ describe('ComponentInfoDialogComponent', () => {
         BrowserAnimationsModule,
         HttpClientTestingModule,
         MatButtonModule,
+        MatCardModule,
         MatDialogModule,
         MatDividerModule,
         MatFormFieldModule,

--- a/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.ts
+++ b/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.ts
@@ -3,6 +3,7 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { ComponentInfoService } from '../../../services/componentInfoService';
 import { ComponentInfo } from '../../../components/ComponentInfo';
 import { ComponentFactory } from '../../../common/ComponentFactory';
+import { Component as WISEComponent } from '../../../common/Component';
 
 @Component({
   selector: 'component-info-dialog',
@@ -10,9 +11,10 @@ import { ComponentFactory } from '../../../common/ComponentFactory';
   styleUrls: ['./component-info-dialog.component.scss']
 })
 export class ComponentInfoDialogComponent {
-  protected component: any;
   private componentInfo: ComponentInfo;
   protected description: string;
+  protected previewComponents: WISEComponent[] = [];
+  protected previewExamples: any[] = [];
 
   constructor(
     private componentInfoService: ComponentInfoService,
@@ -24,12 +26,11 @@ export class ComponentInfoDialogComponent {
   }
 
   protected displayComponent(componentType: any): void {
-    this.componentType = componentType;
     this.componentInfo = this.componentInfoService.getInfo(componentType);
     this.description = this.componentInfo.getDescription();
-    this.component = new ComponentFactory().getComponent(
-      this.componentInfo.getPreviewContent(),
-      'node1'
-    );
+    this.previewExamples = this.componentInfo.getPreviewExamples();
+    this.previewComponents = this.previewExamples.map((example: any) => {
+      return new ComponentFactory().getComponent(example.content, 'node1');
+    });
   }
 }

--- a/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.harness.ts
+++ b/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.harness.ts
@@ -1,6 +1,10 @@
 import { ComponentHarness } from '@angular/cdk/testing';
+import { ComponentTypeSelectorHarness } from '../component-type-selector/component-type-selector.harness';
+import { MatTabGroupHarness } from '@angular/material/tabs/testing';
 
 export class ComponentInfoDialogHarness extends ComponentHarness {
   static hostSelector = 'component-info-dialog';
+  getComponentTypeSelector = this.locatorFor(ComponentTypeSelectorHarness);
   getDescription = this.locatorFor('.description');
+  getTabGroup = this.locatorFor(MatTabGroupHarness);
 }

--- a/src/assets/wise5/authoringTool/components/component-type-selector/component-type-selector.component.html
+++ b/src/assets/wise5/authoringTool/components/component-type-selector/component-type-selector.component.html
@@ -1,4 +1,4 @@
-<div fxLayoutAlign="start center" fxLayoutGap="12px">
+<div fxLayoutAlign="start center" fxLayoutGap="8px">
   <button
     mat-icon-button
     (click)="goToPreviousComponent()"

--- a/src/assets/wise5/components/ComponentInfo.ts
+++ b/src/assets/wise5/components/ComponentInfo.ts
@@ -1,7 +1,7 @@
 export abstract class ComponentInfo {
   protected abstract description: string;
   protected abstract label: string;
-  protected abstract previewContent: any;
+  protected abstract previewExamples: any[];
 
   getDescription(): string {
     return this.description;
@@ -11,7 +11,7 @@ export abstract class ComponentInfo {
     return this.label;
   }
 
-  getPreviewContent(): any {
-    return this.previewContent;
+  getPreviewExamples(): any[] {
+    return this.previewExamples;
   }
 }

--- a/src/assets/wise5/components/animation/AnimationInfo.ts
+++ b/src/assets/wise5/components/animation/AnimationInfo.ts
@@ -3,94 +3,99 @@ import { ComponentInfo } from '../ComponentInfo';
 export class AnimationInfo extends ComponentInfo {
   protected description: string = $localize`Students watch an animation.`;
   protected label: string = $localize`Animation`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'Animation',
-    showSaveButton: false,
-    showSubmitButton: false,
-    widthInPixels: 740,
-    heightInPixels: 200,
-    widthInUnits: 53,
-    heightInUnits: 20,
-    dataXOriginInPixels: 0,
-    dataYOriginInPixels: 90,
-    coordinateSystem: 'screen',
-    objects: [
-      {
-        id: 'qnn0c2xgck',
-        type: 'image',
-        image: '/assets/img/component-preview/pool-background.png',
-        pixelX: 0,
-        pixelY: 90
-      },
-      {
-        id: '8p02z89200',
-        type: 'image',
-        image: '/assets/img/component-preview/Diving-board.png',
-        pixelX: 0,
-        pixelY: 25
-      },
-      {
-        id: 'y2yv5w078a',
-        type: 'text',
-        text: 'Diving board',
-        pixelX: 0,
-        pixelY: 0
-      },
-      {
-        id: 'kjlw72m46a',
-        type: 'text',
-        text: '0',
-        pixelX: 0,
-        pixelY: 60
-      },
-      {
-        id: '3med1wqhac',
-        type: 'text',
-        text: '25',
-        pixelX: 360,
-        pixelY: 60
-      },
-      {
-        id: 'k8hs2qlcxh',
-        type: 'text',
-        text: '50',
-        pixelX: 720,
-        pixelY: 60
-      },
-      {
-        id: 'g1m6j9iyur',
-        type: 'image',
-        image: '/assets/img/component-preview/Swimmer-correct.png',
-        dataX: 0,
-        dataY: 0,
-        data: [
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Animation`,
+      content: {
+        id: 'abcde12345',
+        type: 'Animation',
+        showSaveButton: false,
+        showSubmitButton: false,
+        widthInPixels: 740,
+        heightInPixels: 200,
+        widthInUnits: 53,
+        heightInUnits: 20,
+        dataXOriginInPixels: 0,
+        dataYOriginInPixels: 90,
+        coordinateSystem: 'screen',
+        objects: [
           {
-            t: 0,
-            x: 0
+            id: 'qnn0c2xgck',
+            type: 'image',
+            image: '/assets/img/component-preview/pool-background.png',
+            pixelX: 0,
+            pixelY: 90
           },
           {
-            t: 20,
-            x: 50
+            id: '8p02z89200',
+            type: 'image',
+            image: '/assets/img/component-preview/Diving-board.png',
+            pixelX: 0,
+            pixelY: 25
           },
           {
-            t: 60,
-            x: 0
+            id: 'y2yv5w078a',
+            type: 'text',
+            text: 'Diving board',
+            pixelX: 0,
+            pixelY: 0
+          },
+          {
+            id: 'kjlw72m46a',
+            type: 'text',
+            text: '0',
+            pixelX: 0,
+            pixelY: 60
+          },
+          {
+            id: '3med1wqhac',
+            type: 'text',
+            text: '25',
+            pixelX: 360,
+            pixelY: 60
+          },
+          {
+            id: 'k8hs2qlcxh',
+            type: 'text',
+            text: '50',
+            pixelX: 720,
+            pixelY: 60
+          },
+          {
+            id: 'g1m6j9iyur',
+            type: 'image',
+            image: '/assets/img/component-preview/Swimmer-correct.png',
+            dataX: 0,
+            dataY: 0,
+            data: [
+              {
+                t: 0,
+                x: 0
+              },
+              {
+                t: 20,
+                x: 50
+              },
+              {
+                t: 60,
+                x: 0
+              }
+            ],
+            imageMovingRight: '/assets/img/component-preview/Swimmer-correct.png',
+            imageMovingLeft: '/assets/img/component-preview/Swimmer-correct-reverse.png'
+          },
+          {
+            id: 'og4rulilwn',
+            type: 'image',
+            image: '/assets/img/component-preview/Swimmer.png',
+            dataX: 0,
+            dataY: 0,
+            imageMovingRight: '/assets/img/component-preview/Swimmer.png',
+            imageMovingLeft: '/assets/img/component-preview/Swimmer-reverse.png'
           }
         ],
-        imageMovingRight: '/assets/img/component-preview/Swimmer-correct.png',
-        imageMovingLeft: '/assets/img/component-preview/Swimmer-correct-reverse.png'
-      },
-      {
-        id: 'og4rulilwn',
-        type: 'image',
-        image: '/assets/img/component-preview/Swimmer.png',
-        dataX: 0,
-        dataY: 0,
-        imageMovingRight: '/assets/img/component-preview/Swimmer.png',
-        imageMovingLeft: '/assets/img/component-preview/Swimmer-reverse.png'
+        constraints: []
       }
-    ],
-    constraints: []
-  };
+    }
+  ];
 }

--- a/src/assets/wise5/components/audioOscillator/AudioOscillatorInfo.ts
+++ b/src/assets/wise5/components/audioOscillator/AudioOscillatorInfo.ts
@@ -3,24 +3,29 @@ import { ComponentInfo } from '../ComponentInfo';
 export class AudioOscillatorInfo extends ComponentInfo {
   protected description: string = $localize`Students change the frequency and amplitude of a sound wave. They listen to the resulting sounds and view graphs of the waves.`;
   protected label: string = $localize`Audio Oscillator`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'AudioOscillator',
-    prompt:
-      'Press play to listen to the sound wave and change the frequency to hear the difference.',
-    showSaveButton: false,
-    showSubmitButton: false,
-    oscillatorTypes: ['sine'],
-    startingAmplitude: 44,
-    startingFrequency: 440,
-    oscilloscopeWidth: 800,
-    oscilloscopeHeight: 400,
-    gridCellSize: 50,
-    stopAfterGoodDraw: true,
-    canStudentEditAmplitude: true,
-    canStudentEditFrequency: true,
-    canStudentViewAmplitudeInput: true,
-    canStudentViewFrequencyInput: true,
-    constraints: []
-  };
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Audio Oscillator`,
+      content: {
+        id: 'abcde12345',
+        type: 'AudioOscillator',
+        prompt:
+          'Press play to listen to the sound wave and change the frequency to hear the difference.',
+        showSaveButton: false,
+        showSubmitButton: false,
+        oscillatorTypes: ['sine'],
+        startingAmplitude: 44,
+        startingFrequency: 440,
+        oscilloscopeWidth: 800,
+        oscilloscopeHeight: 400,
+        gridCellSize: 50,
+        stopAfterGoodDraw: true,
+        canStudentEditAmplitude: true,
+        canStudentEditFrequency: true,
+        canStudentViewAmplitudeInput: true,
+        canStudentViewFrequencyInput: true,
+        constraints: []
+      }
+    }
+  ];
 }

--- a/src/assets/wise5/components/conceptMap/ConceptMapInfo.ts
+++ b/src/assets/wise5/components/conceptMap/ConceptMapInfo.ts
@@ -3,72 +3,77 @@ import { ComponentInfo } from '../ComponentInfo';
 export class ConceptMapInfo extends ComponentInfo {
   protected description: string = $localize`Students add items to a canvas and connect the items with links.`;
   protected label: string = $localize`Concept Map`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'ConceptMap',
-    prompt:
-      "How is the Earth warmed by energy from the Sun? It's your turn to show how energy moves between the Sun, the Earth, and Space. Drag the pictures to the canvas and add links between them make your diagram.",
-    showSaveButton: false,
-    showSubmitButton: false,
-    showAddToNotebookButton: false,
-    width: 800,
-    height: 600,
-    background: null,
-    stretchBackground: null,
-    nodes: [
-      {
-        fileName: '/assets/img/component-preview/sun2.png',
-        width: 100,
-        id: 'node1',
-        label: 'Sun',
-        height: 100
-      },
-      {
-        fileName: '/assets/img/component-preview/Space.png',
-        width: 100,
-        id: 'node2',
-        label: 'Space',
-        height: 100
-      },
-      {
-        fileName: '/assets/img/component-preview/Earth_surface.png',
-        width: 100,
-        id: 'node3',
-        label: "Earth's Surface",
-        height: 100
-      },
-      {
-        fileName: '/assets/img/component-preview/Earth_beneath.png',
-        width: 100,
-        id: 'node4',
-        label: 'Beneath Surface',
-        height: 100
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Concept Map`,
+      content: {
+        id: 'abcde12345',
+        type: 'ConceptMap',
+        prompt:
+          "How is the Earth warmed by energy from the Sun? It's your turn to show how energy moves between the Sun, the Earth, and Space. Drag the pictures to the canvas and add links between them make your diagram.",
+        showSaveButton: false,
+        showSubmitButton: false,
+        showAddToNotebookButton: false,
+        width: 800,
+        height: 600,
+        background: null,
+        stretchBackground: null,
+        nodes: [
+          {
+            fileName: '/assets/img/component-preview/sun2.png',
+            width: 100,
+            id: 'node1',
+            label: 'Sun',
+            height: 100
+          },
+          {
+            fileName: '/assets/img/component-preview/Space.png',
+            width: 100,
+            id: 'node2',
+            label: 'Space',
+            height: 100
+          },
+          {
+            fileName: '/assets/img/component-preview/Earth_surface.png',
+            width: 100,
+            id: 'node3',
+            label: "Earth's Surface",
+            height: 100
+          },
+          {
+            fileName: '/assets/img/component-preview/Earth_beneath.png',
+            width: 100,
+            id: 'node4',
+            label: 'Beneath Surface',
+            height: 100
+          }
+        ],
+        linksTitle: '',
+        links: [
+          {
+            color: '#DDD266',
+            id: 'link1',
+            label: 'Solar Radiation'
+          },
+          {
+            color: '#B62467',
+            id: 'link2',
+            label: 'Infrared Radiation'
+          },
+          {
+            color: '#DE2D26',
+            id: 'link3',
+            label: 'Heat'
+          }
+        ],
+        rules: [],
+        starterConceptMap: null,
+        customRuleEvaluator: '',
+        showAutoScore: false,
+        showAutoFeedback: false,
+        showNodeLabels: true,
+        constraints: []
       }
-    ],
-    linksTitle: '',
-    links: [
-      {
-        color: '#DDD266',
-        id: 'link1',
-        label: 'Solar Radiation'
-      },
-      {
-        color: '#B62467',
-        id: 'link2',
-        label: 'Infrared Radiation'
-      },
-      {
-        color: '#DE2D26',
-        id: 'link3',
-        label: 'Heat'
-      }
-    ],
-    rules: [],
-    starterConceptMap: null,
-    customRuleEvaluator: '',
-    showAutoScore: false,
-    showAutoFeedback: false,
-    showNodeLabels: true,
-    constraints: []
-  };
+    }
+  ];
 }

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceInfo.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceInfo.ts
@@ -3,319 +3,326 @@ import { ComponentInfo } from '../ComponentInfo';
 export class DialogGuidanceInfo extends ComponentInfo {
   protected description: string = $localize`Students chat with a computer avatar about a specific topic.`;
   protected label: string = $localize`Dialog Guidance`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'DialogGuidance',
-    itemId: 'PhotoEnergyStory_score-ki_idea-ki_nonscore',
-    version: 2,
-    feedbackRules: [
-      {
-        id: '6encpml66s',
-        expression: 'isFinalSubmit',
-        feedback: [
-          'Thanks for chatting with me! Now revise your response based on the ideas you shared in the chat.'
-        ]
-      },
-      {
-        id: 'ixvd0iaxh7',
-        expression: 'isSubmitNumber(2) && 13a',
-        feedback: [
-          'I agree that animals get energy from sleeping and eating. Where does the energy in their food come from?'
-        ]
-      },
-      {
-        id: 'dculqoydzc',
-        expression: '13a',
-        feedback: [
-          'I agree that animals need sleep! What other types of energy can animals get from the sun?'
-        ]
-      },
-      {
-        id: 'lm0odmyxre',
-        expression: 'isSubmitNumber(2) && 4a',
-        feedback: ['How do plants get energy from the sun, differently than animals?']
-      },
-      {
-        id: '1urvciu5sy',
-        expression: '4a',
-        feedback: [
-          'Interesting Idea! Where does the energy originally come from? How is the energy transformed in the process?'
-        ]
-      },
-      {
-        id: 'jv23u1nmxj',
-        expression: 'isSubmitNumber(2) && 4b',
-        feedback: [
-          'You are thinking like a scientist! Where does the energy come from? What type of energy is released in this process?'
-        ]
-      },
-      {
-        id: 'irhj6xhvft',
-        expression: '4b',
-        feedback: [
-          'Interesting Idea! What is the glucose made from? What happened to the molecules? '
-        ]
-      },
-      {
-        id: 'uubc2szgcm',
-        expression: 'isSubmitNumber(2) && 6b',
-        feedback: [
-          'Interesting idea. When the animal eats plants, how is the energy transferred from plants to animals?'
-        ]
-      },
-      {
-        id: '617hd0zsmt',
-        expression: '6b',
-        feedback: [
-          'Nice thinking! Where does the plant-stored glucose go? What happened to the part of glucose that hasn’t been used for plant growth?'
-        ]
-      },
-      {
-        id: '6n643zmexn',
-        expression: 'isSubmitNumber(2) && 6c',
-        feedback: [
-          'Interesting idea. How is the energy transformed from the plants to animals in this process?'
-        ]
-      },
-      {
-        id: 'gxoeeryzyw',
-        expression: '6c',
-        feedback: ['Nice thinking! What type of energy is released during cellular respiration?']
-      },
-      {
-        id: 'rjvjxzn8fi',
-        expression: 'isSubmitNumber(2) && 11a',
-        feedback: [
-          'The sun helps animals in lots of ways! How do you think the sun helps animals get energy from food?'
-        ]
-      },
-      {
-        id: 'kl5zguma0m',
-        expression: '11a',
-        feedback: [
-          'I agree that animals can directly use the sun’s energy. What are other sources of energy that animals can get from their food?'
-        ]
-      },
-      {
-        id: 'sf8ttj8pzf',
-        expression: 'isSubmitNumber(2) && 11b',
-        feedback: [
-          'I agree that too much sun can be harmful. Imagine what would happen to plants if there were no sunlight. How do you think the sun helps animals get energy from food?'
-        ]
-      },
-      {
-        id: 'g056fzgmij',
-        expression: '11b',
-        feedback: [
-          'Hmm, too much sun can be harmful. What other impacts does the sun’s energy have on animals?'
-        ]
-      },
-      {
-        id: 't1mhcn37qi',
-        expression: 'isSubmitNumber(2) && 9a',
-        feedback: [
-          'I enjoy hearing your thoughts. Where does the energy in the plant come from and how does it get used by the animal?'
-        ]
-      },
-      {
-        id: 'm1hofcqj7a',
-        expression: '9a',
-        feedback: [
-          'Nice thinking! How is the energy from the sun transformed so the animal can use it?'
-        ]
-      },
-      {
-        id: 'yfm6esxnde',
-        expression: 'isSubmitNumber(2) && 12b',
-        feedback: [
-          'Interesting idea. When the animal eats plants, how does the animal get the energy it needs from the plant it ate - what is the process?'
-        ]
-      },
-      {
-        id: 'pwmhvfbdo5',
-        expression: '12b',
-        feedback: [
-          'Nice thinking! Can you tell me more about the process that transfers energy from the plant to the animal?'
-        ]
-      },
-      {
-        id: 'xx1w3rs1cb',
-        expression: 'isSubmitNumber(2) && 6a',
-        feedback: [
-          'Interesting idea. When the animal eats plants, what happens to the stored glucose?'
-        ]
-      },
-      {
-        id: '46duvz3re6',
-        expression: '6a',
-        feedback: ['Nice thinking! What is the stored glucose used for?']
-      },
-      {
-        id: 'cfp2kn3fxy',
-        expression: 'isSubmitNumber(2) && 3a',
-        feedback: [
-          'I like hearing your thoughts. What do you think the plant does with the usable energy?'
-        ]
-      },
-      {
-        id: 'w43b2yu1p5',
-        expression: '3a',
-        feedback: [
-          'Nice thinking about how plants convert light energy to usable energy. How does this energy go from the plant to the animal?'
-        ]
-      },
-      {
-        id: 'vcqortmk5q',
-        expression: 'isSubmitNumber(2) && 3b',
-        feedback: [
-          'Interesting idea about photosynthesis! How does the energy from plants get to an animal?'
-        ]
-      },
-      {
-        id: '26uhwx54e2',
-        expression: '3b',
-        feedback: [
-          'Nice thinking about photosynthesis. How are the products of photosynthesis useful for animals?'
-        ]
-      },
-      {
-        id: 'od5s1no0b4',
-        expression: 'isSubmitNumber(2) && 2',
-        feedback: [
-          'I like hearing your thoughts. How do you think animals make use of the glucose or oxygen produced by plants during photosynthesis?'
-        ]
-      },
-      {
-        id: '62scpp3ndm',
-        expression: '2',
-        feedback: [
-          'Interesting idea about the products of photosynthesis. How are the products useful for animals?'
-        ]
-      },
-      {
-        id: 'ac4nazjj8l',
-        expression: 'isSubmitNumber(2) && 1',
-        feedback: [
-          'I like hearing your thoughts. How does photosynthesis help the animal get energy?'
-        ]
-      },
-      {
-        id: 'wi5dtcmlgu',
-        expression: '1',
-        feedback: [
-          'Nice thinking. You mentioned the inputs of photosynthesis.  Can you tell me more about what happens during photosynthesis?'
-        ]
-      },
-      {
-        id: 'sffk18map8',
-        expression: 'isSubmitNumber(2) && 4c',
-        feedback: [
-          'I like your idea about energy conservation. Do you think energy is transformed into different types in the food chain? If so, how?'
-        ]
-      },
-      {
-        id: '581eophtvi',
-        expression: '4c',
-        feedback: [
-          'I agree about energy conservation! How does energy get transferred in this process?'
-        ]
-      },
-      {
-        id: '8qo8p60wtg',
-        expression: 'isSubmitNumber(2) && 4d',
-        feedback: ['If energy starts with the sun, how does it move through the food chain? ']
-      },
-      {
-        id: 'wylrvpkf22',
-        expression: '4d',
-        feedback: [
-          'Hmmm, I wonder how the energy decreases down the food chain. Tell me more about how energy moves through the food chain.'
-        ]
-      },
-      {
-        id: '2uqgi6lp0l',
-        expression: 'isSubmitNumber(2) && 9',
-        feedback: [
-          'What happens when animals get the glucose from plants? How does the animal use the energy from glucose?'
-        ]
-      },
-      {
-        id: '6rvyqj6rnt',
-        expression: '9',
-        feedback: [
-          'How does the animal get and use the glucose? What changes does the animal make to the glucose?'
-        ]
-      },
-      {
-        id: 'ffdkkanuae',
-        expression: 'isSubmitNumber(2) && 11',
-        feedback: ['How does energy from the sun get to animals to help them survive?']
-      },
-      {
-        id: 'ow60yaplo2',
-        expression: '11',
-        feedback: [
-          'I see, you are saying that animals need the sun to survive. Can you give me an example of how the sun helps animals?'
-        ]
-      },
-      {
-        id: '2mupe6xoyy',
-        expression: 'isSubmitNumber(2) && 3',
-        feedback: [
-          'What else do plants need to grow other than the sun? What happens inside plants for the sun to help them grow??'
-        ]
-      },
-      {
-        id: 'zbus61wnqy',
-        expression: '3',
-        feedback: ['Can you tell me more about how the Sun helps plants survive?']
-      },
-      {
-        id: 'uc4d6jj3zi',
-        expression: 'isSubmitNumber(2) && 12',
-        feedback: [
-          'I enjoy hearing your thoughts. Can you tell me more about how the energy from the sun is transferred from plants to animals?'
-        ]
-      },
-      {
-        id: 'fm7wctlxpr',
-        expression: '12',
-        feedback: ['Interesting idea! What type of energy do animals get from plants?']
-      },
-      {
-        id: 'dzm7j60m0t',
-        expression: 'isDefault',
-        feedback: [
-          'Can you tell me more about this idea or another one in your explanation? I am still learning about student ideas to become a better thought partner.',
-          'How does the energy transfer from the sun to the plants and then to the animals?'
-        ]
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Dialog Guidance`,
+      content: {
+        id: 'abcde12345',
+        type: 'DialogGuidance',
+        itemId: 'PhotoEnergyStory_score-ki_idea-ki_nonscore',
+        version: 2,
+        feedbackRules: [
+          {
+            id: '6encpml66s',
+            expression: 'isFinalSubmit',
+            feedback: [
+              'Thanks for chatting with me! Now revise your response based on the ideas you shared in the chat.'
+            ]
+          },
+          {
+            id: 'ixvd0iaxh7',
+            expression: 'isSubmitNumber(2) && 13a',
+            feedback: [
+              'I agree that animals get energy from sleeping and eating. Where does the energy in their food come from?'
+            ]
+          },
+          {
+            id: 'dculqoydzc',
+            expression: '13a',
+            feedback: [
+              'I agree that animals need sleep! What other types of energy can animals get from the sun?'
+            ]
+          },
+          {
+            id: 'lm0odmyxre',
+            expression: 'isSubmitNumber(2) && 4a',
+            feedback: ['How do plants get energy from the sun, differently than animals?']
+          },
+          {
+            id: '1urvciu5sy',
+            expression: '4a',
+            feedback: [
+              'Interesting Idea! Where does the energy originally come from? How is the energy transformed in the process?'
+            ]
+          },
+          {
+            id: 'jv23u1nmxj',
+            expression: 'isSubmitNumber(2) && 4b',
+            feedback: [
+              'You are thinking like a scientist! Where does the energy come from? What type of energy is released in this process?'
+            ]
+          },
+          {
+            id: 'irhj6xhvft',
+            expression: '4b',
+            feedback: [
+              'Interesting Idea! What is the glucose made from? What happened to the molecules? '
+            ]
+          },
+          {
+            id: 'uubc2szgcm',
+            expression: 'isSubmitNumber(2) && 6b',
+            feedback: [
+              'Interesting idea. When the animal eats plants, how is the energy transferred from plants to animals?'
+            ]
+          },
+          {
+            id: '617hd0zsmt',
+            expression: '6b',
+            feedback: [
+              'Nice thinking! Where does the plant-stored glucose go? What happened to the part of glucose that hasn’t been used for plant growth?'
+            ]
+          },
+          {
+            id: '6n643zmexn',
+            expression: 'isSubmitNumber(2) && 6c',
+            feedback: [
+              'Interesting idea. How is the energy transformed from the plants to animals in this process?'
+            ]
+          },
+          {
+            id: 'gxoeeryzyw',
+            expression: '6c',
+            feedback: [
+              'Nice thinking! What type of energy is released during cellular respiration?'
+            ]
+          },
+          {
+            id: 'rjvjxzn8fi',
+            expression: 'isSubmitNumber(2) && 11a',
+            feedback: [
+              'The sun helps animals in lots of ways! How do you think the sun helps animals get energy from food?'
+            ]
+          },
+          {
+            id: 'kl5zguma0m',
+            expression: '11a',
+            feedback: [
+              'I agree that animals can directly use the sun’s energy. What are other sources of energy that animals can get from their food?'
+            ]
+          },
+          {
+            id: 'sf8ttj8pzf',
+            expression: 'isSubmitNumber(2) && 11b',
+            feedback: [
+              'I agree that too much sun can be harmful. Imagine what would happen to plants if there were no sunlight. How do you think the sun helps animals get energy from food?'
+            ]
+          },
+          {
+            id: 'g056fzgmij',
+            expression: '11b',
+            feedback: [
+              'Hmm, too much sun can be harmful. What other impacts does the sun’s energy have on animals?'
+            ]
+          },
+          {
+            id: 't1mhcn37qi',
+            expression: 'isSubmitNumber(2) && 9a',
+            feedback: [
+              'I enjoy hearing your thoughts. Where does the energy in the plant come from and how does it get used by the animal?'
+            ]
+          },
+          {
+            id: 'm1hofcqj7a',
+            expression: '9a',
+            feedback: [
+              'Nice thinking! How is the energy from the sun transformed so the animal can use it?'
+            ]
+          },
+          {
+            id: 'yfm6esxnde',
+            expression: 'isSubmitNumber(2) && 12b',
+            feedback: [
+              'Interesting idea. When the animal eats plants, how does the animal get the energy it needs from the plant it ate - what is the process?'
+            ]
+          },
+          {
+            id: 'pwmhvfbdo5',
+            expression: '12b',
+            feedback: [
+              'Nice thinking! Can you tell me more about the process that transfers energy from the plant to the animal?'
+            ]
+          },
+          {
+            id: 'xx1w3rs1cb',
+            expression: 'isSubmitNumber(2) && 6a',
+            feedback: [
+              'Interesting idea. When the animal eats plants, what happens to the stored glucose?'
+            ]
+          },
+          {
+            id: '46duvz3re6',
+            expression: '6a',
+            feedback: ['Nice thinking! What is the stored glucose used for?']
+          },
+          {
+            id: 'cfp2kn3fxy',
+            expression: 'isSubmitNumber(2) && 3a',
+            feedback: [
+              'I like hearing your thoughts. What do you think the plant does with the usable energy?'
+            ]
+          },
+          {
+            id: 'w43b2yu1p5',
+            expression: '3a',
+            feedback: [
+              'Nice thinking about how plants convert light energy to usable energy. How does this energy go from the plant to the animal?'
+            ]
+          },
+          {
+            id: 'vcqortmk5q',
+            expression: 'isSubmitNumber(2) && 3b',
+            feedback: [
+              'Interesting idea about photosynthesis! How does the energy from plants get to an animal?'
+            ]
+          },
+          {
+            id: '26uhwx54e2',
+            expression: '3b',
+            feedback: [
+              'Nice thinking about photosynthesis. How are the products of photosynthesis useful for animals?'
+            ]
+          },
+          {
+            id: 'od5s1no0b4',
+            expression: 'isSubmitNumber(2) && 2',
+            feedback: [
+              'I like hearing your thoughts. How do you think animals make use of the glucose or oxygen produced by plants during photosynthesis?'
+            ]
+          },
+          {
+            id: '62scpp3ndm',
+            expression: '2',
+            feedback: [
+              'Interesting idea about the products of photosynthesis. How are the products useful for animals?'
+            ]
+          },
+          {
+            id: 'ac4nazjj8l',
+            expression: 'isSubmitNumber(2) && 1',
+            feedback: [
+              'I like hearing your thoughts. How does photosynthesis help the animal get energy?'
+            ]
+          },
+          {
+            id: 'wi5dtcmlgu',
+            expression: '1',
+            feedback: [
+              'Nice thinking. You mentioned the inputs of photosynthesis.  Can you tell me more about what happens during photosynthesis?'
+            ]
+          },
+          {
+            id: 'sffk18map8',
+            expression: 'isSubmitNumber(2) && 4c',
+            feedback: [
+              'I like your idea about energy conservation. Do you think energy is transformed into different types in the food chain? If so, how?'
+            ]
+          },
+          {
+            id: '581eophtvi',
+            expression: '4c',
+            feedback: [
+              'I agree about energy conservation! How does energy get transferred in this process?'
+            ]
+          },
+          {
+            id: '8qo8p60wtg',
+            expression: 'isSubmitNumber(2) && 4d',
+            feedback: ['If energy starts with the sun, how does it move through the food chain? ']
+          },
+          {
+            id: 'wylrvpkf22',
+            expression: '4d',
+            feedback: [
+              'Hmmm, I wonder how the energy decreases down the food chain. Tell me more about how energy moves through the food chain.'
+            ]
+          },
+          {
+            id: '2uqgi6lp0l',
+            expression: 'isSubmitNumber(2) && 9',
+            feedback: [
+              'What happens when animals get the glucose from plants? How does the animal use the energy from glucose?'
+            ]
+          },
+          {
+            id: '6rvyqj6rnt',
+            expression: '9',
+            feedback: [
+              'How does the animal get and use the glucose? What changes does the animal make to the glucose?'
+            ]
+          },
+          {
+            id: 'ffdkkanuae',
+            expression: 'isSubmitNumber(2) && 11',
+            feedback: ['How does energy from the sun get to animals to help them survive?']
+          },
+          {
+            id: 'ow60yaplo2',
+            expression: '11',
+            feedback: [
+              'I see, you are saying that animals need the sun to survive. Can you give me an example of how the sun helps animals?'
+            ]
+          },
+          {
+            id: '2mupe6xoyy',
+            expression: 'isSubmitNumber(2) && 3',
+            feedback: [
+              'What else do plants need to grow other than the sun? What happens inside plants for the sun to help them grow??'
+            ]
+          },
+          {
+            id: 'zbus61wnqy',
+            expression: '3',
+            feedback: ['Can you tell me more about how the Sun helps plants survive?']
+          },
+          {
+            id: 'uc4d6jj3zi',
+            expression: 'isSubmitNumber(2) && 12',
+            feedback: [
+              'I enjoy hearing your thoughts. Can you tell me more about how the energy from the sun is transferred from plants to animals?'
+            ]
+          },
+          {
+            id: 'fm7wctlxpr',
+            expression: '12',
+            feedback: ['Interesting idea! What type of energy do animals get from plants?']
+          },
+          {
+            id: 'dzm7j60m0t',
+            expression: 'isDefault',
+            feedback: [
+              'Can you tell me more about this idea or another one in your explanation? I am still learning about student ideas to become a better thought partner.',
+              'How does the energy transfer from the sun to the plants and then to the animals?'
+            ]
+          }
+        ],
+        maxSubmitCount: 3,
+        showSubmitButton: false,
+        showSaveButton: false,
+        prompt: '',
+        computerAvatarSettings: {
+          ids: [
+            'person1',
+            'person2',
+            'person3',
+            'person4',
+            'person5',
+            'person6',
+            'person7',
+            'person8',
+            'robot1',
+            'robot2'
+          ],
+          label: 'Thought Buddy',
+          prompt:
+            '<p><b>Discuss with a thought buddy.</b></p><p>Your buddy will ask you to explain your thinking and compare your response to responses from other students around the country.</p>Then your buddy will ask you some questions.',
+          initialResponse:
+            'Hi Preview User!<br>How do you think animals get and use energy from the sun to survive?</br>',
+          useGlobalComputerAvatar: false
+        },
+        isComputerAvatarEnabled: true,
+        constraints: []
       }
-    ],
-    maxSubmitCount: 3,
-    showSubmitButton: false,
-    showSaveButton: false,
-    prompt: '',
-    computerAvatarSettings: {
-      ids: [
-        'person1',
-        'person2',
-        'person3',
-        'person4',
-        'person5',
-        'person6',
-        'person7',
-        'person8',
-        'robot1',
-        'robot2'
-      ],
-      label: 'Thought Buddy',
-      prompt:
-        '<p><b>Discuss with a thought buddy.</b></p><p>Your buddy will ask you to explain your thinking and compare your response to responses from other students around the country.</p>Then your buddy will ask you some questions.',
-      initialResponse:
-        'Hi Preview User!<br>How do you think animals get and use energy from the sun to survive?</br>',
-      useGlobalComputerAvatar: false
-    },
-    isComputerAvatarEnabled: true,
-    constraints: []
-  };
+    }
+  ];
 }

--- a/src/assets/wise5/components/discussion/DiscussionInfo.ts
+++ b/src/assets/wise5/components/discussion/DiscussionInfo.ts
@@ -3,15 +3,20 @@ import { ComponentInfo } from '../ComponentInfo';
 export class DiscussionInfo extends ComponentInfo {
   protected description: string = $localize`Students post messages for the whole class to see and can reply to other students' posts.`;
   protected label: string = $localize`Discussion`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'Discussion',
-    prompt:
-      'Based on your findings, how does the color of the sand affect the population of fish? Post your ideas to share with the class.',
-    showSaveButton: false,
-    showSubmitButton: false,
-    isStudentAttachmentEnabled: true,
-    gateClassmateResponses: true,
-    constraints: []
-  };
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Discussion`,
+      content: {
+        id: 'abcde12345',
+        type: 'Discussion',
+        prompt:
+          'Based on your findings, how does the color of the sand affect the population of fish? Post your ideas to share with the class.',
+        showSaveButton: false,
+        showSubmitButton: false,
+        isStudentAttachmentEnabled: true,
+        gateClassmateResponses: true,
+        constraints: []
+      }
+    }
+  ];
 }

--- a/src/assets/wise5/components/draw/DrawInfo.ts
+++ b/src/assets/wise5/components/draw/DrawInfo.ts
@@ -3,38 +3,43 @@ import { ComponentInfo } from '../ComponentInfo';
 export class DrawInfo extends ComponentInfo {
   protected description: string = $localize`Students draw on a canvas using a variety of tools.`;
   protected label: string = $localize`Draw`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'Draw',
-    prompt: `<p>Draw the path of electrons in a METAL molecular structure. Make sure you distinguish this sketch from your sketch of the plastic and tire rubber in the previous activities.</p>
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Draw`,
+      content: {
+        id: 'abcde12345',
+        type: 'Draw',
+        prompt: `<p>Draw the path of electrons in a METAL molecular structure. Make sure you distinguish this sketch from your sketch of the plastic and tire rubber in the previous activities.</p>
       <ol><li>Use the STAMP tool to place 2 valence electrons on the metal structure.</li><li>Use the stamp tool to shade the part of the atomic structure where each electron spends its time.</ol>`,
-    showSaveButton: false,
-    showSubmitButton: false,
-    showAddToNotebookButton: false,
-    background: '/assets/img/component-preview/metal_draw.jpg',
-    stamps: {
-      Stamps: [
-        '/assets/img/component-preview/electron.png',
-        '/assets/img/component-preview/highlight.png'
-      ]
-    },
-    tools: {
-      select: true,
-      line: true,
-      shape: true,
-      freeHand: true,
-      text: true,
-      stamp: true,
-      strokeColor: true,
-      fillColor: true,
-      clone: true,
-      strokeWidth: true,
-      sendBack: true,
-      sendForward: true,
-      undo: true,
-      redo: true,
-      delete: true
-    },
-    constraints: []
-  };
+        showSaveButton: false,
+        showSubmitButton: false,
+        showAddToNotebookButton: false,
+        background: '/assets/img/component-preview/metal_draw.jpg',
+        stamps: {
+          Stamps: [
+            '/assets/img/component-preview/electron.png',
+            '/assets/img/component-preview/highlight.png'
+          ]
+        },
+        tools: {
+          select: true,
+          line: true,
+          shape: true,
+          freeHand: true,
+          text: true,
+          stamp: true,
+          strokeColor: true,
+          fillColor: true,
+          clone: true,
+          strokeWidth: true,
+          sendBack: true,
+          sendForward: true,
+          undo: true,
+          redo: true,
+          delete: true
+        },
+        constraints: []
+      }
+    }
+  ];
 }

--- a/src/assets/wise5/components/embedded/EmbeddedInfo.ts
+++ b/src/assets/wise5/components/embedded/EmbeddedInfo.ts
@@ -3,16 +3,21 @@ import { ComponentInfo } from '../ComponentInfo';
 export class EmbeddedInfo extends ComponentInfo {
   protected description: string = $localize`Students interact with a custom applicatio, such as a model or simulation.`;
   protected label: string = $localize`Embedded (Custom)`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'Embedded',
-    prompt: 'Click the differnt boundary types to view them in action.',
-    showSaveButton: false,
-    showSubmitButton: false,
-    showAddToNotebookButton: false,
-    url:
-      'https://wise.berkeley.edu/curriculum/shared/plate-tectonics-convection-explorer/v1/index.html?maxWidth=900',
-    height: 600,
-    constraints: []
-  };
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Embedded`,
+      content: {
+        id: 'abcde12345',
+        type: 'Embedded',
+        prompt: 'Click the differnt boundary types to view them in action.',
+        showSaveButton: false,
+        showSubmitButton: false,
+        showAddToNotebookButton: false,
+        url:
+          'https://wise.berkeley.edu/curriculum/shared/plate-tectonics-convection-explorer/v1/index.html?maxWidth=900',
+        height: 600,
+        constraints: []
+      }
+    }
+  ];
 }

--- a/src/assets/wise5/components/graph/GraphInfo.ts
+++ b/src/assets/wise5/components/graph/GraphInfo.ts
@@ -3,69 +3,74 @@ import { ComponentInfo } from '../ComponentInfo';
 export class GraphInfo extends ComponentInfo {
   protected description: string = $localize`Students view graph data or add points to a graph.`;
   protected label: string = $localize`Graph`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'Graph',
-    prompt:
-      'Draw a line that shows the position graph of a person that starts at position 0 meters and then takes 50 seconds to walk 50 meters and then comes back to their start position while moving at a constant speed.',
-    showSaveButton: false,
-    showSubmitButton: false,
-    showAddToNotebookButton: false,
-    title: '',
-    width: 800,
-    height: 500,
-    enableTrials: false,
-    canCreateNewTrials: false,
-    canDeleteTrials: false,
-    hideAllTrialsOnNewTrial: false,
-    canStudentHideSeriesOnLegendClick: false,
-    roundValuesTo: 'integer',
-    graphType: 'line',
-    xAxis: {
-      title: {
-        text: 'Time (seconds)',
-        useHTML: true
-      },
-      min: 0,
-      max: 100,
-      units: 's',
-      locked: true,
-      type: 'limits',
-      allowDecimals: false
-    },
-    yAxis: {
-      title: {
-        text: 'Position (meters)',
-        useHTML: true,
-        style: {
-          color: ''
-        }
-      },
-      labels: {
-        style: {
-          color: ''
-        }
-      },
-      min: 0,
-      max: 100,
-      units: 'm',
-      locked: true,
-      allowDecimals: false,
-      opposite: false
-    },
-    series: [
-      {
-        name: 'Prediction',
-        data: [],
-        color: 'blue',
-        dashStyle: 'Solid',
-        marker: {
-          symbol: 'circle'
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Graph`,
+      content: {
+        id: 'abcde12345',
+        type: 'Graph',
+        prompt:
+          'Draw a line that shows the position graph of a person that starts at position 0 meters and then takes 50 seconds to walk 50 meters and then comes back to their start position while moving at a constant speed.',
+        showSaveButton: false,
+        showSubmitButton: false,
+        showAddToNotebookButton: false,
+        title: '',
+        width: 800,
+        height: 500,
+        enableTrials: false,
+        canCreateNewTrials: false,
+        canDeleteTrials: false,
+        hideAllTrialsOnNewTrial: false,
+        canStudentHideSeriesOnLegendClick: false,
+        roundValuesTo: 'integer',
+        graphType: 'line',
+        xAxis: {
+          title: {
+            text: 'Time (seconds)',
+            useHTML: true
+          },
+          min: 0,
+          max: 100,
+          units: 's',
+          locked: true,
+          type: 'limits',
+          allowDecimals: false
         },
-        canEdit: true,
-        type: 'line'
+        yAxis: {
+          title: {
+            text: 'Position (meters)',
+            useHTML: true,
+            style: {
+              color: ''
+            }
+          },
+          labels: {
+            style: {
+              color: ''
+            }
+          },
+          min: 0,
+          max: 100,
+          units: 'm',
+          locked: true,
+          allowDecimals: false,
+          opposite: false
+        },
+        series: [
+          {
+            name: 'Prediction',
+            data: [],
+            color: 'blue',
+            dashStyle: 'Solid',
+            marker: {
+              symbol: 'circle'
+            },
+            canEdit: true,
+            type: 'line'
+          }
+        ],
+        constraints: []
       }
-    ],
-    constraints: []
-  };
+    }
+  ];
 }

--- a/src/assets/wise5/components/html/HtmlInfo.ts
+++ b/src/assets/wise5/components/html/HtmlInfo.ts
@@ -3,13 +3,16 @@ import { ComponentInfo } from '../ComponentInfo';
 export class HtmlInfo extends ComponentInfo {
   protected description: string = $localize`Students view rich text (HTML) content.`;
   protected label: string = $localize`Rich Text (HTML)`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'HTML',
-    prompt: '',
-    showSaveButton: false,
-    showSubmitButton: false,
-    html: `<h3 style="text-align: center;"><span style="color: #000000; background-color: #fbeeb8; font-size: 24pt;"><strong>How does the Sun warm the Earth?</strong></span></h3>
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Rich Text (HTML)`,
+      content: {
+        id: 'abcde12345',
+        type: 'HTML',
+        prompt: '',
+        showSaveButton: false,
+        showSubmitButton: false,
+        html: `<h3 style="text-align: center;"><span style="color: #000000; background-color: #fbeeb8; font-size: 24pt;"><strong>How does the Sun warm the Earth?</strong></span></h3>
       <p style="text-align: center;"><span style="font-size: 14pt;"><strong><img src="/assets/img/component-preview/sun.png" alt="sun" width="100" height="100" /></strong></span></p>
       <p><span style="font-size: 14pt;">You probably know that the Sun keeps us warm on Earth. But do you know how the Sun does that?</span></p>
       <p><span style="font-size: 14pt;"><strong><span style="color: #843fa1;">In this lesson, you'll explore the following questions:</span><br /></strong></span></p>
@@ -18,6 +21,8 @@ export class HtmlInfo extends ComponentInfo {
         <li><span style="font-size: 14pt;">What happens to the Sun's energy when it reaches the Earth?</span></li>
         <li><span style="font-size: 14pt;">How does the Sun's energy warm the Earth?</span></li>
       </ul>`,
-    constraints: []
-  };
+        constraints: []
+      }
+    }
+  ];
 }

--- a/src/assets/wise5/components/label/LabelInfo.ts
+++ b/src/assets/wise5/components/label/LabelInfo.ts
@@ -3,73 +3,78 @@ import { ComponentInfo } from '../ComponentInfo';
 export class LabelInfo extends ComponentInfo {
   protected description: string = $localize`Students add labels to a canvas.`;
   protected label: string = $localize`Label`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'Label',
-    prompt: 'Label the layers of the Earth by moving the labels to the correct location.',
-    showSaveButton: false,
-    showSubmitButton: false,
-    showAddToNotebookButton: false,
-    backgroundImage: '/assets/img/component-preview/earth-layers.jpg',
-    canCreateLabels: true,
-    canEditLabels: true,
-    canDeleteLabels: true,
-    enableCircles: true,
-    width: 800,
-    height: 600,
-    pointSize: 5,
-    fontSize: 20,
-    labelWidth: 20,
-    labels: [
-      {
-        pointX: 453,
-        pointY: 50,
-        textX: 648,
-        textY: 50,
-        text: 'Crust',
-        color: 'black',
-        canEdit: false,
-        canDelete: false,
-        timestamp: 1697647088109,
-        isStarterLabel: true
-      },
-      {
-        pointX: 449,
-        pointY: 155,
-        textX: 644,
-        textY: 156,
-        text: 'Mantle',
-        color: 'black',
-        canEdit: false,
-        canDelete: false,
-        timestamp: 1697647088112,
-        isStarterLabel: true
-      },
-      {
-        pointX: 445,
-        pointY: 250,
-        textX: 646,
-        textY: 249,
-        text: 'Outer Core',
-        color: 'black',
-        canEdit: false,
-        canDelete: false,
-        timestamp: 1697647088114,
-        isStarterLabel: true
-      },
-      {
-        pointX: 443,
-        pointY: 344,
-        textX: 639,
-        textY: 344,
-        text: 'Inner Core',
-        color: 'black',
-        canEdit: false,
-        canDelete: false,
-        timestamp: 1697647088117,
-        isStarterLabel: true
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Label`,
+      content: {
+        id: 'abcde12345',
+        type: 'Label',
+        prompt: 'Label the layers of the Earth by moving the labels to the correct location.',
+        showSaveButton: false,
+        showSubmitButton: false,
+        showAddToNotebookButton: false,
+        backgroundImage: '/assets/img/component-preview/earth-layers.jpg',
+        canCreateLabels: true,
+        canEditLabels: true,
+        canDeleteLabels: true,
+        enableCircles: true,
+        width: 800,
+        height: 600,
+        pointSize: 5,
+        fontSize: 20,
+        labelWidth: 20,
+        labels: [
+          {
+            pointX: 453,
+            pointY: 50,
+            textX: 648,
+            textY: 50,
+            text: 'Crust',
+            color: 'black',
+            canEdit: false,
+            canDelete: false,
+            timestamp: 1697647088109,
+            isStarterLabel: true
+          },
+          {
+            pointX: 449,
+            pointY: 155,
+            textX: 644,
+            textY: 156,
+            text: 'Mantle',
+            color: 'black',
+            canEdit: false,
+            canDelete: false,
+            timestamp: 1697647088112,
+            isStarterLabel: true
+          },
+          {
+            pointX: 445,
+            pointY: 250,
+            textX: 646,
+            textY: 249,
+            text: 'Outer Core',
+            color: 'black',
+            canEdit: false,
+            canDelete: false,
+            timestamp: 1697647088114,
+            isStarterLabel: true
+          },
+          {
+            pointX: 443,
+            pointY: 344,
+            textX: 639,
+            textY: 344,
+            text: 'Inner Core',
+            color: 'black',
+            canEdit: false,
+            canDelete: false,
+            timestamp: 1697647088117,
+            isStarterLabel: true
+          }
+        ],
+        constraints: []
       }
-    ],
-    constraints: []
-  };
+    }
+  ];
 }

--- a/src/assets/wise5/components/match/MatchInfo.ts
+++ b/src/assets/wise5/components/match/MatchInfo.ts
@@ -3,247 +3,252 @@ import { ComponentInfo } from '../ComponentInfo';
 export class MatchInfo extends ComponentInfo {
   protected description: string = $localize`Students sort items into different buckets.`;
   protected label: string = $localize`Match`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'Match',
-    prompt:
-      'Sort the different environmental pressures that organisms can face into biotic and abiotic pressures.',
-    showSaveButton: false,
-    showSubmitButton: true,
-    choices: [
-      {
-        id: 'evhs07qtqu',
-        type: 'choice',
-        value: 'Predators'
-      },
-      {
-        id: 'sa5w70scaw',
-        type: 'choice',
-        value: 'Dangerous viruses'
-      },
-      {
-        id: 'ofm2mo5mgy',
-        type: 'choice',
-        value: 'High temperatures'
-      },
-      {
-        id: '3unza7haw1',
-        type: 'choice',
-        value: 'Lack of water'
-      },
-      {
-        id: '21noaztqyb',
-        type: 'choice',
-        value: 'Siblings competing for territory'
-      },
-      {
-        id: 'i5n25oq6qy',
-        type: 'choice',
-        value: 'Air pollution'
-      },
-      {
-        id: '6vbjwoo64q',
-        type: 'choice',
-        value: 'Not enough food (prey)'
-      },
-      {
-        id: 'b8lhey6tgp',
-        type: 'choice',
-        value: 'Strong sun light'
-      },
-      {
-        id: 'ocm53nhs1f',
-        type: 'choice',
-        value: 'Parasites'
-      },
-      {
-        id: 'rzas42rtvc',
-        type: 'choice',
-        value: 'Sand storms'
-      }
-    ],
-    choiceReuseEnabled: false,
-    buckets: [
-      {
-        id: 'k7zphrnrym',
-        type: 'bucket',
-        value: 'Biotic pressures'
-      },
-      {
-        id: 't7ij83fu78',
-        type: 'bucket',
-        value: 'Abiotic pressures'
-      }
-    ],
-    choicesLabel: 'Environmental pressures',
-    feedback: [
-      {
-        bucketId: '0',
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Match`,
+      content: {
+        id: 'abcde12345',
+        type: 'Match',
+        prompt:
+          'Sort the different environmental pressures that organisms can face into biotic and abiotic pressures.',
+        showSaveButton: false,
+        showSubmitButton: true,
         choices: [
           {
-            choiceId: 'evhs07qtqu',
-            feedback: '',
-            isCorrect: false
+            id: 'evhs07qtqu',
+            type: 'choice',
+            value: 'Predators'
           },
           {
-            choiceId: 'sa5w70scaw',
-            feedback: '',
-            isCorrect: false
+            id: 'sa5w70scaw',
+            type: 'choice',
+            value: 'Dangerous viruses'
           },
           {
-            choiceId: 'ofm2mo5mgy',
-            feedback: '',
-            isCorrect: false
+            id: 'ofm2mo5mgy',
+            type: 'choice',
+            value: 'High temperatures'
           },
           {
-            choiceId: '3unza7haw1',
-            feedback: '',
-            isCorrect: false
+            id: '3unza7haw1',
+            type: 'choice',
+            value: 'Lack of water'
           },
           {
-            choiceId: '21noaztqyb',
-            feedback: '',
-            isCorrect: false
+            id: '21noaztqyb',
+            type: 'choice',
+            value: 'Siblings competing for territory'
           },
           {
-            choiceId: 'i5n25oq6qy',
-            feedback: '',
-            isCorrect: false
+            id: 'i5n25oq6qy',
+            type: 'choice',
+            value: 'Air pollution'
           },
           {
-            choiceId: '6vbjwoo64q',
-            feedback: '',
-            isCorrect: false
+            id: '6vbjwoo64q',
+            type: 'choice',
+            value: 'Not enough food (prey)'
           },
           {
-            choiceId: 'b8lhey6tgp',
-            feedback: '',
-            isCorrect: false
+            id: 'b8lhey6tgp',
+            type: 'choice',
+            value: 'Strong sun light'
           },
           {
-            choiceId: 'ocm53nhs1f',
-            feedback: '',
-            isCorrect: false
+            id: 'ocm53nhs1f',
+            type: 'choice',
+            value: 'Parasites'
           },
           {
-            choiceId: 'rzas42rtvc',
-            feedback: '',
-            isCorrect: false
+            id: 'rzas42rtvc',
+            type: 'choice',
+            value: 'Sand storms'
           }
-        ]
-      },
-      {
-        bucketId: 'k7zphrnrym',
-        choices: [
+        ],
+        choiceReuseEnabled: false,
+        buckets: [
           {
-            choiceId: 'evhs07qtqu',
-            feedback: '',
-            isCorrect: true
+            id: 'k7zphrnrym',
+            type: 'bucket',
+            value: 'Biotic pressures'
           },
           {
-            choiceId: 'sa5w70scaw',
-            feedback: '',
-            isCorrect: true
-          },
-          {
-            choiceId: 'ofm2mo5mgy',
-            feedback: '',
-            isCorrect: false
-          },
-          {
-            choiceId: '3unza7haw1',
-            feedback: '',
-            isCorrect: false
-          },
-          {
-            choiceId: '21noaztqyb',
-            feedback: '',
-            isCorrect: true
-          },
-          {
-            choiceId: 'i5n25oq6qy',
-            feedback: '',
-            isCorrect: false
-          },
-          {
-            choiceId: '6vbjwoo64q',
-            feedback: '',
-            isCorrect: true
-          },
-          {
-            choiceId: 'b8lhey6tgp',
-            feedback: '',
-            isCorrect: false
-          },
-          {
-            choiceId: 'ocm53nhs1f',
-            feedback: '',
-            isCorrect: true
-          },
-          {
-            choiceId: 'rzas42rtvc',
-            feedback: '',
-            isCorrect: false
+            id: 't7ij83fu78',
+            type: 'bucket',
+            value: 'Abiotic pressures'
           }
-        ]
-      },
-      {
-        bucketId: 't7ij83fu78',
-        choices: [
+        ],
+        choicesLabel: 'Environmental pressures',
+        feedback: [
           {
-            choiceId: 'evhs07qtqu',
-            feedback: '',
-            isCorrect: false
+            bucketId: '0',
+            choices: [
+              {
+                choiceId: 'evhs07qtqu',
+                feedback: '',
+                isCorrect: false
+              },
+              {
+                choiceId: 'sa5w70scaw',
+                feedback: '',
+                isCorrect: false
+              },
+              {
+                choiceId: 'ofm2mo5mgy',
+                feedback: '',
+                isCorrect: false
+              },
+              {
+                choiceId: '3unza7haw1',
+                feedback: '',
+                isCorrect: false
+              },
+              {
+                choiceId: '21noaztqyb',
+                feedback: '',
+                isCorrect: false
+              },
+              {
+                choiceId: 'i5n25oq6qy',
+                feedback: '',
+                isCorrect: false
+              },
+              {
+                choiceId: '6vbjwoo64q',
+                feedback: '',
+                isCorrect: false
+              },
+              {
+                choiceId: 'b8lhey6tgp',
+                feedback: '',
+                isCorrect: false
+              },
+              {
+                choiceId: 'ocm53nhs1f',
+                feedback: '',
+                isCorrect: false
+              },
+              {
+                choiceId: 'rzas42rtvc',
+                feedback: '',
+                isCorrect: false
+              }
+            ]
           },
           {
-            choiceId: 'sa5w70scaw',
-            feedback: '',
-            isCorrect: false
+            bucketId: 'k7zphrnrym',
+            choices: [
+              {
+                choiceId: 'evhs07qtqu',
+                feedback: '',
+                isCorrect: true
+              },
+              {
+                choiceId: 'sa5w70scaw',
+                feedback: '',
+                isCorrect: true
+              },
+              {
+                choiceId: 'ofm2mo5mgy',
+                feedback: '',
+                isCorrect: false
+              },
+              {
+                choiceId: '3unza7haw1',
+                feedback: '',
+                isCorrect: false
+              },
+              {
+                choiceId: '21noaztqyb',
+                feedback: '',
+                isCorrect: true
+              },
+              {
+                choiceId: 'i5n25oq6qy',
+                feedback: '',
+                isCorrect: false
+              },
+              {
+                choiceId: '6vbjwoo64q',
+                feedback: '',
+                isCorrect: true
+              },
+              {
+                choiceId: 'b8lhey6tgp',
+                feedback: '',
+                isCorrect: false
+              },
+              {
+                choiceId: 'ocm53nhs1f',
+                feedback: '',
+                isCorrect: true
+              },
+              {
+                choiceId: 'rzas42rtvc',
+                feedback: '',
+                isCorrect: false
+              }
+            ]
           },
           {
-            choiceId: 'ofm2mo5mgy',
-            feedback: '',
-            isCorrect: true
-          },
-          {
-            choiceId: '3unza7haw1',
-            feedback: '',
-            isCorrect: true
-          },
-          {
-            choiceId: '21noaztqyb',
-            feedback: '',
-            isCorrect: false
-          },
-          {
-            choiceId: 'i5n25oq6qy',
-            feedback: '',
-            isCorrect: true
-          },
-          {
-            choiceId: '6vbjwoo64q',
-            feedback: 'Think - what do animals usually eat?',
-            isCorrect: false
-          },
-          {
-            choiceId: 'b8lhey6tgp',
-            feedback: '',
-            isCorrect: true
-          },
-          {
-            choiceId: 'ocm53nhs1f',
-            feedback: '',
-            isCorrect: false
-          },
-          {
-            choiceId: 'rzas42rtvc',
-            feedback: '',
-            isCorrect: true
+            bucketId: 't7ij83fu78',
+            choices: [
+              {
+                choiceId: 'evhs07qtqu',
+                feedback: '',
+                isCorrect: false
+              },
+              {
+                choiceId: 'sa5w70scaw',
+                feedback: '',
+                isCorrect: false
+              },
+              {
+                choiceId: 'ofm2mo5mgy',
+                feedback: '',
+                isCorrect: true
+              },
+              {
+                choiceId: '3unza7haw1',
+                feedback: '',
+                isCorrect: true
+              },
+              {
+                choiceId: '21noaztqyb',
+                feedback: '',
+                isCorrect: false
+              },
+              {
+                choiceId: 'i5n25oq6qy',
+                feedback: '',
+                isCorrect: true
+              },
+              {
+                choiceId: '6vbjwoo64q',
+                feedback: 'Think - what do animals usually eat?',
+                isCorrect: false
+              },
+              {
+                choiceId: 'b8lhey6tgp',
+                feedback: '',
+                isCorrect: true
+              },
+              {
+                choiceId: 'ocm53nhs1f',
+                feedback: '',
+                isCorrect: false
+              },
+              {
+                choiceId: 'rzas42rtvc',
+                feedback: '',
+                isCorrect: true
+              }
+            ]
           }
-        ]
+        ],
+        ordered: false,
+        constraints: []
       }
-    ],
-    ordered: false,
-    constraints: []
-  };
+    }
+  ];
 }

--- a/src/assets/wise5/components/multipleChoice/MultipleChoiceInfo.ts
+++ b/src/assets/wise5/components/multipleChoice/MultipleChoiceInfo.ts
@@ -3,31 +3,89 @@ import { ComponentInfo } from '../ComponentInfo';
 export class MultipleChoiceInfo extends ComponentInfo {
   protected description: string = $localize`Students select one or more choices.`;
   protected label: string = $localize`Multiple Choice`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'MultipleChoice',
-    prompt: 'When touching a hot METAL bowl and a hot WOODEN bowl that have the same temperature:',
-    showSaveButton: false,
-    showSubmitButton: true,
-    choiceType: 'radio',
-    choices: [
-      {
-        feedback: '',
-        id: '1jmi01ht6t',
-        text: 'The metal bowl will feel hotter.'
-      },
-      {
-        feedback: '',
-        id: '46r96bhek5',
-        text: 'The wooden bowl will feel hotter.'
-      },
-      {
-        feedback: '',
-        id: 'xuikkjc99u',
-        text: 'The bowls will feel the same.'
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Single Answer`,
+      content: {
+        id: 'abcde12345',
+        type: 'MultipleChoice',
+        prompt:
+          'When touching a hot METAL bowl and a hot WOODEN bowl that have the same temperature:',
+        showSaveButton: false,
+        showSubmitButton: true,
+        choiceType: 'radio',
+        choices: [
+          {
+            feedback: '',
+            id: '1jmi01ht6t',
+            text: 'The metal bowl will feel hotter.'
+          },
+          {
+            feedback: '',
+            id: '46r96bhek5',
+            text: 'The wooden bowl will feel hotter.'
+          },
+          {
+            feedback: '',
+            id: 'xuikkjc99u',
+            text: 'The bowls will feel the same.'
+          }
+        ],
+        showFeedback: true,
+        constraints: []
       }
-    ],
-    showFeedback: true,
-    constraints: []
-  };
+    },
+    {
+      label: $localize`Multiple Answer`,
+      content: {
+        id: 'abcde12345',
+        type: 'MultipleChoice',
+        prompt:
+          'PREDICT: Which materials do you think it will be useful to test for your investigation? (Keeping a cold beverage cold.)',
+        showSaveButton: false,
+        showSubmitButton: true,
+        choiceType: 'checkbox',
+        choices: [
+          {
+            feedback: '',
+            id: 'pi76wjaknm',
+            text: 'Aluminum',
+            isCorrect: false
+          },
+          {
+            feedback: '',
+            id: 'btaf2hw3tg',
+            text: 'Clay',
+            isCorrect: false
+          },
+          {
+            feedback: '',
+            id: 'yzz3hpsfaw',
+            text: 'Glass',
+            isCorrect: false
+          },
+          {
+            feedback: '',
+            id: 'r3hm2iz5l5',
+            text: 'Plastic',
+            isCorrect: false
+          },
+          {
+            feedback: '',
+            id: '1ifd6pbeqb',
+            text: 'Styrofoam',
+            isCorrect: false
+          },
+          {
+            feedback: '',
+            id: '544sy1ytam',
+            text: 'Wood',
+            isCorrect: false
+          }
+        ],
+        showFeedback: true,
+        constraints: []
+      }
+    }
+  ];
 }

--- a/src/assets/wise5/components/openResponse/OpenResponseInfo.ts
+++ b/src/assets/wise5/components/openResponse/OpenResponseInfo.ts
@@ -3,15 +3,20 @@ import { ComponentInfo } from '../ComponentInfo';
 export class OpenResponseInfo extends ComponentInfo {
   protected description: string = $localize`Students type a response to a question or prompt.`;
   protected label: string = $localize`Open Response`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'OpenResponse',
-    prompt: 'In your own words, explain what an insulator does and what a conductor does.',
-    showSaveButton: false,
-    showSubmitButton: true,
-    showAddToNotebookButton: false,
-    starterSentence: null,
-    isStudentAttachmentEnabled: false,
-    constraints: []
-  };
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Open Response`,
+      content: {
+        id: 'abcde12345',
+        type: 'OpenResponse',
+        prompt: 'In your own words, explain what an insulator does and what a conductor does.',
+        showSaveButton: false,
+        showSubmitButton: true,
+        showAddToNotebookButton: false,
+        starterSentence: null,
+        isStudentAttachmentEnabled: false,
+        constraints: []
+      }
+    }
+  ];
 }

--- a/src/assets/wise5/components/outsideURL/OutsideUrlInfo.ts
+++ b/src/assets/wise5/components/outsideURL/OutsideUrlInfo.ts
@@ -3,16 +3,21 @@ import { ComponentInfo } from '../ComponentInfo';
 export class OutsideUrlInfo extends ComponentInfo {
   protected description: string = $localize`Students view an external website.`;
   protected label: string = $localize`Outside Resource`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'OutsideURL',
-    prompt: 'Play with the model.',
-    showSaveButton: false,
-    showSubmitButton: false,
-    url:
-      'https://lab.concord.org/embeddable.html#interactives/air-pollution/air-pollution-master.json',
-    height: 600,
-    info: 'https://learn.concord.org/resources/855/air-pollution-model-cross-section',
-    constraints: []
-  };
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Outside Resource`,
+      content: {
+        id: 'abcde12345',
+        type: 'OutsideURL',
+        prompt: 'Play with the model.',
+        showSaveButton: false,
+        showSubmitButton: false,
+        url:
+          'https://lab.concord.org/embeddable.html#interactives/air-pollution/air-pollution-master.json',
+        height: 600,
+        info: 'https://learn.concord.org/resources/855/air-pollution-model-cross-section',
+        constraints: []
+      }
+    }
+  ];
 }

--- a/src/assets/wise5/components/peerChat/PeerChatInfo.ts
+++ b/src/assets/wise5/components/peerChat/PeerChatInfo.ts
@@ -3,41 +3,47 @@ import { ComponentInfo } from '../ComponentInfo';
 export class PeerChatInfo extends ComponentInfo {
   protected description: string = $localize`Students are grouped with other students to discuss a topic.`;
   protected label: string = $localize`Peer Chat`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'PeerChat',
-    prompt: `<p>Hi! You've been paired with a classmate to improve your explanation to the question: "How do you think Mt. Hood formed?"</p>
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Peer Chat`,
+      content: {
+        id: 'abcde12345',
+        type: 'PeerChat',
+        prompt: `<p>Hi! You've been paired with a classmate to improve your explanation to the question: "How do you think Mt. Hood formed?"</p>
       <p>Discuss with your partner in this chat!<br>If you agree, you can describe what you agree on and try to elaborate. If you disagree, try to figure out why.</p>
       <p>You can use questions from the Question Bank if you want help connecting your ideas.</p>`,
-    showSaveButton: false,
-    showSubmitButton: false,
-    peerGroupingTag: '',
-    questionBank: {
-      version: 2,
-      enabled: true,
-      maxQuestionsToShow: 3,
-      clickToUseEnabled: true,
-      rules: [
-        {
-          id: 'lt6a6dwpq3',
-          expression: 'true',
-          questions: [
+        showSaveButton: false,
+        showSubmitButton: false,
+        peerGroupingTag: '',
+        questionBank: {
+          version: 2,
+          enabled: true,
+          maxQuestionsToShow: 3,
+          clickToUseEnabled: true,
+          rules: [
             {
-              text: 'How does convection affect plate movement where Mt. Hood is located?',
-              id: 'vwv7dnbm28'
-            },
-            {
-              text: 'How does density have an effect on how plates interact with one another? ',
-              id: 'vwv7dnbm29'
-            },
-            {
-              text: 'Do you agree or disagree with your partner? What would you add or build on?',
-              id: 'vwv7dnbm27'
+              id: 'lt6a6dwpq3',
+              expression: 'true',
+              questions: [
+                {
+                  text: 'How does convection affect plate movement where Mt. Hood is located?',
+                  id: 'vwv7dnbm28'
+                },
+                {
+                  text: 'How does density have an effect on how plates interact with one another? ',
+                  id: 'vwv7dnbm29'
+                },
+                {
+                  text:
+                    'Do you agree or disagree with your partner? What would you add or build on?',
+                  id: 'vwv7dnbm27'
+                }
+              ]
             }
           ]
-        }
-      ]
-    },
-    constraints: []
-  };
+        },
+        constraints: []
+      }
+    }
+  ];
 }

--- a/src/assets/wise5/components/showGroupWork/ShowGroupWorkInfo.ts
+++ b/src/assets/wise5/components/showGroupWork/ShowGroupWorkInfo.ts
@@ -3,17 +3,22 @@ import { ComponentInfo } from '../ComponentInfo';
 export class ShowGroupWorkInfo extends ComponentInfo {
   protected description: string = $localize`Students are shown work that everyone in their group submitted for a specific item.`;
   protected label: string = $localize`Show Group Work`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'ShowGroupWork',
-    prompt: `Hi! You've been paired with a classmate to improve your explanation.<br>Here are your responses to the question "How do you think Mt. Hood formed?":`,
-    showSaveButton: false,
-    showSubmitButton: false,
-    showWorkNodeId: '',
-    showWorkComponentId: '',
-    peerGroupingTag: '',
-    isShowMyWork: true,
-    layout: 'column',
-    constraints: []
-  };
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Show Group Work`,
+      content: {
+        id: 'abcde12345',
+        type: 'ShowGroupWork',
+        prompt: `Hi! You've been paired with a classmate to improve your explanation.<br>Here are your responses to the question "How do you think Mt. Hood formed?":`,
+        showSaveButton: false,
+        showSubmitButton: false,
+        showWorkNodeId: '',
+        showWorkComponentId: '',
+        peerGroupingTag: '',
+        isShowMyWork: true,
+        layout: 'column',
+        constraints: []
+      }
+    }
+  ];
 }

--- a/src/assets/wise5/components/showMyWork/ShowMyWorkInfo.ts
+++ b/src/assets/wise5/components/showMyWork/ShowMyWorkInfo.ts
@@ -3,14 +3,19 @@ import { ComponentInfo } from '../ComponentInfo';
 export class ShowMyWorkInfo extends ComponentInfo {
   protected description: string = $localize`Students are shown work that they submitted for a specific item.`;
   protected label: string = $localize`Show My Work`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'ShowMyWork',
-    prompt: 'Here is your previous answer to the question "How do you think Mt. Hood formed?":',
-    showSaveButton: false,
-    showSubmitButton: false,
-    showWorkNodeId: '',
-    showWorkComponentId: '',
-    constraints: []
-  };
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Show My Work`,
+      content: {
+        id: 'abcde12345',
+        type: 'ShowMyWork',
+        prompt: 'Here is your previous answer to the question "How do you think Mt. Hood formed?":',
+        showSaveButton: false,
+        showSubmitButton: false,
+        showWorkNodeId: '',
+        showWorkComponentId: '',
+        constraints: []
+      }
+    }
+  ];
 }

--- a/src/assets/wise5/components/summary/SummaryInfo.ts
+++ b/src/assets/wise5/components/summary/SummaryInfo.ts
@@ -3,20 +3,25 @@ import { ComponentInfo } from '../ComponentInfo';
 export class SummaryInfo extends ComponentInfo {
   protected description: string = $localize`Students are shown an aggregate graph summarizing data from the class.`;
   protected label: string = $localize`Summary`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'Summary',
-    prompt: 'This graph shows a summary of the data collected by you and your classmates:',
-    showSaveButton: false,
-    showSubmitButton: false,
-    summaryNodeId: null,
-    summaryComponentId: null,
-    source: 'period',
-    studentDataType: null,
-    chartType: 'column',
-    requirementToSeeSummary: 'submitWork',
-    highlightCorrectAnswer: false,
-    customLabelColors: [],
-    constraints: []
-  };
+  protected previewExamples: any[] = [
+    {
+      lable: $localize`Summary`,
+      content: {
+        id: 'abcde12345',
+        type: 'Summary',
+        prompt: 'This graph shows a summary of the data collected by you and your classmates:',
+        showSaveButton: false,
+        showSubmitButton: false,
+        summaryNodeId: null,
+        summaryComponentId: null,
+        source: 'period',
+        studentDataType: null,
+        chartType: 'column',
+        requirementToSeeSummary: 'submitWork',
+        highlightCorrectAnswer: false,
+        customLabelColors: [],
+        constraints: []
+      }
+    }
+  ];
 }

--- a/src/assets/wise5/components/table/TableInfo.ts
+++ b/src/assets/wise5/components/table/TableInfo.ts
@@ -3,139 +3,144 @@ import { ComponentInfo } from '../ComponentInfo';
 export class TableInfo extends ComponentInfo {
   protected description: string = $localize`Students view and/or edit table data.`;
   protected label: string = $localize`Table`;
-  protected previewContent: any = {
-    id: 'abcde12345',
-    type: 'Table',
-    prompt: `<p>Document your findings!</p>
+  protected previewExamples: any[] = [
+    {
+      label: $localize`Table`,
+      content: {
+        id: 'abcde12345',
+        type: 'Table',
+        prompt: `<p>Document your findings!</p>
       <p>Run at least 3 trials with the simulation: one with dark sand, one with medium colored sand, and one with light sand. Record the results in the table below.</p>`,
-    showSaveButton: false,
-    showSubmitButton: false,
-    showAddToNotebookButton: false,
-    globalCellSize: 9,
-    numRows: 4,
-    nuColumns: 8,
-    tableData: [
-      [
-        {
-          editable: false,
-          text: 'Trial'
-        },
-        {
-          editable: false,
-          text: 'Sand Color'
-        },
-        {
-          editable: false,
-          text: 'Initial number of fish'
-        },
-        {
-          editable: false,
-          text: 'Initial number of sharks'
-        },
-        {
-          editable: false,
-          text: 'Generations passed'
-        },
-        {
-          editable: false,
-          text: 'Resulting number of dark fish'
-        },
-        {
-          editable: false,
-          text: 'Resulting number of light fish'
-        }
-      ],
-      [
-        {
-          editable: false,
-          text: '1'
-        },
-        {
-          editable: true,
-          text: ''
-        },
-        {
-          editable: true,
-          text: ''
-        },
-        {
-          editable: true,
-          text: ''
-        },
-        {
-          editable: true,
-          text: ''
-        },
-        {
-          editable: true,
-          text: ''
-        },
-        {
-          editable: true,
-          text: ''
-        }
-      ],
-      [
-        {
-          editable: false,
-          text: '2'
-        },
-        {
-          editable: true,
-          text: ''
-        },
-        {
-          editable: true,
-          text: ''
-        },
-        {
-          editable: true,
-          text: ''
-        },
-        {
-          editable: true,
-          text: ''
-        },
-        {
-          editable: true,
-          text: ''
-        },
-        {
-          editable: true,
-          text: ''
-        }
-      ],
-      [
-        {
-          editable: false,
-          text: '3'
-        },
-        {
-          editable: true,
-          text: ''
-        },
-        {
-          editable: true,
-          text: ''
-        },
-        {
-          editable: true,
-          text: ''
-        },
-        {
-          editable: true,
-          text: ''
-        },
-        {
-          editable: true,
-          text: ''
-        },
-        {
-          editable: true,
-          text: ''
-        }
-      ]
-    ],
-    constraints: []
-  };
+        showSaveButton: false,
+        showSubmitButton: false,
+        showAddToNotebookButton: false,
+        globalCellSize: 9,
+        numRows: 4,
+        nuColumns: 8,
+        tableData: [
+          [
+            {
+              editable: false,
+              text: 'Trial'
+            },
+            {
+              editable: false,
+              text: 'Sand Color'
+            },
+            {
+              editable: false,
+              text: 'Initial number of fish'
+            },
+            {
+              editable: false,
+              text: 'Initial number of sharks'
+            },
+            {
+              editable: false,
+              text: 'Generations passed'
+            },
+            {
+              editable: false,
+              text: 'Resulting number of dark fish'
+            },
+            {
+              editable: false,
+              text: 'Resulting number of light fish'
+            }
+          ],
+          [
+            {
+              editable: false,
+              text: '1'
+            },
+            {
+              editable: true,
+              text: ''
+            },
+            {
+              editable: true,
+              text: ''
+            },
+            {
+              editable: true,
+              text: ''
+            },
+            {
+              editable: true,
+              text: ''
+            },
+            {
+              editable: true,
+              text: ''
+            },
+            {
+              editable: true,
+              text: ''
+            }
+          ],
+          [
+            {
+              editable: false,
+              text: '2'
+            },
+            {
+              editable: true,
+              text: ''
+            },
+            {
+              editable: true,
+              text: ''
+            },
+            {
+              editable: true,
+              text: ''
+            },
+            {
+              editable: true,
+              text: ''
+            },
+            {
+              editable: true,
+              text: ''
+            },
+            {
+              editable: true,
+              text: ''
+            }
+          ],
+          [
+            {
+              editable: false,
+              text: '3'
+            },
+            {
+              editable: true,
+              text: ''
+            },
+            {
+              editable: true,
+              text: ''
+            },
+            {
+              editable: true,
+              text: ''
+            },
+            {
+              editable: true,
+              text: ''
+            },
+            {
+              editable: true,
+              text: ''
+            },
+            {
+              editable: true,
+              text: ''
+            }
+          ]
+        ],
+        constraints: []
+      }
+    }
+  ];
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -295,7 +295,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">30</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/preview-component-dialog/preview-component-dialog.component.html</context>
@@ -2067,10 +2067,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
           <context context-type="linenumber">89</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html</context>
-          <context context-type="linenumber">10</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/milestones-authoring/milestones-authoring.component.html</context>
@@ -9765,15 +9761,18 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">2</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6db909a826f1878ad78bf853a62b6cc5cbda3d3f" datatype="html">
-        <source>Example</source>
+      <trans-unit id="4a22c6843133f0b0d7dc0d28f864f2f90c1de7ad" datatype="html">
+        <source>Description:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">10</context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="5473e36f5102e2ae22ce4c6620cacc40cc98da95" datatype="html">
+        <source>Example:</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
-          <context context-type="linenumber">184</context>
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html</context>
+          <context context-type="linenumber">13</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7e3335111c33faf6526597a2b84893369b11bc60" datatype="html">
@@ -10152,7 +10151,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">395</context>
+          <context context-type="linenumber">396</context>
         </context-group>
       </trans-unit>
       <trans-unit id="185559960832537937" datatype="html">
@@ -15703,7 +15702,7 @@ Are you ready to receive feedback on this answer?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">329</context>
+          <context context-type="linenumber">330</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3308736994783976865" datatype="html">
@@ -16275,6 +16274,13 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">181</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="6db909a826f1878ad78bf853a62b6cc5cbda3d3f" datatype="html">
+        <source>Example</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
+          <context context-type="linenumber">184</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="f5d726bee0fd8a545258990d929f39b68549dd87" datatype="html">
         <source>Evaluates to true if neither idea 4a nor idea 12 were found.</source>
         <context-group purpose="location">
@@ -16562,7 +16568,7 @@ Label: <x id="PH" equiv-text="linkLabel"/></source>
         <source>You have no more chances to receive feedback on your answer.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">323</context>
+          <context context-type="linenumber">324</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1088900768760788337" datatype="html">
@@ -16571,7 +16577,7 @@ Label: <x id="PH" equiv-text="linkLabel"/></source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">326</context>
+          <context context-type="linenumber">327</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
@@ -16582,11 +16588,11 @@ Are you ready to receive feedback on this answer?</source>
         <source>Feedback</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">404</context>
+          <context context-type="linenumber">405</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">413</context>
+          <context context-type="linenumber">414</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/componentAnnotations/component-annotations.component.ts</context>
@@ -16597,7 +16603,7 @@ Are you ready to receive feedback on this answer?</source>
         <source>Are you sure you want to reset your work?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">1412</context>
+          <context context-type="linenumber">1413</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4d5d5b4e6b3c3a79914e4c5a72054018599ac2c4" datatype="html">
@@ -17151,11 +17157,11 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Add Comment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response/class-response.component.html</context>
-          <context context-type="linenumber">171</context>
+          <context context-type="linenumber">167</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response/class-response.component.html</context>
-          <context context-type="linenumber">173</context>
+          <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6209923492332399608" datatype="html">
@@ -17225,7 +17231,7 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source><x id="PH" equiv-text="usernames"/> replied to a discussion you were in!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/discussion-student/discussion-student.component.ts</context>
-          <context context-type="linenumber">203</context>
+          <context context-type="linenumber">196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="831017338718169987" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -295,7 +295,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html</context>
-          <context context-type="linenumber">16</context>
+          <context context-type="linenumber">27</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/preview-component-dialog/preview-component-dialog.component.html</context>
@@ -10152,7 +10152,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">396</context>
+          <context context-type="linenumber">395</context>
         </context-group>
       </trans-unit>
       <trans-unit id="185559960832537937" datatype="html">
@@ -14369,49 +14369,49 @@ Are you sure you want to proceed?</source>
         <source>Correctness column key: 0 = Incorrect, 1 = Correct, 2 = Correct bucket but wrong position</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">140</context>
+          <context context-type="linenumber">139</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7865202073915909645" datatype="html">
         <source>One Workgroup Per Row</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">163</context>
+          <context context-type="linenumber">162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="789970879723970594" datatype="html">
         <source>Latest Student Work</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">165</context>
+          <context context-type="linenumber">164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6593306077428507515" datatype="html">
         <source>All Student Work</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">167</context>
+          <context context-type="linenumber">166</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5729418620241283277" datatype="html">
         <source>Events</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">169</context>
+          <context context-type="linenumber">168</context>
         </context-group>
       </trans-unit>
       <trans-unit id="347166173746466674" datatype="html">
         <source>Raw Data</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">171</context>
+          <context context-type="linenumber">170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="456492495567778711" datatype="html">
         <source>Downloading Export</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">2022</context>
+          <context context-type="linenumber">2027</context>
         </context-group>
       </trans-unit>
       <trans-unit id="18a393cd6211a7e1f51159db6b49637ee7c61490" datatype="html">
@@ -15068,6 +15068,10 @@ Are you sure you want to proceed?</source>
           <context context-type="linenumber">5</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/animation/AnimationInfo.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/animation/animationService.ts</context>
           <context context-type="linenumber">9</context>
         </context-group>
@@ -15172,7 +15176,7 @@ Are you sure you want to proceed?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/discussion-student/discussion-student.component.html</context>
-          <context context-type="linenumber">53</context>
+          <context context-type="linenumber">54</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/label-authoring/label-authoring.component.html</context>
@@ -15699,7 +15703,7 @@ Are you ready to receive feedback on this answer?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">329</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3308736994783976865" datatype="html">
@@ -15714,6 +15718,10 @@ Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/AudioOscillatorInfo.ts</context>
           <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/AudioOscillatorInfo.ts</context>
+          <context context-type="linenumber">8</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/audioOscillatorService.ts</context>
@@ -16309,6 +16317,10 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">5</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/conceptMap/ConceptMapInfo.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/conceptMapService.ts</context>
           <context context-type="linenumber">22</context>
         </context-group>
@@ -16550,7 +16562,7 @@ Label: <x id="PH" equiv-text="linkLabel"/></source>
         <source>You have no more chances to receive feedback on your answer.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">324</context>
+          <context context-type="linenumber">323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1088900768760788337" datatype="html">
@@ -16559,7 +16571,7 @@ Label: <x id="PH" equiv-text="linkLabel"/></source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">327</context>
+          <context context-type="linenumber">326</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
@@ -16570,11 +16582,11 @@ Are you ready to receive feedback on this answer?</source>
         <source>Feedback</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">405</context>
+          <context context-type="linenumber">404</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">414</context>
+          <context context-type="linenumber">413</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/componentAnnotations/component-annotations.component.ts</context>
@@ -16585,7 +16597,7 @@ Are you ready to receive feedback on this answer?</source>
         <source>Are you sure you want to reset your work?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">1413</context>
+          <context context-type="linenumber">1412</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4d5d5b4e6b3c3a79914e4c5a72054018599ac2c4" datatype="html">
@@ -16837,6 +16849,10 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">5</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/DialogGuidanceInfo.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialogGuidanceService.ts</context>
           <context context-type="linenumber">12</context>
         </context-group>
@@ -17045,6 +17061,10 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">5</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/DiscussionInfo.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/discussionService.ts</context>
           <context context-type="linenumber">16</context>
         </context-group>
@@ -17131,11 +17151,11 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Add Comment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response/class-response.component.html</context>
-          <context context-type="linenumber">167</context>
+          <context context-type="linenumber">171</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response/class-response.component.html</context>
-          <context context-type="linenumber">169</context>
+          <context context-type="linenumber">173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6209923492332399608" datatype="html">
@@ -17184,28 +17204,28 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Remove file</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/discussion-student/discussion-student.component.html</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c648889391b76acac6870869f928f33920241c76" datatype="html">
         <source>Add picture</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/discussion-student/discussion-student.component.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cf52ff0f4f9dc792b81e652fc6f0c2e83d14d56b" datatype="html">
         <source> Post </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/discussion-student/discussion-student.component.html</context>
-          <context context-type="linenumber">92,94</context>
+          <context context-type="linenumber">93,95</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3210146777760299474" datatype="html">
         <source><x id="PH" equiv-text="usernames"/> replied to a discussion you were in!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/discussion-student/discussion-student.component.ts</context>
-          <context context-type="linenumber">196</context>
+          <context context-type="linenumber">203</context>
         </context-group>
       </trans-unit>
       <trans-unit id="831017338718169987" datatype="html">
@@ -17220,6 +17240,10 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/draw/DrawInfo.ts</context>
           <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/draw/DrawInfo.ts</context>
+          <context context-type="linenumber">8</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/draw/drawService.ts</context>
@@ -17460,6 +17484,13 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="7120485563504644471" datatype="html">
+        <source>Embedded</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/embedded/EmbeddedInfo.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="f753799cecb5ea7e8d3c0c69851d91ce5303b08a" datatype="html">
         <source>Model Parameters</source>
         <context-group purpose="location">
@@ -17536,6 +17567,10 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/GraphInfo.ts</context>
           <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/graph/GraphInfo.ts</context>
+          <context context-type="linenumber">8</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graphService.ts</context>
@@ -18421,6 +18456,10 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">5</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/html/HtmlInfo.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/html/htmlService.ts</context>
           <context context-type="linenumber">7</context>
         </context-group>
@@ -18444,6 +18483,10 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/LabelInfo.ts</context>
           <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/label/LabelInfo.ts</context>
+          <context context-type="linenumber">8</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/label/labelService.ts</context>
@@ -18682,6 +18725,10 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/MatchInfo.ts</context>
           <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/match/MatchInfo.ts</context>
+          <context context-type="linenumber">8</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/matchService.ts</context>
@@ -19038,6 +19085,20 @@ Warning: This will delete all existing choices and buckets in this component.</s
           <context context-type="linenumber">10</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="9007972153162147219" datatype="html">
+        <source>Single Answer</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/MultipleChoiceInfo.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3410089385743867046" datatype="html">
+        <source>Multiple Answer</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/MultipleChoiceInfo.ts</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="2d07aed510fda739dd79dcbc3a9d807af224e41f" datatype="html">
         <source> Show Feedback </source>
         <context-group purpose="location">
@@ -19148,6 +19209,10 @@ Warning: This will delete all existing choices in this component.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/OpenResponseInfo.ts</context>
           <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/openResponse/OpenResponseInfo.ts</context>
+          <context context-type="linenumber">8</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/openResponseService.ts</context>
@@ -19682,6 +19747,10 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">5</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/outsideURL/OutsideUrlInfo.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/outsideURL/outsideURLService.ts</context>
           <context context-type="linenumber">14</context>
         </context-group>
@@ -19801,6 +19870,10 @@ If this problem continues, let your teacher know and move on to the next activit
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/PeerChatInfo.ts</context>
           <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/peerChat/PeerChatInfo.ts</context>
+          <context context-type="linenumber">8</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peerChatService.ts</context>
@@ -19927,6 +20000,10 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">5</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/showGroupWork/ShowGroupWorkInfo.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/showGroupWork/showGroupWorkService.ts</context>
           <context context-type="linenumber">7</context>
         </context-group>
@@ -20035,6 +20112,10 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="sourcefile">src/assets/wise5/components/showMyWork/ShowMyWorkInfo.ts</context>
           <context context-type="linenumber">5</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/showMyWork/ShowMyWorkInfo.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="3e4063d41615b0bdb15dd79a55e0334dabeb361f" datatype="html">
         <source>(No response)</source>
@@ -20062,6 +20143,10 @@ If this problem continues, let your teacher know and move on to the next activit
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/SummaryInfo.ts</context>
           <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/summary/SummaryInfo.ts</context>
+          <context context-type="linenumber">8</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summaryService.ts</context>
@@ -20263,6 +20348,10 @@ If this problem continues, let your teacher know and move on to the next activit
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/TableInfo.ts</context>
           <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/table/TableInfo.ts</context>
+          <context context-type="linenumber">8</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/table/tableService.ts</context>


### PR DESCRIPTION
## Changes
- Allow multiple examples per component type in the component info popup
- If a component type has multiple examples, it will display tabs
- If a component type only has one example, it will not display tabs
- Multiple Choice now has two examples but all others still only have one
- Updated all component type info classes to contain an array of preview examples even if they only have one example

## Test
- Make sure Multiple Choice shows two examples
- Make sure all other component types only show one example

Closes #1519
