### PR TITLE
refactor(Archive Units): use string union keys

### DIFF
--- a/src/app/modules/library/personal-library/personal-library.component.html
+++ b/src/app/modules/library/personal-library/personal-library.component.html
@@ -15,9 +15,10 @@
     <div fxLayoutAlign="center center" fxLayoutGap="4px" fxFlexAlign.xs="start" fxFlexOrder.xs="1">
       <select-all-items-checkbox
         [label]="projectsLabel"
-        [selectedAllItems]="selectedAllProjects()"
-        [selectedSomeItems]="selectedSomeProjects()"
-        (selectAllItemsEvent)="selectAllProjects($event)"
+        [numAllItems]="numProjectsInView"
+        [numSelectedItems]="numSelectedProjects()"
+        (selectAllItemsEvent)="selectAllProjects()"
+        (selectNoItemsEvent)="unselectAllProjects()"
       ></select-all-items-checkbox>
       <span *ngIf="numSelectedProjects() > 0" class="secondary-text" i18n>
         {{ numSelectedProjects() }} selected

--- a/src/app/modules/library/personal-library/personal-library.component.html
+++ b/src/app/modules/library/personal-library/personal-library.component.html
@@ -17,8 +17,8 @@
         [label]="projectsLabel"
         [numAllItems]="numProjectsInView"
         [numSelectedItems]="numSelectedProjects()"
-        (selectAllItemsEvent)="selectAllProjects()"
-        (selectNoItemsEvent)="unselectAllProjects()"
+        (allSelectedEvent)="selectAllProjects()"
+        (noneSelectedEvent)="unselectAllProjects()"
       ></select-all-items-checkbox>
       <span *ngIf="numSelectedProjects() > 0" class="secondary-text" i18n>
         {{ numSelectedProjects() }} selected

--- a/src/app/modules/library/personal-library/personal-library.component.ts
+++ b/src/app/modules/library/personal-library/personal-library.component.ts
@@ -16,6 +16,7 @@ import { ProjectSelectionEvent } from '../../../domain/projectSelectionEvent';
 })
 export class PersonalLibraryComponent extends LibraryComponent {
   filteredProjects: LibraryProject[] = [];
+  protected numProjectsInView: number;
   protected numSelectedProjects: Signal<number> = computed(() => this.selectedProjects().length);
   protected personalProjects: LibraryProject[] = [];
   protected projectIdToIsSelected: Signal<{ [key: number]: boolean }> = computed(() =>
@@ -26,14 +27,7 @@ export class PersonalLibraryComponent extends LibraryComponent {
   );
   projects: LibraryProject[] = [];
   protected projectsLabel: string = $localize`units`;
-  protected selectedAllProjects: Signal<boolean> = computed(() => {
-    const numSelectedProjects = this.numSelectedProjects();
-    return numSelectedProjects !== 0 && numSelectedProjects === this.getProjectsInView().length;
-  });
   protected selectedProjects: WritableSignal<LibraryProject[]> = signal([]);
-  protected selectedSomeProjects: Signal<boolean> = computed(
-    () => this.numSelectedProjects() !== 0 && !this.selectedAllProjects()
-  );
   protected sharedProjects: LibraryProject[] = [];
   protected showArchived: boolean = false;
 
@@ -122,6 +116,7 @@ export class PersonalLibraryComponent extends LibraryComponent {
     this.filteredProjects = this.filteredProjects.filter(
       (project) => project.hasTag('archived') == this.showArchived
     );
+    this.numProjectsInView = this.getProjectsInView().length;
   }
 
   protected switchActiveArchivedView(): void {
@@ -166,12 +161,12 @@ export class PersonalLibraryComponent extends LibraryComponent {
     });
   }
 
-  private unselectAllProjects(): void {
-    this.selectAllProjects(false);
+  protected unselectAllProjects(): void {
+    this.selectedProjects.set([]);
   }
 
-  protected selectAllProjects(selectAll: boolean): void {
-    this.selectedProjects.set(selectAll ? this.getProjectsInView() : []);
+  protected selectAllProjects(): void {
+    this.selectedProjects.set(this.getProjectsInView());
   }
 
   private getProjectsInView(): LibraryProject[] {

--- a/src/app/modules/library/select-all-items-checkbox/select-all-items-checkbox.component.html
+++ b/src/app/modules/library/select-all-items-checkbox/select-all-items-checkbox.component.html
@@ -1,7 +1,7 @@
 <mat-checkbox
   color="primary"
-  [checked]="status == 'all'"
-  [indeterminate]="status == 'some'"
+  [checked]="status === 'all'"
+  [indeterminate]="status === 'some'"
   (click)="select()"
   [matTooltip]="'Select all ' + label"
   matTooltipPosition="above"

--- a/src/app/modules/library/select-all-items-checkbox/select-all-items-checkbox.component.html
+++ b/src/app/modules/library/select-all-items-checkbox/select-all-items-checkbox.component.html
@@ -1,7 +1,7 @@
 <mat-checkbox
   color="primary"
-  [checked]="selectedAllItems"
-  [indeterminate]="selectedSomeItems"
+  [checked]="status == 'all'"
+  [indeterminate]="status == 'some'"
   (click)="select()"
   [matTooltip]="'Select all ' + label"
   matTooltipPosition="above"

--- a/src/app/modules/library/select-all-items-checkbox/select-all-items-checkbox.component.ts
+++ b/src/app/modules/library/select-all-items-checkbox/select-all-items-checkbox.component.ts
@@ -1,6 +1,8 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { MAT_CHECKBOX_DEFAULT_OPTIONS } from '@angular/material/checkbox';
 
+type SelectAllItemsStatus = 'none' | 'some' | 'all';
+
 @Component({
   selector: 'select-all-items-checkbox',
   templateUrl: './select-all-items-checkbox.component.html',
@@ -8,11 +10,27 @@ import { MAT_CHECKBOX_DEFAULT_OPTIONS } from '@angular/material/checkbox';
 })
 export class SelectAllItemsCheckboxComponent {
   @Input() label: string = $localize`items`;
-  @Input() selectedAllItems: boolean = false;
-  @Input() selectedSomeItems: boolean = false;
-  @Output() selectAllItemsEvent: EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Input() numAllItems: number;
+  @Input() numSelectedItems: number;
+  @Output() selectAllItemsEvent: EventEmitter<void> = new EventEmitter<void>();
+  @Output() selectNoItemsEvent: EventEmitter<void> = new EventEmitter<void>();
+  protected status: SelectAllItemsStatus;
+
+  ngOnChanges(): void {
+    if (this.numSelectedItems == 0) {
+      this.status = 'none';
+    } else if (this.numSelectedItems < this.numAllItems) {
+      this.status = 'some';
+    } else {
+      this.status = 'all';
+    }
+  }
 
   protected select(): void {
-    this.selectAllItemsEvent.emit(!(this.selectedAllItems || this.selectedSomeItems));
+    if (this.status === 'none') {
+      this.selectAllItemsEvent.emit();
+    } else {
+      this.selectNoItemsEvent.emit();
+    }
   }
 }

--- a/src/app/modules/library/select-all-items-checkbox/select-all-items-checkbox.component.ts
+++ b/src/app/modules/library/select-all-items-checkbox/select-all-items-checkbox.component.ts
@@ -9,11 +9,11 @@ type SelectAllItemsStatus = 'none' | 'some' | 'all';
   providers: [{ provide: MAT_CHECKBOX_DEFAULT_OPTIONS, useValue: { clickAction: 'noop' } }]
 })
 export class SelectAllItemsCheckboxComponent {
+  @Output() allSelectedEvent: EventEmitter<void> = new EventEmitter<void>();
   @Input() label: string = $localize`items`;
+  @Output() noneSelectedEvent: EventEmitter<void> = new EventEmitter<void>();
   @Input() numAllItems: number;
   @Input() numSelectedItems: number;
-  @Output() selectAllItemsEvent: EventEmitter<void> = new EventEmitter<void>();
-  @Output() selectNoItemsEvent: EventEmitter<void> = new EventEmitter<void>();
   protected status: SelectAllItemsStatus;
 
   ngOnChanges(): void {
@@ -28,9 +28,9 @@ export class SelectAllItemsCheckboxComponent {
 
   protected select(): void {
     if (this.status === 'none') {
-      this.selectAllItemsEvent.emit();
+      this.allSelectedEvent.emit();
     } else {
-      this.selectNoItemsEvent.emit();
+      this.noneSelectedEvent.emit();
     }
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -5910,7 +5910,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>items</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/select-all-items-checkbox/select-all-items-checkbox.component.ts</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">13</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6028472408314831177" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -5867,14 +5867,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source> <x id="INTERPOLATION" equiv-text="{{ numSelectedProjects() }}"/> selected </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library.component.html</context>
-          <context context-type="linenumber">22,24</context>
+          <context context-type="linenumber">23,25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="df4115facc79e0525f99fd896748f35f7a6906ad" datatype="html">
         <source>Archive selected units</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library.component.html</context>
-          <context context-type="linenumber">29</context>
+          <context context-type="linenumber">30</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/select-runs-controls/select-runs-controls.component.html</context>
@@ -5885,7 +5885,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Restore selected units</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library.component.html</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">40</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/select-runs-controls/select-runs-controls.component.html</context>
@@ -5896,21 +5896,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source> No owned or shared units found. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library.component.html</context>
-          <context context-type="linenumber">70,72</context>
+          <context context-type="linenumber">71,73</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8443540764676509944" datatype="html">
         <source>units</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library.component.ts</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">29</context>
         </context-group>
       </trans-unit>
       <trans-unit id="413346167952108153" datatype="html">
         <source>items</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/select-all-items-checkbox/select-all-items-checkbox.component.ts</context>
-          <context context-type="linenumber">10</context>
+          <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6028472408314831177" datatype="html">


### PR DESCRIPTION
## Changes
- Use SelectAllItemsStatus string literal union keys ('none' | 'some' | 'all') to indicate the current status of the
SelectAllItemsCheckboxComponent. The status makes it easy to see the current state of the checkbox, compared to using two variables (selectedAllItems and selectedSomeItems). Since there can only be one state (none, some, all) for the checkbox, I think this change would make it simpler and easier to understand.

- Move status calculation from PersonalLibraryComponent to the SelectAllItemsCheckboxComponent, where it's actually being used. This requires passing in numSelectedItems and numAllItems. This reduces PersonalLibraryComponent's responsibility of calculating and remembering the status values.

- Call PersonalLibraryComponent.(un)selectAllProjects() directly as a result of the output from the SelectAllItemsCheckboxComponent. This makes PersonalLibraryComponent's API a bit more clear for outside classes: call unselectAllProjects() to unselect all projects, and selectAllProjects() to select all projects, making the body of SelectAllItemsCheckboxComponent.select() easier to follow. Also remove the need to pass in a boolean flag.