### PR TITLE
feat(Multiple Languages): TranslatableInputComponent

### DIFF
--- a/src/app/domain/projectLocale.ts
+++ b/src/app/domain/projectLocale.ts
@@ -42,7 +42,7 @@ export class ProjectLocale {
     return !this.isDefaultLocale(locale) && this.hasLocale(locale);
   }
 
-  private isDefaultLocale(locale: string): boolean {
+  isDefaultLocale(locale: string): boolean {
     return this.locale.default === locale;
   }
 

--- a/src/app/domain/translations.ts
+++ b/src/app/domain/translations.ts
@@ -1,0 +1,6 @@
+export interface Translations extends Record<string, TranslationValue> {}
+
+export interface TranslationValue {
+  value: string;
+  modified: number;
+}

--- a/src/app/teacher/component-authoring.module.ts
+++ b/src/app/teacher/component-authoring.module.ts
@@ -84,6 +84,7 @@ import { ComponentAuthoringComponent } from '../../assets/wise5/authoringTool/co
 import { WiseTinymceEditorModule } from '../../assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.module';
 import { WiseLinkAuthoringDialogComponent } from '../../assets/wise5/authoringTool/wise-link-authoring-dialog/wise-link-authoring-dialog.component';
 import { EditComponentAdvancedButtonComponent } from '../../assets/wise5/authoringTool/components/edit-component-advanced-button/edit-component-advanced-button.component';
+import { TranslatableInputComponent } from '../../assets/wise5/authoringTool/components/translatable-input/translatable-input.component';
 
 @NgModule({
   declarations: [
@@ -173,6 +174,7 @@ import { EditComponentAdvancedButtonComponent } from '../../assets/wise5/authori
     ConstraintAuthoringModule,
     StudentTeacherCommonModule,
     PeerGroupingAuthoringModule,
+    TranslatableInputComponent,
     WiseTinymceEditorModule
   ],
   exports: [

--- a/src/assets/wise5/authoringTool/components/top-bar/top-bar.component.ts
+++ b/src/assets/wise5/authoringTool/components/top-bar/top-bar.component.ts
@@ -106,5 +106,7 @@ export class TopBarComponent implements OnInit {
     this.sessionService.logOut();
   }
 
-  protected changeLanguage(language: Language): void {}
+  protected changeLanguage(language: Language): void {
+    this.projectService.setCurrentLanguage(language);
+  }
 }

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
@@ -1,0 +1,10 @@
+<ng-content *ngIf="!showTranslationInput()"></ng-content>
+<mat-form-field *ngIf="showTranslationInput()">
+  <mat-label i18n>{{ labelRef.nativeElement.innerHTML }}</mat-label>
+  <input
+    matInput
+    [ngModel]="translatedText()"
+    (ngModelChange)="saveTranslationText($event)"
+    placeholder="{{ input.placeholder }}"
+  />
+</mat-form-field>

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
@@ -1,10 +1,10 @@
 <ng-content *ngIf="!showTranslationInput()"></ng-content>
 <mat-form-field *ngIf="showTranslationInput()">
-  <mat-label i18n>{{ labelRef.nativeElement.innerHTML }}</mat-label>
+  <mat-label i18n>{{ defaultLanguageLabelRef.nativeElement.innerHTML }}</mat-label>
   <input
     matInput
     [ngModel]="translatedText()"
     (ngModelChange)="saveTranslationText($event)"
-    placeholder="{{ input.placeholder }}"
+    placeholder="{{ defaultLanguageInput.placeholder }}"
   />
 </mat-form-field>

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.scss
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.scss
@@ -1,0 +1,3 @@
+mat-form-field {
+  width: 100%;
+}

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.spec.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.spec.ts
@@ -1,0 +1,31 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TranslatableInputComponent } from './translatable-input.component';
+import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+describe('TranslatableInputComponent', () => {
+  let component: TranslatableInputComponent;
+  let fixture: ComponentFixture<TranslatableInputComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        StudentTeacherCommonServicesModule,
+        TranslatableInputComponent
+      ],
+      providers: [TeacherProjectService]
+    });
+    spyOn(TestBed.inject(TeacherProjectService), 'isDefaultLocale').and.returnValue(true);
+    fixture = TestBed.createComponent(TranslatableInputComponent);
+    component = fixture.componentInstance;
+    component.content = {};
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.spec.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { TranslatableInputComponent } from './translatable-input.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { TeacherProjectService } from '../../../services/teacherProjectService';

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
@@ -15,9 +15,9 @@ import { MatLabel } from '@angular/material/form-field';
 })
 export class TranslatableInputComponent {
   @Input() content: object;
+  @ContentChild(MatInput) defaultLanguageInput: MatInput;
+  @ContentChild(MatLabel, { read: ElementRef }) defaultLanguageLabelRef: ElementRef;
   @Input() key: string;
-  @ContentChild(MatInput) input: MatInput;
-  @ContentChild(MatLabel, { read: ElementRef }) labelRef: ElementRef;
   protected showTranslationInput: Signal<boolean>;
   protected translatedText: Signal<string>;
 
@@ -32,9 +32,7 @@ export class TranslatableInputComponent {
     const i18nId = this.content[`${this.key}.i18n`]?.id;
     this.translatedText = computed(() => {
       if (this.showTranslationInput()) {
-        if (this.translateProjectService.currentTranslations()[i18nId]?.value) {
-          return this.translateProjectService.currentTranslations()[i18nId]?.value;
-        }
+        return this.translateProjectService.currentTranslations()[i18nId]?.value ?? '';
       }
     });
   }

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
@@ -1,0 +1,45 @@
+import { Component, ContentChild, ElementRef, Input, Signal, computed } from '@angular/core';
+import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { CommonModule } from '@angular/common';
+import { MatInput, MatInputModule } from '@angular/material/input';
+import { FormsModule } from '@angular/forms';
+import { TranslateProjectService } from '../../../services/translateProjectService';
+import { MatLabel } from '@angular/material/form-field';
+
+@Component({
+  standalone: true,
+  selector: 'translatable-input',
+  imports: [CommonModule, FormsModule, MatInputModule],
+  styleUrls: ['./translatable-input.component.scss'],
+  templateUrl: './translatable-input.component.html'
+})
+export class TranslatableInputComponent {
+  @Input() content: object;
+  @Input() key: string;
+  @ContentChild(MatInput) input: MatInput;
+  @ContentChild(MatLabel, { read: ElementRef }) labelRef: ElementRef;
+  protected showTranslationInput: Signal<boolean>;
+  protected translatedText: Signal<string>;
+
+  constructor(
+    private projectService: TeacherProjectService,
+    private translateProjectService: TranslateProjectService
+  ) {
+    this.showTranslationInput = computed(() => !this.projectService.isDefaultLocale());
+  }
+
+  ngOnInit(): void {
+    const i18nId = this.content[`${this.key}.i18n`]?.id;
+    this.translatedText = computed(() => {
+      if (this.showTranslationInput()) {
+        if (this.translateProjectService.currentTranslations()[i18nId]?.value) {
+          return this.translateProjectService.currentTranslations()[i18nId]?.value;
+        }
+      }
+    });
+  }
+
+  protected saveTranslationText(text: string): void {
+    // TODO: save translation text to server
+  }
+}

--- a/src/assets/wise5/components/match/match-authoring/match-authoring.component.html
+++ b/src/assets/wise5/components/match/match-authoring/match-authoring.component.html
@@ -63,16 +63,18 @@
     fxLayout="row"
     fxLayoutAlign="start center"
   >
-    <mat-form-field class="name">
-      <mat-label i18n>Choice Name</mat-label>
-      <input
-        matInput
-        [(ngModel)]="choice.value"
-        (ngModelChange)="inputChange.next($event)"
-        placeholder="Type text or choose an image"
-        i18n-placeholder
-      />
-    </mat-form-field>
+    <translatable-input [content]="choice" key="value" class="name">
+      <mat-form-field>
+        <mat-label i18n>Choice Name</mat-label>
+        <input
+          matInput
+          [(ngModel)]="choice.value"
+          (ngModelChange)="inputChange.next($event)"
+          placeholder="Type text or choose an image"
+          i18n-placeholder
+        />
+      </mat-form-field>
+    </translatable-input>
     <button
       mat-raised-button
       color="primary"
@@ -130,14 +132,16 @@
   </div>
 </div>
 <div class="section">
-  <mat-form-field class="name">
-    <mat-label i18n>Source Bucket Name</mat-label>
-    <input
-      matInput
-      [(ngModel)]="componentContent.choicesLabel"
-      (ngModelChange)="inputChange.next($event)"
-    />
-  </mat-form-field>
+  <translatable-input [content]="componentContent" key="choicesLabel" class="name">
+    <mat-form-field>
+      <mat-label i18n>Source Bucket Name</mat-label>
+      <input
+        matInput
+        [(ngModel)]="componentContent.choicesLabel"
+        (ngModelChange)="inputChange.next($event)"
+      />
+    </mat-form-field>
+  </translatable-input>
   <br />
   <span i18n>Target Buckets</span>
   <button
@@ -246,7 +250,10 @@
   </div>
   <div *ngFor="let bucketFeedback of componentContent.feedback" class="section">
     <p i18n>Bucket Name: {{ getBucketNameById(bucketFeedback.bucketId) }}</p>
-    <div *ngFor="let choiceFeedback of bucketFeedback.choices" class="choice-feedback-container notice-bg-bg">
+    <div
+      *ngFor="let choiceFeedback of bucketFeedback.choices"
+      class="choice-feedback-container notice-bg-bg"
+    >
       <span i18n> Choice: {{ getChoiceTextById(choiceFeedback.choiceId) }} </span>
       <div layout="row">
         <mat-form-field class="feedback">

--- a/src/assets/wise5/components/match/match-authoring/match-authoring.component.scss
+++ b/src/assets/wise5/components/match/match-authoring/match-authoring.component.scss
@@ -17,6 +17,9 @@
 .name {
   width: 60%;
   margin-right: 10px;
+  mat-form-field {
+    width: 100%;
+  }
 }
 
 .choice-ordered-checkbox {

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html
@@ -39,16 +39,18 @@
   class="choice-container"
 >
   <div fxLayout="row wrap" fxLayoutAlign="start center">
-    <mat-form-field class="choice-text-input-container">
-      <mat-label i18n>Choice Text</mat-label>
-      <input
-        matInput
-        [(ngModel)]="choice.text"
-        (ngModelChange)="choiceTextChange.next($event)"
-        i18n-placeholder
-        placeholder="Type text or choose an image"
-      />
-    </mat-form-field>
+    <translatable-input [content]="choice" key="text" class="choice-text-input-container">
+      <mat-form-field>
+        <mat-label i18n>Choice Text</mat-label>
+        <input
+          matInput
+          [(ngModel)]="choice.text"
+          (ngModelChange)="choiceTextChange.next($event)"
+          i18n-placeholder
+          placeholder="Type text or choose an image"
+        />
+      </mat-form-field>
+    </translatable-input>
     <button
       mat-raised-button
       color="primary"
@@ -76,16 +78,18 @@
     </div>
   </div>
   <div fxLayout="row wrap" fxLayoutAlign="start center">
-    <mat-form-field class="choice-feedback-input-container">
-      <mat-label i18n>Feeback</mat-label>
-      <input
-        matInput
-        [(ngModel)]="choice.feedback"
-        (ngModelChange)="feedbackTextChange.next($event)"
-        i18n-placeholder
-        placeholder="Optional"
-      />
-    </mat-form-field>
+    <translatable-input [content]="choice" key="feedback" class="choice-feedback-input-container">
+      <mat-form-field>
+        <mat-label i18n>Feeback</mat-label>
+        <input
+          matInput
+          [(ngModel)]="choice.feedback"
+          (ngModelChange)="feedbackTextChange.next($event)"
+          i18n-placeholder
+          placeholder="Optional"
+        />
+      </mat-form-field>
+    </translatable-input>
     <button
       mat-raised-button
       color="primary"

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.scss
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.scss
@@ -42,6 +42,9 @@ label.mat-radio-label {
 
 .choice-text-input-container, .choice-feedback-input-container {
   width: 70%;
+  mat-form-field {
+    width: 100%;
+  }
 }
 
 .reload-preview-container {

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.spec.ts
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.spec.ts
@@ -16,6 +16,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MultipleChoiceAuthoringHarness } from './multiple-choice-authoring.harness';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { TeacherNodeService } from '../../../services/teacherNodeService';
+import { TranslatableInputComponent } from '../../../authoringTool/components/translatable-input/translatable-input.component';
 
 let component: MultipleChoiceAuthoring;
 let fixture: ComponentFixture<MultipleChoiceAuthoring>;
@@ -36,7 +37,8 @@ describe('MultipleChoiceAuthoringComponent', () => {
           MatIconModule,
           MatInputModule,
           MatRadioModule,
-          StudentTeacherCommonServicesModule
+          StudentTeacherCommonServicesModule,
+          TranslatableInputComponent
         ],
         providers: [ProjectAssetService, TeacherNodeService, TeacherProjectService]
       });
@@ -53,6 +55,7 @@ describe('MultipleChoiceAuthoringComponent', () => {
       showFeedback: true,
       type: 'MultipleChoice'
     };
+    spyOn(TestBed.inject(TeacherProjectService), 'isDefaultLocale').and.returnValue(true);
     fixture.detectChanges();
     multipleChoiceAuthoringHarness = await TestbedHarnessEnvironment.harnessForFixture(
       fixture,

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import { ConfigService } from './configService';
-import { Injectable } from '@angular/core';
+import { Injectable, WritableSignal, signal } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable, Subject, tap } from 'rxjs';
 import { Node } from '../common/Node';
@@ -19,6 +19,7 @@ import { QuestionBank } from '../components/peerChat/peer-chat-question-bank/Que
 import { DynamicPrompt } from '../directives/dynamic-prompt/DynamicPrompt';
 import { Component } from '../common/Component';
 import { ProjectLocale } from '../../../app/domain/projectLocale';
+import { Language } from '../../../app/domain/language';
 
 @Injectable()
 export class ProjectService {
@@ -26,6 +27,9 @@ export class ProjectService {
   additionalProcessingFunctionsMap: any = {};
   allPaths: string[][] = [];
   applicationNodes: any = [];
+  private currentLanguageSignal: WritableSignal<Language> = signal(null);
+  readonly currentLanguage = this.currentLanguageSignal.asReadonly();
+
   flattenedProjectAsNodeIds: any = null;
   groupNodes: any[] = [];
   idToNode: any = {};
@@ -226,6 +230,7 @@ export class ProjectService {
     if (this.project.projectAchievements != null) {
       this.achievements = this.project.projectAchievements;
     }
+    this.currentLanguageSignal.set(this.getLocale().getDefaultLanguage());
     this.broadcastProjectParsed();
   }
 
@@ -2010,5 +2015,13 @@ export class ProjectService {
 
   getLocale(): ProjectLocale {
     return new ProjectLocale(this.project.metadata.locale);
+  }
+
+  setCurrentLanguage(language: Language): void {
+    this.currentLanguageSignal.set(language);
+  }
+
+  isDefaultLocale(): boolean {
+    return this.getLocale().isDefaultLocale(this.currentLanguage().locale);
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -629,15 +629,15 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">95</context>
+          <context context-type="linenumber">97</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">202</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">100</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html</context>
@@ -688,15 +688,15 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">111</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">212</context>
+          <context context-type="linenumber">216</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html</context>
-          <context context-type="linenumber">110</context>
+          <context context-type="linenumber">114</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html</context>
@@ -795,19 +795,19 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">125</context>
+          <context context-type="linenumber">127</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">228</context>
+          <context context-type="linenumber">232</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html</context>
-          <context context-type="linenumber">123</context>
+          <context context-type="linenumber">127</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html</context>
-          <context context-type="linenumber">126</context>
+          <context context-type="linenumber">130</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html</context>
@@ -7580,7 +7580,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">151</context>
+          <context context-type="linenumber">155</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html</context>
@@ -9515,11 +9515,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">237</context>
+          <context context-type="linenumber">241</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">253</context>
+          <context context-type="linenumber">260</context>
         </context-group>
       </trans-unit>
       <trans-unit id="29242856838907f4f025afb9a0467fbe4511c055" datatype="html">
@@ -10009,6 +10009,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/top-bar/top-bar.component.ts</context>
           <context context-type="linenumber">75</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="b64bf5c633699fe1a003ecbc4a29cd3fe8f9ad27" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="{{ labelRef.nativeElement.innerHTML }}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html</context>
+          <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1318680729593701201" datatype="html">
@@ -15275,7 +15282,7 @@ Are you sure you want to proceed?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">63</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ac7627de4d6171adbfba4d934025c8c39debc469" datatype="html">
@@ -15354,23 +15361,23 @@ Are you sure you want to proceed?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">83</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">86</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">184</context>
+          <context context-type="linenumber">188</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">187</context>
+          <context context-type="linenumber">191</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html</context>
-          <context context-type="linenumber">58</context>
+          <context context-type="linenumber">60</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8ba143716c2da6e4120c0c1a804f0bdd9a7e5f5b" datatype="html">
@@ -15415,15 +15422,15 @@ Are you sure you want to proceed?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">98</context>
+          <context context-type="linenumber">100</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">205</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html</context>
-          <context context-type="linenumber">99</context>
+          <context context-type="linenumber">103</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html</context>
@@ -15453,15 +15460,15 @@ Are you sure you want to proceed?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">112</context>
+          <context context-type="linenumber">114</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">215</context>
+          <context context-type="linenumber">219</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html</context>
-          <context context-type="linenumber">113</context>
+          <context context-type="linenumber">117</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html</context>
@@ -18863,113 +18870,113 @@ Warning: This will delete all existing choices and buckets in this component.</s
         <source>Choice Name</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">68</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6b4a8fd4b52fd563b4963ab19f34658e069382d7" datatype="html">
         <source>Type text or choose an image</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">73</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">175</context>
+          <context context-type="linenumber">179</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">50</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b75de65916c3254e808d6757d451c2c9abe56d06" datatype="html">
         <source>Delete Choice</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">122</context>
+          <context context-type="linenumber">124</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1bc6e061f99432db1b8eec4ff9950d9a1d4db009" datatype="html">
         <source>Source Bucket Name</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">134</context>
+          <context context-type="linenumber">137</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7d67cd1ec9de433aecc989c79d8dbe6e46bed75e" datatype="html">
         <source>Target Buckets</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">142</context>
+          <context context-type="linenumber">146</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bfa7f4834e7d273288f8e9cab9e1417a5ad0659d" datatype="html">
         <source>Add Target Bucket</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">148</context>
+          <context context-type="linenumber">152</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f19596381eebb477dab97b17c96d92468fbebced" datatype="html">
         <source> There are no target buckets. Click the &quot;Add Target Bucket&quot; button to add a bucket. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">156,158</context>
+          <context context-type="linenumber">160,162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e36f8feebf8f84ea6d1a1d5db05acaf38556e1f8" datatype="html">
         <source>Target Bucket Name</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">170</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b2f29bd0840c2702dc0fc7fb9c0d90b405b5a21d" datatype="html">
         <source>Delete Bucket</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">225</context>
+          <context context-type="linenumber">229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f3540227c398d8d2a32067863ec5ad68a4bb8274" datatype="html">
         <source> Choices need to be ordered within buckets </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">243,245</context>
+          <context context-type="linenumber">247,249</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e90158c0cc39ddf1bfd591227d3be680d90b08ed" datatype="html">
         <source>Bucket Name: <x id="INTERPOLATION" equiv-text="{{ getBucketNameById(bucketFeedback.bucketId) }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">248</context>
+          <context context-type="linenumber">252</context>
         </context-group>
       </trans-unit>
       <trans-unit id="45d72e3062a6f44cf4ba11188a15a1464c298f2e" datatype="html">
         <source> Choice: <x id="INTERPOLATION" equiv-text="{{ getChoiceTextById(choiceFeedback.choiceId) }}"/> </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">250</context>
+          <context context-type="linenumber">257</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d691ea4cc55c019d5f51686544e8a4976f67e376" datatype="html">
         <source> Is Correct </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">267,269</context>
+          <context context-type="linenumber">274,276</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1ba7568bba29f8d8e352f93e67002d0b548eb838" datatype="html">
         <source>Position</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">273</context>
+          <context context-type="linenumber">280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9f8ca6981e65ef1902817fd074bb92aa4f3cf085" datatype="html">
         <source>Incorrect Position Feedback</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
-          <context context-type="linenumber">282</context>
+          <context context-type="linenumber">289</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2258610804716750608" datatype="html">
@@ -19179,35 +19186,35 @@ Warning: This will delete all existing choices in this component.</source>
         <source>Choice Text</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html</context>
-          <context context-type="linenumber">43</context>
+          <context context-type="linenumber">44</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4488359b3a14b99b193ac292e1f16ee47766ab8b" datatype="html">
         <source>Is Correct</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html</context>
-          <context context-type="linenumber">71</context>
+          <context context-type="linenumber">73</context>
         </context-group>
       </trans-unit>
       <trans-unit id="946344604c321ff0c86a78f6e047f9142b309dd1" datatype="html">
         <source> Is Correct </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html</context>
-          <context context-type="linenumber">73,75</context>
+          <context context-type="linenumber">75,77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e29c5e189e57e8d8dc3f52df4abe7bce4bfca53c" datatype="html">
         <source>Feeback</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">83</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5317cde482fdb766008de3e1ae09cf0610366abc" datatype="html">
         <source>Optional</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html</context>
-          <context context-type="linenumber">86</context>
+          <context context-type="linenumber">89</context>
         </context-group>
       </trans-unit>
       <trans-unit id="deba9a93d665caab3fa0ee8701dc14a482bee9c7" datatype="html">
@@ -21228,112 +21235,112 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Complete &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1196</context>
+          <context context-type="linenumber">1201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4750375498606149231" datatype="html">
         <source>Visit &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1202</context>
+          <context context-type="linenumber">1207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6126058561630526429" datatype="html">
         <source>Correctly answer &lt;b&gt;<x id="PH" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1208</context>
+          <context context-type="linenumber">1213</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7085241847460263487" datatype="html">
         <source>Obtain a score of &lt;b&gt;<x id="PH" equiv-text="scoresString"/>&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1223</context>
+          <context context-type="linenumber">1228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5469027549306748048" datatype="html">
         <source>You must choose &quot;<x id="PH" equiv-text="choiceText"/>&quot; on &quot;<x id="PH_1" equiv-text="nodeTitle"/>&quot;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1231</context>
+          <context context-type="linenumber">1236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6293177000168372990" datatype="html">
         <source>Submit &lt;b&gt;<x id="PH" equiv-text="requiredSubmitCount"/>&lt;/b&gt; time on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1243</context>
+          <context context-type="linenumber">1248</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4693324974790890133" datatype="html">
         <source>Submit &lt;b&gt;<x id="PH" equiv-text="requiredSubmitCount"/>&lt;/b&gt; times on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1245</context>
+          <context context-type="linenumber">1250</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8416169412912074869" datatype="html">
         <source>Take the branch path from &lt;b&gt;<x id="PH" equiv-text="fromNodeTitle"/>&lt;/b&gt; to &lt;b&gt;<x id="PH_1" equiv-text="toNodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1252</context>
+          <context context-type="linenumber">1257</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8087029188038414167" datatype="html">
         <source>Write &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfWords"/>&lt;/b&gt; words on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1258</context>
+          <context context-type="linenumber">1263</context>
         </context-group>
       </trans-unit>
       <trans-unit id="22049568725715518" datatype="html">
         <source>&quot;<x id="PH" equiv-text="nodeTitle"/>&quot; is visible</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1264</context>
+          <context context-type="linenumber">1269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5023130174506669799" datatype="html">
         <source>&quot;<x id="PH" equiv-text="nodeTitle"/>&quot; is visitable</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1270</context>
+          <context context-type="linenumber">1275</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1185133360670447094" datatype="html">
         <source>Add &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfNotes"/>&lt;/b&gt; note on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1277</context>
+          <context context-type="linenumber">1282</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5985921753090789216" datatype="html">
         <source>Add &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfNotes"/>&lt;/b&gt; notes on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1279</context>
+          <context context-type="linenumber">1284</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4560070803879446782" datatype="html">
         <source>You must fill in &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfFilledRows"/>&lt;/b&gt; row in the &lt;b&gt;Table&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1286</context>
+          <context context-type="linenumber">1291</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2804292280751903227" datatype="html">
         <source>You must fill in &lt;b&gt;<x id="PH" equiv-text="requiredNumberOfFilledRows"/>&lt;/b&gt; rows in the &lt;b&gt;Table&lt;/b&gt; on &lt;b&gt;<x id="PH_1" equiv-text="nodeTitle"/>&lt;/b&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1288</context>
+          <context context-type="linenumber">1293</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4171523921205906508" datatype="html">
         <source>Wait for your teacher to unlock the item</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/projectService.ts</context>
-          <context context-type="linenumber">1291</context>
+          <context context-type="linenumber">1296</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8770055323459972095" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10011,8 +10011,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="b64bf5c633699fe1a003ecbc4a29cd3fe8f9ad27" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="{{ labelRef.nativeElement.innerHTML }}"/></source>
+      <trans-unit id="7bd83cfa9e268b699d003e1b37b428995d29fc27" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="{{ defaultLanguageLabelRef.nativeElement.innerHTML }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html</context>
           <context context-type="linenumber">3</context>


### PR DESCRIPTION
## Notes
- Don't worry about styles in this PR

## Changes
- Create TranslatableInputComponent to show translated text for the current language in the input box and allow author to make changes. (Saving those changes is not yet implement)
- Convert some inputs in MC and Match authoring to use TranslatableInputComponent
   - MC: choice text and feedback
   - Match: source bucket and choices
## Test AT (with unit available in multiple languages)
- Switching to a supported language using the language chooser (top-right corner of AT) shows...
   - the correct text in the specified language, if it has been translated before
   - empty box, if it has not been translated before
   - for the MC and Match inputs that have been modified to use the TranslatableInputComponent, check that the placeholder and label appear correctly.
- Making changes
   - in the default language => should save changes as before
   - in a supported language => does nothing at the moment (saving will be implemented in the future)

## Test AT (with single-language unit)
- Authoring works as before