### PR TITLE
fix(Grade by Team): Changing workgroup using select updates status/score

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/student-grading-tools/student-grading-tools.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/student-grading-tools/student-grading-tools.component.ts
@@ -48,6 +48,7 @@ export class StudentGradingToolsComponent implements OnInit {
         .subscribe(({ currentWorkgroup }) => {
           this.workgroupId = currentWorkgroup.workgroupId;
           this.updateModel();
+          this.router.navigate(['team', this.workgroupId], { relativeTo: this.route });
         })
     );
   }
@@ -100,6 +101,5 @@ export class StudentGradingToolsComponent implements OnInit {
 
   protected goToTeam(workgroup: Workgroup): void {
     this.dataService.setCurrentWorkgroup(workgroup);
-    this.router.navigate(['team', workgroup.workgroupId], { relativeTo: this.route });
   }
 }


### PR DESCRIPTION
## Changes
- Changing workgroup using select drop down now also changes the route. Previously only the next and previous buttons would change the route but now using the select drop down also changes the route.

## Test
1. Open the Classroom Monitor for a run
2. Go to the Grade by Team view
3. Click on a team
4. Use the team select drop down to switch to a different team
5. The Status and Score should update. Previously it would show the Status as "No Work" and Score as "-/0" for all the steps even if the workgroup worked on the step and had scores

Closes #1580
