### PR TITLE
feat(Multiple Languages): Show default language text hint below the translatable input box

### DIFF
--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
@@ -8,3 +8,4 @@
     placeholder="{{ defaultLanguageInput.placeholder }}"
   />
 </mat-form-field>
+<span *ngIf="showTranslationInput()">{{ defaultLanguageTextHint() }}</span>

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
@@ -8,4 +8,4 @@
     placeholder="{{ defaultLanguageInput.placeholder }}"
   />
 </mat-form-field>
-<span *ngIf="showTranslationInput()">{{ defaultLanguageTextHint() }}</span>
+<span *ngIf="showTranslationInput()">{{ defaultLanguageText() }}</span>

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
@@ -17,6 +17,7 @@ export class TranslatableInputComponent {
   @Input() content: object;
   @ContentChild(MatInput) defaultLanguageInput: MatInput;
   @ContentChild(MatLabel, { read: ElementRef }) defaultLanguageLabelRef: ElementRef;
+  protected defaultLanguageTextHint: Signal<string>;
   @Input() key: string;
   protected showTranslationInput: Signal<boolean>;
   protected translatedText: Signal<string>;
@@ -30,11 +31,18 @@ export class TranslatableInputComponent {
 
   ngOnInit(): void {
     const i18nId = this.content[`${this.key}.i18n`]?.id;
-    this.translatedText = computed(() => {
-      if (this.showTranslationInput()) {
-        return this.translateProjectService.currentTranslations()[i18nId]?.value ?? '';
-      }
-    });
+    this.translatedText = computed(() =>
+      this.showTranslationInput()
+        ? this.translateProjectService.currentTranslations()[i18nId]?.value
+        : ''
+    );
+    this.defaultLanguageTextHint = computed(() =>
+      this.showTranslationInput()
+        ? $localize`(${this.projectService.getLocale().getDefaultLanguage().language}\: ${
+            this.content[this.key]
+          })`
+        : ''
+    );
   }
 
   protected saveTranslationText(text: string): void {

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
@@ -17,7 +17,7 @@ export class TranslatableInputComponent {
   @Input() content: object;
   @ContentChild(MatInput) defaultLanguageInput: MatInput;
   @ContentChild(MatLabel, { read: ElementRef }) defaultLanguageLabelRef: ElementRef;
-  protected defaultLanguageTextHint: Signal<string>;
+  protected defaultLanguageText: Signal<string>;
   @Input() key: string;
   protected showTranslationInput: Signal<boolean>;
   protected translatedText: Signal<string>;
@@ -36,7 +36,7 @@ export class TranslatableInputComponent {
         ? this.translateProjectService.currentTranslations()[i18nId]?.value
         : ''
     );
-    this.defaultLanguageTextHint = computed(() =>
+    this.defaultLanguageText = computed(() =>
       this.showTranslationInput()
         ? $localize`(${this.projectService.getLocale().getDefaultLanguage().language}\: ${
             this.content[this.key]

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10123,6 +10123,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="4565494938772544139" datatype="html">
+        <source>(<x id="PH" equiv-text="this.projectService.getLocale().getDefaultLanguage().language"/>: <x id="PH_1" equiv-text="this.content[this.key]"/>)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts</context>
+          <context context-type="linenumber">41,43</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1318680729593701201" datatype="html">
         <source>Also currently editing this unit: <x id="PH" equiv-text="otherAuthors.join(
               &apos;, &apos;


### PR DESCRIPTION
## Notes
- Don't worry about styles in this PR

## Changes
- Show default language text hint below the translatable input box. This only appears when the current language is not the default language
- Cleaned up code to compute translatedText using ternary statement

## Test AT (with unit available in multiple languages)
- Switching to a supported language using the language chooser (top-right corner of AT) shows the default language text hint below the translatable input box
- Switching to the default language using the language chooser hides the default language text hint