### PR TITLE
feat(Multiple Languages): Convert EditComponentPrompt input to TranslatableInput

### DIFF
--- a/src/app/authoring-tool/edit-component-prompt/edit-component-prompt.component.html
+++ b/src/app/authoring-tool/edit-component-prompt/edit-component-prompt.component.html
@@ -2,7 +2,7 @@
   <mat-label i18n>Prompt</mat-label>
   <textarea
     matInput
-    [(ngModel)]="prompt"
+    [(ngModel)]="componentContent.prompt"
     (ngModelChange)="promptChangedEvent.next($event)"
     placeholder="Enter Prompt Here"
     i18n-placeholder

--- a/src/app/authoring-tool/edit-component-prompt/edit-component-prompt.component.html
+++ b/src/app/authoring-tool/edit-component-prompt/edit-component-prompt.component.html
@@ -1,12 +1,14 @@
-<mat-form-field class="prompt" appearance="fill">
-  <mat-label i18n>Prompt</mat-label>
-  <textarea
-    matInput
-    [(ngModel)]="componentContent.prompt"
-    (ngModelChange)="promptChangedEvent.next($event)"
-    placeholder="Enter Prompt Here"
-    i18n-placeholder
-    cdkTextareaAutosize
-  >
-  </textarea>
-</mat-form-field>
+<translatable-input [content]="componentContent" key="prompt" class="prompt" appearance="fill">
+  <mat-form-field>
+    <mat-label i18n>Prompt</mat-label>
+    <textarea
+      matInput
+      [(ngModel)]="componentContent.prompt"
+      (ngModelChange)="promptChangedEvent.next($event)"
+      placeholder="Enter Prompt Here"
+      i18n-placeholder
+      cdkTextareaAutosize
+    >
+    </textarea>
+  </mat-form-field>
+</translatable-input>

--- a/src/app/authoring-tool/edit-component-prompt/edit-component-prompt.component.ts
+++ b/src/app/authoring-tool/edit-component-prompt/edit-component-prompt.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ComponentContent } from '../../../assets/wise5/common/ComponentContent';
 
 @Component({
   selector: 'edit-component-prompt',
@@ -6,9 +7,6 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
   templateUrl: 'edit-component-prompt.component.html'
 })
 export class EditComponentPrompt {
-  @Input()
-  prompt: string;
-
-  @Output()
-  promptChangedEvent = new EventEmitter<string>();
+  @Input() componentContent: ComponentContent;
+  @Output() promptChangedEvent = new EventEmitter<string>();
 }

--- a/src/app/authoring-tool/edit-component-prompt/edit-component-prompt.component.ts
+++ b/src/app/authoring-tool/edit-component-prompt/edit-component-prompt.component.ts
@@ -3,7 +3,7 @@ import { ComponentContent } from '../../../assets/wise5/common/ComponentContent'
 
 @Component({
   selector: 'edit-component-prompt',
-  styles: ['.prompt {width: 100%; }'],
+  styles: ['.prompt {width: 100%; mat-form-field { width:100%} }'],
   templateUrl: 'edit-component-prompt.component.html'
 })
 export class EditComponentPrompt {

--- a/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.html
+++ b/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.html
@@ -1,5 +1,5 @@
 <edit-component-prompt
-  [prompt]="componentContent.prompt"
+  [componentContent]="componentContent"
   (promptChangedEvent)="promptChanged($event)"
 ></edit-component-prompt>
 <div fxLayout="row">

--- a/src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.html
+++ b/src/assets/wise5/components/audioOscillator/audio-oscillator-authoring/audio-oscillator-authoring.component.html
@@ -1,5 +1,5 @@
 <edit-component-prompt
-  [prompt]="componentContent.prompt"
+  [componentContent]="componentContent"
   (promptChangedEvent)="promptChanged($event)"
 ></edit-component-prompt>
 <span i18n>Oscillator Types</span>

--- a/src/assets/wise5/components/conceptMap/concept-map-authoring/concept-map-authoring.component.html
+++ b/src/assets/wise5/components/conceptMap/concept-map-authoring/concept-map-authoring.component.html
@@ -1,6 +1,6 @@
 <div fxLayout="column" fxLayoutGap="16px">
   <edit-component-prompt
-    [prompt]="componentContent.prompt"
+    [componentContent]="componentContent"
     (promptChangedEvent)="promptChanged($event)"
   ></edit-component-prompt>
   <div fxLayoutGap="16px">

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.html
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.html
@@ -1,6 +1,6 @@
 <div fxLayout="column" fxLayoutGap="16px">
   <edit-component-prompt
-    [prompt]="componentContent.prompt"
+    [componentContent]="componentContent"
     (promptChangedEvent)="promptChanged($event)"
   ></edit-component-prompt>
   <mat-form-field>

--- a/src/assets/wise5/components/discussion/discussion-authoring/discussion-authoring.component.html
+++ b/src/assets/wise5/components/discussion/discussion-authoring/discussion-authoring.component.html
@@ -1,5 +1,5 @@
 <edit-component-prompt
-  [prompt]="componentContent.prompt"
+  [componentContent]="componentContent"
   (promptChangedEvent)="promptChanged($event)"
 ></edit-component-prompt>
 <div class="checkbox-container">

--- a/src/assets/wise5/components/draw/draw-authoring/draw-authoring.component.html
+++ b/src/assets/wise5/components/draw/draw-authoring/draw-authoring.component.html
@@ -1,5 +1,5 @@
 <edit-component-prompt
-  [prompt]="componentContent.prompt"
+  [componentContent]="componentContent"
   (promptChangedEvent)="promptChanged($event)"
 ></edit-component-prompt>
 <div fxLayout="row" fxLayoutAlign="start center">

--- a/src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.html
+++ b/src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.html
@@ -1,5 +1,5 @@
 <edit-component-prompt
-  [prompt]="componentContent.prompt"
+  [componentContent]="componentContent"
   (promptChangedEvent)="promptChanged($event)"
 ></edit-component-prompt>
 <div fxLayout="row wrap">

--- a/src/assets/wise5/components/label/label-authoring/label-authoring.component.html
+++ b/src/assets/wise5/components/label/label-authoring/label-authoring.component.html
@@ -1,5 +1,5 @@
 <edit-component-prompt
-  [prompt]="componentContent.prompt"
+  [componentContent]="componentContent"
   (promptChangedEvent)="promptChanged($event)"
 ></edit-component-prompt>
 <div>

--- a/src/assets/wise5/components/match/match-authoring/match-authoring.component.html
+++ b/src/assets/wise5/components/match/match-authoring/match-authoring.component.html
@@ -1,5 +1,5 @@
 <edit-component-prompt
-  [prompt]="componentContent.prompt"
+  [componentContent]="componentContent"
   (promptChangedEvent)="promptChanged($event)"
 ></edit-component-prompt>
 <p>

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html
@@ -1,5 +1,5 @@
 <edit-component-prompt
-  [prompt]="componentContent.prompt"
+  [componentContent]="componentContent"
   (promptChangedEvent)="promptChanged($event)"
 ></edit-component-prompt>
 <p>

--- a/src/assets/wise5/components/openResponse/open-response-authoring/open-response-authoring.component.html
+++ b/src/assets/wise5/components/openResponse/open-response-authoring/open-response-authoring.component.html
@@ -11,7 +11,7 @@
         >announcement</mat-icon
       >
       <edit-component-prompt
-        [prompt]="componentContent.prompt"
+        [componentContent]="componentContent"
         (promptChangedEvent)="promptChanged($event)"
       ></edit-component-prompt>
     </div>

--- a/src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html
+++ b/src/assets/wise5/components/peerChat/peer-chat-authoring/peer-chat-authoring.component.html
@@ -1,6 +1,6 @@
 <edit-component-prompt
   *ngIf="!componentContent.dynamicPrompt?.enabled"
-  [prompt]="componentContent.prompt"
+  [componentContent]="componentContent"
   (promptChangedEvent)="promptChanged($event)"
 ></edit-component-prompt>
 <edit-dynamic-prompt

--- a/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.html
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.html
@@ -1,5 +1,5 @@
 <edit-component-prompt
-  [prompt]="componentContent.prompt"
+  [componentContent]="componentContent"
   (promptChangedEvent)="promptChanged($event)"
 ></edit-component-prompt>
 <div fxLayoutGap="20px">

--- a/src/assets/wise5/components/showMyWork/show-my-work-authoring/show-my-work-authoring.component.html
+++ b/src/assets/wise5/components/showMyWork/show-my-work-authoring/show-my-work-authoring.component.html
@@ -1,5 +1,5 @@
 <edit-component-prompt
-  [prompt]="componentContent.prompt"
+  [componentContent]="componentContent"
   (promptChangedEvent)="promptChanged($event)"
 ></edit-component-prompt>
 <div fxLayoutGap="20px">

--- a/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html
+++ b/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html
@@ -1,5 +1,5 @@
 <edit-component-prompt
-  [prompt]="componentContent.prompt"
+  [componentContent]="componentContent"
   (promptChangedEvent)="promptChanged($event)"
 ></edit-component-prompt>
 <p i18n>Choose the step and component to show the summary data for:</p>

--- a/src/assets/wise5/components/table/table-authoring/table-authoring.component.html
+++ b/src/assets/wise5/components/table/table-authoring/table-authoring.component.html
@@ -1,5 +1,5 @@
 <edit-component-prompt
-  [prompt]="componentContent.prompt"
+  [componentContent]="componentContent"
   (promptChangedEvent)="promptChanged($event)"
 ></edit-component-prompt>
 <div fxLayout="row wrap">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -967,7 +967,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Prompt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-component-prompt/edit-component-prompt.component.html</context>
-          <context context-type="linenumber">2</context>
+          <context context-type="linenumber">3</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-dynamic-prompt-rules/edit-dynamic-prompt-rules.component.html</context>
@@ -986,7 +986,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Enter Prompt Here</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-component-prompt/edit-component-prompt.component.html</context>
-          <context context-type="linenumber">7</context>
+          <context context-type="linenumber">8</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7affaae0e14529c0192d5a4bfabd6fcb1ea27529" datatype="html">


### PR DESCRIPTION
## Notes
- Don't worry about styles in this PR
 
## Changes
- Pass in ComponentContent object to EditComponentPrompt instead of just the prompt string. This lets us convert the input to TranslatableInput.
- Convert EditComponentPrompt's input to TranslatableInput

## Test in AT
These should apply to all components, but you can just test with handful of components to save time (since they all use the same code in EditComponentPrompt):
- In default language, editing prompt should save as before
- Switching to a supported language using the language chooser (top-right corner of AT)...
   - shows the correct prompt text in the specified language, if it has been translated before
   - shows empty box, if it has not been translated before
   - shows the placeholder and label appear correctly
   - making changes to the prompt does nothing at the moment (saving will be implemented in the future)