### PR TITLE
refactor(Archive Run): Reference run.project.archived field

### DIFF
--- a/src/app/teacher/run-menu/run-menu.component.html
+++ b/src/app/teacher/run-menu/run-menu.component.html
@@ -29,11 +29,11 @@
       <mat-icon>report_problem</mat-icon>
       <span i18n>Report Problem</span>
     </a>
-    <a mat-menu-item *ngIf="!run.archived" (click)="archive(true)">
+    <a mat-menu-item *ngIf="!run.project.archived" (click)="archive(true)">
       <mat-icon>archive</mat-icon>
       <span i18n>Archive</span>
     </a>
-    <a mat-menu-item *ngIf="run.archived" (click)="archive(false)">
+    <a mat-menu-item *ngIf="run.project.archived" (click)="archive(false)">
       <mat-icon>unarchive</mat-icon>
       <span i18n>Restore</span>
     </a>

--- a/src/app/teacher/run-menu/run-menu.component.spec.ts
+++ b/src/app/teacher/run-menu/run-menu.component.spec.ts
@@ -11,7 +11,7 @@ import { TeacherRun } from '../teacher-run';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { Course } from '../../domain/course';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ArchiveProjectService } from '../../services/archive-project.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -121,11 +121,11 @@ function setRun(archived: boolean): void {
     name: 'Photosynthesis',
     owner: owner,
     project: {
+      archived: archived,
       id: 1,
       owner: owner,
       sharedOwners: []
-    },
-    archived: archived
+    }
   });
 }
 
@@ -133,18 +133,18 @@ function archive() {
   describe('archive()', () => {
     it('should archive a run', async () => {
       await runMenuHarness.clickArchiveMenuButton();
-      expect(component.run.archived).toEqual(true);
+      expect(component.run.project.archived).toEqual(true);
       const snackBar = await getSnackBar();
       expect(await snackBar.getMessage()).toEqual('Successfully archived unit.');
     });
     it('should archive a run and then undo', async () => {
       await runMenuHarness.clickArchiveMenuButton();
-      expect(component.run.archived).toEqual(true);
+      expect(component.run.project.archived).toEqual(true);
       let snackBar = await getSnackBar();
       expect(await snackBar.getMessage()).toEqual('Successfully archived unit.');
       expect(await snackBar.getActionDescription()).toEqual('Undo');
       await snackBar.dismissWithAction();
-      expect(component.run.archived).toEqual(false);
+      expect(component.run.project.archived).toEqual(false);
       snackBar = await getSnackBar();
       expect(await snackBar.getMessage()).toEqual('Action undone.');
     });
@@ -157,7 +157,7 @@ function unarchive() {
       setRun(true);
       component.ngOnInit();
       await runMenuHarness.clickUnarchiveMenuButton();
-      expect(component.run.archived).toEqual(false);
+      expect(component.run.project.archived).toEqual(false);
       const snackBar = await getSnackBar();
       expect(await snackBar.getMessage()).toEqual('Successfully restored unit.');
     });
@@ -165,12 +165,12 @@ function unarchive() {
       setRun(true);
       component.ngOnInit();
       await runMenuHarness.clickUnarchiveMenuButton();
-      expect(component.run.archived).toEqual(false);
+      expect(component.run.project.archived).toEqual(false);
       let snackBar = await getSnackBar();
       expect(await snackBar.getMessage()).toEqual('Successfully restored unit.');
       expect(await snackBar.getActionDescription()).toEqual('Undo');
       await snackBar.dismissWithAction();
-      expect(component.run.archived).toEqual(true);
+      expect(component.run.project.archived).toEqual(true);
       snackBar = await getSnackBar();
       expect(await snackBar.getMessage()).toEqual('Action undone.');
     });

--- a/src/app/teacher/run-menu/run-menu.component.ts
+++ b/src/app/teacher/run-menu/run-menu.component.ts
@@ -111,7 +111,7 @@ export class RunMenuComponent implements OnInit {
   }
 
   private updateArchivedStatus(run: TeacherRun, archived: boolean): void {
-    run.archived = archived;
+    run.project.archived = archived;
     this.runArchiveStatusChangedEvent.emit();
   }
 
@@ -127,7 +127,7 @@ export class RunMenuComponent implements OnInit {
   private undoArchiveAction(run: TeacherRun, archiveFunctionName: string): void {
     this.archiveProjectService[archiveFunctionName](run.project).subscribe({
       next: (response: ArchiveProjectResponse) => {
-        run.archived = response.archived;
+        run.project.archived = response.archived;
         this.archiveProjectService.refreshProjects();
         this.snackBar.open($localize`Action undone.`);
       },

--- a/src/app/teacher/select-runs-controls/select-runs-controls.component.ts
+++ b/src/app/teacher/select-runs-controls/select-runs-controls.component.ts
@@ -72,7 +72,7 @@ export class SelectRunsControlsComponent {
   ): void {
     for (const archiveProjectResponse of archiveProjectsResponse) {
       const run = runs.find((run: TeacherRun) => run.project.id === archiveProjectResponse.id);
-      run.archived = archiveProjectResponse.archived;
+      run.project.archived = archiveProjectResponse.archived;
     }
     this.archiveActionEvent.emit();
   }

--- a/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
+++ b/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
@@ -152,11 +152,10 @@ export class TeacherRunListComponent implements OnInit {
   }
 
   private performFilter(): void {
-    this.filteredRuns = this.filteredRuns.filter((run: TeacherRun) => {
-      return (
+    this.filteredRuns = this.filteredRuns.filter(
+      (run: TeacherRun) =>
         (!this.showArchived && !run.project.archived) || (this.showArchived && run.project.archived)
-      );
-    });
+    );
   }
 
   private performSearch(searchValue: string): TeacherRun[] {

--- a/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
+++ b/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
@@ -77,7 +77,7 @@ export class TeacherRunListComponent implements OnInit {
     this.runs = runs.map((run) => {
       const teacherRun = new TeacherRun(run);
       teacherRun.shared = !teacherRun.isOwner(userId);
-      teacherRun.archived = teacherRun.project.tags.includes('archived');
+      teacherRun.project.archived = teacherRun.project.tags.includes('archived');
       return teacherRun;
     });
     this.filteredRuns = this.runs;
@@ -153,7 +153,9 @@ export class TeacherRunListComponent implements OnInit {
 
   private performFilter(): void {
     this.filteredRuns = this.filteredRuns.filter((run: TeacherRun) => {
-      return (!this.showArchived && !run.archived) || (this.showArchived && run.archived);
+      return (
+        (!this.showArchived && !run.project.archived) || (this.showArchived && run.project.archived)
+      );
     });
   }
 


### PR DESCRIPTION
## Changes
- Archive run now uses the run.project.archived field instead of run.archived. This is so we have a common field to reference whether we are archiving a run in the class schedule or archiving a unit in the library.

## Test
- Make sure archiving/restoring runs using the global archive/restore button works
- Make sure archiving/restoring a run from the run menu works
- Make sure archive/restore undo works