### PR TITLE
feat(Multiple Languages): Convert language chooser to menu

### DIFF
--- a/src/app/common/project-language-chooser/project-language-chooser.component.html
+++ b/src/app/common/project-language-chooser/project-language-chooser.component.html
@@ -1,4 +1,9 @@
-<button mat-icon-button [matMenuTriggerFor]="languageSelect" matTooltip="Select Language">
+<button
+  mat-icon-button
+  [matMenuTriggerFor]="languageSelect"
+  matTooltip="Select Language"
+  i18n-matTooltip
+>
   <mat-icon>translate</mat-icon>
 </button>
 <mat-menu #languageSelect="matMenu">

--- a/src/app/common/project-language-chooser/project-language-chooser.component.html
+++ b/src/app/common/project-language-chooser/project-language-chooser.component.html
@@ -1,12 +1,13 @@
-<span i18n>Language:</span>
-<mat-form-field fxFlex appearance="fill">
-  <mat-select
-    [(ngModel)]="selectedLanguage"
-    (ngModelChange)="languageChangedEvent.emit(selectedLanguage)"
-    [compareWith]="isSameLanguage"
+<button mat-icon-button [matMenuTriggerFor]="languageSelect" matTooltip="Select Language">
+  <mat-icon>translate</mat-icon>
+</button>
+<mat-menu #languageSelect="matMenu">
+  <button
+    *ngFor="let language of availableLanguages"
+    mat-menu-item
+    (click)="changeLanguage(language)"
+    [class]="{ primary: language.locale === selectedLanguage.locale }"
   >
-    <mat-option *ngFor="let language of availableLanguages" [value]="language">
-      {{ language.language }}
-    </mat-option>
-  </mat-select>
-</mat-form-field>
+    {{ language.language }}
+  </button>
+</mat-menu>

--- a/src/app/common/project-language-chooser/project-language-chooser.component.spec.ts
+++ b/src/app/common/project-language-chooser/project-language-chooser.component.spec.ts
@@ -5,8 +5,7 @@ import { ProjectLocale } from '../../domain/projectLocale';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { MatSelectHarness } from '@angular/material/select/testing';
-import { MatOptionHarness } from '@angular/material/core/testing';
+import { MatMenuHarness, MatMenuItemHarness } from '@angular/material/menu/testing';
 
 let loader: HarnessLoader;
 let component: ProjectLanguageChooserComponent;
@@ -31,14 +30,17 @@ describe('ProjectLanguageChooserComponent', () => {
     expect(await options[0].getText()).toMatch('English');
     expect(await options[1].getText()).toMatch('Japanese');
     expect(await options[2].getText()).toMatch('Spanish');
-    expect(await options[0].isSelected()).toBeTrue();
+    const selected = await options[0].host();
+    expect(await selected.getAttribute('class')).toContain('primary');
   });
 
   it('keeps selected language option when language option changes', async () => {
-    const selectHarness = await loader.getHarness(MatSelectHarness);
-    await selectHarness.clickOptions({ text: 'Japanese' });
+    const menuHarness = await loader.getHarness(MatMenuHarness);
+    await menuHarness.clickItem({ text: 'Japanese' });
     setProjectLocale(new ProjectLocale({ default: 'it', supported: ['de', 'fr', 'ja', 'es'] }));
-    expect(await selectHarness.getValueText()).toEqual('Japanese');
+    const options = await getOptions();
+    const selected = await options[3].host();
+    expect(await selected.getAttribute('class')).toContain('primary');
   });
 });
 
@@ -48,8 +50,8 @@ function setProjectLocale(locale: ProjectLocale): void {
   fixture.detectChanges();
 }
 
-async function getOptions(): Promise<MatOptionHarness[]> {
-  const selectHarness = await loader.getHarness(MatSelectHarness);
-  await selectHarness.open();
-  return await selectHarness.getOptions();
+async function getOptions(): Promise<MatMenuItemHarness[]> {
+  const menuHarness = await loader.getHarness(MatMenuHarness);
+  await menuHarness.open();
+  return await menuHarness.getItems();
 }

--- a/src/app/common/project-language-chooser/project-language-chooser.component.ts
+++ b/src/app/common/project-language-chooser/project-language-chooser.component.ts
@@ -1,15 +1,16 @@
 import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
-import { FormsModule } from '@angular/forms';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectModule } from '@angular/material/select';
 import { Language } from '../../domain/language';
 import { ProjectLocale } from '../../domain/projectLocale';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
   standalone: true,
   selector: 'project-language-chooser',
-  imports: [CommonModule, FormsModule, MatFormFieldModule, MatSelectModule],
+  imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule, MatTooltipModule],
   templateUrl: './project-language-chooser.component.html'
 })
 export class ProjectLanguageChooserComponent implements OnChanges {
@@ -28,7 +29,8 @@ export class ProjectLanguageChooserComponent implements OnChanges {
     }
   }
 
-  protected isSameLanguage(lang1: Language, lang2: Language): boolean {
-    return lang1 && lang2 ? lang1.locale === lang2.locale : lang1 === lang2;
+  protected changeLanguage(language: Language): void {
+    this.selectedLanguage = language;
+    this.languageChangedEvent.emit(language);
   }
 }

--- a/src/app/student/top-bar/top-bar.component.html
+++ b/src/app/student/top-bar/top-bar.component.html
@@ -25,29 +25,27 @@
       </button>
       <span *ngIf="isConstraintsDisabled" i18n>Constraints Are Off</span>
     </div>
-    <project-language-chooser
-      *ngIf="hasTranslations"
-      [projectLocale]="projectLocale"
-      (languageChangedEvent)="changeLanguage($event)"
-    ></project-language-chooser>
-    <div fxLayout="row" fxLayoutGap="16px">
-      <div>
-        <button
-          mat-icon-button
-          (click)="viewAlerts($event)"
-          id="viewNotificationsButton"
-          aria-label="View alerts"
-          i18n-aria-label
-          class="alerts"
+    <div fxLayout="row" fxLayoutGap="4px">
+      <project-language-chooser
+        *ngIf="hasTranslations"
+        [projectLocale]="projectLocale"
+        (languageChangedEvent)="changeLanguage($event)"
+      ></project-language-chooser>
+      <button
+        mat-icon-button
+        (click)="viewAlerts($event)"
+        id="viewNotificationsButton"
+        aria-label="View alerts"
+        i18n-aria-label
+        class="alerts"
+      >
+        <mat-icon
+          matBadge="{{ newNotifications.length }}"
+          matBadgeColor="accent"
+          [matBadgeHidden]="!hasNewNotifications()"
+          >notifications</mat-icon
         >
-          <mat-icon
-            matBadge="{{ newNotifications.length }}"
-            matBadgeColor="accent"
-            [matBadgeHidden]="!hasNewNotifications()"
-            >notifications</mat-icon
-          >
-        </button>
-      </div>
+      </button>
       <div class="account-menu-container">
         <mat-progress-spinner
           class="menu-progress"

--- a/src/assets/wise5/authoringTool/components/top-bar/top-bar.component.html
+++ b/src/assets/wise5/authoringTool/components/top-bar/top-bar.component.html
@@ -1,38 +1,42 @@
-<mat-toolbar class="l-header" color="primary">
+<mat-toolbar
+  class="l-header"
+  color="primary"
+  fxLayout="row"
+  fxLayoutAlign="start center"
+  fxLayoutGap="4px"
+>
   <span class="button logo-link">
     <a href="{{ contextPath }}/teacher" target="_self">
       <img [src]="logoPath" alt="WISE logo" i18n-alt class="logo" />
     </a>
   </span>
-  <h3 fxLayout="row" fxLayoutAlign="start center" class="title-header">
+  <h3 class="title-header">
     <span *ngIf="projectTitle" id="projectTitleSpan">{{ projectTitle }}</span>
     <span *ngIf="!projectTitle" id="projectTitleSpan" i18n>Authoring Tool</span>&nbsp;
-    <span class="mat-caption" *ngIf="projectId" fxLayout="row" fxLayoutAlign="start center">
-      <span fxHide.xs fxHide.sm fxHide.md>({{ projectInfo }})</span>
-      <button
-        mat-icon-button
-        aria-label="Project Info"
-        i18n-aria-label
-        fxHide.gt-md
-        [matTooltip]="projectInfo"
-      >
-        <mat-icon>info</mat-icon>
-      </button>
-      <button
-        mat-icon-button
-        *ngIf="runId"
-        fxHide.xs
-        matTooltip="Switch to Grading View"
-        i18n-matTooltip
-        (click)="switchToGradingView()"
-      >
-        <mat-icon mat-menu-origin>assignment_turned_in</mat-icon>
-      </button>
-      <button mat-icon-button matTooltip="Preview Unit" i18n-matTooltip (click)="previewProject()">
-        <mat-icon>preview</mat-icon>
-      </button>
-    </span>
+    <span class="mat-caption" fxHide.xs fxHide.sm fxHide.md>({{ projectInfo }})</span>
   </h3>
+  <button
+    mat-icon-button
+    aria-label="Project Info"
+    i18n-aria-label
+    fxHide.gt-md
+    [matTooltip]="projectInfo"
+  >
+    <mat-icon>info</mat-icon>
+  </button>
+  <button
+    mat-icon-button
+    *ngIf="runId"
+    fxHide.xs
+    matTooltip="Switch to Grading View"
+    i18n-matTooltip
+    (click)="switchToGradingView()"
+  >
+    <mat-icon mat-menu-origin>assignment_turned_in</mat-icon>
+  </button>
+  <button mat-icon-button matTooltip="Preview Unit" i18n-matTooltip (click)="previewProject()">
+    <mat-icon>preview</mat-icon>
+  </button>
   <span fxFlex></span>
   <project-language-chooser
     *ngIf="hasTranslations"

--- a/src/assets/wise5/authoringTool/components/top-bar/top-bar.component.scss
+++ b/src/assets/wise5/authoringTool/components/top-bar/top-bar.component.scss
@@ -18,7 +18,6 @@
 }
 
 .mat-mdc-icon-button {
-  margin: 0 4px;
   font-size: 16px;
 }
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1866,6 +1866,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">61</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="65f3c9045a86c9daedfe950eebe44ce2392607de" datatype="html">
+        <source>Select Language</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/common/project-language-chooser/project-language-chooser.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="4c00c8f929591b166c1e22e74a414a4dd42ff00b" datatype="html">
         <source>Thank you for contacting WISE!</source>
         <context-group purpose="location">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1153,7 +1153,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/top-bar/top-bar.component.html</context>
-          <context context-type="linenumber">44</context>
+          <context context-type="linenumber">48</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.html</context>
@@ -1461,7 +1461,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/top-bar/top-bar.component.html</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">37</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/top-bar/top-bar.component.html</context>
@@ -1864,13 +1864,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/author-peer-grouping-dialog/author-peer-grouping-dialog.component.ts</context>
           <context context-type="linenumber">61</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3bb351ea6c98d11eb111708c2d620a3e79029ee6" datatype="html">
-        <source>Language:</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/common/project-language-chooser/project-language-chooser.component.html</context>
-          <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4c00c8f929591b166c1e22e74a414a4dd42ff00b" datatype="html">
@@ -5158,7 +5151,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/top-bar/top-bar.component.html</context>
-          <context context-type="linenumber">4</context>
+          <context context-type="linenumber">10</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/top-bar/top-bar.component.html</context>
@@ -8078,21 +8071,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>View alerts</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/student/top-bar/top-bar.component.html</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">38</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c0961a71d775c905195f97cfd155f9b34052b1c6" datatype="html">
         <source>Unit percent completed</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/student/top-bar/top-bar.component.html</context>
-          <context context-type="linenumber">58</context>
+          <context context-type="linenumber">56</context>
         </context-group>
       </trans-unit>
       <trans-unit id="72778a65e8adb61055af9ac6e0f5dc566502ed16" datatype="html">
         <source>Open Account Menu</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/student/top-bar/top-bar.component.html</context>
-          <context context-type="linenumber">68</context>
+          <context context-type="linenumber">66</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e438ba78cbafdb5bcbce0820bfaad995a504f222" datatype="html">
@@ -9029,7 +9022,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/top-bar/top-bar.component.html</context>
-          <context context-type="linenumber">9</context>
+          <context context-type="linenumber">15</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4778985982508820766" datatype="html">
@@ -10048,28 +10041,28 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Project Info</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/top-bar/top-bar.component.html</context>
-          <context context-type="linenumber">14</context>
+          <context context-type="linenumber">20</context>
         </context-group>
       </trans-unit>
       <trans-unit id="14a1210f8f622c4a380ea92081b3fe68ef434da8" datatype="html">
         <source>Switch to Grading View</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/top-bar/top-bar.component.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b8ae83571c90788bf730befdbb3de4c7cf14ed8e" datatype="html">
         <source> Help </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/top-bar/top-bar.component.html</context>
-          <context context-type="linenumber">49,51</context>
+          <context context-type="linenumber">53,55</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ffac8783eaf153173408c8a9014a7484fa6a9175" datatype="html">
         <source>User Menu</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/top-bar/top-bar.component.html</context>
-          <context context-type="linenumber">54</context>
+          <context context-type="linenumber">58</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/top-bar/top-bar.component.html</context>
@@ -10080,7 +10073,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source> Go Home </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/top-bar/top-bar.component.html</context>
-          <context context-type="linenumber">79,81</context>
+          <context context-type="linenumber">83,85</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/top-bar/top-bar.component.html</context>
@@ -10091,7 +10084,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source> Sign Out </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/top-bar/top-bar.component.html</context>
-          <context context-type="linenumber">83,85</context>
+          <context context-type="linenumber">87,89</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/top-bar/top-bar.component.html</context>


### PR DESCRIPTION
## Changes
- Replace mat-select for language chooser with mat-menu and icon button trigger.
- Clean up some styles/layout in the authoring and VLE top bars.

## Test
- Make sure switching languages still works as before in the authoring tool and VLE.
- Make sure currently selected language is indicated (with primary color text) in the language select menu.
