### PR TITLE
feat(Multiple Languages): Show current language in TranslatableInput's label

### DIFF
--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
@@ -1,6 +1,6 @@
 <ng-content *ngIf="!showTranslationInput()"></ng-content>
 <mat-form-field *ngIf="showTranslationInput()">
-  <mat-label i18n
+  <mat-label
     >{{ defaultLanguageLabelRef.nativeElement.innerHTML }} ({{
       currentLanguage().language
     }})</mat-label

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
@@ -1,6 +1,10 @@
 <ng-content *ngIf="!showTranslationInput()"></ng-content>
 <mat-form-field *ngIf="showTranslationInput()">
-  <mat-label i18n>{{ defaultLanguageLabelRef.nativeElement.innerHTML }}</mat-label>
+  <mat-label i18n
+    >{{ defaultLanguageLabelRef.nativeElement.innerHTML }} ({{
+      currentLanguage().language
+    }})</mat-label
+  >
   <input
     matInput
     [ngModel]="translatedText()"

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
@@ -5,6 +5,7 @@ import { MatInput, MatInputModule } from '@angular/material/input';
 import { FormsModule } from '@angular/forms';
 import { TranslateProjectService } from '../../../services/translateProjectService';
 import { MatLabel } from '@angular/material/form-field';
+import { Language } from '../../../../../app/domain/language';
 
 @Component({
   standalone: true,
@@ -15,6 +16,7 @@ import { MatLabel } from '@angular/material/form-field';
 })
 export class TranslatableInputComponent {
   @Input() content: object;
+  protected currentLanguage: Signal<Language>;
   @ContentChild(MatInput) defaultLanguageInput: MatInput;
   @ContentChild(MatLabel, { read: ElementRef }) defaultLanguageLabelRef: ElementRef;
   protected defaultLanguageText: Signal<string>;
@@ -26,6 +28,7 @@ export class TranslatableInputComponent {
     private projectService: TeacherProjectService,
     private translateProjectService: TranslateProjectService
   ) {
+    this.currentLanguage = projectService.currentLanguage;
     this.showTranslationInput = computed(() => !this.projectService.isDefaultLocale());
   }
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10116,18 +10116,20 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7bd83cfa9e268b699d003e1b37b428995d29fc27" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="{{ defaultLanguageLabelRef.nativeElement.innerHTML }}"/></source>
+      <trans-unit id="735cfe8637753e64e9adb0e901dcd4b24a3c8aea" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="{{ defaultLanguageLabelRef.nativeElement.innerHTML }}"/> (<x id="INTERPOLATION_1" equiv-text="{{
+      currentLanguage().language
+    }}"/>)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html</context>
-          <context context-type="linenumber">3</context>
+          <context context-type="linenumber">4,6</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4565494938772544139" datatype="html">
         <source>(<x id="PH" equiv-text="this.projectService.getLocale().getDefaultLanguage().language"/>: <x id="PH_1" equiv-text="this.content[this.key]"/>)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts</context>
-          <context context-type="linenumber">41,43</context>
+          <context context-type="linenumber">44,46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1318680729593701201" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10116,15 +10116,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="735cfe8637753e64e9adb0e901dcd4b24a3c8aea" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="{{ defaultLanguageLabelRef.nativeElement.innerHTML }}"/> (<x id="INTERPOLATION_1" equiv-text="{{
-      currentLanguage().language
-    }}"/>)</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html</context>
-          <context context-type="linenumber">4,6</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="4565494938772544139" datatype="html">
         <source>(<x id="PH" equiv-text="this.projectService.getLocale().getDefaultLanguage().language"/>: <x id="PH_1" equiv-text="this.content[this.key]"/>)</source>
         <context-group purpose="location">


### PR DESCRIPTION
## Changes
- Display language word directly in the TranslatableInput label  “[label] (Language)”, e.g. "Prompt (Japanese)", "Choice Text (Spanish)". This helps the translator know to type the translation for the currently-selected language.

## Test in AT with supported languages
- Switch between languages
   - When you choose a supported language, the TranslatableInput shows the selected language in the label.
   - When you choose the default language, TranslatableInput does not show the language.

<img width="399" alt="image" src="https://github.com/WISE-Community/WISE-Client/assets/119416/1e709338-4e2d-4bf9-bc55-8006a0e9949d">
