### PR TITLE
feat(TranslatableInput): Move default language text to hint

### DIFF
--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
@@ -7,5 +7,5 @@
     (ngModelChange)="saveTranslationText($event)"
     placeholder="{{ defaultLanguageInput.placeholder }}"
   />
+  <mat-hint *ngIf="showTranslationInput()">{{ defaultLanguageText() }}</mat-hint>
 </mat-form-field>
-<span *ngIf="showTranslationInput()">{{ defaultLanguageText() }}</span>

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
@@ -38,9 +38,9 @@ export class TranslatableInputComponent {
     );
     this.defaultLanguageText = computed(() =>
       this.showTranslationInput()
-        ? $localize`(${this.projectService.getLocale().getDefaultLanguage().language}\: ${
+        ? `[${this.projectService.getLocale().getDefaultLanguage().language}\] ${
             this.content[this.key]
-          })`
+          }`
         : ''
     );
   }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10123,13 +10123,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4565494938772544139" datatype="html">
-        <source>(<x id="PH" equiv-text="this.projectService.getLocale().getDefaultLanguage().language"/>: <x id="PH_1" equiv-text="this.content[this.key]"/>)</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts</context>
-          <context context-type="linenumber">41,43</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="1318680729593701201" datatype="html">
         <source>Also currently editing this unit: <x id="PH" equiv-text="otherAuthors.join(
               &apos;, &apos;


### PR DESCRIPTION
## Changes
Move the default language text display to a hint for the form field.

## Test
Make sure default language text appears directly below input (in a `mat-hint` element) field when translating to a supported language.
