### PR TITLE
refactor(ArchiveProjectsButton): Input selected projects only

### DIFF
--- a/src/app/modules/library/personal-library/personal-library.component.html
+++ b/src/app/modules/library/personal-library/personal-library.component.html
@@ -26,7 +26,7 @@
       <archive-projects-button
         *ngIf="selectedProjects().length > 0"
         [showArchive]="!showArchivedView"
-        [projects]="filteredProjects"
+        [projects]="selectedProjects()"
         (archiveActionEvent)="refreshProjects()"
       ></archive-projects-button>
     </div>

--- a/src/app/teacher/archive-projects-button/archive-projects-button.component.html
+++ b/src/app/teacher/archive-projects-button/archive-projects-button.component.html
@@ -1,7 +1,7 @@
 <button
   mat-icon-button
   *ngIf="showArchive"
-  (click)="archiveSelectedProjects(true)"
+  (click)="archiveProjects(true)"
   matTooltip="Archive"
   matTooltipPosition="above"
   i18n-matTooltip
@@ -11,7 +11,7 @@
 <button
   mat-icon-button
   *ngIf="!showArchive"
-  (click)="archiveSelectedProjects(false)"
+  (click)="archiveProjects(false)"
   matTooltip="Restore"
   matTooltipPosition="above"
   i18n-matTooltip

--- a/src/app/teacher/archive-projects-button/archive-projects-button.component.ts
+++ b/src/app/teacher/archive-projects-button/archive-projects-button.component.ts
@@ -26,14 +26,13 @@ export class ArchiveProjectsButtonComponent {
     private snackBar: MatSnackBar
   ) {}
 
-  protected archiveSelectedProjects(archive: boolean): Subscription {
-    const projects = this.getSelectedProjects();
+  protected archiveProjects(archive: boolean): Subscription {
     return this.archiveProjectService[archive ? 'archiveProjects' : 'unarchiveProjects'](
-      projects
+      this.projects
     ).subscribe({
       next: (archiveProjectsResponse: ArchiveProjectResponse[]) => {
-        this.updateProjectsArchivedStatus(projects, archiveProjectsResponse);
-        this.openSuccessSnackBar(projects, archiveProjectsResponse, archive);
+        this.updateProjectsArchivedStatus(this.projects, archiveProjectsResponse);
+        this.openSuccessSnackBar(this.projects, archiveProjectsResponse, archive);
       },
       error: () => {
         this.showErrorSnackBar(archive);
@@ -90,9 +89,5 @@ export class ArchiveProjectsButtonComponent {
         this.snackBar.open($localize`Error undoing action.`);
       }
     });
-  }
-
-  private getSelectedProjects(): Project[] {
-    return this.projects.filter((project: Project) => project.selected);
   }
 }

--- a/src/app/teacher/select-runs-controls/select-runs-controls.component.html
+++ b/src/app/teacher/select-runs-controls/select-runs-controls.component.html
@@ -29,7 +29,7 @@
   <archive-projects-button
     *ngIf="numSelectedRuns > 0"
     [showArchive]="showArchive"
-    [projects]="projects"
+    [projects]="selectedProjects"
     (archiveActionEvent)="archiveActionEvent.emit()"
   ></archive-projects-button>
 </div>

--- a/src/app/teacher/select-runs-controls/select-runs-controls.component.ts
+++ b/src/app/teacher/select-runs-controls/select-runs-controls.component.ts
@@ -13,7 +13,7 @@ import { SelectRunsOption } from './select-runs-option';
 export class SelectRunsControlsComponent {
   @Output() archiveActionEvent = new EventEmitter<void>();
   protected numSelectedRuns: number = 0;
-  protected projects: Project[] = [];
+  protected selectedProjects: Project[] = [];
   @Input() runChangedEventEmitter: EventEmitter<void> = new EventEmitter<void>();
   @Input() runs: TeacherRun[] = [];
   protected selectedAllRuns: boolean = false;
@@ -28,7 +28,9 @@ export class SelectRunsControlsComponent {
   }
 
   ngOnChanges(): void {
-    this.projects = this.runs.map((run: TeacherRun) => run.project);
+    this.selectedProjects = this.runs
+      .map((run: TeacherRun) => run.project)
+      .filter((project: Project) => project.selected);
     this.numSelectedRuns = this.runs.filter((run: TeacherRun) => run.project.selected).length;
     this.selectedAllRuns = this.numSelectedRuns === this.runs.length;
     this.selectedSomeRuns = this.numSelectedRuns !== 0 && !this.selectedAllRuns;

--- a/src/app/teacher/select-runs-controls/select-runs-controls.component.ts
+++ b/src/app/teacher/select-runs-controls/select-runs-controls.component.ts
@@ -22,21 +22,16 @@ export class SelectRunsControlsComponent {
   @Input() showArchive: boolean = false;
 
   ngOnInit(): void {
-    this.extractProjects();
     this.runChangedEventEmitter.subscribe(() => {
       this.ngOnChanges();
     });
   }
 
   ngOnChanges(): void {
-    this.extractProjects();
+    this.projects = this.runs.map((run: TeacherRun) => run.project);
     this.numSelectedRuns = this.runs.filter((run: TeacherRun) => run.project.selected).length;
     this.selectedAllRuns = this.numSelectedRuns === this.runs.length;
     this.selectedSomeRuns = this.numSelectedRuns !== 0 && !this.selectedAllRuns;
-  }
-
-  private extractProjects(): void {
-    this.projects = this.runs.map((run: TeacherRun) => run.project);
   }
 
   protected selectAllRunsCheckboxClicked(): void {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -7431,7 +7431,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/archive-projects-button/archive-projects-button.component.ts</context>
-          <context context-type="linenumber">68</context>
+          <context context-type="linenumber">67</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-menu/run-menu.component.ts</context>
@@ -7450,7 +7450,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/archive-projects-button/archive-projects-button.component.ts</context>
-          <context context-type="linenumber">87</context>
+          <context context-type="linenumber">86</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-menu/run-menu.component.ts</context>
@@ -7469,7 +7469,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/archive-projects-button/archive-projects-button.component.ts</context>
-          <context context-type="linenumber">90</context>
+          <context context-type="linenumber">89</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-menu/run-menu.component.ts</context>
@@ -7484,7 +7484,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/archive-projects-button/archive-projects-button.component.ts</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">65</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6233410407787231949" datatype="html">
@@ -7495,7 +7495,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/archive-projects-button/archive-projects-button.component.ts</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">66</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4649373271512187502" datatype="html">
@@ -8040,14 +8040,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Error archiving unit(s).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/archive-projects-button/archive-projects-button.component.ts</context>
-          <context context-type="linenumber">78</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3419148337120710852" datatype="html">
         <source>Error restoring unit(s).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/archive-projects-button/archive-projects-button.component.ts</context>
-          <context context-type="linenumber">78</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a2d9400df68d9f4e89fe24f6a3f40bc5322f19f2" datatype="html">


### PR DESCRIPTION
## Changes
- Only send selected projects as input to ArchiveProjectsButtonComponent. This component did not need all the projects to do its work.
- Don't call extractProjects() in ngOnInit() because it's already called in ngOnChanges(). Move extractProjects()'s body to ngOnChanges().

## Test
- Archiving and restoring units work as before in Project Library and Class Schedule pages