### PR TITLE
fix(Project Library): Search unselects projects that do not match search

### DIFF
--- a/src/app/modules/library/personal-library/personal-library.component.spec.ts
+++ b/src/app/modules/library/personal-library/personal-library.component.spec.ts
@@ -81,15 +81,36 @@ describe('PersonalLibraryComponent', () => {
   allProjectsSelected_clickSelectAllProjects_unselectsAllProjects();
   projectsAreSelected_goToArchivedView_projectsAreUnselected();
   projectsAreSelected_goToNextPage_projectsAreUnselected();
+  projectsAreSelected_performSearch_projectsNotMatchingSearchAreUnselected();
 });
 
 function setUpFiveProjects() {
   TestBed.inject(LibraryService).personalLibraryProjectsSource$ = fakeAsyncResponse([
-    new LibraryProject({ id: projectId1, metadata: {}, tags: ['archived'] }),
-    new LibraryProject({ id: projectId2, metadata: {}, tags: ['archived'] }),
-    new LibraryProject({ id: projectId3, metadata: {}, tags: [] }),
-    new LibraryProject({ id: projectId4, metadata: {}, tags: [] }),
-    new LibraryProject({ id: projectId5, metadata: {}, tags: [] })
+    new LibraryProject({
+      id: projectId1,
+      metadata: { title: 'Hello' },
+      tags: ['archived']
+    }),
+    new LibraryProject({
+      id: projectId2,
+      metadata: { title: 'Hello World' },
+      tags: ['archived']
+    }),
+    new LibraryProject({
+      id: projectId3,
+      metadata: { title: 'World Energy' },
+      tags: []
+    }),
+    new LibraryProject({
+      id: projectId4,
+      metadata: { title: 'World Climate' },
+      tags: []
+    }),
+    new LibraryProject({
+      id: projectId5,
+      metadata: { title: 'Recycling' },
+      tags: []
+    })
   ]);
 }
 
@@ -222,6 +243,24 @@ function projectsAreSelected_goToNextPage_projectsAreUnselected() {
         expect(await harness.getSelectedProjectIds()).toEqual([]);
         await (await harness.getPaginator()).goToPreviousPage();
         expect(await harness.getSelectedProjectIds()).toEqual([]);
+      });
+    });
+  });
+}
+
+function projectsAreSelected_performSearch_projectsNotMatchingSearchAreUnselected() {
+  describe('projects are selected', () => {
+    describe('perform search', () => {
+      it('projects that do not match search are unselected', async () => {
+        await (await harness.getSelectAllCheckbox()).check();
+        expect(await harness.getSelectedProjectIds()).toEqual([projectId5, projectId4, projectId3]);
+        component.filterUpdated({
+          searchValue: 'world',
+          dciArrangementValue: [],
+          disciplineValue: [],
+          peValue: []
+        });
+        expect(await harness.getSelectedProjectIds()).toEqual([projectId4, projectId3]);
       });
     });
   });

--- a/src/app/modules/library/personal-library/personal-library.component.ts
+++ b/src/app/modules/library/personal-library/personal-library.component.ts
@@ -116,6 +116,16 @@ export class PersonalLibraryComponent extends LibraryComponent {
       (project) => project.hasTag('archived') == this.showArchivedView
     );
     this.numProjectsInView = this.getProjectsInView().length;
+    this.unselectProjectsOutOfView();
+  }
+
+  private unselectProjectsOutOfView(): void {
+    const projectsInView = this.getProjectsInView();
+    this.projects.forEach((project) => {
+      if (!projectsInView.includes(project)) {
+        this.unselectProject(project);
+      }
+    });
   }
 
   protected switchActiveArchivedView(): void {
@@ -145,6 +155,16 @@ export class PersonalLibraryComponent extends LibraryComponent {
   protected refreshProjects(): void {
     this.unselectAllProjects();
     this.archiveProjectService.refreshProjects();
+  }
+
+  private unselectProject(project: LibraryProject): void {
+    project.selected = false;
+    if (this.selectedProjects().includes(project)) {
+      this.selectedProjects.update((selectedProjects) => {
+        selectedProjects.splice(selectedProjects.indexOf(project), 1);
+        return selectedProjects;
+      });
+    }
   }
 
   protected unselectAllProjects(): void {


### PR DESCRIPTION
## Changes
- Selected projects should be unselected if a search is performed and the project does not match the search criteria

On a related note, I think we might be able to get rid of the projectIdToIsSelected variable due to recent changes where we use the project.selected field to store whether a project is selected. I can look into this in another issue.

## Test
1. Go to the personal unit library
2. Select all the units using the select all checkbox
3. Go to the search input and type in a string that only matches some of the units
4. The number of selected units should update accordingly

Closes #1593
