### PR TITLE
fix(Authoring Tool): Move first lesson no longer breaks step numbering

### DIFF
--- a/src/app/services/teacherProjectService.spec.ts
+++ b/src/app/services/teacherProjectService.spec.ts
@@ -815,5 +815,11 @@ function removeNodeIdFromTransitions() {
         expect(service.getNodeById('group3').startId).toEqual('');
       });
     });
+    describe('remove the first lesson', () => {
+      it('changes the start id of the root group to be the second lesson', () => {
+        deleteNodeService.deleteNode('group1');
+        expect(service.getNodeById('group0').startId).toEqual('group2');
+      });
+    });
   });
 }

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -1753,7 +1753,7 @@ export class TeacherProjectService extends ProjectService {
   private updateParentGroupStartId(nodeId: string): void {
     const parentGroup = this.getParentGroup(nodeId);
     if (parentGroup != null && parentGroup.startId === nodeId) {
-      const transitions = this.getTransitionsFromNode(nodeId);
+      const transitions = this.getTransitionsFromNode(this.getNodeById(nodeId));
       if (transitions.length > 0) {
         for (const transition of transitions) {
           const toNodeId = transition.to;


### PR DESCRIPTION
## Changes
- Fixed a bug where moving the first lesson after any other lesson would cause all the lesson and step numbers to disappear

## Test
1. Open a unit in the Authoring Tool
2. Move the first lesson and insert it after any other lesson
3. All the lesson and step numbers should update properly. Previously they would disappear.

Closes #1600
