### PR TITLE
feat(Multiple languages): Save changes to existing translations

### DIFF
--- a/src/app/services/editProjectTranslationService.spec.ts
+++ b/src/app/services/editProjectTranslationService.spec.ts
@@ -1,0 +1,47 @@
+import { TestBed } from '@angular/core/testing';
+import { EditProjectTranslationService } from '../../assets/wise5/services/editProjectTranslationService';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TeacherProjectService } from '../../assets/wise5/services/teacherProjectService';
+import { ConfigService } from '../../assets/wise5/services/configService';
+import { signal } from '@angular/core';
+
+class ConfigServiceStub {
+  getProjectId() {
+    return 1;
+  }
+}
+
+class TeacherProjectServiceStub {
+  readonly currentLanguage = signal({
+    language: 'Spanish',
+    locale: 'es'
+  });
+}
+
+let http: HttpTestingController;
+let projectService: TeacherProjectService;
+let service: EditProjectTranslationService;
+describe('EditProjectTranslationService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        EditProjectTranslationService,
+        HttpClientTestingModule,
+        { provide: ConfigService, useClass: ConfigServiceStub },
+        { provide: TeacherProjectService, useClass: TeacherProjectServiceStub }
+      ],
+      imports: [HttpClientTestingModule]
+    });
+    http = TestBed.inject(HttpTestingController);
+    projectService = TestBed.inject(TeacherProjectService);
+    service = TestBed.inject(EditProjectTranslationService);
+  });
+  describe('saveCurrentTranslations()', () => {
+    it('makes a POST request to backend', () => {
+      service.saveCurrentTranslations({}).subscribe();
+      const request = http.expectOne(`/api/author/project/translate/1/es`);
+      expect(request.request.method).toEqual('POST');
+      expect(request.request.body).toEqual({});
+    });
+  });
+});

--- a/src/app/teacher/teacher-authoring.module.ts
+++ b/src/app/teacher/teacher-authoring.module.ts
@@ -32,6 +32,7 @@ import { MilestoneReportService } from '../../assets/wise5/services/milestoneRep
 import { AuthoringRoutingModule } from './authoring-routing.module';
 import { RouterModule } from '@angular/router';
 import { ComponentInfoService } from '../../assets/wise5/services/componentInfoService';
+import { EditProjectTranslationService } from '../../assets/wise5/services/editProjectTranslationService';
 
 @NgModule({
   imports: [StudentTeacherCommonModule, AuthoringToolModule, RouterModule, AuthoringRoutingModule],
@@ -42,6 +43,7 @@ import { ComponentInfoService } from '../../assets/wise5/services/componentInfoS
     CopyProjectService,
     DataExportService,
     { provide: DataService, useExisting: TeacherDataService },
+    EditProjectTranslationService,
     GetWorkgroupService,
     DeleteNodeService,
     ImportComponentService,

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
@@ -8,7 +8,7 @@
   <input
     matInput
     [ngModel]="translatedText()"
-    (ngModelChange)="saveTranslationText($event)"
+    (ngModelChange)="translatedTextChanged.next($event)"
     placeholder="{{ defaultLanguageInput.placeholder }}"
   />
   <mat-hint *ngIf="showTranslationInput()">{{ defaultLanguageText() }}</mat-hint>

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
@@ -7,8 +7,8 @@
   >
   <input
     matInput
-    [ngModel]="translatedText()"
-    (ngModelChange)="translatedTextChanged.next($event)"
+    [ngModel]="translationText()"
+    (ngModelChange)="translationTextChanged.next($event)"
     placeholder="{{ defaultLanguageInput.placeholder }}"
   />
   <mat-hint *ngIf="showTranslationInput()">{{ defaultLanguageText() }}</mat-hint>

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
@@ -23,12 +23,12 @@ export class TranslatableInputComponent {
   @ContentChild(MatInput) defaultLanguageInput: MatInput;
   @ContentChild(MatLabel, { read: ElementRef }) defaultLanguageLabelRef: ElementRef;
   protected defaultLanguageText: Signal<string>;
-  @Input() key: string;
   private i18nId: string;
+  @Input() key: string;
   protected showTranslationInput: Signal<boolean>;
-  protected translatedText: Signal<string>;
-  protected translatedTextChanged: Subject<string> = new Subject<string>();
-  protected translatedTextChangedSubscription: Subscription;
+  protected translationText: Signal<string>;
+  protected translationTextChanged: Subject<string> = new Subject<string>();
+  protected translationTextChangedSubscription: Subscription;
 
   constructor(
     private editProjectTranslationService: EditProjectTranslationService,
@@ -41,7 +41,7 @@ export class TranslatableInputComponent {
 
   ngOnInit(): void {
     this.i18nId = this.content[`${this.key}.i18n`]?.id;
-    this.translatedText = computed(() =>
+    this.translationText = computed(() =>
       this.showTranslationInput()
         ? this.translateProjectService.currentTranslations()[this.i18nId]?.value
         : ''
@@ -53,7 +53,7 @@ export class TranslatableInputComponent {
           }`
         : ''
     );
-    this.translatedTextChangedSubscription = this.translatedTextChanged
+    this.translationTextChangedSubscription = this.translationTextChanged
       .pipe(debounceTime(1000), distinctUntilChanged())
       .subscribe((text: string) => {
         this.saveTranslationText(text);
@@ -61,7 +61,7 @@ export class TranslatableInputComponent {
   }
 
   ngOnDestory(): void {
-    this.translatedTextChangedSubscription.unsubscribe();
+    this.translationTextChangedSubscription.unsubscribe();
   }
 
   private saveTranslationText(text: string): void {

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
@@ -1,16 +1,19 @@
 import { Component, ContentChild, ElementRef, Input, Signal, computed } from '@angular/core';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { EditProjectTranslationService } from '../../../services/editProjectTranslationService';
 import { CommonModule } from '@angular/common';
 import { MatInput, MatInputModule } from '@angular/material/input';
 import { FormsModule } from '@angular/forms';
 import { TranslateProjectService } from '../../../services/translateProjectService';
 import { MatLabel } from '@angular/material/form-field';
 import { Language } from '../../../../../app/domain/language';
+import { Subject, Subscription, debounceTime, distinctUntilChanged } from 'rxjs';
 
 @Component({
   standalone: true,
   selector: 'translatable-input',
   imports: [CommonModule, FormsModule, MatInputModule],
+  providers: [EditProjectTranslationService],
   styleUrls: ['./translatable-input.component.scss'],
   templateUrl: './translatable-input.component.html'
 })
@@ -21,10 +24,14 @@ export class TranslatableInputComponent {
   @ContentChild(MatLabel, { read: ElementRef }) defaultLanguageLabelRef: ElementRef;
   protected defaultLanguageText: Signal<string>;
   @Input() key: string;
+  private i18nId: string;
   protected showTranslationInput: Signal<boolean>;
   protected translatedText: Signal<string>;
+  protected translatedTextChanged: Subject<string> = new Subject<string>();
+  protected translatedTextChangedSubscription: Subscription;
 
   constructor(
+    private editProjectTranslationService: EditProjectTranslationService,
     private projectService: TeacherProjectService,
     private translateProjectService: TranslateProjectService
   ) {
@@ -33,10 +40,10 @@ export class TranslatableInputComponent {
   }
 
   ngOnInit(): void {
-    const i18nId = this.content[`${this.key}.i18n`]?.id;
+    this.i18nId = this.content[`${this.key}.i18n`]?.id;
     this.translatedText = computed(() =>
       this.showTranslationInput()
-        ? this.translateProjectService.currentTranslations()[i18nId]?.value
+        ? this.translateProjectService.currentTranslations()[this.i18nId]?.value
         : ''
     );
     this.defaultLanguageText = computed(() =>
@@ -46,9 +53,25 @@ export class TranslatableInputComponent {
           }`
         : ''
     );
+    this.translatedTextChangedSubscription = this.translatedTextChanged
+      .pipe(debounceTime(1000), distinctUntilChanged())
+      .subscribe((text: string) => {
+        this.saveTranslationText(text);
+      });
   }
 
-  protected saveTranslationText(text: string): void {
-    // TODO: save translation text to server
+  ngOnDestory(): void {
+    this.translatedTextChangedSubscription.unsubscribe();
+  }
+
+  private saveTranslationText(text: string): void {
+    this.projectService.broadcastSavingProject();
+    const currentTranslations = this.translateProjectService.currentTranslations();
+    currentTranslations[this.i18nId] = { value: text, modified: new Date().getTime() };
+    this.editProjectTranslationService
+      .saveCurrentTranslations(currentTranslations)
+      .subscribe(() => {
+        this.projectService.broadcastProjectSaved();
+      });
   }
 }

--- a/src/assets/wise5/components/component-authoring.module.ts
+++ b/src/assets/wise5/components/component-authoring.module.ts
@@ -1,8 +1,10 @@
 import { NgModule } from '@angular/core';
 import { TranslatableInputComponent } from '../authoringTool/components/translatable-input/translatable-input.component';
+import { EditProjectTranslationService } from '../services/editProjectTranslationService';
 
 @NgModule({
   imports: [TranslatableInputComponent],
+  providers: [EditProjectTranslationService],
   exports: [TranslatableInputComponent]
 })
 export class ComponentAuthoringModule {}

--- a/src/assets/wise5/services/editProjectTranslationService.ts
+++ b/src/assets/wise5/services/editProjectTranslationService.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { Observable, catchError, throwError } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+import { ConfigService } from './configService';
+import { TeacherProjectService } from './teacherProjectService';
+import { Translations } from '../../../app/domain/translations';
+
+@Injectable()
+export class EditProjectTranslationService {
+  constructor(
+    private configService: ConfigService,
+    private http: HttpClient,
+    private projectService: TeacherProjectService
+  ) {}
+
+  saveCurrentTranslations(translations: Translations): Observable<void> {
+    return this.http
+      .post<void>(
+        `/api/author/project/translate/${this.configService.getProjectId()}/${
+          this.projectService.currentLanguage().locale
+        }`,
+        translations
+      )
+      .pipe(
+        catchError(() => {
+          this.projectService.broadcastErrorSavingProject();
+          return throwError(
+            () => new Error($localize`Error saving translation. Please try again later.`)
+          );
+        })
+      );
+  }
+}

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -3046,7 +3046,7 @@ export class TeacherProjectService extends ProjectService {
     return a.order - b.order;
   }
 
-  private broadcastSavingProject(): void {
+  broadcastSavingProject(): void {
     this.savingProjectSource.next();
   }
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -21355,6 +21355,13 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">560</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="6103908175957925049" datatype="html">
+        <source>Error saving translation. Please try again later.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/services/editProjectTranslationService.ts</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1384916903989385807" datatype="html">
         <source>Notebook</source>
         <context-group purpose="location">


### PR DESCRIPTION
## Changes
- Save changes to an existing translatable field (one that already has a value in translations.[locale].json)

## Test Prep
- Test with https://github.com/WISE-Community/WISE-API/pull/253

## Test in AT with project that support additional languages
- Change the text of an existing translation (one that already has a value in translations.[locale].json).
   - There should be a debounce before the saving sequence starts 
   - The saving...saved indicator should appear in the top-right corner of the AT
   - New translation text should be saved. You can verify this by reloading the AT or previewing the unit.