### PR TITLE
fix(Authoring): Move two lessons into unused section bug

### DIFF
--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -721,10 +721,10 @@ export class TeacherProjectService extends ProjectService {
       this.insertNodeAfterInactiveNode(node, nodeIdToInsertAfter);
     }
     if (node.type === 'group') {
-      this.inactiveGroupNodes.push(node.id);
+      this.inactiveGroupNodes.push(node);
       this.addGroupChildNodesToInactive(node);
     } else {
-      this.inactiveStepNodes.push(node.id);
+      this.inactiveStepNodes.push(node);
     }
   }
 
@@ -803,10 +803,10 @@ export class TeacherProjectService extends ProjectService {
       this.insertNodeInsideInactiveNode(node, nodeIdToInsertInside);
     }
     if (node.type === 'group') {
-      this.inactiveGroupNodes.push(node.id);
+      this.inactiveGroupNodes.push(node);
       this.addGroupChildNodesToInactive(node);
     } else {
-      this.inactiveStepNodes.push(node.id);
+      this.inactiveStepNodes.push(node);
     }
   }
 


### PR DESCRIPTION
## Changes
- Fixed a bug where node id strings were being added to the inactiveGroupNodes and inactiveStepNodes arrays which actually expect node objects. This caused an error when moving two lessons into the Unused Lessons section.

## Test
1. Open a unit in the Authoring Tool
2. Select two lessons
3. Click the "Move" button
4. Click "Insert Inside" the Unused Lessons section
5. The lessons should be moved to the Unused Lessons section. Previously, an error would occur and the lessons would not be moved.

Closes #1604
