### PR TITLE
fix(Teacher Library): Ensure checkbox appears at top of library unit card

### DIFF
--- a/src/app/modules/library/library-project/library-project.component.scss
+++ b/src/app/modules/library/library-project/library-project.component.scss
@@ -82,8 +82,9 @@ $config: mat.define-typography-config();
   right: 10px;
 }
 
-.library-project__checkbox {
+.mat-mdc-checkbox.library-project__checkbox {
   position: absolute;
   top: 0;
   z-index: 1;
+  border-end-end-radius: $button-border-radius;
 }


### PR DESCRIPTION
## Changes
- Ensures that the checkboxes on teacher library units appears at the top of the unit card.
- Fixes a bug where the checkbox would appear at the bottom sometimes.
- Also added a border-radius to the checkbox to make it's appearance less harsh.

## Test
- Make sure checkboxes always appear the top of the unit card.
