### PR TITLE
fix(Authoring Tool): Copying a step to inside an unused lesson

### DIFF
--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -344,8 +344,8 @@ export class TeacherProjectService extends ProjectService {
    */
   createNodeAfter(newNode, nodeId) {
     if (this.isInactive(nodeId)) {
-      this.addInactiveNodeInsertAfter(newNode, nodeId);
       this.setIdToNode(newNode.id, newNode);
+      this.addInactiveNodeInsertAfter(newNode, nodeId);
     } else {
       this.addNode(newNode);
       this.setIdToNode(newNode.id, newNode);


### PR DESCRIPTION
## Changes
Fixed copying an active step and putting it inside an unused lesson.

## Test
1. Open a unit in the Authoring Tool
2. Select a step
3. Click the copy button
4. Insert it inside a unused lesson. Previously this would not work and would throw an error. Now it should work.

Closes #1608