### PR TITLE
feat(Unit Lists): Unselect all units when search is performed

### DIFF
--- a/src/app/modules/library/personal-library/personal-library.component.spec.ts
+++ b/src/app/modules/library/personal-library/personal-library.component.spec.ts
@@ -81,7 +81,7 @@ describe('PersonalLibraryComponent', () => {
   allProjectsSelected_clickSelectAllProjects_unselectsAllProjects();
   projectsAreSelected_goToArchivedView_projectsAreUnselected();
   projectsAreSelected_goToNextPage_projectsAreUnselected();
-  projectsAreSelected_performSearch_projectsNotMatchingSearchAreUnselected();
+  projectsAreSelected_performSearch_allProjectsAreUnselected();
 });
 
 function setUpFiveProjects() {
@@ -248,10 +248,10 @@ function projectsAreSelected_goToNextPage_projectsAreUnselected() {
   });
 }
 
-function projectsAreSelected_performSearch_projectsNotMatchingSearchAreUnselected() {
+function projectsAreSelected_performSearch_allProjectsAreUnselected() {
   describe('projects are selected', () => {
     describe('perform search', () => {
-      it('projects that do not match search are unselected', async () => {
+      it('unselects all projects', async () => {
         await (await harness.getSelectAllCheckbox()).check();
         expect(await harness.getSelectedProjectIds()).toEqual([projectId5, projectId4, projectId3]);
         component.filterUpdated({
@@ -260,7 +260,7 @@ function projectsAreSelected_performSearch_projectsNotMatchingSearchAreUnselecte
           disciplineValue: [],
           peValue: []
         });
-        expect(await harness.getSelectedProjectIds()).toEqual([projectId4, projectId3]);
+        expect(await harness.getSelectedProjectIds()).toEqual([]);
       });
     });
   });

--- a/src/app/modules/library/personal-library/personal-library.component.ts
+++ b/src/app/modules/library/personal-library/personal-library.component.ts
@@ -116,16 +116,7 @@ export class PersonalLibraryComponent extends LibraryComponent {
       (project) => project.hasTag('archived') == this.showArchivedView
     );
     this.numProjectsInView = this.getProjectsInView().length;
-    this.unselectProjectsOutOfView();
-  }
-
-  private unselectProjectsOutOfView(): void {
-    const projectsInView = this.getProjectsInView();
-    this.projects.forEach((project) => {
-      if (!projectsInView.includes(project)) {
-        this.unselectProject(project);
-      }
-    });
+    this.unselectAllProjects();
   }
 
   protected switchActiveArchivedView(): void {
@@ -155,16 +146,6 @@ export class PersonalLibraryComponent extends LibraryComponent {
   protected refreshProjects(): void {
     this.unselectAllProjects();
     this.archiveProjectService.refreshProjects();
-  }
-
-  private unselectProject(project: LibraryProject): void {
-    project.selected = false;
-    if (this.selectedProjects().includes(project)) {
-      this.selectedProjects.update((selectedProjects) => {
-        selectedProjects.splice(selectedProjects.indexOf(project), 1);
-        return selectedProjects;
-      });
-    }
   }
 
   protected unselectAllProjects(): void {

--- a/src/app/teacher/teacher-run-list/teacher-run-list.component.spec.ts
+++ b/src/app/teacher/teacher-run-list/teacher-run-list.component.spec.ts
@@ -19,7 +19,7 @@ import { TeacherRunListHarness } from './teacher-run-list.harness';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatInputModule } from '@angular/material/input';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { RunMenuComponent } from '../run-menu/run-menu.component';
 import { MatMenuModule } from '@angular/material/menu';
@@ -29,6 +29,7 @@ import { MockArchiveProjectService } from '../../services/mock-archive-project.s
 import { MatSelectModule } from '@angular/material/select';
 import { ArchiveProjectsButtonComponent } from '../archive-projects-button/archive-projects-button.component';
 import { Project } from '../../domain/project';
+import { SearchBarComponent } from '../../modules/shared/search-bar/search-bar.component';
 
 class TeacherScheduleStubComponent {}
 
@@ -75,7 +76,12 @@ describe('TeacherRunListComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [RunMenuComponent, TeacherRunListComponent, TeacherRunListItemComponent],
+        declarations: [
+          RunMenuComponent,
+          SearchBarComponent,
+          TeacherRunListComponent,
+          TeacherRunListItemComponent
+        ],
         imports: [
           ArchiveProjectsButtonComponent,
           BrowserAnimationsModule,
@@ -90,6 +96,7 @@ describe('TeacherRunListComponent', () => {
           MatMenuModule,
           MatSelectModule,
           MatSnackBarModule,
+          ReactiveFormsModule,
           RouterTestingModule.withRoutes([
             { path: 'teacher/home/schedule', component: TeacherScheduleStubComponent }
           ]),
@@ -138,6 +145,7 @@ describe('TeacherRunListComponent', () => {
   selectRunsOptionChosen();
   unarchiveSelectedRuns();
   noRuns();
+  searchUnselectAllRuns();
 });
 
 function archiveSelectedRuns(): void {
@@ -348,6 +356,21 @@ function noRuns(): void {
         expect(await runListHarness.getNoRunsMessage()).toContain(
           "Looks like you don't have any archived classroom units."
         );
+      });
+    });
+  });
+}
+
+function searchUnselectAllRuns(): void {
+  describe('runs are selected', () => {
+    describe('perform search', () => {
+      it('unselects all runs', async () => {
+        await runListHarness.clickRunListItemCheckbox(0);
+        await runListHarness.clickRunListItemCheckbox(1);
+        await runListHarness.clickRunListItemCheckbox(2);
+        const searchInput = await runListHarness.getSearchInput();
+        await searchInput.sendKeys('first');
+        await expectRunsIsSelected([false]);
       });
     });
   });

--- a/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
+++ b/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
@@ -143,6 +143,7 @@ export class TeacherRunListComponent implements OnInit {
   private performSearchAndFilter(): void {
     this.filteredRuns = this.searchValue ? this.performSearch(this.searchValue) : this.runs;
     this.performFilter();
+    this.unselectAllRuns();
     this.runSelectedStatusChanged();
   }
 

--- a/src/app/teacher/teacher-run-list/teacher-run-list.harness.ts
+++ b/src/app/teacher/teacher-run-list/teacher-run-list.harness.ts
@@ -9,6 +9,7 @@ export class TeacherRunListHarness extends ComponentHarness {
   private ARCHIVED_TEXT = 'Archived';
   protected getNoRunsMessageDiv = this.locatorFor('.no-runs-message');
   protected getRunListItems = this.locatorForAll(TeacherRunListItemHarness);
+  getSearchInput = this.locatorFor('.search-bar input');
   protected getSelectRunsControls = this.locatorFor(SelectRunsControlsHarness);
   protected getViewSelect = this.locatorFor(MatSelectHarness);
 


### PR DESCRIPTION
## Changes
- In the run list and personal unit library, when a search is performed, unselect all the units

## Test
In the run list and personal unit library
1. Select all units using the checkbox
2. Type something in the search box that will match at least one of the units
3. The unit(s) that match should have their checkboxes unchecked
4. Clear the search text and all the units should show up again and they should all be unselected

Closes #1615
