### PR TITLE
feat(Classroom Monitor): Sort by first and last names in Grade by Team

### DIFF
--- a/src/app/help/faq/teacher-faq/teacher-faq.component.html
+++ b/src/app/help/faq/teacher-faq/teacher-faq.component.html
@@ -256,7 +256,7 @@
     <li i18n>Here you will be able to look at your students' work.</li>
     <li i18n>
       On the left sidebar you can choose to look at the work by step by clicking "Grade By Step" or
-      you can choose to look at the work by team by clicking "Grade By Team".
+      you can choose to look at the work by student by clicking "Grade By Student".
     </li>
     <li i18n>Next to each student's work, you will be able to give them a score and comment.</li>
   </ul>

--- a/src/assets/wise5/classroomMonitor/classroom-monitor.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroom-monitor.component.ts
@@ -101,7 +101,7 @@ export class ClassroomMonitorComponent implements OnInit {
       },
       {
         route: ['team'],
-        name: $localize`Grade by Team`,
+        name: $localize`Grade by Student`,
         icon: 'people',
         type: 'primary',
         active: true

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/testing/ClassroomMonitorTestHelper.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/testing/ClassroomMonitorTestHelper.ts
@@ -1,9 +1,59 @@
+import { StudentProgress } from '../../../student-progress/student-progress.component';
+
 export class ClassroomMonitorTestHelper {
   workgroupId1: number = 1;
   workgroupId2: number = 2;
   workgroupId3: number = 3;
   workgroupId4: number = 4;
   workgroupId5: number = 5;
+
+  students: StudentProgress[] = [
+    new StudentProgress({
+      location: '1.2: Open Response',
+      workgroupId: this.workgroupId1,
+      username: 'Spongebob Squarepants',
+      firstName: 'Spongebob',
+      lastName: 'Squarepants',
+      completionPct: 30,
+      scorePct: 0.8
+    }),
+    new StudentProgress({
+      location: '1.1: Open Response',
+      workgroupId: this.workgroupId5,
+      username: 'Patrick Star',
+      firstName: 'Patrick',
+      lastName: 'Star',
+      completionPct: 10,
+      scorePct: 0.6
+    }),
+    new StudentProgress({
+      location: '1.5: Open Response',
+      workgroupId: this.workgroupId3,
+      username: 'Squidward Tentacles',
+      firstName: 'Squidward',
+      lastName: 'Tentacles',
+      completionPct: 20,
+      scorePct: 0.4
+    }),
+    new StudentProgress({
+      location: '1.9: Open Response',
+      workgroupId: this.workgroupId2,
+      username: 'Sandy Cheeks',
+      firstName: 'Sandy',
+      lastName: 'Cheeks',
+      completionPct: 50,
+      scorePct: 0.8
+    }),
+    new StudentProgress({
+      location: '1.5: Open Response',
+      workgroupId: this.workgroupId4,
+      username: 'Sheldon Plankton',
+      firstName: 'Sheldon',
+      lastName: 'Plankton',
+      completionPct: 20,
+      scorePct: 0.8
+    })
+  ];
 
   expectWorkgroupOrder(workgroups: any[], expectedWorkgroupIdOrder: number[]): void {
     for (let w = 0; w < workgroups.length; w++) {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.ts
@@ -43,7 +43,7 @@ export class ToolBarComponent implements OnInit {
         'manage-students': $localize`Manage Students`,
         milestones: $localize`Milestones`,
         notebook: $localize`Student Notebooks`,
-        team: $localize`Grade by Team`
+        team: $localize`Grade by Student`
       }[path] ?? $localize`Grade by Step`;
     this.showPeriodSelect = path != 'export';
     this.showTeamTools = /\/team\/(\d+)$/.test(this.router.url);

--- a/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html
+++ b/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html
@@ -13,8 +13,6 @@
               <button
                 mat-button
                 class="table--list__thead__link"
-                aria-label="Team ID"
-                i18n-aria-label
                 (click)="setSort('team')"
                 title="Sort by team"
                 i18n-title
@@ -32,19 +30,17 @@
                 </mat-icon>
               </button>
             </th>
-            <th class="table--list__thead__th" sticky>
+            <th *ngIf="!permissions.canViewStudentNames" class="table--list__thead__th" sticky>
               <button
                 mat-button
                 class="table--list__thead__link"
-                aria-label="Names"
-                i18n-aria-label
                 (click)="setSort('student')"
-                title="Sort by names"
+                title="Sort by student"
                 i18n-title
                 fxFill
                 fxLayoutAlign="start center"
               >
-                <span i18n>Names</span>
+                <span i18n>Student</span>
                 <mat-icon
                   *ngIf="sort === 'student' || sort === '-student'"
                   class="table--list__thead__sort"
@@ -54,12 +50,52 @@
                 </mat-icon>
               </button>
             </th>
+            <ng-container *ngIf="permissions.canViewStudentNames">
+              <th class="table--list__thead__th" sticky>
+                <button
+                  mat-button
+                  class="table--list__thead__link"
+                  (click)="setSort('firstName')"
+                  title="Sort by first name"
+                  i18n-title
+                  fxFill
+                  fxLayoutAlign="start center"
+                >
+                  <span i18n>First Name</span>
+                  <mat-icon
+                    *ngIf="sort === 'firstName' || sort === '-firstName'"
+                    class="table--list__thead__sort"
+                    [ngClass]="{ 'table--list__thead__sort--reverse': sort === '-firstName' }"
+                  >
+                    arrow_drop_up
+                  </mat-icon>
+                </button>
+              </th>
+              <th class="table--list__thead__th" sticky>
+                <button
+                  mat-button
+                  class="table--list__thead__link"
+                  (click)="setSort('lastName')"
+                  title="Sort by last name"
+                  i18n-title
+                  fxFill
+                  fxLayoutAlign="start center"
+                >
+                  <span i18n>Last Name</span>
+                  <mat-icon
+                    *ngIf="sort === 'lastName' || sort === '-lastName'"
+                    class="table--list__thead__sort"
+                    [ngClass]="{ 'table--list__thead__sort--reverse': sort === '-lastName' }"
+                  >
+                    arrow_drop_up
+                  </mat-icon>
+                </button>
+              </th>
+            </ng-container>
             <th class="table--list__thead__th" sticky>
               <button
                 mat-button
                 class="table--list__thead__link"
-                aria-label="Current Location"
-                i18n-aria-label
                 (click)="setSort('location')"
                 title="Sort by location"
                 i18n-title
@@ -81,8 +117,6 @@
               <button
                 mat-button
                 class="table--list__thead__link"
-                aria-label="Project Completion"
-                i18n-aria-label
                 (click)="setSort('completion')"
                 title="Sort by completion"
                 i18n-title
@@ -104,8 +138,6 @@
               <button
                 mat-button
                 class="table--list__thead__link"
-                aria-label="Score"
-                i18n-aria-label
                 (click)="setSort('score')"
                 title="Sort by score"
                 i18n-title
@@ -126,24 +158,32 @@
           </tr>
         </thead>
         <tbody>
-          <ng-container *ngFor="let team of sortedTeams">
+          <ng-container *ngFor="let student of sortedStudents">
             <tr
               class="list-item workgroup-row button"
-              *ngIf="isWorkgroupShown(team)"
-              (click)="showStudentGradingView(team)"
+              *ngIf="isWorkgroupShown(student)"
+              (click)="showStudentGradingView(student)"
             >
-              <td class="center">{{ team.workgroupId }}</td>
-              <td class="heavy td--wrap">
-                <div fxLayout="row wrap">{{ team.username }}</div>
+              <td class="center">{{ student.workgroupId }}</td>
+              <td *ngIf="!permissions.canViewStudentNames" class="heavy td--wrap">
+                {{ student.username }}
               </td>
+              <ng-container *ngIf="permissions.canViewStudentNames">
+                <td class="heavy td--max-width">
+                  {{ student.firstName }}
+                </td>
+                <td class="heavy td--max-width">
+                  {{ student.lastName }}
+                </td>
+              </ng-container>
               <td class="center td--wrap td--max-width">
-                {{ team.location }}
+                {{ student.location }}
               </td>
               <td fxLayout="row" fxLayoutAlign="center center">
                 <project-progress
-                  [completed]="team.completion.completedItems"
-                  [total]="team.completion.totalItems"
-                  [percent]="team.completion.completionPct"
+                  [completed]="student.completion.completedItems"
+                  [total]="student.completion.totalItems"
+                  [percent]="student.completion.completionPct"
                 >
                 </project-progress>
               </td>
@@ -153,9 +193,9 @@
                   fxLayoutAlign="center center"
                   class="layout-align-center-center layout-row"
                 >
-                  <span class="mat-headline-5">{{ team.score }}</span
+                  <span class="mat-headline-5">{{ student.score }}</span
                   >&nbsp;
-                  <span class="text-secondary mat-body-2">/{{ team.maxScore }}</span>
+                  <span class="text-secondary mat-body-2">/{{ student.maxScore }}</span>
                 </div>
               </td>
             </tr>

--- a/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.spec.ts
@@ -12,22 +12,6 @@ import { ClassroomMonitorTestHelper } from '../classroomMonitorComponents/shared
 import { StudentProgressComponent } from './student-progress.component';
 import { RouterTestingModule } from '@angular/router/testing';
 
-class Team {
-  public completion: any;
-
-  constructor(
-    public workgroupId: number,
-    public username: string,
-    public location: string,
-    completionPct: number,
-    public scorePct: number
-  ) {
-    this.completion = {
-      completionPct
-    };
-  }
-}
-
 class SortTestParams {
   constructor(
     public testDescription: string,
@@ -76,13 +60,7 @@ describe('StudentProgressComponent', () => {
 });
 
 function initializeWorkgroups(component: StudentProgressComponent) {
-  component.teams = [
-    new Team(workgroupId1, 'Spongebob', '1.2: Open Response', 30, 0.8),
-    new Team(workgroupId5, 'Patrick', '1.1: Open Response', 10, 0.6),
-    new Team(workgroupId3, 'Squidward', '1.5: Open Response', 20, 0.4),
-    new Team(workgroupId2, 'Sandy', '1.9: Open Response', 50, 0.8),
-    new Team(workgroupId4, 'Plankton', '1.5: Open Response', 20, 0.8)
-  ];
+  component.students = testHelper.students;
 }
 
 function setSort() {
@@ -107,57 +85,85 @@ function setSort() {
       ]),
       new SortTestParams('should sort by student ascending', 'student', 'asc', [
         workgroupId5,
-        workgroupId4,
         workgroupId2,
+        workgroupId4,
         workgroupId1,
         workgroupId3
       ]),
       new SortTestParams('should sort by student descending', 'student', 'desc', [
         workgroupId3,
         workgroupId1,
+        workgroupId4,
+        workgroupId2,
+        workgroupId5
+      ]),
+      new SortTestParams('should sort by first name ascending', 'firstName', 'asc', [
+        workgroupId5,
         workgroupId2,
         workgroupId4,
+        workgroupId1,
+        workgroupId3
+      ]),
+      new SortTestParams('should sort by first name descending', 'firstName', 'desc', [
+        workgroupId3,
+        workgroupId1,
+        workgroupId4,
+        workgroupId2,
         workgroupId5
+      ]),
+      new SortTestParams('should sort by last name ascending', 'lastName', 'asc', [
+        workgroupId2,
+        workgroupId4,
+        workgroupId1,
+        workgroupId5,
+        workgroupId3
+      ]),
+      new SortTestParams('should sort by last name descending', 'lastName', 'desc', [
+        workgroupId3,
+        workgroupId5,
+        workgroupId1,
+        workgroupId4,
+        workgroupId2
       ]),
       new SortTestParams('should sort by score ascending', 'score', 'asc', [
         workgroupId3,
         workgroupId5,
-        workgroupId4,
+        workgroupId1,
         workgroupId2,
-        workgroupId1
+        workgroupId4
       ]),
       new SortTestParams('should sort by score descending', 'score', 'desc', [
-        workgroupId4,
-        workgroupId2,
         workgroupId1,
+        workgroupId2,
+        workgroupId4,
         workgroupId5,
         workgroupId3
       ]),
       new SortTestParams('should sort by completion ascending', 'completion', 'asc', [
         workgroupId5,
-        workgroupId4,
         workgroupId3,
+        workgroupId4,
         workgroupId1,
         workgroupId2
       ]),
       new SortTestParams('should sort by completion descending', 'completion', 'desc', [
         workgroupId2,
         workgroupId1,
-        workgroupId4,
         workgroupId3,
+        workgroupId4,
         workgroupId5
       ]),
       new SortTestParams('should sort by location ascending', 'location', 'asc', [
         workgroupId5,
         workgroupId1,
-        workgroupId4,
         workgroupId3,
+        workgroupId4,
         workgroupId2
       ]),
       new SortTestParams('should sort by location descending', 'location', 'desc', [
         workgroupId2,
-        workgroupId4,
         workgroupId3,
+        workgroupId4,
         workgroupId1,
         workgroupId5
       ])
@@ -165,7 +171,10 @@ function setSort() {
     for (const sortTest of sortTests) {
       it(sortTest.testDescription, () => {
         setSortAndDirection(sortTest.sortField, sortTest.sortDirection);
-        testHelper.expectWorkgroupOrder(component.sortedTeams, sortTest.expectedWorkgroupIdOrder);
+        testHelper.expectWorkgroupOrder(
+          component.sortedStudents,
+          sortTest.expectedWorkgroupIdOrder
+        );
       });
     }
   });

--- a/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts
+++ b/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts
@@ -80,7 +80,7 @@ export class StudentProgressComponent implements OnInit {
   }
 
   private updateTeam(workgroupId: number): void {
-    const location = this.getCurrentNodeForWorkgroupId(workgroupId);
+    const location = this.getCurrentNodeForWorkgroupId(workgroupId) || '';
     const completion = this.classroomStatusService.getStudentProjectCompletion(workgroupId);
     const score = this.getStudentTotalScore(workgroupId);
     let maxScore = this.classroomStatusService.getMaxScoreForWorkgroupId(workgroupId);
@@ -90,7 +90,7 @@ export class StudentProgressComponent implements OnInit {
       if (student.workgroupId === workgroupId) {
         student.location = location;
         student.completion = completion;
-        student.completionPct = completion.completionPct;
+        student.completionPct = completion.completionPct || 0;
         student.score = score;
         student.maxScore = maxScore;
         student.scorePct = maxScore ? score / maxScore : score;

--- a/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts
+++ b/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '../../services/configService';
 import { ClassroomStatusService } from '../../services/classroomStatusService';
 import { TeacherDataService } from '../../services/teacherDataService';
 import { ActivatedRoute, Router } from '@angular/router';
+import { ProjectCompletion } from '../../common/ProjectCompletion';
 
 @Component({
   selector: 'student-progress',
@@ -15,10 +16,10 @@ export class StudentProgressComponent implements OnInit {
   currentWorkgroup: any;
   permissions: any;
   sort: any;
-  sortedTeams: any[];
+  sortedStudents: StudentProgress[];
   subscriptions: Subscription = new Subscription();
   teacherWorkgroupId: number;
-  teams: any;
+  students: StudentProgress[];
 
   constructor(
     private classroomStatusService: ClassroomStatusService,
@@ -37,7 +38,7 @@ export class StudentProgressComponent implements OnInit {
       this.classroomStatusService.studentStatusReceived$.subscribe((args) => {
         const studentStatus = args.studentStatus;
         const workgroupId = studentStatus.workgroupId;
-        this.updateTeam(workgroupId);
+        this.updateStudent(workgroupId);
       })
     );
     this.subscriptions.add(
@@ -52,39 +53,47 @@ export class StudentProgressComponent implements OnInit {
   }
 
   private initializeStudents(): void {
-    this.teams = [];
+    this.students = [];
     const workgroups = this.configService
       .getClassmateUserInfos()
       .filter((workgroup: any) => workgroup.workgroupId != null);
     for (const workgroup of workgroups) {
       const workgroupId = workgroup.workgroupId;
-      const displayNames = this.configService.getDisplayUsernamesByWorkgroupId(workgroupId);
-      const team = {
-        periodId: workgroup.periodId,
-        periodName: workgroup.periodName,
-        workgroupId: workgroupId,
-        username: displayNames
-      };
-      this.teams.push(team);
-      this.updateTeam(workgroupId);
+      const userNames = this.configService
+        .getDisplayUsernamesByWorkgroupId(workgroupId)
+        .split(', ');
+      userNames.forEach((user: any) => {
+        const names = user.split(' ');
+        const student = new StudentProgress({
+          periodId: workgroup.periodId,
+          periodName: workgroup.periodName,
+          workgroupId: workgroupId,
+          username: names[0] + ' ' + names[1],
+          firstName: names[0],
+          lastName: names[1]
+        });
+        this.students.push(student);
+        this.updateStudent(workgroupId);
+      });
     }
     this.sortWorkgroups();
   }
 
-  private updateTeam(workgroupId: number): void {
+  private updateStudent(workgroupId: number): void {
     const location = this.getCurrentNodeForWorkgroupId(workgroupId);
     const completion = this.classroomStatusService.getStudentProjectCompletion(workgroupId);
     const score = this.getStudentTotalScore(workgroupId);
     let maxScore = this.classroomStatusService.getMaxScoreForWorkgroupId(workgroupId);
     maxScore = maxScore ? maxScore : 0;
 
-    for (const team of this.teams) {
-      if (team.workgroupId === workgroupId) {
-        team.location = location;
-        team.completion = completion;
-        team.score = score;
-        team.maxScore = maxScore;
-        team.scorePct = maxScore ? score / maxScore : score;
+    for (const student of this.students) {
+      if (student.workgroupId === workgroupId) {
+        student.location = location;
+        student.completion = completion;
+        student.completionPct = completion.completionPct;
+        student.score = score;
+        student.maxScore = maxScore;
+        student.scorePct = maxScore ? score / maxScore : score;
       }
     }
   }
@@ -100,89 +109,131 @@ export class StudentProgressComponent implements OnInit {
   }
 
   private sortWorkgroups(): void {
-    this.sortedTeams = [...this.teams];
+    this.sortedStudents = [...this.students];
     switch (this.sort) {
       case 'team':
-        this.sortedTeams.sort(this.createSortTeam('asc'));
+        this.sortedStudents.sort(this.createSortTeam('asc'));
         break;
       case '-team':
-        this.sortedTeams.sort(this.createSortTeam('desc'));
+        this.sortedStudents.sort(this.createSortTeam('desc'));
         break;
       case 'student':
-        this.sortedTeams.sort(this.createSortStudent('asc'));
+        this.sortedStudents.sort(this.createSortStudent('asc'));
         break;
       case '-student':
-        this.sortedTeams.sort(this.createSortStudent('desc'));
+        this.sortedStudents.sort(this.createSortStudent('desc'));
+        break;
+      case 'firstName':
+        this.sortedStudents.sort(this.createSortFirstName('asc'));
+        break;
+      case '-firstName':
+        this.sortedStudents.sort(this.createSortFirstName('desc'));
+        break;
+      case 'lastName':
+        this.sortedStudents.sort(this.createSortLastName('asc'));
+        break;
+      case '-lastName':
+        this.sortedStudents.sort(this.createSortLastName('desc'));
         break;
       case 'score':
-        this.sortedTeams.sort(this.createSortScore('asc'));
+        this.sortedStudents.sort(this.createSortScore('asc'));
         break;
       case '-score':
-        this.sortedTeams.sort(this.createSortScore('desc'));
+        this.sortedStudents.sort(this.createSortScore('desc'));
         break;
       case 'completion':
-        this.sortedTeams.sort(this.createSortCompletion('asc'));
+        this.sortedStudents.sort(this.createSortCompletion('asc'));
         break;
       case '-completion':
-        this.sortedTeams.sort(this.createSortCompletion('desc'));
+        this.sortedStudents.sort(this.createSortCompletion('desc'));
         break;
       case 'location':
-        this.sortedTeams.sort(this.createSortLocation('asc'));
+        this.sortedStudents.sort(this.createSortLocation('asc'));
         break;
       case '-location':
-        this.sortedTeams.sort(this.createSortLocation('desc'));
+        this.sortedStudents.sort(this.createSortLocation('desc'));
         break;
     }
   }
 
   private createSortTeam(direction: string): any {
-    return (workgroupA: any, workgroupB: any): number => {
+    return (studentA: any, studentB: any): number => {
       return direction === 'asc'
-        ? workgroupA.workgroupId - workgroupB.workgroupId
-        : workgroupB.workgroupId - workgroupA.workgroupId;
+        ? studentA.workgroupId - studentB.workgroupId
+        : studentB.workgroupId - studentA.workgroupId;
     };
   }
 
   private createSortStudent(direction: string): any {
-    return (workgroupA: any, workgroupB: any): number => {
+    return (studentA: any, studentB: any): number => {
       const localeCompare =
         direction === 'asc'
-          ? workgroupA.username.localeCompare(workgroupB.username)
-          : workgroupB.username.localeCompare(workgroupA.username);
-      return localeCompare === 0 ? workgroupA.workgroupId - workgroupB.workgroupId : localeCompare;
+          ? studentA.username.localeCompare(studentB.username)
+          : studentB.username.localeCompare(studentA.username);
+      return localeCompare === 0 ? studentA.workgroupId - studentB.workgroupId : localeCompare;
+    };
+  }
+
+  private createSortFirstName(direction: string): any {
+    return (studentA: any, studentB: any): number => {
+      const localeCompare =
+        direction === 'asc'
+          ? studentA.firstName.localeCompare(studentB.firstName)
+          : studentB.firstName.localeCompare(studentA.firstName);
+      return localeCompare === 0 ? studentA.workgroupId - studentB.workgroupId : localeCompare;
+    };
+  }
+
+  private createSortLastName(direction: string): any {
+    return (studentA: any, studentB: any): number => {
+      const localeCompare =
+        direction === 'asc'
+          ? studentA.lastName.localeCompare(studentB.lastName)
+          : studentB.lastName.localeCompare(studentA.lastName);
+      return localeCompare === 0 ? studentA.workgroupId - studentB.workgroupId : localeCompare;
     };
   }
 
   private createSortScore(direction: string): any {
-    return (workgroupA: any, workgroupB: any): number => {
-      if (workgroupA.scorePct === workgroupB.scorePct) {
-        return workgroupA.username.localeCompare(workgroupB.username);
+    return (studentA: any, studentB: any): number => {
+      if (studentA.scorePct === studentB.scorePct) {
+        return studentA.workgroupId
+          .toString()
+          .localeCompare(studentB.workgroupId.toString(), undefined, {
+            numeric: true
+          });
       }
       return direction === 'asc'
-        ? workgroupA.scorePct - workgroupB.scorePct
-        : workgroupB.scorePct - workgroupA.scorePct;
+        ? studentA.scorePct - studentB.scorePct
+        : studentB.scorePct - studentA.scorePct;
     };
   }
 
   private createSortCompletion(direction: string): any {
-    return (workgroupA: any, workgroupB: any): number => {
-      const completionA = workgroupA.completion.completionPct;
-      const completionB = workgroupB.completion.completionPct;
+    return (studentA: any, studentB: any): number => {
+      const completionA = studentA.completionPct;
+      const completionB = studentB.completionPct;
       if (completionA === completionB) {
-        return workgroupA.username.localeCompare(workgroupB.username);
+        return studentA.workgroupId
+          .toString()
+          .localeCompare(studentB.workgroupId.toString(), undefined, {
+            numeric: true
+          });
       }
       return direction === 'asc' ? completionA - completionB : completionB - completionA;
     };
   }
 
   private createSortLocation(direction: string): any {
-    return (workgroupA: any, workgroupB: any): number => {
+    return (studentA: any, studentB: any): number => {
       const localeCompare =
         direction === 'asc'
-          ? workgroupA.location.localeCompare(workgroupB.location)
-          : workgroupB.location.localeCompare(workgroupA.location);
+          ? studentA.location.localeCompare(studentB.location)
+          : studentB.location.localeCompare(studentA.location);
       return localeCompare === 0
-        ? workgroupA.username.localeCompare(workgroupB.username)
+        ? studentA.workgroupId
+            .toString()
+            .localeCompare(studentB.workgroupId.toString(), undefined, { numeric: true })
         : localeCompare;
     };
   }
@@ -205,5 +256,26 @@ export class StudentProgressComponent implements OnInit {
     }
     this.dataService.studentProgressSort = this.sort;
     this.sortWorkgroups();
+  }
+}
+
+export class StudentProgress {
+  periodId: string;
+  periodName: string;
+  workgroupId: number;
+  username: string;
+  firstName: string;
+  lastName: string;
+  location: string;
+  completion: ProjectCompletion;
+  completionPct: number;
+  score: number;
+  maxScore: number;
+  scorePct: number;
+
+  constructor(jsonObject: any = {}) {
+    for (const key of Object.keys(jsonObject)) {
+      this[key] = jsonObject[key];
+    }
   }
 }

--- a/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts
+++ b/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts
@@ -38,7 +38,7 @@ export class StudentProgressComponent implements OnInit {
       this.classroomStatusService.studentStatusReceived$.subscribe((args) => {
         const studentStatus = args.studentStatus;
         const workgroupId = studentStatus.workgroupId;
-        this.updateStudent(workgroupId);
+        this.updateTeam(workgroupId);
       })
     );
     this.subscriptions.add(
@@ -73,13 +73,13 @@ export class StudentProgressComponent implements OnInit {
           lastName: names[1]
         });
         this.students.push(student);
-        this.updateStudent(workgroupId);
+        this.updateTeam(workgroupId);
       });
     }
     this.sortWorkgroups();
   }
 
-  private updateStudent(workgroupId: number): void {
+  private updateTeam(workgroupId: number): void {
     const location = this.getCurrentNodeForWorkgroupId(workgroupId);
     const completion = this.classroomStatusService.getStudentProjectCompletion(workgroupId);
     const score = this.getStudentTotalScore(workgroupId);

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -2604,6 +2604,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/app/register/register-home/register-home.component.html</context>
           <context context-type="linenumber">17</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="9b59fedafe883c50e868d884b7a0faeca8f2ccc9" datatype="html">
         <source>Look up username or reset password for a student account</source>
@@ -2866,6 +2870,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.html</context>
           <context context-type="linenumber">11</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="dfb446b53f5c04e99f7deed2f454d3e959e1d324" datatype="html">
         <source>First Name required</source>
@@ -2915,6 +2923,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.html</context>
           <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="17de8a2f90413b5c8a6d622d9cfa4c5eda8bb742" datatype="html">
@@ -4622,8 +4634,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">256</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3f10bb5130f6d7f6d22fb47cfe1c082f01f21ebc" datatype="html">
-        <source> On the left sidebar you can choose to look at the work by step by clicking &quot;Grade By Step&quot; or you can choose to look at the work by team by clicking &quot;Grade By Team&quot;. </source>
+      <trans-unit id="7ace25ec9c013e8fc697d97a29edd0d319ffd27c" datatype="html">
+        <source> On the left sidebar you can choose to look at the work by step by clicking &quot;Grade By Step&quot; or you can choose to look at the work by student by clicking &quot;Grade By Student&quot;. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/help/faq/teacher-faq/teacher-faq.component.html</context>
           <context context-type="linenumber">257,260</context>
@@ -11085,11 +11097,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">107</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">116</context>
+          <context context-type="linenumber">148</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
@@ -12636,8 +12644,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">47</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4221507970327052966" datatype="html">
-        <source>Grade by Team</source>
+      <trans-unit id="2629092933625844061" datatype="html">
+        <source>Grade by Student</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroom-monitor.component.ts</context>
           <context context-type="linenumber">104</context>
@@ -13256,7 +13264,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">23</context>
         </context-group>
       </trans-unit>
       <trans-unit id="33e92d77f1e9c87792c5d839e2fefffde477aca9" datatype="html">
@@ -13311,7 +13319,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">19</context>
+          <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
       <trans-unit id="67b7f7068758d9cd539b9d3b24f0967323a43fe6" datatype="html">
@@ -13326,7 +13334,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">87</context>
+          <context context-type="linenumber">121</context>
         </context-group>
       </trans-unit>
       <trans-unit id="81b97b8ea996ad1e4f9fca8415021850214884b1" datatype="html">
@@ -13360,7 +13368,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">110</context>
+          <context context-type="linenumber">142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b4c3a4560c25436cae3baeaa862f0e4a9ef6d3b1" datatype="html">
@@ -14764,10 +14772,6 @@ Are you sure you want to proceed?</source>
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/notebook-grading/notebook-grading.component.html</context>
           <context context-type="linenumber">45</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">16</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="f7e865440dc3b9d0424773e70d9adf60dbad1ac6" datatype="html">
         <source>Sort By Team</source>
@@ -14785,14 +14789,6 @@ Are you sure you want to proceed?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/notebook-grading/notebook-grading.component.html</context>
           <context context-type="linenumber">72</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">39</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">47</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ff706bcc195a56a7a24646c6ec75cf22d1e9ce46" datatype="html">
@@ -14848,43 +14844,46 @@ Are you sure you want to proceed?</source>
           <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="cb914728a3b7e341fda25f3c040d3498737334e4" datatype="html">
-        <source>Sort by names</source>
+      <trans-unit id="2f322f1b1d0a61638e2cb63bfaef8009c06c2f3f" datatype="html">
+        <source>Sort by student</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">38</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6e8bcf34d728e5d0a52321c4d27b8ba2aaf6e18f" datatype="html">
-        <source>Current Location</source>
+      <trans-unit id="8164c6affed601d590951cadda411162fbfe1bef" datatype="html">
+        <source>Sort by first name</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">59</context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="048e525dac900a13d3e0452f66c9d0c5a34f4e7c" datatype="html">
+        <source>Sort by last name</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">70</context>
+          <context context-type="linenumber">79</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7caf244c4c8c15f20fe70f5c995feeb78f5277cb" datatype="html">
         <source>Sort by location</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">64</context>
+          <context context-type="linenumber">100</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="d4c86ab7df1ba303ea3371b3976f15e1fac85e6f" datatype="html">
-        <source>Project Completion</source>
+      <trans-unit id="6e8bcf34d728e5d0a52321c4d27b8ba2aaf6e18f" datatype="html">
+        <source>Current Location</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1bda3502b1b8833d88448e87041c252aff841379" datatype="html">
         <source>Unit Completion</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">93</context>
+          <context context-type="linenumber">127</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/student-account-menu/student-account-menu.component.html</context>


### PR DESCRIPTION
## Changes
- Add "First Name" and "Last Name" columns to the Grade by Team view in the Classroom Monitor.
- Display one row per student instead of one row per workgroup.
- When user doesn't have view student names permission, include a "Student" column with student id # instead of first name/last name columns.
- Rename "Grade by Team" to "Grade by Student".

## Test
- Ensure that first name and last name columns are displayed in Grade by Student view and there is one row per student.
- Ensure that sorting students by each column header works as expected.

The StudentProgress component  could use some refactoring to reduce complexity and the template could be refactored to reduce duplication. We can address this in a separate PR.

