### PR TITLE
feat(Authoring): Allow expanding and collapsing lessons

### DIFF
--- a/src/assets/wise5/authoringTool/domain/expand-event.ts
+++ b/src/assets/wise5/authoringTool/domain/expand-event.ts
@@ -1,0 +1,4 @@
+export interface ExpandEvent {
+  expanded: boolean;
+  id: string;
+}

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -21,7 +21,7 @@
           [showPosition]="showPosition"
         ></node-icon-and-title>
       </div>
-      <div fxLayout="row" fxLayoutAlign="end center">
+      <div *ngIf="lesson.ids.length > 0" fxLayout="row" fxLayoutAlign="end center">
         <button
           mat-icon-button
           *ngIf="!expanded"

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -1,26 +1,60 @@
-<div id="{{ lesson.id }}" fxLayoutAlign="start center" class="pointer groupHeader projectItem">
-  <mat-checkbox
-    color="primary"
-    (change)="selectNode($event.checked)"
-    [disabled]="nodeTypeSelected() === 'step'"
-    aria-label="Select lesson"
-    i18n-aria-label
-  >
-  </mat-checkbox>
-  <div
-    class="projectItemTitleDiv"
-    fxLayoutAlign="start center"
-    fxLayoutGap="10px"
-    (click)="setCurrentNode(lesson.id)"
-  >
-    <node-icon-and-title [nodeId]="lesson.id" [showPosition]="showPosition"></node-icon-and-title>
+<div id="{{ lesson.id }}" class="lesson">
+  <div class="lesson-bar full-width pointer" fxLayoutAlign="start center">
+    <mat-checkbox
+      color="primary"
+      (change)="selectNode($event.checked)"
+      [disabled]="nodeTypeSelected() === 'step'"
+      aria-label="Select lesson"
+      i18n-aria-label
+    >
+    </mat-checkbox>
+    <div class="full-width" fxLayoutAlign="start center" fxLayoutGap="10px">
+      <div
+        (click)="setCurrentNode(lesson.id)"
+        fxFlex
+        matTooltip="Click to enter lesson"
+        matTooltipPosition="above"
+        i18n-matTooltip
+      >
+        <node-icon-and-title
+          [nodeId]="lesson.id"
+          [showPosition]="showPosition"
+        ></node-icon-and-title>
+      </div>
+      <div fxLayout="row" fxLayoutAlign="end center">
+        <button
+          mat-icon-button
+          *ngIf="!expanded"
+          (click)="toggleExpanded()"
+          fxLayoutAlign="end center"
+          matTooltip="Click to expand"
+          matTooltipPosition="above"
+          i18n-matTooltip
+        >
+          <mat-icon>expand_more</mat-icon>
+        </button>
+        <button
+          mat-icon-button
+          *ngIf="expanded"
+          (click)="toggleExpanded()"
+          fxLayoutAlign="end center"
+          matTooltip="Click to collapse"
+          matTooltipPosition="above"
+          i18n-matTooltip
+        >
+          <mat-icon>expand_less</mat-icon>
+        </button>
+      </div>
+    </div>
   </div>
-</div>
-<div *ngFor="let childId of lesson.ids">
-  <project-authoring-step
-    [step]="idToNode[childId]"
-    (selectNodeEvent)="selectNodeEvent.emit($event)"
-    [showPosition]="showPosition"
-    [projectId]="projectId"
-  ></project-authoring-step>
+  <div *ngIf="expanded" fxLayout="column">
+    <ng-container *ngFor="let childId of lesson.ids">
+      <project-authoring-step
+        [step]="idToNode[childId]"
+        (selectNodeEvent)="selectNodeEvent.emit($event)"
+        [showPosition]="showPosition"
+        [projectId]="projectId"
+      ></project-authoring-step>
+    </ng-container>
+  </div>
 </div>

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.scss
@@ -1,20 +1,19 @@
-.groupHeader {
-  margin-left: 5px !important;
+.lesson {
+  padding: 8px;
+  margin: 16px 0px;
+  border: 2px solid #dddddd;
+  border-radius: 6px;
+  position: relative;
+}
+
+.lesson-bar:hover {
+  background-color: #add8e6;
+}
+
+.full-width {
+  width: 100%;
 }
 
 .pointer {
   cursor: pointer;
-}
-
-.projectItem:hover {
-  background-color: #add8e6;
-}
-
-.projectItemTitleDiv:hover {
-  background-color: #add8e6;
-}
-
-.projectItemTitleDiv {
-  width: 100%;
-  font-weight: initial;
 }

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
@@ -12,14 +12,27 @@ import { NodeIconAndTitleComponent } from '../choose-node-location/node-icon-and
 import { NodeIconComponent } from '../../vle/node-icon/node-icon.component';
 import { FormsModule } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
+import { ProjectAuthoringStepComponent } from '../project-authoring-step/project-authoring-step.component';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ProjectAuthoringLessonHarness } from './project-authoring-lesson.harness';
+
+let component: ProjectAuthoringLessonComponent;
+let fixture: ComponentFixture<ProjectAuthoringLessonComponent>;
+const groupId1 = 'group1';
+let harness: ProjectAuthoringLessonHarness;
+const nodeId1 = 'node1';
+const nodeId2 = 'node2';
+let teacherProjectService: TeacherProjectService;
 
 describe('ProjectAuthoringLessonComponent', () => {
-  let component: ProjectAuthoringLessonComponent;
-  let fixture: ComponentFixture<ProjectAuthoringLessonComponent>;
-
-  beforeEach(() => {
+  beforeEach(async () => {
     TestBed.configureTestingModule({
-      declarations: [NodeIconComponent, NodeIconAndTitleComponent, ProjectAuthoringLessonComponent],
+      declarations: [
+        NodeIconComponent,
+        NodeIconAndTitleComponent,
+        ProjectAuthoringLessonComponent,
+        ProjectAuthoringStepComponent
+      ],
       imports: [
         FormsModule,
         HttpClientTestingModule,
@@ -35,13 +48,59 @@ describe('ProjectAuthoringLessonComponent', () => {
         TeacherWebSocketService
       ]
     });
+    teacherProjectService = TestBed.inject(TeacherProjectService);
+    teacherProjectService.idToNode = {
+      node1: {
+        id: nodeId1,
+        title: 'Step 1'
+      },
+      node2: {
+        id: nodeId2,
+        title: 'Step 2'
+      }
+    };
     fixture = TestBed.createComponent(ProjectAuthoringLessonComponent);
     component = fixture.componentInstance;
-    component.lesson = {};
+    component.lesson = {
+      id: groupId1,
+      ids: [nodeId1, nodeId2],
+      type: 'group'
+    };
     fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(
+      fixture,
+      ProjectAuthoringLessonHarness
+    );
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+  lessonIsExpanded_clickCollapseButton_hideSteps();
+  lessonIsCollapsed_clickExpandButton_showSteps();
 });
+
+function lessonIsExpanded_clickCollapseButton_hideSteps() {
+  describe('lesson is expanded', () => {
+    describe('collapse button is clicked', () => {
+      it('hides steps', async () => {
+        component.expanded = true;
+        await (await harness.getCollapseButton()).click();
+        expect(component.expanded).toBeFalse();
+        const steps = await harness.getSteps();
+        expect(steps.length).toEqual(0);
+      });
+    });
+  });
+}
+
+function lessonIsCollapsed_clickExpandButton_showSteps() {
+  describe('lesson is collapsed', () => {
+    describe('expand button is clicked', () => {
+      it('shows steps', async () => {
+        component.expanded = false;
+        await (await harness.getExpandButton()).click();
+        expect(component.expanded).toBeTrue();
+        const steps = await harness.getSteps();
+        expect(steps.length).toEqual(2);
+      });
+    });
+  });
+}

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -12,7 +12,7 @@ import { ExpandEvent } from '../domain/expand-event';
 })
 export class ProjectAuthoringLessonComponent {
   @Input() expanded: boolean = true;
-  @Output() expandedChangeEvent: EventEmitter<ExpandEvent> = new EventEmitter<ExpandEvent>();
+  @Output() onExpandedChanged: EventEmitter<ExpandEvent> = new EventEmitter<ExpandEvent>();
   protected idToNode: any = {};
   @Input() lesson: any;
   protected nodeTypeSelected: Signal<NodeTypeSelected>;
@@ -41,6 +41,6 @@ export class ProjectAuthoringLessonComponent {
 
   protected toggleExpanded(): void {
     this.expanded = !this.expanded;
-    this.expandedChangeEvent.emit({ id: this.lesson.id, expanded: this.expanded });
+    this.onExpandedChanged.emit({ id: this.lesson.id, expanded: this.expanded });
   }
 }

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -3,6 +3,7 @@ import { TeacherDataService } from '../../services/teacherDataService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { SelectNodeEvent } from '../domain/select-node-event';
 import { NodeTypeSelected } from '../domain/node-type-selected';
+import { ExpandEvent } from '../domain/expand-event';
 
 @Component({
   selector: 'project-authoring-lesson',
@@ -10,6 +11,8 @@ import { NodeTypeSelected } from '../domain/node-type-selected';
   styleUrls: ['./project-authoring-lesson.component.scss']
 })
 export class ProjectAuthoringLessonComponent {
+  @Input() expanded: boolean = true;
+  @Output() expandedChangeEvent: EventEmitter<ExpandEvent> = new EventEmitter<ExpandEvent>();
   protected idToNode: any = {};
   @Input() lesson: any;
   protected nodeTypeSelected: Signal<NodeTypeSelected>;
@@ -34,5 +37,10 @@ export class ProjectAuthoringLessonComponent {
 
   protected setCurrentNode(nodeId: string): void {
     this.dataService.setCurrentNodeByNodeId(nodeId);
+  }
+
+  protected toggleExpanded(): void {
+    this.expanded = !this.expanded;
+    this.expandedChangeEvent.emit({ id: this.lesson.id, expanded: this.expanded });
   }
 }

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.harness.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.harness.ts
@@ -1,0 +1,22 @@
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { ProjectAuthoringStepHarness } from '../project-authoring-step/project-authoring-step.harness';
+
+export class ProjectAuthoringLessonHarness extends ComponentHarness {
+  static hostSelector = 'project-authoring-lesson';
+  getExpandButton = this.locatorForOptional(
+    MatButtonHarness.with({ selector: '[matTooltip="Click to expand"]' })
+  );
+  getCollapseButton = this.locatorForOptional(
+    MatButtonHarness.with({ selector: '[matTooltip="Click to collapse"]' })
+  );
+  getSteps = this.locatorForAll(ProjectAuthoringStepHarness);
+
+  async isExpanded(): Promise<boolean> {
+    return (await this.getExpandButton()) == null;
+  }
+
+  async isCollapsed(): Promise<boolean> {
+    return (await this.getCollapseButton()) == null;
+  }
+}

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
@@ -18,6 +18,9 @@
     fxLayoutAlign="start center"
     fxLayoutGap="10px"
     (click)="setCurrentNode(step.id)"
+    matTooltip="Click to enter step"
+    matTooltipPosition="above"
+    i18n-matTooltip
   >
     <node-icon-and-title [nodeId]="step.id" [showPosition]="showPosition"></node-icon-and-title>
     <p fxLayoutAlign="start center" fxLayoutGap="10px">

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.harness.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.harness.ts
@@ -1,0 +1,5 @@
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class ProjectAuthoringStepHarness extends ComponentHarness {
+  static hostSelector = 'project-authoring-step';
+}

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -54,6 +54,25 @@
   >
     <mat-icon>delete</mat-icon>
   </button>
+  <div fxFlex></div>
+  <button
+    (click)="expandAllLessons()"
+    [disabled]="isAllLessonsExpanded()"
+    mat-raised-button
+    color="primary"
+    i18n
+  >
+    + Expand All
+  </button>
+  <button
+    (click)="collapseAllLessons()"
+    [disabled]="isAllLessonsCollapsed()"
+    mat-raised-button
+    color="primary"
+    i18n
+  >
+    - Collapse All
+  </button>
 </div>
 <div class="all-nodes-div">
   <div *ngFor="let lesson of lessons">
@@ -62,6 +81,8 @@
       (selectNodeEvent)="selectNode($event)"
       [showPosition]="true"
       [projectId]="projectId"
+      [expanded]="lessonIdToExpanded()[lesson.id]"
+      (expandedChangeEvent)="expandedChangeEvent($event)"
     ></project-authoring-lesson>
   </div>
   <div>
@@ -73,6 +94,8 @@
         (selectNodeEvent)="selectNode($event)"
         [showPosition]="false"
         [projectId]="projectId"
+        [expanded]="lessonIdToExpanded()[inactiveGroupNode.id]"
+        (expandedChangeEvent)="expandedChangeEvent($event)"
       ></project-authoring-lesson>
     </div>
     <div>

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -57,7 +57,7 @@
   <div fxFlex></div>
   <button
     (click)="expandAllLessons()"
-    [disabled]="isAllLessonsExpanded()"
+    [disabled]="allLessonsExpanded()"
     mat-raised-button
     color="primary"
     i18n
@@ -66,7 +66,7 @@
   </button>
   <button
     (click)="collapseAllLessons()"
-    [disabled]="isAllLessonsCollapsed()"
+    [disabled]="allLessonsCollapsed()"
     mat-raised-button
     color="primary"
     i18n
@@ -82,7 +82,7 @@
       [showPosition]="true"
       [projectId]="projectId"
       [expanded]="lessonIdToExpanded()[lesson.id]"
-      (expandedChangeEvent)="expandedChangeEvent($event)"
+      (onExpandedChanged)="onExpandedChanged($event)"
     ></project-authoring-lesson>
   </div>
   <div>
@@ -95,7 +95,7 @@
         [showPosition]="false"
         [projectId]="projectId"
         [expanded]="lessonIdToExpanded()[inactiveGroupNode.id]"
-        (expandedChangeEvent)="expandedChangeEvent($event)"
+        (onExpandedChanged)="onExpandedChanged($event)"
       ></project-authoring-lesson>
     </div>
     <div>

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.scss
@@ -8,7 +8,6 @@
 
 .all-nodes-div {
   margin-top: 20px;
-  margin-left: 20px;
 }
 
 .componentHeader {

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.harness.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.harness.ts
@@ -1,0 +1,10 @@
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { ProjectAuthoringLessonHarness } from '../project-authoring-lesson/project-authoring-lesson.harness';
+
+export class ProjectAuthoringHarness extends ComponentHarness {
+  static hostSelector = 'project-authoring';
+  getExpandAllButton = this.locatorFor(MatButtonHarness.with({ text: '+ Expand All' }));
+  getCollapseAllButton = this.locatorFor(MatButtonHarness.with({ text: '- Collapse All' }));
+  getLessons = this.locatorForAll(ProjectAuthoringLessonHarness);
+}

--- a/src/assets/wise5/authoringTool/tsconfig.json
+++ b/src/assets/wise5/authoringTool/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "resolveJsonModule": true,
     "target": "es5",
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2017", "dom"]

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9197,7 +9197,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">68</context>
+          <context context-type="linenumber">89</context>
         </context-group>
       </trans-unit>
       <trans-unit id="24b2aed16c8aef6c967fb04c48adde152cf40193" datatype="html">
@@ -9762,7 +9762,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">69</context>
+          <context context-type="linenumber">90</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a10dba8eb1f22a5f90f90e79b8305963eec3ee38" datatype="html">
@@ -9777,7 +9777,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">79</context>
+          <context context-type="linenumber">102</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0217500199a3e48a7b95762b14b79dad49e76beb" datatype="html">
@@ -9792,7 +9792,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">103</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f951d80b53d5536f79142285e8ba09f190a3c723" datatype="html">
@@ -12195,7 +12195,28 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Select lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">6</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="bed409327441403b4138bdbe2289b3bc58b61f86" datatype="html">
+        <source>Click to enter lesson</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7ea36eedd5af1d2e78d642c80ded9ea3cc830e7f" datatype="html">
+        <source>Click to expand</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="c4ac015c8e81aa2be8dc2a3f5aa06ef098099b53" datatype="html">
+        <source>Click to collapse</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
+          <context context-type="linenumber">41</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0788cea8f340f4f5399901765d2003f90af76669" datatype="html">
@@ -12205,13 +12226,20 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="86b684959993240cec0e9ff07ca51d8b3dedbb75" datatype="html">
+        <source>Click to enter step</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="62547d9d6ebd4fe6c10b47b87c9b603978fde580" datatype="html">
         <source>Branch point with <x id="INTERPOLATION" equiv-text="{{ getNumberOfBranchPaths(step.id) }}"/> paths based on <x id="INTERPOLATION_1" equiv-text="{{
           getBranchCriteriaDescription(step.id)
         }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">28,30</context>
+          <context context-type="linenumber">31,33</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dac51bbe210a29f2e5d14a0b3442cae1aeefe4a3" datatype="html">
@@ -12220,14 +12248,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">38,40</context>
+          <context context-type="linenumber">41,43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b3b4847175a6193afa85eb431bbe16d1f04470fa" datatype="html">
         <source>Has Rubric</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">47</context>
+          <context context-type="linenumber">50</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e5e0c8fd39cb0db7735731e3ae7d2108f430f16e" datatype="html">
@@ -12251,18 +12279,32 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">29</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="01a365a6898674b9e2ae299c03986e33d82d88da" datatype="html">
+        <source> + Expand All </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
+          <context context-type="linenumber">64,66</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="f38b6d67175548a28ac5f5aea4e105c79e295531" datatype="html">
+        <source> - Collapse All </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
+          <context context-type="linenumber">73,75</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="791981839110791639" datatype="html">
         <source>Are you sure you want to delete the selected item?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">89</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1189930234736223663" datatype="html">
         <source>Are you sure you want to delete the <x id="PH" equiv-text="selectedNodeIds.length"/> selected items?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">90</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e8fb2ceb6f8d4c3e90a6a688e9024461e67f44f0" datatype="html">


### PR DESCRIPTION
## Changes
- Added expand/collapse button to lessons
- Added border around lessons
- Added expand all button
- Added collapse all button

## Test
Make sure clicking
- the expand lesson button, shows the steps in the lesson
- the collapse lesson button, hides the steps in the lesson
- on a lesson, opens the lesson
- expand all, expands all lessons
- collapse all, collapses all lessons

Closes #1621
