### PR TITLE
feat(Authoring Tool): Create TranslatableTextareaComponent

### DIFF
--- a/src/app/authoring-tool/edit-component-prompt/edit-component-prompt.component.html
+++ b/src/app/authoring-tool/edit-component-prompt/edit-component-prompt.component.html
@@ -1,14 +1,11 @@
-<translatable-input [content]="componentContent" key="prompt" class="prompt" appearance="fill">
-  <mat-form-field>
-    <mat-label i18n>Prompt</mat-label>
-    <textarea
-      matInput
-      [(ngModel)]="componentContent.prompt"
-      (ngModelChange)="promptChangedEvent.next($event)"
-      placeholder="Enter Prompt Here"
-      i18n-placeholder
-      cdkTextareaAutosize
-    >
-    </textarea>
-  </mat-form-field>
-</translatable-input>
+<translatable-textarea
+  [content]="componentContent"
+  key="prompt"
+  label="Prompt"
+  i18n-label
+  placeholder="Enter Prompt Here"
+  i18n-placeholder
+  (defaultLanguageTextChanged)="promptChangedEvent.next($event)"
+  class="prompt"
+  appearance="fill"
+/>

--- a/src/app/teacher/component-authoring.module.ts
+++ b/src/app/teacher/component-authoring.module.ts
@@ -85,6 +85,7 @@ import { WiseTinymceEditorModule } from '../../assets/wise5/directives/wise-tiny
 import { WiseLinkAuthoringDialogComponent } from '../../assets/wise5/authoringTool/wise-link-authoring-dialog/wise-link-authoring-dialog.component';
 import { EditComponentAdvancedButtonComponent } from '../../assets/wise5/authoringTool/components/edit-component-advanced-button/edit-component-advanced-button.component';
 import { TranslatableInputComponent } from '../../assets/wise5/authoringTool/components/translatable-input/translatable-input.component';
+import { TranslatableTextareaComponent } from '../../assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component';
 
 @NgModule({
   declarations: [
@@ -175,6 +176,7 @@ import { TranslatableInputComponent } from '../../assets/wise5/authoringTool/com
     StudentTeacherCommonModule,
     PeerGroupingAuthoringModule,
     TranslatableInputComponent,
+    TranslatableTextareaComponent,
     WiseTinymceEditorModule
   ],
   exports: [

--- a/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.html
@@ -1,0 +1,22 @@
+<mat-form-field *ngIf="!showTranslationInput()">
+  <mat-label>{{ label }}</mat-label>
+  <textarea
+    matInput
+    [(ngModel)]="content[key]"
+    (ngModelChange)="defaultLanguageTextChanged.next($event)"
+    placeholder="{{ placeholder }}"
+    cdkTextareaAutosize
+  >
+  </textarea>
+</mat-form-field>
+<mat-form-field *ngIf="showTranslationInput()">
+  <mat-label>{{ label }} ({{ currentLanguage().language }})</mat-label>
+  <textarea
+    matInput
+    [ngModel]="translationText()"
+    (ngModelChange)="translationTextChanged.next($event)"
+    placeholder="{{ placeholder }}"
+    cdkTextareaAutosize
+  ></textarea>
+  <mat-hint>{{ defaultLanguageText() }}</mat-hint>
+</mat-form-field>

--- a/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.spec.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.spec.ts
@@ -1,0 +1,32 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslatableTextareaComponent } from './translatable-textarea.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { TeacherProjectService } from '../../../services/teacherProjectService';
+
+describe('TranslatableTextareaComponent', () => {
+  let component: TranslatableTextareaComponent;
+  let fixture: ComponentFixture<TranslatableTextareaComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        BrowserAnimationsModule,
+        HttpClientTestingModule,
+        StudentTeacherCommonServicesModule,
+        TranslatableTextareaComponent
+      ],
+      providers: [TeacherProjectService]
+    });
+    spyOn(TestBed.inject(TeacherProjectService), 'isDefaultLocale').and.returnValue(true);
+    fixture = TestBed.createComponent(TranslatableTextareaComponent);
+    component = fixture.componentInstance;
+    component.content = {};
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.ts
@@ -1,0 +1,76 @@
+import { Component, Input, Output, Signal, computed } from '@angular/core';
+import { EditProjectTranslationService } from '../../../services/editProjectTranslationService';
+import { Subject, Subscription, debounceTime, distinctUntilChanged } from 'rxjs';
+import { Language } from '../../../../../app/domain/language';
+import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { TranslateProjectService } from '../../../services/translateProjectService';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatInputModule } from '@angular/material/input';
+
+@Component({
+  standalone: true,
+  selector: 'translatable-textarea',
+  imports: [CommonModule, FormsModule, MatInputModule],
+  providers: [EditProjectTranslationService],
+  templateUrl: './translatable-textarea.component.html'
+})
+export class TranslatableTextareaComponent {
+  @Input() content: object;
+  protected currentLanguage: Signal<Language>;
+  protected defaultLanguageText: Signal<string>;
+  @Output() defaultLanguageTextChanged: Subject<string> = new Subject<string>();
+  private i18nId: string;
+  @Input() key: string;
+  @Input() label: string;
+  @Input() placeholder: string;
+  protected showTranslationInput: Signal<boolean>;
+  protected translationText: Signal<string>;
+  protected translationTextChanged: Subject<string> = new Subject<string>();
+  protected translationTextChangedSubscription: Subscription;
+
+  constructor(
+    private editProjectTranslationService: EditProjectTranslationService,
+    private projectService: TeacherProjectService,
+    private translateProjectService: TranslateProjectService
+  ) {
+    this.currentLanguage = projectService.currentLanguage;
+    this.showTranslationInput = computed(() => !this.projectService.isDefaultLocale());
+  }
+
+  ngOnInit(): void {
+    this.i18nId = this.content[`${this.key}.i18n`]?.id;
+    this.translationText = computed(() =>
+      this.showTranslationInput()
+        ? this.translateProjectService.currentTranslations()[this.i18nId]?.value
+        : ''
+    );
+    this.defaultLanguageText = computed(() =>
+      this.showTranslationInput()
+        ? `[${this.projectService.getLocale().getDefaultLanguage().language}\] ${
+            this.content[this.key]
+          }`
+        : ''
+    );
+    this.translationTextChangedSubscription = this.translationTextChanged
+      .pipe(debounceTime(1000), distinctUntilChanged())
+      .subscribe((text: string) => {
+        this.saveTranslationText(text);
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.translationTextChangedSubscription.unsubscribe();
+  }
+
+  private saveTranslationText(text: string): void {
+    this.projectService.broadcastSavingProject();
+    const currentTranslations = this.translateProjectService.currentTranslations();
+    currentTranslations[this.i18nId] = { value: text, modified: new Date().getTime() };
+    this.editProjectTranslationService
+      .saveCurrentTranslations(currentTranslations)
+      .subscribe(() => {
+        this.projectService.broadcastProjectSaved();
+      });
+  }
+}

--- a/src/assets/wise5/components/component-authoring.module.ts
+++ b/src/assets/wise5/components/component-authoring.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { TranslatableInputComponent } from '../authoringTool/components/translatable-input/translatable-input.component';
 import { EditProjectTranslationService } from '../services/editProjectTranslationService';
+import { TranslatableTextareaComponent } from '../authoringTool/components/translatable-textarea/translatable-textarea.component';
 
 @NgModule({
-  imports: [TranslatableInputComponent],
+  imports: [TranslatableInputComponent, TranslatableTextareaComponent],
   providers: [EditProjectTranslationService],
-  exports: [TranslatableInputComponent]
+  exports: [TranslatableInputComponent, TranslatableTextareaComponent]
 })
 export class ComponentAuthoringModule {}

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -967,7 +967,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Prompt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-component-prompt/edit-component-prompt.component.html</context>
-          <context context-type="linenumber">3</context>
+          <context context-type="linenumber">4</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-dynamic-prompt-rules/edit-dynamic-prompt-rules.component.html</context>
@@ -986,7 +986,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Enter Prompt Here</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-component-prompt/edit-component-prompt.component.html</context>
-          <context context-type="linenumber">8</context>
+          <context context-type="linenumber">6</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7affaae0e14529c0192d5a4bfabd6fcb1ea27529" datatype="html">


### PR DESCRIPTION
## Notes
- After this PR is merged, TranslatableTextareaComponent and TranslatableInputComponent will have a lot of duplicated code. Don't worry about the duplication in this review. After this, we'll do a separate refactor PR to extract common code in this feature branch (to ensure that the duplication won't make it into the develop branch). 
- Please style as you see fit

## Changes
- Create TranslatableTextareaComponent to allow translators to translate textarea fields in the authoring tool
- Modify EditComponentPromptComponent to use this new component

## Test
- Component prompt authoring work as before and can be translated into different languages, including
   - shows text, label, placeholder in default and translated languages
   - shows default language text as hint if you're authoring in translated language
   - saves text in default and translated languages. Note that at the moment, saving only works in the translated language if translation already exists in the translation file.
