### PR TITLE
feat(Multiple Languages): Save new translations

### DIFF
--- a/src/assets/wise5/authoringTool/components/abstract-translatable-field/abstract-translatable-field.component.ts
+++ b/src/assets/wise5/authoringTool/components/abstract-translatable-field/abstract-translatable-field.component.ts
@@ -4,6 +4,7 @@ import { Language } from '../../../../../app/domain/language';
 import { EditProjectTranslationService } from '../../../services/editProjectTranslationService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { TranslateProjectService } from '../../../services/translateProjectService';
+import { generateRandomKey } from '../../../common/string/string';
 
 @Directive()
 export abstract class AbstractTranslatableFieldComponent {
@@ -45,13 +46,22 @@ export abstract class AbstractTranslatableFieldComponent {
     );
     this.translationTextChangedSubscription = this.translationTextChanged
       .pipe(debounceTime(1000), distinctUntilChanged())
-      .subscribe((text: string) => {
+      .subscribe(async (text: string) => {
+        if (this.i18nId == null) {
+          await this.createI18NField();
+        }
         this.saveTranslationText(text);
       });
   }
 
   ngOnDestroy(): void {
     this.translationTextChangedSubscription.unsubscribe();
+  }
+
+  private createI18NField(): Promise<any> {
+    this.i18nId = generateRandomKey(30);
+    this.content[`${this.key}.i18n`] = { id: this.i18nId, modified: new Date().getTime() };
+    return this.projectService.saveProject();
   }
 
   private saveTranslationText(text: string): void {


### PR DESCRIPTION
## Changes
This change allows translators to save translations for fields that have never been translated into another language before. The code adds a new i18n field to the default language content, and uses the new i18nId (30-character random string) to save the new translation text.

## Known issue
If you have two translatable languages (e.g. Default=English, Translatable Languages=[Spanish, Italian]), and you save a new translation text in Spanish and then switch to Italian, the Spanish text appears in the input, even though it should show empty. This is not an issue that this PR introduced, so you can ignore it for now. I'll look into it later.

## Test
- Enter translation texts for fields that have never been translated before.
   - This should create a new i18n field in the default language's content (with new 30-character i18n ID and modified timestamp) and save the project.json
   - This should also save the new translation in the translations.[locale].json file using the new 30-character i18n ID.
- Updating existing translations should work as before