### PR TITLE
feat(Speech to Text): Ensure only one component on a step is recording

### DIFF
--- a/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.html
+++ b/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.html
@@ -22,7 +22,8 @@
     </button>
   </mat-menu>
   <button
-    *ngIf="!recording()"
+    *ngIf="!(recording() && requestedRecording)"
+    [disabled]="recording() && !requestedRecording"
     mat-icon-button
     id="recordButton"
     (click)="toggleRecording()"
@@ -32,7 +33,7 @@
     <mat-icon color="primary">mic</mat-icon>
   </button>
   <button
-    *ngIf="recording()"
+    *ngIf="recording() && requestedRecording"
     mat-icon-button
     id="recordButton"
     (click)="toggleRecording()"
@@ -41,5 +42,7 @@
   >
     <mat-icon color="warn">stop_circle</mat-icon>
   </button>
-  <span *ngIf="recording()" class="mat-caption text-secondary" i18n>Recording...</span>
+  <span *ngIf="recording() && requestedRecording" class="mat-caption text-secondary" i18n
+    >Recording...</span
+  >
 </div>

--- a/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.html
+++ b/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.html
@@ -3,7 +3,7 @@
   <button
     mat-stroked-button
     [matMenuTriggerFor]="languageSelect"
-    #languageSelectButton
+    [disabled]="recording()"
     matTooltip="Select language"
     i18n-mat-tooltip
   >
@@ -22,7 +22,7 @@
     </button>
   </mat-menu>
   <button
-    *ngIf="!recording"
+    *ngIf="!recording()"
     mat-icon-button
     id="recordButton"
     (click)="toggleRecording()"
@@ -32,7 +32,7 @@
     <mat-icon color="primary">mic</mat-icon>
   </button>
   <button
-    *ngIf="recording"
+    *ngIf="recording()"
     mat-icon-button
     id="recordButton"
     (click)="toggleRecording()"
@@ -41,5 +41,5 @@
   >
     <mat-icon color="warn">stop_circle</mat-icon>
   </button>
-  <span *ngIf="recording" class="mat-caption text-secondary" i18n>Recording...</span>
+  <span *ngIf="recording()" class="mat-caption text-secondary" i18n>Recording...</span>
 </div>

--- a/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.html
+++ b/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.html
@@ -22,27 +22,25 @@
     </button>
   </mat-menu>
   <button
-    *ngIf="!(recording() && requestedRecording)"
-    [disabled]="recording() && !requestedRecording"
+    *ngIf="!(recording() && recordingRequester)"
+    [disabled]="recording()"
     mat-icon-button
-    id="recordButton"
+    color="primary"
     (click)="toggleRecording()"
     matTooltip="Record voice"
     i18n-mat-tooltip
   >
-    <mat-icon color="primary">mic</mat-icon>
+    <mat-icon>mic</mat-icon>
   </button>
-  <button
-    *ngIf="recording() && requestedRecording"
-    mat-icon-button
-    id="recordButton"
-    (click)="toggleRecording()"
-    matTooltip="Stop recording"
-    i18n-mat-tooltip
-  >
-    <mat-icon color="warn">stop_circle</mat-icon>
-  </button>
-  <span *ngIf="recording() && requestedRecording" class="mat-caption text-secondary" i18n
-    >Recording...</span
-  >
+  <ng-container *ngIf="recording() && recordingRequester">
+    <button
+      mat-icon-button
+      (click)="toggleRecording()"
+      matTooltip="Stop recording"
+      i18n-mat-tooltip
+    >
+      <mat-icon color="warn">stop_circle</mat-icon>
+    </button>
+    <span class="mat-caption text-secondary" i18n>Recording...</span>
+  </ng-container>
 </div>

--- a/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts
+++ b/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts
@@ -47,7 +47,7 @@ export class SpeechToTextComponent {
   protected languages: Language[];
   @Output() newTextEvent: EventEmitter<string> = new EventEmitter<string>();
   protected recording: Signal<boolean> = this.transcribeService.recording;
-  protected requestedRecording = false;
+  protected recordingRequester = false;
   protected selectedLanguage: Language = { languageCode: null, language: null };
 
   constructor(
@@ -83,7 +83,7 @@ export class SpeechToTextComponent {
 
   private async startRecording(): Promise<void> {
     try {
-      this.requestedRecording = true;
+      this.recordingRequester = true;
       await this.transcribeService.startRecording(
         this.selectedLanguage.languageCode,
         this.processTranscriptionText.bind(this)
@@ -96,7 +96,7 @@ export class SpeechToTextComponent {
 
   private stopRecording(): void {
     this.transcribeService.stopRecording();
-    this.requestedRecording = false;
+    this.recordingRequester = false;
   }
 
   private processTranscriptionText(text: string): void {

--- a/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts
+++ b/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts
@@ -47,6 +47,7 @@ export class SpeechToTextComponent {
   protected languages: Language[];
   @Output() newTextEvent: EventEmitter<string> = new EventEmitter<string>();
   protected recording: Signal<boolean> = this.transcribeService.recording;
+  protected requestedRecording = false;
   protected selectedLanguage: Language = { languageCode: null, language: null };
 
   constructor(
@@ -82,6 +83,7 @@ export class SpeechToTextComponent {
 
   private async startRecording(): Promise<void> {
     try {
+      this.requestedRecording = true;
       await this.transcribeService.startRecording(
         this.selectedLanguage.languageCode,
         this.processTranscriptionText.bind(this)
@@ -94,6 +96,7 @@ export class SpeechToTextComponent {
 
   private stopRecording(): void {
     this.transcribeService.stopRecording();
+    this.requestedRecording = false;
   }
 
   private processTranscriptionText(text: string): void {

--- a/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts
+++ b/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts
@@ -1,11 +1,11 @@
-import { Component, EventEmitter, Output, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Output, Signal } from '@angular/core';
 import { TranscribeService } from '../../../services/transcribeService';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { LanguageCode } from '@aws-sdk/client-transcribe-streaming';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { ProjectService } from '../../../services/projectService';
-import { MatButton, MatButtonModule } from '@angular/material/button';
+import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatMenuModule } from '@angular/material/menu';
@@ -44,10 +44,9 @@ export class SpeechToTextComponent {
     { languageCode: 'pt-BR', language: $localize`Portuguese (Brazilian)` },
     { languageCode: 'es-US', language: $localize`Spanish` }
   ];
-  @ViewChild('languageSelectButton') languageSelectButton: MatButton;
   protected languages: Language[];
   @Output() newTextEvent: EventEmitter<string> = new EventEmitter<string>();
-  protected recording: boolean;
+  protected recording: Signal<boolean> = this.transcribeService.recording;
   protected selectedLanguage: Language = { languageCode: null, language: null };
 
   constructor(
@@ -70,9 +69,7 @@ export class SpeechToTextComponent {
   }
 
   protected toggleRecording(): void {
-    this.recording = !this.recording;
-    this.languageSelectButton.disabled = this.recording;
-    if (this.recording) {
+    if (!this.recording()) {
       this.startRecording();
     } else {
       this.stopRecording();

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -19902,7 +19902,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>An error occurred while recording: <x id="PH" equiv-text="error.message"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts</context>
-          <context context-type="linenumber">93</context>
+          <context context-type="linenumber">90</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1509148984305384330" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -19832,7 +19832,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Recording...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.html</context>
-          <context context-type="linenumber">44</context>
+          <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="511208907501917679" datatype="html">
@@ -19902,7 +19902,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>An error occurred while recording: <x id="PH" equiv-text="error.message"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts</context>
-          <context context-type="linenumber">90</context>
+          <context context-type="linenumber">92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1509148984305384330" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -19832,7 +19832,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Recording...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">44</context>
         </context-group>
       </trans-unit>
       <trans-unit id="511208907501917679" datatype="html">


### PR DESCRIPTION
## Changes
- Introduced a ```recording``` boolean signal in TranscribeService to globally keep track of when transcription recording is happening. Use this variable to enable/disable the controls (language selection and record button) in the SpeechToTextComponent
- When one component is recording, other component(s)' STT controls are displayed but disabled.

## Test (on a step with two or more OR components with STT controls enabled)
- Click record for one component
   - It should disable language selection and record button for the other component(s).
  - Transcription should work as before
- Click stop for the component. It should re-enable language selection and record button for the other component(s).