### PR TITLE
feat(Speech to Text): Persist language selection across components

### DIFF
--- a/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.html
+++ b/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.html
@@ -8,7 +8,7 @@
     i18n-mat-tooltip
   >
     <mat-icon>translate</mat-icon>
-    <span *ngIf="selectedLanguage()">{{ selectedLanguage().language }}</span>
+    <span *ngIf="selectedLanguage()">{{ selectedLanguage().name }}</span>
   </button>
   <mat-menu #languageSelect="matMenu">
     <button
@@ -16,9 +16,9 @@
       [value]="language"
       mat-menu-item
       (click)="changeLanguage(language)"
-      [class]="{ primary: language.languageCode === selectedLanguage().languageCode }"
+      [class]="{ primary: language.code === selectedLanguage().code }"
     >
-      {{ language.language }}
+      {{ language.name }}
     </button>
   </mat-menu>
   <button

--- a/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.html
+++ b/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.html
@@ -8,7 +8,7 @@
     i18n-mat-tooltip
   >
     <mat-icon>translate</mat-icon>
-    <span *ngIf="selectedLanguage">{{ selectedLanguage.language }}</span>
+    <span *ngIf="selectedLanguage()">{{ selectedLanguage().language }}</span>
   </button>
   <mat-menu #languageSelect="matMenu">
     <button
@@ -16,7 +16,7 @@
       [value]="language"
       mat-menu-item
       (click)="changeLanguage(language)"
-      [class]="{ primary: language.languageCode === selectedLanguage.languageCode }"
+      [class]="{ primary: language.languageCode === selectedLanguage().languageCode }"
     >
       {{ language.language }}
     </button>

--- a/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts
+++ b/src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts
@@ -54,7 +54,7 @@ export class SpeechToTextComponent {
     try {
       this.recordingRequester = true;
       await this.transcribeService.startRecording(
-        this.selectedLanguage().languageCode,
+        this.selectedLanguage().code,
         this.processTranscriptionText.bind(this)
       );
     } catch (error) {

--- a/src/assets/wise5/services/transcribeService.ts
+++ b/src/assets/wise5/services/transcribeService.ts
@@ -18,8 +18,8 @@ window.process = process;
 window.Buffer = Buffer;
 
 export interface Language {
-  languageCode: LanguageCode;
-  language: string;
+  code: LanguageCode;
+  name: string;
 }
 
 @Injectable()
@@ -27,23 +27,23 @@ export class TranscribeService {
   private SAMPLE_RATE = 44100;
 
   private allLanguages: Language[] = [
-    { languageCode: 'zh-CN', language: $localize`Chinese (Simplified)` },
-    { languageCode: 'en-US', language: $localize`English` },
-    { languageCode: 'fr-FR', language: $localize`French` },
-    { languageCode: 'de-DE', language: $localize`German` },
-    { languageCode: 'it-IT', language: $localize`Italian` },
-    { languageCode: 'ja-JP', language: $localize`Japanese` },
-    { languageCode: 'ko-KR', language: $localize`Korean` },
-    { languageCode: 'pt-BR', language: $localize`Portuguese (Brazilian)` },
-    { languageCode: 'es-US', language: $localize`Spanish` }
+    { code: 'zh-CN', name: $localize`Chinese (Simplified)` },
+    { code: 'en-US', name: $localize`English` },
+    { code: 'fr-FR', name: $localize`French` },
+    { code: 'de-DE', name: $localize`German` },
+    { code: 'it-IT', name: $localize`Italian` },
+    { code: 'ja-JP', name: $localize`Japanese` },
+    { code: 'ko-KR', name: $localize`Korean` },
+    { code: 'pt-BR', name: $localize`Portuguese (Brazilian)` },
+    { code: 'es-US', name: $localize`Spanish` }
   ];
   readonly languages: Language[];
   private microphoneStream = undefined;
   private recordingSignal: WritableSignal<boolean> = signal(false);
   readonly recording = this.recordingSignal.asReadonly();
   private selectedLanguageSignal: WritableSignal<Language> = signal({
-    languageCode: null,
-    language: null
+    code: null,
+    name: null
   });
   readonly selectedLanguage = this.selectedLanguageSignal.asReadonly();
   private transcribeClient = undefined;
@@ -51,12 +51,11 @@ export class TranscribeService {
   constructor(private configService: ConfigService, private projectService: ProjectService) {
     const { defaultLanguage, supportedLanguages } = this.projectService.project.speechToText;
     this.selectedLanguageSignal.set({
-      languageCode: defaultLanguage,
-      language: this.allLanguages.find((language) => language.languageCode === defaultLanguage)
-        .language
+      code: defaultLanguage,
+      name: this.allLanguages.find((language) => language.code === defaultLanguage).name
     });
     this.languages = this.allLanguages.filter((language) =>
-      supportedLanguages.includes(language.languageCode)
+      supportedLanguages.includes(language.code)
     );
   }
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -19835,74 +19835,11 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">44</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="511208907501917679" datatype="html">
-        <source>Chinese (Simplified)</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts</context>
-          <context context-type="linenumber">37</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="5866254605255506989" datatype="html">
-        <source>English</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts</context>
-          <context context-type="linenumber">38</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7633754075223722162" datatype="html">
-        <source>French</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts</context>
-          <context context-type="linenumber">39</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1858110241312746425" datatype="html">
-        <source>German</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts</context>
-          <context context-type="linenumber">40</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2935232983274991580" datatype="html">
-        <source>Italian</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts</context>
-          <context context-type="linenumber">41</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6924606686202701860" datatype="html">
-        <source>Japanese</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts</context>
-          <context context-type="linenumber">42</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6145439649200570157" datatype="html">
-        <source>Korean</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts</context>
-          <context context-type="linenumber">43</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="5673214158044687618" datatype="html">
-        <source>Portuguese (Brazilian)</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts</context>
-          <context context-type="linenumber">44</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="5190825892106392539" datatype="html">
-        <source>Spanish</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts</context>
-          <context context-type="linenumber">45</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="3885391545392231744" datatype="html">
         <source>An error occurred while recording: <x id="PH" equiv-text="error.message"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/speech-to-text/speech-to-text.component.ts</context>
-          <context context-type="linenumber">92</context>
+          <context context-type="linenumber">61</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1509148984305384330" datatype="html">
@@ -21733,6 +21670,69 @@ If this problem continues, let your teacher know and move on to the next activit
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
           <context context-type="linenumber">960</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="511208907501917679" datatype="html">
+        <source>Chinese (Simplified)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/services/transcribeService.ts</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5866254605255506989" datatype="html">
+        <source>English</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/services/transcribeService.ts</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7633754075223722162" datatype="html">
+        <source>French</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/services/transcribeService.ts</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1858110241312746425" datatype="html">
+        <source>German</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/services/transcribeService.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2935232983274991580" datatype="html">
+        <source>Italian</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/services/transcribeService.ts</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6924606686202701860" datatype="html">
+        <source>Japanese</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/services/transcribeService.ts</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6145439649200570157" datatype="html">
+        <source>Korean</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/services/transcribeService.ts</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5673214158044687618" datatype="html">
+        <source>Portuguese (Brazilian)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/services/transcribeService.ts</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5190825892106392539" datatype="html">
+        <source>Spanish</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/services/transcribeService.ts</context>
+          <context context-type="linenumber">38</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846fecebb7756c6127955bc2c08d2111dce64c3c" datatype="html">


### PR DESCRIPTION
## Changes
- Use a shared signal in TranscribeService to store the user's language selection. This way, students will no longer need to choose their preferred language each time they need to transcribe.
   - This required moving the initialization code (for ```selectedLanguage``` and ```languages```) from SpeechToTextComponent to TranscribeService

## Test
- Choose a language on one component
   - It should immediately update the selection on another component (if on the same step)
   - The selection should persist across steps too
- Transcription works as before