### PR TITLE
fix(Authoring): Move inactive lesson duplicates steps

### DIFF
--- a/src/app/services/deleteNodeService.spec.ts
+++ b/src/app/services/deleteNodeService.spec.ts
@@ -59,10 +59,10 @@ function shouldDeleteAStepFromTheProject() {
 function shouldDeleteAnInactiveStepFromTheProject() {
   it('should delete an inactive step from the project', () => {
     projectService.setProject(demoProjectJSON);
-    expect(projectService.getInactiveNodes().length).toEqual(1);
+    const numInactiveNodes = projectService.getInactiveNodes().length;
     expect(projectService.getNodeById('node789')).not.toBeNull();
     service.deleteNode('node789');
-    expect(projectService.getInactiveNodes().length).toEqual(0);
+    expect(projectService.getInactiveNodes().length).toEqual(numInactiveNodes - 1);
     expect(projectService.getNodeById('node789')).toBeNull();
   });
 }

--- a/src/app/services/moveNodesService.spec.ts
+++ b/src/app/services/moveNodesService.spec.ts
@@ -1,0 +1,48 @@
+import { TestBed } from '@angular/core/testing';
+import { MoveNodesService } from '../../assets/wise5/services/moveNodesService';
+import { copy } from '../../assets/wise5/common/object/object';
+import demoProjectJSON_import from './sampleData/curriculum/Demo.project.json';
+import { TeacherProjectService } from '../../assets/wise5/services/teacherProjectService';
+import { StudentTeacherCommonServicesModule } from '../student-teacher-common-services.module';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+let demoProjectJSON: any;
+const inactiveLessonId1 = 'group6';
+const inactiveLessonId2 = 'group7';
+let service: MoveNodesService;
+let teacherProjectService: TeacherProjectService;
+
+describe('MoveNodesService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, StudentTeacherCommonServicesModule],
+      providers: [MoveNodesService, TeacherProjectService]
+    });
+    service = TestBed.inject(MoveNodesService);
+    demoProjectJSON = copy(demoProjectJSON_import);
+    teacherProjectService = TestBed.inject(TeacherProjectService);
+    teacherProjectService.setProject(demoProjectJSON);
+  });
+  moveInactiveLessonAfterInactiveLesson();
+});
+
+function moveInactiveLessonAfterInactiveLesson() {
+  describe('move an inactive lesson after another inactive lesson', () => {
+    it('moves inactive lesson', () => {
+      let inactiveNodeIds = teacherProjectService.getInactiveNodeIds();
+      expect(inactiveNodeIds.indexOf(inactiveLessonId1)).toBeLessThan(
+        inactiveNodeIds.indexOf(inactiveLessonId2)
+      );
+      service.moveNodesAfter([inactiveLessonId1], inactiveLessonId2);
+      inactiveNodeIds = teacherProjectService.getInactiveNodeIds();
+      expect(inactiveNodeIds.indexOf(inactiveLessonId1)).toBeGreaterThan(
+        inactiveNodeIds.indexOf(inactiveLessonId2)
+      );
+    });
+    it('number of inactive nodes does not change', () => {
+      const numInactiveNodes = teacherProjectService.getInactiveNodes().length;
+      service.moveNodesAfter([inactiveLessonId1], inactiveLessonId2);
+      expect(teacherProjectService.getInactiveNodes().length).toEqual(numInactiveNodes);
+    });
+  });
+}

--- a/src/app/services/sampleData/curriculum/Demo.project.json
+++ b/src/app/services/sampleData/curriculum/Demo.project.json
@@ -5,7 +5,13 @@
       "type": "group",
       "title": "Master",
       "startId": "group1",
-      "ids": ["group1", "group2", "group3", "group4", "group5"],
+      "ids": [
+        "group1",
+        "group2",
+        "group3",
+        "group4",
+        "group5"
+      ],
       "transitionLogic": {
         "transitions": [
           {
@@ -670,12 +676,16 @@
           "choices": [
             {
               "id": "y1cdkafo2u",
-              "text": ["Enter choice text here"],
+              "text": [
+                "Enter choice text here"
+              ],
               "feedback": ""
             },
             {
               "id": "lcnhnc2myc",
-              "text": ["Enter choice text here"],
+              "text": [
+                "Enter choice text here"
+              ],
               "feedback": ""
             }
           ]
@@ -735,7 +745,11 @@
           "type": "Draw",
           "prompt": "<p style=\"text-align: left;\">This is an auto graded draw step. Click the 'Submit' button to have your drawing auto graded.</p>\n<p style=\"text-align: left;\">&nbsp;</p>\n<p style=\"text-align: left;\">(1) Use stamps to create TWO methane molecules (CH<sub>4</sub>).&nbsp;</p>\n<p style=\"text-align: left;\">(2) Create EXACTLY the number of oxygen molecules (O<sub>2</sub>) needed to react with your TWO methane molecules.</p>\n<p style=\"text-align: left;\">(3) Create a new frame.</p>\n<p style=\"text-align: left;\">(4) REARRANGE the atoms in the 2nd frame to make carbon dioxide (CO<sub>2</sub>) and water (H<sub>2</sub>O) molecules. Show clearly which atoms belong to which molecules.</p>",
           "stamps": {
-            "Stamps": ["carbon.png", "oxygen.png", "hydrogen.png"]
+            "Stamps": [
+              "carbon.png",
+              "oxygen.png",
+              "hydrogen.png"
+            ]
           }
         }
       ]
@@ -1863,7 +1877,10 @@
           }
         ]
       },
-      "ids": ["node790", "node791"]
+      "ids": [
+        "node790",
+        "node791"
+      ]
     },
     {
       "id": "node790",
@@ -1946,7 +1963,9 @@
                 "name": "choiceChosen",
                 "params": {
                   "componentId": "0w3e2kgerw",
-                  "choiceIds": ["4z4f8xiqsj"],
+                  "choiceIds": [
+                    "4z4f8xiqsj"
+                  ],
                   "nodeId": "node792"
                 }
               }
@@ -1959,7 +1978,9 @@
                 "name": "choiceChosen",
                 "params": {
                   "componentId": "0w3e2kgerw",
-                  "choiceIds": ["2824d0tdlr"],
+                  "choiceIds": [
+                    "2824d0tdlr"
+                  ],
                   "nodeId": "node792"
                 }
               }
@@ -2438,7 +2459,15 @@
           }
         ]
       },
-      "ids": ["node792", "node793", "node794", "node795", "node796", "node797", "node798"],
+      "ids": [
+        "node792",
+        "node793",
+        "node794",
+        "node795",
+        "node796",
+        "node797",
+        "node798"
+      ],
       "icons": {
         "default": {
           "color": "#2196F3",
@@ -2461,7 +2490,13 @@
       "transitionLogic": {
         "transitions": []
       },
-      "ids": ["node799", "node800", "node801", "node802", "node803"]
+      "ids": [
+        "node799",
+        "node800",
+        "node801",
+        "node802",
+        "node803"
+      ]
     },
     {
       "id": "node799",
@@ -2654,6 +2689,100 @@
     ]
   },
   "inactiveNodes": [
+    {
+      "id": "group6",
+      "type": "group",
+      "title": "Inactive Lesson One",
+      "startId": "node804",
+      "constraints": [],
+      "transitionLogic": {
+        "transitions": []
+      },
+      "ids": [
+        "node804"
+      ],
+      "checked": false
+    },
+    {
+      "id": "node804",
+      "title": "Inactive Open Response",
+      "type": "node",
+      "constraints": [],
+      "transitionLogic": {
+        "transitions": []
+      },
+      "showSaveButton": true,
+      "showSubmitButton": false,
+      "components": [
+        {
+          "id": "kolblxecom",
+          "type": "OpenResponse",
+          "prompt": "",
+          "showSaveButton": false,
+          "showSubmitButton": false,
+          "starterSentence": null,
+          "isStudentAttachmentEnabled": false
+        }
+      ],
+      "checked": false
+    },
+    {
+      "id": "group7",
+      "type": "group",
+      "title": "Inactive Lesson Two",
+      "startId": "node805",
+      "constraints": [],
+      "transitionLogic": {
+        "transitions": []
+      },
+      "ids": [
+        "node805"
+      ],
+      "checked": false
+    },
+    {
+      "id": "node805",
+      "title": "Inactive Multiple Choice",
+      "type": "node",
+      "constraints": [],
+      "transitionLogic": {
+        "transitions": []
+      },
+      "showSaveButton": true,
+      "showSubmitButton": false,
+      "components": [
+        {
+          "id": "brou4pcdv0",
+          "type": "MultipleChoice",
+          "prompt": "",
+          "showSaveButton": false,
+          "showSubmitButton": false,
+          "choiceType": "radio",
+          "choices": [
+            {
+              "id": "ds1olpz3ny",
+              "text": "A",
+              "feedback": "",
+              "isCorrect": false
+            },
+            {
+              "id": "m2of2ppqrp",
+              "text": "B",
+              "feedback": "",
+              "isCorrect": false
+            },
+            {
+              "id": "h51cxw8h57",
+              "text": "C",
+              "feedback": "",
+              "isCorrect": false
+            }
+          ],
+          "showFeedback": true
+        }
+      ],
+      "checked": false
+    },
     {
       "id": "node789",
       "title": "inactive node",

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -2574,9 +2574,11 @@ export class TeacherProjectService extends ProjectService {
    */
   addGroupChildNodesToInactive(node) {
     for (const childId of node.ids) {
-      const childNode = this.getNodeById(childId);
-      this.project.inactiveNodes.push(childNode);
-      this.inactiveStepNodes.push(childNode);
+      if (!this.isInactive(childId)) {
+        const childNode = this.getNodeById(childId);
+        this.project.inactiveNodes.push(childNode);
+        this.inactiveStepNodes.push(childNode);
+      }
     }
   }
 


### PR DESCRIPTION
## Changes
- When moving an inactive lesson after another inactive lesson, check if its child steps are already in the inactive array and do not add them if they are already in the inactive array
- Added inactive lessons to the demo project used for testing

## Test
1. Open a project in the Authoring Tool
2. Create or move two lessons (that have at least one step) into the Unused Lessons section
3. Move the top unused lesson after the other unused lesson
4. Make sure the steps in the unused lesson that was moved were not duplicated in the inactiveNodes within the project.json. Previously these steps would show up twice in the inactiveNodes array but now they should only show up once.

Closes #1640
