### PR TITLE
feat(Classroom Monitor): Sort by first and last names in Grade by Team

### DIFF
--- a/src/app/help/faq/teacher-faq/teacher-faq.component.html
+++ b/src/app/help/faq/teacher-faq/teacher-faq.component.html
@@ -256,7 +256,7 @@
     <li i18n>Here you will be able to look at your students' work.</li>
     <li i18n>
       On the left sidebar you can choose to look at the work by step by clicking "Grade By Step" or
-      you can choose to look at the work by team by clicking "Grade By Team".
+      you can choose to look at the work by student by clicking "Grade By Student".
     </li>
     <li i18n>Next to each student's work, you will be able to give them a score and comment.</li>
   </ul>

--- a/src/assets/wise5/classroomMonitor/classroom-monitor.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroom-monitor.component.ts
@@ -101,7 +101,7 @@ export class ClassroomMonitorComponent implements OnInit {
       },
       {
         route: ['team'],
-        name: $localize`Grade by Team`,
+        name: $localize`Grade by Student`,
         icon: 'people',
         type: 'primary',
         active: true

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/testing/ClassroomMonitorTestHelper.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/testing/ClassroomMonitorTestHelper.ts
@@ -1,9 +1,59 @@
+import { StudentProgress } from '../../../student-progress/student-progress.component';
+
 export class ClassroomMonitorTestHelper {
   workgroupId1: number = 1;
   workgroupId2: number = 2;
   workgroupId3: number = 3;
   workgroupId4: number = 4;
   workgroupId5: number = 5;
+
+  students: StudentProgress[] = [
+    new StudentProgress({
+      location: '1.2: Open Response',
+      workgroupId: this.workgroupId1,
+      username: 'Spongebob Squarepants',
+      firstName: 'Spongebob',
+      lastName: 'Squarepants',
+      completionPct: 30,
+      scorePct: 0.8
+    }),
+    new StudentProgress({
+      location: '1.1: Open Response',
+      workgroupId: this.workgroupId5,
+      username: 'Patrick Star',
+      firstName: 'Patrick',
+      lastName: 'Star',
+      completionPct: 10,
+      scorePct: 0.6
+    }),
+    new StudentProgress({
+      location: '1.5: Open Response',
+      workgroupId: this.workgroupId3,
+      username: 'Squidward Tentacles',
+      firstName: 'Squidward',
+      lastName: 'Tentacles',
+      completionPct: 20,
+      scorePct: 0.4
+    }),
+    new StudentProgress({
+      location: '1.9: Open Response',
+      workgroupId: this.workgroupId2,
+      username: 'Sandy Cheeks',
+      firstName: 'Sandy',
+      lastName: 'Cheeks',
+      completionPct: 50,
+      scorePct: 0.8
+    }),
+    new StudentProgress({
+      location: '1.5: Open Response',
+      workgroupId: this.workgroupId4,
+      username: 'Sheldon Plankton',
+      firstName: 'Sheldon',
+      lastName: 'Plankton',
+      completionPct: 20,
+      scorePct: 0.8
+    })
+  ];
 
   expectWorkgroupOrder(workgroups: any[], expectedWorkgroupIdOrder: number[]): void {
     for (let w = 0; w < workgroups.length; w++) {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/tool-bar/tool-bar.component.ts
@@ -43,7 +43,7 @@ export class ToolBarComponent implements OnInit {
         'manage-students': $localize`Manage Students`,
         milestones: $localize`Milestones`,
         notebook: $localize`Student Notebooks`,
-        team: $localize`Grade by Team`
+        team: $localize`Grade by Student`
       }[path] ?? $localize`Grade by Step`;
     this.showPeriodSelect = path != 'export';
     this.showTeamTools = /\/team\/(\d+)$/.test(this.router.url);

--- a/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html
+++ b/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html
@@ -13,8 +13,6 @@
               <button
                 mat-button
                 class="table--list__thead__link"
-                aria-label="Team ID"
-                i18n-aria-label
                 (click)="setSort('team')"
                 title="Sort by team"
                 i18n-title
@@ -32,19 +30,17 @@
                 </mat-icon>
               </button>
             </th>
-            <th class="table--list__thead__th" sticky>
+            <th *ngIf="!permissions.canViewStudentNames" class="table--list__thead__th" sticky>
               <button
                 mat-button
                 class="table--list__thead__link"
-                aria-label="Names"
-                i18n-aria-label
                 (click)="setSort('student')"
-                title="Sort by names"
+                title="Sort by student"
                 i18n-title
                 fxFill
                 fxLayoutAlign="start center"
               >
-                <span i18n>Names</span>
+                <span i18n>Student</span>
                 <mat-icon
                   *ngIf="sort === 'student' || sort === '-student'"
                   class="table--list__thead__sort"
@@ -54,12 +50,52 @@
                 </mat-icon>
               </button>
             </th>
+            <ng-container *ngIf="permissions.canViewStudentNames">
+              <th class="table--list__thead__th" sticky>
+                <button
+                  mat-button
+                  class="table--list__thead__link"
+                  (click)="setSort('firstName')"
+                  title="Sort by first name"
+                  i18n-title
+                  fxFill
+                  fxLayoutAlign="start center"
+                >
+                  <span i18n>First Name</span>
+                  <mat-icon
+                    *ngIf="sort === 'firstName' || sort === '-firstName'"
+                    class="table--list__thead__sort"
+                    [ngClass]="{ 'table--list__thead__sort--reverse': sort === '-firstName' }"
+                  >
+                    arrow_drop_up
+                  </mat-icon>
+                </button>
+              </th>
+              <th class="table--list__thead__th" sticky>
+                <button
+                  mat-button
+                  class="table--list__thead__link"
+                  (click)="setSort('lastName')"
+                  title="Sort by last name"
+                  i18n-title
+                  fxFill
+                  fxLayoutAlign="start center"
+                >
+                  <span i18n>Last Name</span>
+                  <mat-icon
+                    *ngIf="sort === 'lastName' || sort === '-lastName'"
+                    class="table--list__thead__sort"
+                    [ngClass]="{ 'table--list__thead__sort--reverse': sort === '-lastName' }"
+                  >
+                    arrow_drop_up
+                  </mat-icon>
+                </button>
+              </th>
+            </ng-container>
             <th class="table--list__thead__th" sticky>
               <button
                 mat-button
                 class="table--list__thead__link"
-                aria-label="Current Location"
-                i18n-aria-label
                 (click)="setSort('location')"
                 title="Sort by location"
                 i18n-title
@@ -81,8 +117,6 @@
               <button
                 mat-button
                 class="table--list__thead__link"
-                aria-label="Project Completion"
-                i18n-aria-label
                 (click)="setSort('completion')"
                 title="Sort by completion"
                 i18n-title
@@ -104,8 +138,6 @@
               <button
                 mat-button
                 class="table--list__thead__link"
-                aria-label="Score"
-                i18n-aria-label
                 (click)="setSort('score')"
                 title="Sort by score"
                 i18n-title
@@ -126,24 +158,32 @@
           </tr>
         </thead>
         <tbody>
-          <ng-container *ngFor="let team of sortedTeams">
+          <ng-container *ngFor="let student of sortedStudents">
             <tr
               class="list-item workgroup-row button"
-              *ngIf="isWorkgroupShown(team)"
-              (click)="showStudentGradingView(team)"
+              *ngIf="isWorkgroupShown(student)"
+              (click)="showStudentGradingView(student)"
             >
-              <td class="center">{{ team.workgroupId }}</td>
-              <td class="heavy td--wrap">
-                <div fxLayout="row wrap">{{ team.username }}</div>
+              <td class="center">{{ student.workgroupId }}</td>
+              <td *ngIf="!permissions.canViewStudentNames" class="heavy td--wrap">
+                {{ student.username }}
               </td>
+              <ng-container *ngIf="permissions.canViewStudentNames">
+                <td class="heavy td--max-width">
+                  {{ student.firstName }}
+                </td>
+                <td class="heavy td--max-width">
+                  {{ student.lastName }}
+                </td>
+              </ng-container>
               <td class="center td--wrap td--max-width">
-                {{ team.location }}
+                {{ student.location }}
               </td>
               <td fxLayout="row" fxLayoutAlign="center center">
                 <project-progress
-                  [completed]="team.completion.completedItems"
-                  [total]="team.completion.totalItems"
-                  [percent]="team.completion.completionPct"
+                  [completed]="student.completion.completedItems"
+                  [total]="student.completion.totalItems"
+                  [percent]="student.completion.completionPct"
                 >
                 </project-progress>
               </td>
@@ -153,9 +193,9 @@
                   fxLayoutAlign="center center"
                   class="layout-align-center-center layout-row"
                 >
-                  <span class="mat-headline-5">{{ team.score }}</span
+                  <span class="mat-headline-5">{{ student.score }}</span
                   >&nbsp;
-                  <span class="text-secondary mat-body-2">/{{ team.maxScore }}</span>
+                  <span class="text-secondary mat-body-2">/{{ student.maxScore }}</span>
                 </div>
               </td>
             </tr>

--- a/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html
+++ b/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html
@@ -1,3 +1,27 @@
+<ng-template #thead let-sortBy="sortBy">
+  <th class="table--list__thead__th" sticky>
+    <button
+      mat-button
+      class="table--list__thead__link"
+      (click)="setSort(sortBy)"
+      title="Sort by {{ sortOptions[sortBy].label }}"
+      i18n-title
+      fxFill
+      fxLayout="row"
+      fxLayoutAlign="center center"
+    >
+      <span>{{ sortOptions[sortBy].label }}</span>
+      <mat-icon
+        *ngIf="sort === sortBy || sort === '-' + sortBy"
+        class="table--list__thead__sort"
+        [ngClass]="{ 'table--list__thead__sort--reverse': sort === '-' + sortBy }"
+      >
+        arrow_drop_up
+      </mat-icon>
+    </button>
+  </th>
+</ng-template>
+
 <div class="view-content view-content--with-sidemenu">
   <div class="l-constrained student-progress" fxLayout="column">
     <mat-list class="user-list student-select mat-elevation-z1">
@@ -9,152 +33,25 @@
       <table class="table--list mat-elevation-z1">
         <thead class="table--list__thead dark-theme">
           <tr>
-            <th class="table--list__thead__th">
-              <button
-                mat-button
-                class="table--list__thead__link"
-                (click)="setSort('team')"
-                title="Sort by team"
-                i18n-title
-                fxFill
-                fxLayout="row"
-                fxLayoutAlign="center center"
-              >
-                <span i18n>Team</span>
-                <mat-icon
-                  *ngIf="sort === 'team' || sort === '-team'"
-                  class="table--list__thead__sort"
-                  [ngClass]="{ 'table--list__thead__sort--reverse': sort === '-team' }"
-                >
-                  arrow_drop_up
-                </mat-icon>
-              </button>
-            </th>
-            <th *ngIf="!permissions.canViewStudentNames" class="table--list__thead__th" sticky>
-              <button
-                mat-button
-                class="table--list__thead__link"
-                (click)="setSort('student')"
-                title="Sort by student"
-                i18n-title
-                fxFill
-                fxLayoutAlign="start center"
-              >
-                <span i18n>Student</span>
-                <mat-icon
-                  *ngIf="sort === 'student' || sort === '-student'"
-                  class="table--list__thead__sort"
-                  [ngClass]="{ 'table--list__thead__sort--reverse': sort === '-student' }"
-                >
-                  arrow_drop_up
-                </mat-icon>
-              </button>
-            </th>
-            <ng-container *ngIf="permissions.canViewStudentNames">
-              <th class="table--list__thead__th" sticky>
-                <button
-                  mat-button
-                  class="table--list__thead__link"
-                  (click)="setSort('firstName')"
-                  title="Sort by first name"
-                  i18n-title
-                  fxFill
-                  fxLayoutAlign="start center"
-                >
-                  <span i18n>First Name</span>
-                  <mat-icon
-                    *ngIf="sort === 'firstName' || sort === '-firstName'"
-                    class="table--list__thead__sort"
-                    [ngClass]="{ 'table--list__thead__sort--reverse': sort === '-firstName' }"
-                  >
-                    arrow_drop_up
-                  </mat-icon>
-                </button>
-              </th>
-              <th class="table--list__thead__th" sticky>
-                <button
-                  mat-button
-                  class="table--list__thead__link"
-                  (click)="setSort('lastName')"
-                  title="Sort by last name"
-                  i18n-title
-                  fxFill
-                  fxLayoutAlign="start center"
-                >
-                  <span i18n>Last Name</span>
-                  <mat-icon
-                    *ngIf="sort === 'lastName' || sort === '-lastName'"
-                    class="table--list__thead__sort"
-                    [ngClass]="{ 'table--list__thead__sort--reverse': sort === '-lastName' }"
-                  >
-                    arrow_drop_up
-                  </mat-icon>
-                </button>
-              </th>
+            <ng-container *ngTemplateOutlet="thead; context: { sortBy: 'team' }"></ng-container>
+            <ng-container *ngIf="!permissions.canViewStudentNames">
+              <ng-container
+                *ngTemplateOutlet="thead; context: { sortBy: 'student' }"
+              ></ng-container>
             </ng-container>
-            <th class="table--list__thead__th" sticky>
-              <button
-                mat-button
-                class="table--list__thead__link"
-                (click)="setSort('location')"
-                title="Sort by location"
-                i18n-title
-                fxFill
-                fxLayout="row"
-                fxLayoutAlign="center center"
-              >
-                <span i18n>Current Location</span>
-                <mat-icon
-                  *ngIf="sort === 'location' || sort === '-location'"
-                  class="table--list__thead__sort"
-                  [ngClass]="{ 'table--list__thead__sort--reverse': sort === '-location' }"
-                >
-                  arrow_drop_up
-                </mat-icon>
-              </button>
-            </th>
-            <th class="table--list__thead__th" sticky>
-              <button
-                mat-button
-                class="table--list__thead__link"
-                (click)="setSort('completion')"
-                title="Sort by completion"
-                i18n-title
-                fxFill
-                fxLayout="row"
-                fxLayoutAlign="center center"
-              >
-                <span i18n>Unit Completion</span>
-                <mat-icon
-                  *ngIf="sort === 'completion' || sort === '-completion'"
-                  class="table--list__thead__sort"
-                  [ngClass]="{ 'table--list__thead__sort--reverse': sort === '-completion' }"
-                >
-                  arrow_drop_up
-                </mat-icon>
-              </button>
-            </th>
-            <th class="table--list__thead__th" sticky>
-              <button
-                mat-button
-                class="table--list__thead__link"
-                (click)="setSort('score')"
-                title="Sort by score"
-                i18n-title
-                fxFill
-                fxLayout="row"
-                fxLayoutAlign="center center"
-              >
-                <span i18n>Score</span>
-                <mat-icon
-                  *ngIf="sort === 'score' || sort === '-score'"
-                  class="table--list__thead__sort"
-                  [ngClass]="{ 'table--list__thead__sort--reverse': sort === '-score' }"
-                >
-                  arrow_drop_up
-                </mat-icon>
-              </button>
-            </th>
+            <ng-container *ngIf="permissions.canViewStudentNames">
+              <ng-container
+                *ngTemplateOutlet="thead; context: { sortBy: 'firstName' }"
+              ></ng-container>
+              <ng-container
+                *ngTemplateOutlet="thead; context: { sortBy: 'lastName' }"
+              ></ng-container>
+            </ng-container>
+            <ng-container *ngTemplateOutlet="thead; context: { sortBy: 'location' }"></ng-container>
+            <ng-container
+              *ngTemplateOutlet="thead; context: { sortBy: 'completion' }"
+            ></ng-container>
+            <ng-container *ngTemplateOutlet="thead; context: { sortBy: 'score' }"></ng-container>
           </tr>
         </thead>
         <tbody>

--- a/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.spec.ts
@@ -12,22 +12,6 @@ import { ClassroomMonitorTestHelper } from '../classroomMonitorComponents/shared
 import { StudentProgressComponent } from './student-progress.component';
 import { RouterTestingModule } from '@angular/router/testing';
 
-class Team {
-  public completion: any;
-
-  constructor(
-    public workgroupId: number,
-    public username: string,
-    public location: string,
-    completionPct: number,
-    public scorePct: number
-  ) {
-    this.completion = {
-      completionPct
-    };
-  }
-}
-
 class SortTestParams {
   constructor(
     public testDescription: string,
@@ -76,13 +60,7 @@ describe('StudentProgressComponent', () => {
 });
 
 function initializeWorkgroups(component: StudentProgressComponent) {
-  component.teams = [
-    new Team(workgroupId1, 'Spongebob', '1.2: Open Response', 30, 0.8),
-    new Team(workgroupId5, 'Patrick', '1.1: Open Response', 10, 0.6),
-    new Team(workgroupId3, 'Squidward', '1.5: Open Response', 20, 0.4),
-    new Team(workgroupId2, 'Sandy', '1.9: Open Response', 50, 0.8),
-    new Team(workgroupId4, 'Plankton', '1.5: Open Response', 20, 0.8)
-  ];
+  component.students = testHelper.students;
 }
 
 function setSort() {
@@ -107,57 +85,85 @@ function setSort() {
       ]),
       new SortTestParams('should sort by student ascending', 'student', 'asc', [
         workgroupId5,
-        workgroupId4,
         workgroupId2,
+        workgroupId4,
         workgroupId1,
         workgroupId3
       ]),
       new SortTestParams('should sort by student descending', 'student', 'desc', [
         workgroupId3,
         workgroupId1,
+        workgroupId4,
+        workgroupId2,
+        workgroupId5
+      ]),
+      new SortTestParams('should sort by first name ascending', 'firstName', 'asc', [
+        workgroupId5,
         workgroupId2,
         workgroupId4,
+        workgroupId1,
+        workgroupId3
+      ]),
+      new SortTestParams('should sort by first name descending', 'firstName', 'desc', [
+        workgroupId3,
+        workgroupId1,
+        workgroupId4,
+        workgroupId2,
         workgroupId5
+      ]),
+      new SortTestParams('should sort by last name ascending', 'lastName', 'asc', [
+        workgroupId2,
+        workgroupId4,
+        workgroupId1,
+        workgroupId5,
+        workgroupId3
+      ]),
+      new SortTestParams('should sort by last name descending', 'lastName', 'desc', [
+        workgroupId3,
+        workgroupId5,
+        workgroupId1,
+        workgroupId4,
+        workgroupId2
       ]),
       new SortTestParams('should sort by score ascending', 'score', 'asc', [
         workgroupId3,
         workgroupId5,
-        workgroupId4,
+        workgroupId1,
         workgroupId2,
-        workgroupId1
+        workgroupId4
       ]),
       new SortTestParams('should sort by score descending', 'score', 'desc', [
-        workgroupId4,
-        workgroupId2,
         workgroupId1,
+        workgroupId2,
+        workgroupId4,
         workgroupId5,
         workgroupId3
       ]),
       new SortTestParams('should sort by completion ascending', 'completion', 'asc', [
         workgroupId5,
-        workgroupId4,
         workgroupId3,
+        workgroupId4,
         workgroupId1,
         workgroupId2
       ]),
       new SortTestParams('should sort by completion descending', 'completion', 'desc', [
         workgroupId2,
         workgroupId1,
-        workgroupId4,
         workgroupId3,
+        workgroupId4,
         workgroupId5
       ]),
       new SortTestParams('should sort by location ascending', 'location', 'asc', [
         workgroupId5,
         workgroupId1,
-        workgroupId4,
         workgroupId3,
+        workgroupId4,
         workgroupId2
       ]),
       new SortTestParams('should sort by location descending', 'location', 'desc', [
         workgroupId2,
-        workgroupId4,
         workgroupId3,
+        workgroupId4,
         workgroupId1,
         workgroupId5
       ])
@@ -165,7 +171,10 @@ function setSort() {
     for (const sortTest of sortTests) {
       it(sortTest.testDescription, () => {
         setSortAndDirection(sortTest.sortField, sortTest.sortDirection);
-        testHelper.expectWorkgroupOrder(component.sortedTeams, sortTest.expectedWorkgroupIdOrder);
+        testHelper.expectWorkgroupOrder(
+          component.sortedStudents,
+          sortTest.expectedWorkgroupIdOrder
+        );
       });
     }
   });

--- a/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts
+++ b/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts
@@ -19,6 +19,36 @@ export class StudentProgressComponent implements OnInit {
   sortedStudents: StudentProgress[];
   subscriptions: Subscription = new Subscription();
   teacherWorkgroupId: number;
+  sortOptions: any = {
+    team: {
+      label: $localize`Team`,
+      method: this.createSortTeam
+    },
+    student: {
+      label: $localize`Student`,
+      method: this.createSortStudent
+    },
+    firstName: {
+      label: $localize`First Name`,
+      method: this.createSortFirstName
+    },
+    lastName: {
+      label: $localize`Last Name`,
+      method: this.createSortLastName
+    },
+    location: {
+      label: $localize`Location`,
+      method: this.createSortLocation
+    },
+    completion: {
+      label: $localize`Completion`,
+      method: this.createSortCompletion
+    },
+    score: {
+      label: $localize`Score`,
+      method: this.createSortScore
+    }
+  };
   students: StudentProgress[];
 
   constructor(
@@ -34,6 +64,7 @@ export class StudentProgressComponent implements OnInit {
     this.sort = this.dataService.studentProgressSort;
     this.permissions = this.configService.getPermissions();
     this.initializeStudents();
+    this.sortWorkgroups();
     this.subscriptions.add(
       this.classroomStatusService.studentStatusReceived$.subscribe((args) => {
         const studentStatus = args.studentStatus;
@@ -76,7 +107,6 @@ export class StudentProgressComponent implements OnInit {
         this.updateTeam(workgroupId);
       });
     }
-    this.sortWorkgroups();
   }
 
   private updateTeam(workgroupId: number): void {
@@ -110,53 +140,12 @@ export class StudentProgressComponent implements OnInit {
 
   private sortWorkgroups(): void {
     this.sortedStudents = [...this.students];
-    switch (this.sort) {
-      case 'team':
-        this.sortedStudents.sort(this.createSortTeam('asc'));
-        break;
-      case '-team':
-        this.sortedStudents.sort(this.createSortTeam('desc'));
-        break;
-      case 'student':
-        this.sortedStudents.sort(this.createSortStudent('asc'));
-        break;
-      case '-student':
-        this.sortedStudents.sort(this.createSortStudent('desc'));
-        break;
-      case 'firstName':
-        this.sortedStudents.sort(this.createSortFirstName('asc'));
-        break;
-      case '-firstName':
-        this.sortedStudents.sort(this.createSortFirstName('desc'));
-        break;
-      case 'lastName':
-        this.sortedStudents.sort(this.createSortLastName('asc'));
-        break;
-      case '-lastName':
-        this.sortedStudents.sort(this.createSortLastName('desc'));
-        break;
-      case 'score':
-        this.sortedStudents.sort(this.createSortScore('asc'));
-        break;
-      case '-score':
-        this.sortedStudents.sort(this.createSortScore('desc'));
-        break;
-      case 'completion':
-        this.sortedStudents.sort(this.createSortCompletion('asc'));
-        break;
-      case '-completion':
-        this.sortedStudents.sort(this.createSortCompletion('desc'));
-        break;
-      case 'location':
-        this.sortedStudents.sort(this.createSortLocation('asc'));
-        break;
-      case '-location':
-        this.sortedStudents.sort(this.createSortLocation('desc'));
-        break;
-    }
+    const dir = this.sort.charAt(0) === '-' ? 'desc' : 'asc';
+    const sort = this.sort.charAt(0) === '-' ? this.sort.slice(1) : this.sort;
+    this.sortedStudents.sort(this.sortOptions[sort].method(dir));
   }
 
-  private createSortTeam(direction: string): any {
+  private createSortTeam(direction: 'asc' | 'desc'): any {
     return (studentA: any, studentB: any): number => {
       return direction === 'asc'
         ? studentA.workgroupId - studentB.workgroupId
@@ -164,7 +153,7 @@ export class StudentProgressComponent implements OnInit {
     };
   }
 
-  private createSortStudent(direction: string): any {
+  private createSortStudent(direction: 'asc' | 'desc'): any {
     return (studentA: any, studentB: any): number => {
       const localeCompare =
         direction === 'asc'
@@ -174,7 +163,7 @@ export class StudentProgressComponent implements OnInit {
     };
   }
 
-  private createSortFirstName(direction: string): any {
+  private createSortFirstName(direction: 'asc' | 'desc'): any {
     return (studentA: any, studentB: any): number => {
       const localeCompare =
         direction === 'asc'
@@ -184,7 +173,7 @@ export class StudentProgressComponent implements OnInit {
     };
   }
 
-  private createSortLastName(direction: string): any {
+  private createSortLastName(direction: 'asc' | 'desc'): any {
     return (studentA: any, studentB: any): number => {
       const localeCompare =
         direction === 'asc'
@@ -194,7 +183,7 @@ export class StudentProgressComponent implements OnInit {
     };
   }
 
-  private createSortScore(direction: string): any {
+  private createSortScore(direction: 'asc' | 'desc'): any {
     return (studentA: any, studentB: any): number => {
       if (studentA.scorePct === studentB.scorePct) {
         return studentA.workgroupId
@@ -209,7 +198,7 @@ export class StudentProgressComponent implements OnInit {
     };
   }
 
-  private createSortCompletion(direction: string): any {
+  private createSortCompletion(direction: 'asc' | 'desc'): any {
     return (studentA: any, studentB: any): number => {
       const completionA = studentA.completionPct;
       const completionB = studentB.completionPct;
@@ -224,7 +213,7 @@ export class StudentProgressComponent implements OnInit {
     };
   }
 
-  private createSortLocation(direction: string): any {
+  private createSortLocation(direction: 'asc' | 'desc'): any {
     return (studentA: any, studentB: any): number => {
       const localeCompare =
         direction === 'asc'

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -2604,10 +2604,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/app/register/register-home/register-home.component.html</context>
           <context context-type="linenumber">17</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">43</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="9b59fedafe883c50e868d884b7a0faeca8f2ccc9" datatype="html">
         <source>Look up username or reset password for a student account</source>
@@ -2870,10 +2866,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.html</context>
           <context context-type="linenumber">11</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">64</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="dfb446b53f5c04e99f7deed2f454d3e959e1d324" datatype="html">
         <source>First Name required</source>
@@ -2923,10 +2915,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.html</context>
           <context context-type="linenumber">20</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="17de8a2f90413b5c8a6d622d9cfa4c5eda8bb742" datatype="html">
@@ -10250,6 +10238,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">21</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
           <context context-type="linenumber">395</context>
         </context-group>
@@ -11094,10 +11086,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-grading/student-grading.component.html</context>
           <context context-type="linenumber">100</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">148</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
@@ -13262,10 +13250,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/notebook-grading/notebook-grading.component.html</context>
           <context context-type="linenumber">52</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">23</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="33e92d77f1e9c87792c5d839e2fefffde477aca9" datatype="html">
         <source>Not Completed</source>
@@ -13317,10 +13301,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading-view/node-grading-view.component.html</context>
           <context context-type="linenumber">115</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">17</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="67b7f7068758d9cd539b9d3b24f0967323a43fe6" datatype="html">
         <source>Sort by completion</source>
@@ -13331,10 +13311,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-grading/student-grading.component.html</context>
           <context context-type="linenumber">78</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">121</context>
         </context-group>
       </trans-unit>
       <trans-unit id="81b97b8ea996ad1e4f9fca8415021850214884b1" datatype="html">
@@ -13365,10 +13341,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-grading/student-grading.component.html</context>
           <context context-type="linenumber">97</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b4c3a4560c25436cae3baeaa862f0e4a9ef6d3b1" datatype="html">
@@ -14844,50 +14816,57 @@ Are you sure you want to proceed?</source>
           <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2f322f1b1d0a61638e2cb63bfaef8009c06c2f3f" datatype="html">
-        <source>Sort by student</source>
+      <trans-unit id="ab5dbbea309d8a807bd7b7d99fb9cd0d805a0049" datatype="html">
+        <source>Sort by <x id="INTERPOLATION" equiv-text="{{ sortOptions[sortBy].label }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">38</context>
+          <context context-type="linenumber">7</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8164c6affed601d590951cadda411162fbfe1bef" datatype="html">
-        <source>Sort by first name</source>
+      <trans-unit id="3724068243287682962" datatype="html">
+        <source>Team</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">59</context>
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts</context>
+          <context context-type="linenumber">24</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="048e525dac900a13d3e0452f66c9d0c5a34f4e7c" datatype="html">
-        <source>Sort by last name</source>
+      <trans-unit id="1951089763019042037" datatype="html">
+        <source>Student</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">79</context>
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/discussion-show-work/discussion-show-work.component.ts</context>
+          <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7caf244c4c8c15f20fe70f5c995feeb78f5277cb" datatype="html">
-        <source>Sort by location</source>
+      <trans-unit id="6028371114637047813" datatype="html">
+        <source>First Name</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">100</context>
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts</context>
+          <context context-type="linenumber">32</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6e8bcf34d728e5d0a52321c4d27b8ba2aaf6e18f" datatype="html">
-        <source>Current Location</source>
+      <trans-unit id="4407559560004943843" datatype="html">
+        <source>Last Name</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">106</context>
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts</context>
+          <context context-type="linenumber">36</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1bda3502b1b8833d88448e87041c252aff841379" datatype="html">
-        <source>Unit Completion</source>
+      <trans-unit id="471816275243265264" datatype="html">
+        <source>Location</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">127</context>
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts</context>
+          <context context-type="linenumber">40</context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="1134043805497572295" datatype="html">
+        <source>Completion</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/vle/student-account-menu/student-account-menu.component.html</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts</context>
+          <context context-type="linenumber">44</context>
         </context-group>
       </trans-unit>
       <trans-unit id="66abb23ed9adf4aa03eab3e4b75234d32748e44c" datatype="html">
@@ -17271,13 +17250,6 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/discussion-authoring/discussion-authoring.component.html</context>
           <context context-type="linenumber">21,23</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1951089763019042037" datatype="html">
-        <source>Student</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/discussion/discussion-show-work/discussion-show-work.component.ts</context>
-          <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
       <trans-unit id="589d24cbc7062742ed7fac343fb76c5207631490" datatype="html">
@@ -21940,6 +21912,13 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>This unit ended on <x id="PH" equiv-text="endDate"/>. You can no longer save new work.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/run-ended-and-locked-message/run-ended-and-locked-message.component.ts</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1bda3502b1b8833d88448e87041c252aff841379" datatype="html">
+        <source>Unit Completion</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/vle/student-account-menu/student-account-menu.component.html</context>
           <context context-type="linenumber">15</context>
         </context-group>
       </trans-unit>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -2604,6 +2604,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/app/register/register-home/register-home.component.html</context>
           <context context-type="linenumber">17</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="9b59fedafe883c50e868d884b7a0faeca8f2ccc9" datatype="html">
         <source>Look up username or reset password for a student account</source>
@@ -2866,6 +2870,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.html</context>
           <context context-type="linenumber">11</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="dfb446b53f5c04e99f7deed2f454d3e959e1d324" datatype="html">
         <source>First Name required</source>
@@ -2915,6 +2923,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.html</context>
           <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="17de8a2f90413b5c8a6d622d9cfa4c5eda8bb742" datatype="html">
@@ -4622,8 +4634,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">256</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3f10bb5130f6d7f6d22fb47cfe1c082f01f21ebc" datatype="html">
-        <source> On the left sidebar you can choose to look at the work by step by clicking &quot;Grade By Step&quot; or you can choose to look at the work by team by clicking &quot;Grade By Team&quot;. </source>
+      <trans-unit id="7ace25ec9c013e8fc697d97a29edd0d319ffd27c" datatype="html">
+        <source> On the left sidebar you can choose to look at the work by step by clicking &quot;Grade By Step&quot; or you can choose to look at the work by student by clicking &quot;Grade By Student&quot;. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/help/faq/teacher-faq/teacher-faq.component.html</context>
           <context context-type="linenumber">257,260</context>
@@ -11085,11 +11097,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">107</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">116</context>
+          <context context-type="linenumber">148</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
@@ -12636,8 +12644,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">47</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4221507970327052966" datatype="html">
-        <source>Grade by Team</source>
+      <trans-unit id="2629092933625844061" datatype="html">
+        <source>Grade by Student</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroom-monitor.component.ts</context>
           <context context-type="linenumber">104</context>
@@ -13256,7 +13264,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">23</context>
         </context-group>
       </trans-unit>
       <trans-unit id="33e92d77f1e9c87792c5d839e2fefffde477aca9" datatype="html">
@@ -13311,7 +13319,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">19</context>
+          <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
       <trans-unit id="67b7f7068758d9cd539b9d3b24f0967323a43fe6" datatype="html">
@@ -13326,7 +13334,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">87</context>
+          <context context-type="linenumber">121</context>
         </context-group>
       </trans-unit>
       <trans-unit id="81b97b8ea996ad1e4f9fca8415021850214884b1" datatype="html">
@@ -13360,7 +13368,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">110</context>
+          <context context-type="linenumber">142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b4c3a4560c25436cae3baeaa862f0e4a9ef6d3b1" datatype="html">
@@ -14764,10 +14772,6 @@ Are you sure you want to proceed?</source>
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/notebook-grading/notebook-grading.component.html</context>
           <context context-type="linenumber">45</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">16</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="f7e865440dc3b9d0424773e70d9adf60dbad1ac6" datatype="html">
         <source>Sort By Team</source>
@@ -14785,14 +14789,6 @@ Are you sure you want to proceed?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/notebook-grading/notebook-grading.component.html</context>
           <context context-type="linenumber">72</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">39</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">47</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ff706bcc195a56a7a24646c6ec75cf22d1e9ce46" datatype="html">
@@ -14848,43 +14844,46 @@ Are you sure you want to proceed?</source>
           <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="cb914728a3b7e341fda25f3c040d3498737334e4" datatype="html">
-        <source>Sort by names</source>
+      <trans-unit id="2f322f1b1d0a61638e2cb63bfaef8009c06c2f3f" datatype="html">
+        <source>Sort by student</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">38</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6e8bcf34d728e5d0a52321c4d27b8ba2aaf6e18f" datatype="html">
-        <source>Current Location</source>
+      <trans-unit id="8164c6affed601d590951cadda411162fbfe1bef" datatype="html">
+        <source>Sort by first name</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">59</context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="048e525dac900a13d3e0452f66c9d0c5a34f4e7c" datatype="html">
+        <source>Sort by last name</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">70</context>
+          <context context-type="linenumber">79</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7caf244c4c8c15f20fe70f5c995feeb78f5277cb" datatype="html">
         <source>Sort by location</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">64</context>
+          <context context-type="linenumber">100</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="d4c86ab7df1ba303ea3371b3976f15e1fac85e6f" datatype="html">
-        <source>Project Completion</source>
+      <trans-unit id="6e8bcf34d728e5d0a52321c4d27b8ba2aaf6e18f" datatype="html">
+        <source>Current Location</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1bda3502b1b8833d88448e87041c252aff841379" datatype="html">
         <source>Unit Completion</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html</context>
-          <context context-type="linenumber">93</context>
+          <context context-type="linenumber">127</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/student-account-menu/student-account-menu.component.html</context>


### PR DESCRIPTION
## Changes
- Show one row per student instead of one row per workgroup (team).
- Remove the Student Names column and replace with two columns: First Name, Last Name. This will allow teachers to sort by first name or last name, as well as by team number.
- Rename Grade by Team view to Grade by Student.
- Refactor Grade by Student to reduce duplication and complexity.

## Test
- Grade by Student view now has First Name and Last Name columns if teacher has permission to view names.
- Grade by Student view has Student column if teacher doesn't have permission to view names.
- Sorting and filtering works as before.
