### PR TITLE
refactor(Authoring): Move event stop propagation to step template

### DIFF
--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
@@ -59,7 +59,7 @@
       <button
         mat-icon-button
         class="move-button"
-        (click)="move($event)"
+        (click)="move(); $event.stopPropagation()"
         color="primary"
         matTooltip="Move step"
         matTooltipPosition="above"
@@ -70,7 +70,7 @@
       <button
         mat-icon-button
         class="copy-button"
-        (click)="copy($event)"
+        (click)="copy(); $event.stopPropagation()"
         color="primary"
         matTooltip="Copy step"
         matTooltipPosition="above"
@@ -81,7 +81,7 @@
       <button
         mat-icon-button
         class="delete-button"
-        (click)="delete($event)"
+        (click)="delete(); $event.stopPropagation()"
         color="primary"
         matTooltip="Delete step"
         matTooltipPosition="above"

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
@@ -96,22 +96,19 @@ export class ProjectAuthoringStepComponent {
     this.router.navigate([`/teacher/edit/unit/${this.projectId}/node/${nodeId}/advanced/path`]);
   }
 
-  protected move(event: Event): void {
-    event.stopPropagation();
+  protected move(): void {
     this.router.navigate(['choose-move-location'], {
       relativeTo: this.route,
       state: { selectedNodeIds: [this.step.id] }
     });
   }
 
-  protected copy(event: Event): void {
-    event.stopPropagation();
+  protected copy(): void {
     this.copyNodesService.copyNodesAfter([this.step.id], this.step.id);
     this.saveAndRefreshProject();
   }
 
-  protected delete(event: Event): void {
-    event.stopPropagation();
+  protected delete(): void {
     if (confirm($localize`Are you sure you want to delete this step?`)) {
       this.deleteNodeService.deleteNode(this.step.id);
       this.saveAndRefreshProject();

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12274,7 +12274,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete this step?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts</context>
-          <context context-type="linenumber">115</context>
+          <context context-type="linenumber">112</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e5e0c8fd39cb0db7735731e3ae7d2108f430f16e" datatype="html">


### PR DESCRIPTION
## Changes
- In the ProjectAuthoringStepComponent, moved $event.stopPropagation() calls from the functions to the template

## Test
- Make sure that in the project authoring view, the step move, copy, and delete functionality still works properly


