### PR TITLE
refactor(Authoring): Remove classes only used for testing

### DIFF
--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -34,7 +34,6 @@
       </button>
       <button
         mat-icon-button
-        class="delete-button"
         (click)="$event.stopPropagation(); delete()"
         color="primary"
         matTooltip="Delete lesson"

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
@@ -58,7 +58,6 @@
     <div fxLayoutAlign="start center">
       <button
         mat-icon-button
-        class="move-button"
         (click)="move(); $event.stopPropagation()"
         color="primary"
         matTooltip="Move step"
@@ -69,7 +68,6 @@
       </button>
       <button
         mat-icon-button
-        class="copy-button"
         (click)="copy(); $event.stopPropagation()"
         color="primary"
         matTooltip="Copy step"
@@ -80,7 +78,6 @@
       </button>
       <button
         mat-icon-button
-        class="delete-button"
         (click)="delete(); $event.stopPropagation()"
         color="primary"
         matTooltip="Delete step"

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.harness.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.harness.ts
@@ -8,9 +8,8 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 export class ProjectAuthoringStepHarness extends ProjectAuthoringNodeHarness {
   static hostSelector = 'project-authoring-step';
 
-  getCopyButton = this.locatorFor(MatButtonHarness.with({ selector: '.copy-button' }));
-  getDeleteButton = this.locatorFor(MatButtonHarness.with({ selector: '.delete-button' }));
-  getMoveButton = this.locatorFor(MatButtonHarness.with({ selector: '.move-button' }));
+  getCopyButton = this.locatorFor(MatButtonHarness.with({ selector: '[matTooltip="Copy step"]' }));
+  getMoveButton = this.locatorFor(MatButtonHarness.with({ selector: '[matTooltip="Move step"]' }));
 
   static with(
     options: ProjectAuthoringNodeHarnessFilters

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring-node.harness.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring-node.harness.ts
@@ -7,7 +7,7 @@ export interface ProjectAuthoringNodeHarnessFilters extends BaseHarnessFilters {
 }
 
 export class ProjectAuthoringNodeHarness extends ComponentHarness {
-  getDeleteButton = this.locatorFor(MatButtonHarness.with({ selector: '.delete-button' }));
+  getDeleteButton = this.locatorFor(MatButtonHarness.with({ selector: '[matTooltip^="Delete"]' }));
   getTitleElement = this.locatorFor(NodeIconAndTitleHarness);
 
   async getTitle(): Promise<string> {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12200,7 +12200,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Delete lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">40</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2751426191436053350" datatype="html">
@@ -12253,21 +12253,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Move step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">64</context>
+          <context context-type="linenumber">63</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6e3d4bf4bfb1dd3195c4e1d59b0fdbacd1d68db4" datatype="html">
         <source>Copy step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">75</context>
+          <context context-type="linenumber">73</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0faf7dd5b826ee951da05aaad4063e8794de757b" datatype="html">
         <source>Delete step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">86</context>
+          <context context-type="linenumber">83</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8656136323789683230" datatype="html">


### PR DESCRIPTION
## Changes
- Remove classes only used for testing
- Use matTooltip attribute value to select elements when testing

## Test
- Make sure the move, copy, and delete buttons still work