### PR TITLE
feat(Authoring): Implement add step button menu next to all steps

### DIFF
--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -96,8 +96,18 @@
         </button>
       </mat-menu>
     </div>
-    <div *ngIf="lesson.ids.length === 0" class="no-steps-message" fxLayoutAlign="start center" i18n>
-      This lesson has no steps
+    <div *ngIf="lesson.ids.length === 0" class="no-steps-message" fxLayoutAlign="start center">
+      <div i18n>This lesson has no steps</div>
+      <button
+        mat-icon-button
+        color="primary"
+        (click)="addStepInside(lesson.id)"
+        matTooltip="Add step"
+        matTooltipPosition="above"
+        i18n-matTooltip
+      >
+        <mat-icon>add_circle</mat-icon>
+      </button>
     </div>
   </div>
 </div>

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -76,29 +76,25 @@
         [projectId]="projectId"
         fxFlex
       ></project-authoring-step>
-      <div class="div-next-to-step">
-        <button
-          mat-icon-button
-          color="primary"
-          class="add-button-next-to-step"
-          [matMenuTriggerFor]="step"
-          [ngClass]="{ 'show-add-button-next-to-step': menuTrigger.menuOpen }"
-          #menuTrigger="matMenuTrigger"
-          matTooltip="Add step"
-          matTooltipPosition="above"
-          i18n-matTooltip
-        >
-          <mat-icon>add_circle</mat-icon>
+      <button
+        mat-icon-button
+        color="primary"
+        [matMenuTriggerFor]="step"
+        #menuTrigger="matMenuTrigger"
+        matTooltip="Add step"
+        matTooltipPosition="above"
+        i18n-matTooltip
+      >
+        <mat-icon>add_circle</mat-icon>
+      </button>
+      <mat-menu #step="matMenu">
+        <button mat-menu-item (click)="addStepBefore(childId)" i18n>
+          <mat-icon>add_circle</mat-icon>Add Step Before
         </button>
-        <mat-menu #step="matMenu" class="add-step-menu">
-          <button mat-menu-item (click)="addStepBefore(childId)" i18n>
-            <mat-icon>add_circle</mat-icon>Add Step Before
-          </button>
-          <button mat-menu-item (click)="addStepAfter(childId)" i18n>
-            <mat-icon>add_circle</mat-icon>Add Step After
-          </button>
-        </mat-menu>
-      </div>
+        <button mat-menu-item (click)="addStepAfter(childId)" i18n>
+          <mat-icon>add_circle</mat-icon>Add Step After
+        </button>
+      </mat-menu>
     </div>
     <div *ngIf="lesson.ids.length === 0" class="no-steps-message" fxLayoutAlign="start center" i18n>
       This lesson has no steps

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -63,15 +63,44 @@
     </div>
   </div>
   <div *ngIf="expanded" fxLayout="column">
-    <ng-container *ngFor="let childId of lesson.ids">
+    <div
+      *ngFor="let childId of lesson.ids"
+      class="step-div"
+      fxLayout="row wrap"
+      fxLayoutAlign="start center"
+    >
       <project-authoring-step
         [step]="idToNode[childId]"
         (selectNodeEvent)="selectNodeEvent.emit($event)"
         [showPosition]="showPosition"
         [projectId]="projectId"
+        fxFlex
       ></project-authoring-step>
-    </ng-container>
-    <div *ngIf="lesson.ids.length === 0" class="no-steps-message" fxLayoutAlign="start center">
+      <div class="div-next-to-step">
+        <button
+          mat-icon-button
+          color="primary"
+          class="add-button-next-to-step"
+          [matMenuTriggerFor]="step"
+          [ngClass]="{ 'show-add-button-next-to-step': menuTrigger.menuOpen }"
+          #menuTrigger="matMenuTrigger"
+          matTooltip="Add step"
+          matTooltipPosition="above"
+          i18n-matTooltip
+        >
+          <mat-icon>add_circle</mat-icon>
+        </button>
+        <mat-menu #step="matMenu" class="add-step-menu">
+          <button mat-menu-item (click)="addStepBefore(childId)" i18n>
+            <mat-icon>add_circle</mat-icon>Add Step Before
+          </button>
+          <button mat-menu-item (click)="addStepAfter(childId)" i18n>
+            <mat-icon>add_circle</mat-icon>Add Step After
+          </button>
+        </mat-menu>
+      </div>
+    </div>
+    <div *ngIf="lesson.ids.length === 0" class="no-steps-message" fxLayoutAlign="start center" i18n>
       This lesson has no steps
     </div>
   </div>

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -88,7 +88,12 @@
         <mat-icon>add_circle</mat-icon>
       </button>
       <mat-menu #step="matMenu">
-        <button mat-menu-item (click)="addStepBefore(childId)" i18n>
+        <button
+          mat-menu-item
+          (click)="addStepBefore(childId)"
+          [disabled]="isFirstNodeInBranchPath(childId)"
+          i18n
+        >
           <mat-icon>add_circle</mat-icon>Add Step Before
         </button>
         <button mat-menu-item (click)="addStepAfter(childId)" i18n>

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.scss
@@ -51,20 +51,3 @@
   height: 40px;
   margin-left: 40px;
 }
-
-.div-next-to-step {
-  min-width: 50px;
-  min-height: 50px;
-}
-
-.add-button-next-to-step {
-  display: none;
-}
-
-.show-add-button-next-to-step {
-  display: block;
-}
-
-.step-div:hover .add-button-next-to-step {
-  display: block;
-}

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.scss
@@ -51,3 +51,20 @@
   height: 40px;
   margin-left: 40px;
 }
+
+.div-next-to-step {
+  min-width: 50px;
+  min-height: 50px;
+}
+
+.add-button-next-to-step {
+  display: none;
+}
+
+.show-add-button-next-to-step {
+  display: block;
+}
+
+.step-div:hover .add-button-next-to-step {
+  display: block;
+}

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
@@ -28,6 +28,9 @@ const nodeId1 = 'node1';
 const nodeId2 = 'node2';
 let teacherProjectService: TeacherProjectService;
 
+const node1 = { id: nodeId1, title: 'Step 1' };
+const node2 = { id: nodeId2, title: 'Step 2' };
+
 describe('ProjectAuthoringLessonComponent', () => {
   beforeEach(async () => {
     TestBed.configureTestingModule({
@@ -58,15 +61,10 @@ describe('ProjectAuthoringLessonComponent', () => {
     });
     teacherProjectService = TestBed.inject(TeacherProjectService);
     teacherProjectService.idToNode = {
-      node1: {
-        id: nodeId1,
-        title: 'Step 1'
-      },
-      node2: {
-        id: nodeId2,
-        title: 'Step 2'
-      }
+      node1: node1,
+      node2: node2
     };
+    teacherProjectService.project = { nodes: [node1, node2] };
     fixture = TestBed.createComponent(ProjectAuthoringLessonComponent);
     component = fixture.componentInstance;
     component.lesson = {

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
@@ -18,6 +18,7 @@ import { ProjectAuthoringLessonHarness } from './project-authoring-lesson.harnes
 import { DeleteNodeService } from '../../services/deleteNodeService';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CopyNodesService } from '../../services/copyNodesService';
+import { MatMenuModule } from '@angular/material/menu';
 
 let component: ProjectAuthoringLessonComponent;
 let fixture: ComponentFixture<ProjectAuthoringLessonComponent>;
@@ -42,6 +43,7 @@ describe('ProjectAuthoringLessonComponent', () => {
         MatCheckboxModule,
         MatDialogModule,
         MatIconModule,
+        MatMenuModule,
         RouterTestingModule,
         StudentTeacherCommonServicesModule
       ],

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -83,6 +83,12 @@ export class ProjectAuthoringLessonComponent {
     this.updateProject(newStep.id);
   }
 
+  protected addStepInside(nodeId: string): void {
+    const newStep = this.createNewEmptyStep();
+    this.projectService.createNodeInside(newStep, nodeId);
+    this.updateProject(newStep.id);
+  }
+
   private createNewEmptyStep(): any {
     return this.projectService.createNode('New Step');
   }

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -64,6 +64,10 @@ export class ProjectAuthoringLessonComponent {
     }
   }
 
+  protected isFirstNodeInBranchPath(nodeId: string): boolean {
+    return this.projectService.isFirstNodeInBranchPath(nodeId);
+  }
+
   protected addStepBefore(nodeId: string): void {
     const newStep = this.createNewEmptyStep();
     if (this.projectService.isFirstStepInLesson(nodeId)) {

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -6,6 +6,7 @@ import { NodeTypeSelected } from '../domain/node-type-selected';
 import { ExpandEvent } from '../domain/expand-event';
 import { DeleteNodeService } from '../../services/deleteNodeService';
 import { ActivatedRoute, Router } from '@angular/router';
+import { temporarilyHighlightElement } from '../../common/dom/dom';
 
 @Component({
   selector: 'project-authoring-lesson',
@@ -61,6 +62,36 @@ export class ProjectAuthoringLessonComponent {
       this.deleteNodeService.deleteNode(this.lesson.id);
       this.saveAndRefreshProject();
     }
+  }
+
+  protected addStepBefore(nodeId: string): void {
+    const newStep = this.createNewEmptyStep();
+    if (this.projectService.isFirstStepInLesson(nodeId)) {
+      this.projectService.createNodeInside(newStep, this.projectService.getParentGroupId(nodeId));
+    } else {
+      this.projectService.createNodeAfter(
+        newStep,
+        this.projectService.getPreviousStepNodeId(nodeId)
+      );
+    }
+    this.updateProject(newStep.id);
+  }
+
+  protected addStepAfter(nodeId: string): void {
+    const newStep = this.createNewEmptyStep();
+    this.projectService.createNodeAfter(newStep, nodeId);
+    this.updateProject(newStep.id);
+  }
+
+  private createNewEmptyStep(): any {
+    return this.projectService.createNode('New Step');
+  }
+
+  private updateProject(newNodeId: string): void {
+    this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
+      this.projectService.refreshProject();
+      temporarilyHighlightElement(newNodeId);
+    });
   }
 
   private saveAndRefreshProject(): void {

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -96,7 +96,11 @@ export class ProjectAuthoringLessonComponent {
   private updateProject(newNodeId: string): void {
     this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
       this.projectService.refreshProject();
-      temporarilyHighlightElement(newNodeId);
+      // This timeout is used to allow steps to have time to apply background color if they are in a
+      // branch path
+      setTimeout(() => {
+        temporarilyHighlightElement(newNodeId);
+      });
     });
   }
 

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.scss
@@ -1,7 +1,7 @@
 .step {
   height: 50px;
   padding: 4px;
-  margin: 4px 30px;
+  margin: 4px 10px 4px 30px;
   border: 2px solid #dddddd;
   border-radius: 6px;
   position: relative;

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.harness.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.harness.ts
@@ -1,10 +1,15 @@
 import { ComponentHarness } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatMenuHarness } from '@angular/material/menu/testing';
 import { ProjectAuthoringLessonHarness } from '../project-authoring-lesson/project-authoring-lesson.harness';
 import { ProjectAuthoringStepHarness } from '../project-authoring-step/project-authoring-step.harness';
 
 export class ProjectAuthoringHarness extends ComponentHarness {
   static hostSelector = 'project-authoring';
+  getAddStepButtons = this.locatorForAll(
+    MatButtonHarness.with({ selector: '[matTooltip="Add step"]' })
+  );
+  getAddStepMenus = this.locatorForAll(MatMenuHarness);
   getCollapseAllButton = this.locatorFor(MatButtonHarness.with({ text: '- Collapse All' }));
   getExpandAllButton = this.locatorFor(MatButtonHarness.with({ text: '+ Expand All' }));
   getLessons = this.locatorForAll(ProjectAuthoringLessonHarness);
@@ -16,5 +21,15 @@ export class ProjectAuthoringHarness extends ComponentHarness {
 
   getStep(title: string): Promise<ProjectAuthoringStepHarness> {
     return this.locatorForOptional(ProjectAuthoringStepHarness.with({ title: title }))();
+  }
+
+  async getOpenedAddStepMenu(): Promise<MatMenuHarness> {
+    const addStepMenus = await this.getAddStepMenus();
+    for (const menu of addStepMenus) {
+      if (await menu.isOpen()) {
+        return menu;
+      }
+    }
+    return null;
   }
 }

--- a/src/assets/wise5/common/dom/dom.ts
+++ b/src/assets/wise5/common/dom/dom.ts
@@ -25,8 +25,7 @@ export function temporarilyHighlightElement(id: string, duration: number = 1000)
      */
     setTimeout(() => {
       element.css({
-        transition: '',
-        'background-color': ''
+        transition: ''
       });
     }, 2000);
   }, duration);

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -2004,13 +2004,19 @@ export class ProjectService {
   }
 
   getPreviousStepNodeId(nodeId: string): string {
-    const nodeIds = this.getFlattenedProjectAsNodeIds();
-    return nodeIds[nodeIds.indexOf(nodeId) - 1];
+    const parentGroup = this.getParentGroup(nodeId);
+    const childIds = parentGroup.ids;
+    return childIds[childIds.indexOf(nodeId) - 1];
   }
 
   isFirstStepInLesson(nodeId: string): boolean {
     for (const lesson of this.getGroupNodes()) {
       if (lesson.startId === nodeId) {
+        return true;
+      }
+    }
+    for (const inactiveLesson of this.getInactiveGroupNodes()) {
+      if (inactiveLesson.startId === nodeId) {
         return true;
       }
     }

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -2002,4 +2002,18 @@ export class ProjectService {
   getSpeechToTextSettings(): any {
     return this.project.speechToText;
   }
+
+  getPreviousStepNodeId(nodeId: string): string {
+    const nodeIds = this.getFlattenedProjectAsNodeIds();
+    return nodeIds[nodeIds.indexOf(nodeId) - 1];
+  }
+
+  isFirstStepInLesson(nodeId: string): boolean {
+    for (const lesson of this.getGroupNodes()) {
+      if (lesson.startId === nodeId) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -2968,7 +2968,7 @@ export class TeacherProjectService extends ProjectService {
    */
   isFirstNodeInBranchPath(nodeId) {
     for (const node of this.getNodes()) {
-      if (node.transitionLogic != null && node.transitionLogic.transitions != null) {
+      if (node.transitionLogic?.transitions?.length > 1) {
         for (const transition of node.transitionLogic.transitions) {
           if (transition.to === nodeId) {
             return true;

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12216,6 +12216,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
           <context context-type="linenumber">84</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
+          <context context-type="linenumber">105</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="f28facec49bae19961cf1c78a7e6e2c0fcf1e617" datatype="html">
         <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon&gt;"/>add_circle<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/>Add Step Before </source>
@@ -12231,11 +12235,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">95,96</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="25858b2de87dfc281f278554dfa6d2546bbac9ce" datatype="html">
-        <source> This lesson has no steps </source>
+      <trans-unit id="66084384cb169b4f9d7836c16f37b8b9dfc5a049" datatype="html">
+        <source>This lesson has no steps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">99,101</context>
+          <context context-type="linenumber">100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2751426191436053350" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12210,11 +12210,39 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="3f3eed30db20799da458408b4d53206e5c8c8684" datatype="html">
+        <source>Add step</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
+          <context context-type="linenumber">87</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="a3cb5a1391c960f23ef032416d231e494a57bf76" datatype="html">
+        <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon&gt;"/>add_circle<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/>Add Step Before </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
+          <context context-type="linenumber">95,96</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="974910710f8456d53037a5a112ac3f9451d8b433" datatype="html">
+        <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon&gt;"/>add_circle<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/>Add Step After </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
+          <context context-type="linenumber">98,99</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="25858b2de87dfc281f278554dfa6d2546bbac9ce" datatype="html">
+        <source> This lesson has no steps </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
+          <context context-type="linenumber">103,105</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="2751426191436053350" datatype="html">
         <source>Are you sure you want to delete this lesson?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">61</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0788cea8f340f4f5399901765d2003f90af76669" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12214,28 +12214,28 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Add step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">87</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="a3cb5a1391c960f23ef032416d231e494a57bf76" datatype="html">
+      <trans-unit id="f28facec49bae19961cf1c78a7e6e2c0fcf1e617" datatype="html">
         <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon&gt;"/>add_circle<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/>Add Step Before </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">95,96</context>
+          <context context-type="linenumber">92,93</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="974910710f8456d53037a5a112ac3f9451d8b433" datatype="html">
+      <trans-unit id="b954bd44d8e965f064fddd3ebbf401b71786535d" datatype="html">
         <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon&gt;"/>add_circle<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/>Add Step After </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">98,99</context>
+          <context context-type="linenumber">95,96</context>
         </context-group>
       </trans-unit>
       <trans-unit id="25858b2de87dfc281f278554dfa6d2546bbac9ce" datatype="html">
         <source> This lesson has no steps </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">103,105</context>
+          <context context-type="linenumber">99,101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2751426191436053350" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12218,28 +12218,28 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">105</context>
+          <context context-type="linenumber">110</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f28facec49bae19961cf1c78a7e6e2c0fcf1e617" datatype="html">
         <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon&gt;"/>add_circle<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/>Add Step Before </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">92,93</context>
+          <context context-type="linenumber">97,98</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b954bd44d8e965f064fddd3ebbf401b71786535d" datatype="html">
         <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon&gt;"/>add_circle<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/>Add Step After </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">95,96</context>
+          <context context-type="linenumber">100,101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="66084384cb169b4f9d7836c16f37b8b9dfc5a049" datatype="html">
         <source>This lesson has no steps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">100</context>
+          <context context-type="linenumber">105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2751426191436053350" datatype="html">


### PR DESCRIPTION
## Changes
- Added an add button next to all the steps in the project view
- Clicking on the add button will open a menu that has the options "Add Step Before" and "Add Step After"
- Clicking on either of the options will create a new step named "New Step"
- The new step will have no components

## Test
- Use the new add step button menus to add a step
  - before the first step in a lesson
  - before a step that is not the first step in a lesson
  - after a step

Closes #1661
