### PR TITLE
fix(Classroom Monitor): Grade by Student sort by location

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/testing/ClassroomMonitorTestHelper.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/testing/ClassroomMonitorTestHelper.ts
@@ -10,6 +10,7 @@ export class ClassroomMonitorTestHelper {
   students: StudentProgress[] = [
     new StudentProgress({
       location: '1.2: Open Response',
+      order: 2,
       workgroupId: this.workgroupId1,
       username: 'Spongebob Squarepants',
       firstName: 'Spongebob',
@@ -19,6 +20,7 @@ export class ClassroomMonitorTestHelper {
     }),
     new StudentProgress({
       location: '1.1: Open Response',
+      order: 1,
       workgroupId: this.workgroupId5,
       username: 'Patrick Star',
       firstName: 'Patrick',
@@ -28,6 +30,7 @@ export class ClassroomMonitorTestHelper {
     }),
     new StudentProgress({
       location: '1.5: Open Response',
+      order: 5,
       workgroupId: this.workgroupId3,
       username: 'Squidward Tentacles',
       firstName: 'Squidward',
@@ -36,7 +39,8 @@ export class ClassroomMonitorTestHelper {
       scorePct: 0.4
     }),
     new StudentProgress({
-      location: '1.9: Open Response',
+      location: '1.11: Open Response',
+      order: 11,
       workgroupId: this.workgroupId2,
       username: 'Sandy Cheeks',
       firstName: 'Sandy',
@@ -46,6 +50,7 @@ export class ClassroomMonitorTestHelper {
     }),
     new StudentProgress({
       location: '1.5: Open Response',
+      order: 5,
       workgroupId: this.workgroupId4,
       username: 'Sheldon Plankton',
       firstName: 'Sheldon',

--- a/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html
+++ b/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html
@@ -74,7 +74,7 @@
                 </td>
               </ng-container>
               <td class="center td--wrap td--max-width">
-                {{ student.location }}
+                {{ student.position }}
               </td>
               <td fxLayout="row" fxLayoutAlign="center center">
                 <project-progress

--- a/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts
+++ b/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts
@@ -42,7 +42,7 @@ export class StudentProgressComponent implements OnInit {
     },
     location: {
       label: $localize`Location`,
-      fieldName: 'location',
+      fieldName: 'order',
       isNumeric: true
     },
     completion: {
@@ -117,7 +117,7 @@ export class StudentProgressComponent implements OnInit {
   }
 
   private updateTeam(workgroupId: number): void {
-    const location = this.getCurrentNodeForWorkgroupId(workgroupId) || '';
+    const location = this.classroomStatusService.getCurrentNodeLocationForWorkgroupId(workgroupId);
     const completion = this.classroomStatusService.getStudentProjectCompletion(workgroupId);
     const score = this.getStudentTotalScore(workgroupId) || 0;
     let maxScore = this.classroomStatusService.getMaxScoreForWorkgroupId(workgroupId);
@@ -125,7 +125,8 @@ export class StudentProgressComponent implements OnInit {
 
     for (const student of this.students) {
       if (student.workgroupId === workgroupId) {
-        student.location = location;
+        student.position = location?.position || '';
+        student.order = location?.order || 0;
         student.completion = completion;
         student.completionPct = completion.completionPct || 0;
         student.score = score;
@@ -133,12 +134,6 @@ export class StudentProgressComponent implements OnInit {
         student.scorePct = maxScore ? score / maxScore : score;
       }
     }
-  }
-
-  private getCurrentNodeForWorkgroupId(workgroupId: number): string {
-    return this.classroomStatusService.getCurrentNodePositionAndNodeTitleForWorkgroupId(
-      workgroupId
-    );
   }
 
   private getStudentTotalScore(workgroupId: number): number {
@@ -214,7 +209,8 @@ export class StudentProgress {
   username: string;
   firstName: string;
   lastName: string;
-  location: string;
+  position: string;
+  order: number;
   completion: ProjectCompletion;
   completionPct: number;
   score: number;

--- a/src/assets/wise5/services/classroomStatusService.ts
+++ b/src/assets/wise5/services/classroomStatusService.ts
@@ -51,7 +51,7 @@ export class ClassroomStatusService {
     return this.studentStatuses;
   }
 
-  getCurrentNodeLocationForWorkgroupId(workgroupId): any {
+  getCurrentNodeLocationForWorkgroupId(workgroupId: number): any {
     const studentStatus = this.getStudentStatusForWorkgroupId(workgroupId);
     if (studentStatus != null) {
       const currentNodeId = studentStatus.currentNodeId;

--- a/src/assets/wise5/services/classroomStatusService.ts
+++ b/src/assets/wise5/services/classroomStatusService.ts
@@ -51,17 +51,14 @@ export class ClassroomStatusService {
     return this.studentStatuses;
   }
 
-  /**
-   * Get the current node position and title for a workgroup
-   * e.g. 2.2: Newton Scooter Concepts
-   * @param workgroupId the workgroup id
-   * @returns the node position and title
-   */
-  getCurrentNodePositionAndNodeTitleForWorkgroupId(workgroupId) {
+  getCurrentNodeLocationForWorkgroupId(workgroupId): any {
     const studentStatus = this.getStudentStatusForWorkgroupId(workgroupId);
     if (studentStatus != null) {
       const currentNodeId = studentStatus.currentNodeId;
-      return this.projectService.getNodePositionAndTitle(currentNodeId);
+      return {
+        position: this.projectService.getNodePositionAndTitle(currentNodeId),
+        order: this.projectService.getNodeOrderById(currentNodeId)
+      };
     }
     return null;
   }


### PR DESCRIPTION
## Changes
- Use node order in unit to perform sort by location in Classroom Monitor Grade by Student.

## Test
- Make sure sorting by location in Grade by Student now performs correctly in all cases (e.g. students on step 2.12 come after students on step 2.2 when sorted by location ascending).

Closes #1666.
