### PR TITLE
feat(Multiple Languages): Disable default language editor

### DIFF
--- a/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html
@@ -20,7 +20,7 @@
   ></mat-tab>
   <mat-tab label="{{ defaultLanguage.language }}">
     <ng-template matTabContent>
-      <wise-authoring-tinymce-editor [model]="html"></wise-authoring-tinymce-editor>
+      <wise-authoring-tinymce-editor [model]="html" disabled="true"></wise-authoring-tinymce-editor>
     </ng-template>
   </mat-tab>
 </mat-tab-group>

--- a/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html
@@ -20,6 +20,10 @@
   ></mat-tab>
   <mat-tab label="{{ defaultLanguage.language }}">
     <ng-template matTabContent>
+      <span i18n
+        >Editing is disabled. Please switch back to {{ defaultLanguage.language }} if you want to
+        edit.</span
+      >
       <wise-authoring-tinymce-editor [model]="html" disabled="true"></wise-authoring-tinymce-editor>
     </ng-template>
   </mat-tab>

--- a/src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.html
+++ b/src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.html
@@ -1,6 +1,7 @@
 <editor
   [init]="config"
   [initialValue]="model"
+  [disabled]="disabled"
   (onChange)="onChange($event)"
   (onKeyUp)="onChange($event)"
 >

--- a/src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts
+++ b/src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts
@@ -17,6 +17,7 @@ export class WiseTinymceEditorComponent {
   @ViewChild(EditorComponent) editorComponent: EditorComponent;
   public editor: any;
   public config: any;
+  @Input() disabled: boolean;
   private previousContent: string;
 
   @Input() language: Language;

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -21325,28 +21325,28 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>File</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts</context>
-          <context context-type="linenumber">170</context>
+          <context context-type="linenumber">171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3075681036535086015" datatype="html">
         <source>Insert from Notebook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts</context>
-          <context context-type="linenumber">184</context>
+          <context context-type="linenumber">185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="535405804327281099" datatype="html">
         <source>Insert note +</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts</context>
-          <context context-type="linenumber">185</context>
+          <context context-type="linenumber">186</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7138428925866529608" datatype="html">
         <source>Image from notebook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts</context>
-          <context context-type="linenumber">211</context>
+          <context context-type="linenumber">212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3570422532828875517" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10129,6 +10129,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="9c87505361726ff6c363fb8e19efe9832f666c14" datatype="html">
+        <source>Editing is disabled. Please switch back to <x id="INTERPOLATION" equiv-text="{{ defaultLanguage.language }}"/> if you want to edit.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html</context>
+          <context context-type="linenumber">24,25</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1318680729593701201" datatype="html">
         <source>Also currently editing this unit: <x id="PH" equiv-text="otherAuthors.join(
               &apos;, &apos;


### PR DESCRIPTION
## Changes
- Disable the default language editor to prevent authors from editing the default language HTML content when in translation mode.

## Test prep
- Test with https://github.com/WISE-Community/WISE-API/pull/253. Make sure to get the latest changes.

## Test HTMLComponent in AT with translation enabled unit
- When in another language
   - you can translate the content in the first tab (translation language)
   - you cannot edit the content in the second tab (default langauge)
- When in default language
   - you can edit the content
