### PR TITLE
feat(Authoring): Implement add lesson button menu next to lessons

### DIFF
--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -61,10 +61,12 @@ import { CopyComponentButtonComponent } from '../../assets/wise5/authoringTool/n
 import { SaveIndicatorComponent } from '../../assets/wise5/common/save-indicator/save-indicator.component';
 import { ProjectAuthoringLessonComponent } from '../../assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component';
 import { ProjectAuthoringStepComponent } from '../../assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component';
+import { AddLessonButtonComponent } from '../../assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component';
 
 @NgModule({
   declarations: [
     AddComponentButtonComponent,
+    AddLessonButtonComponent,
     AddLessonChooseLocationComponent,
     AddLessonChooseTemplateComponent,
     AddLessonConfigureComponent,

--- a/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html
+++ b/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html
@@ -1,0 +1,20 @@
+<button
+  mat-icon-button
+  color="primary"
+  class="add-lesson-button"
+  [matMenuTriggerFor]="lessonMenu"
+  #menuTrigger="matMenuTrigger"
+  matTooltip="Add lesson"
+  matTooltipPosition="above"
+  i18n-matTooltip
+>
+  <mat-icon>add_circle</mat-icon>
+</button>
+<mat-menu #lessonMenu="matMenu">
+  <button mat-menu-item (click)="addLessonBefore()">
+    <mat-icon>add_circle</mat-icon><span i18n>Add Lesson Before</span>
+  </button>
+  <button mat-menu-item (click)="addLessonAfter()">
+    <mat-icon>add_circle</mat-icon><span i18n>Add Lesson After</span>
+  </button>
+</mat-menu>

--- a/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html
+++ b/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html
@@ -2,8 +2,9 @@
   mat-icon-button
   color="primary"
   class="add-lesson-button"
-  [matMenuTriggerFor]="lessonMenu"
-  #menuTrigger="matMenuTrigger"
+  (click)="addLesson()"
+  [matMenuTriggerFor]="lessonId == null ? null : lessonMenu"
+  #menuTrigger
   matTooltip="Add lesson"
   matTooltipPosition="above"
   i18n-matTooltip

--- a/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html
+++ b/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html
@@ -1,7 +1,6 @@
 <button
   mat-icon-button
   color="primary"
-  class="add-lesson-button"
   (click)="addLesson()"
   [matMenuTriggerFor]="lessonId == null ? null : lessonMenu"
   #menuTrigger

--- a/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.scss
+++ b/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.scss
@@ -1,3 +1,0 @@
-.add-lesson-button {
-  margin-top: 20px;
-}

--- a/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.scss
+++ b/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.scss
@@ -1,0 +1,3 @@
+.add-lesson-button {
+  margin-top: 20px;
+}

--- a/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.spec.ts
+++ b/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.spec.ts
@@ -1,0 +1,32 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AddLessonButtonComponent } from './add-lesson-button.component';
+import { TeacherProjectService } from '../../services/teacherProjectService';
+import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatIconModule } from '@angular/material/icon';
+
+describe('AddLessonButtonComponent', () => {
+  let component: AddLessonButtonComponent;
+  let fixture: ComponentFixture<AddLessonButtonComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [AddLessonButtonComponent],
+      imports: [
+        HttpClientTestingModule,
+        StudentTeacherCommonServicesModule,
+        MatIconModule,
+        MatMenuModule
+      ],
+      providers: [TeacherProjectService]
+    });
+    fixture = TestBed.createComponent(AddLessonButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.ts
+++ b/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.ts
@@ -48,7 +48,7 @@ export class AddLessonButtonComponent {
   }
 
   private createNewLesson(): any {
-    return this.projectService.createGroup('New Lesson');
+    return this.projectService.createGroup($localize`New Lesson`);
   }
 
   private updateProject(newNodeId: string): void {

--- a/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.ts
+++ b/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.ts
@@ -1,0 +1,38 @@
+import { Component, Input } from '@angular/core';
+import { TeacherProjectService } from '../../services/teacherProjectService';
+import { temporarilyHighlightElement } from '../../common/dom/dom';
+
+@Component({
+  selector: 'add-lesson-button',
+  templateUrl: './add-lesson-button.component.html',
+  styleUrls: ['./add-lesson-button.component.scss']
+})
+export class AddLessonButtonComponent {
+  @Input() lessonId: string;
+
+  constructor(private projectService: TeacherProjectService) {}
+
+  protected addLessonBefore(): void {
+    const newLesson = this.projectService.createGroup('New Lesson');
+    const previousLessonId = this.projectService.getPreviousStepNodeId(this.lessonId);
+    if (previousLessonId == null) {
+      this.projectService.createNodeInside(newLesson, 'group0');
+    } else {
+      this.projectService.createNodeAfter(newLesson, previousLessonId);
+    }
+    this.updateProject(newLesson.id);
+  }
+
+  protected addLessonAfter(): void {
+    const newLesson = this.projectService.createGroup('New Lesson');
+    this.projectService.createNodeAfter(newLesson, this.lessonId);
+    this.updateProject(newLesson.id);
+  }
+
+  private updateProject(newNodeId: string): void {
+    this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
+      this.projectService.refreshProject();
+      temporarilyHighlightElement(newNodeId);
+    });
+  }
+}

--- a/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.ts
+++ b/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.ts
@@ -1,6 +1,7 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ViewChild } from '@angular/core';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { temporarilyHighlightElement } from '../../common/dom/dom';
+import { MatMenuTrigger } from '@angular/material/menu';
 
 @Component({
   selector: 'add-lesson-button',
@@ -8,28 +9,46 @@ import { temporarilyHighlightElement } from '../../common/dom/dom';
   styleUrls: ['./add-lesson-button.component.scss']
 })
 export class AddLessonButtonComponent {
+  @Input() active: boolean;
   @Input() lessonId: string;
+  @ViewChild(MatMenuTrigger) menuTrigger: MatMenuTrigger;
 
   constructor(private projectService: TeacherProjectService) {}
 
+  protected addLesson(): void {
+    if (this.lessonId == null) {
+      this.addFirstLesson();
+    } else {
+      this.menuTrigger.openMenu();
+    }
+  }
+
   protected addLessonBefore(): void {
-    const newLesson = this.projectService.createGroup('New Lesson');
     const previousLessonId = this.projectService.getPreviousNodeId(this.lessonId);
     if (previousLessonId == null) {
-      const insertLocation = this.projectService.isActive(this.lessonId)
-        ? 'group0'
-        : 'inactiveGroups';
-      this.projectService.createNodeInside(newLesson, insertLocation);
+      this.addFirstLesson();
     } else {
+      const newLesson = this.createNewLesson();
       this.projectService.createNodeAfter(newLesson, previousLessonId);
+      this.updateProject(newLesson.id);
     }
+  }
+
+  private addFirstLesson(): void {
+    const newLesson = this.createNewLesson();
+    const insertLocation = this.active ? 'group0' : 'inactiveGroups';
+    this.projectService.createNodeInside(newLesson, insertLocation);
     this.updateProject(newLesson.id);
   }
 
   protected addLessonAfter(): void {
-    const newLesson = this.projectService.createGroup('New Lesson');
+    const newLesson = this.createNewLesson();
     this.projectService.createNodeAfter(newLesson, this.lessonId);
     this.updateProject(newLesson.id);
+  }
+
+  private createNewLesson(): any {
+    return this.projectService.createGroup('New Lesson');
   }
 
   private updateProject(newNodeId: string): void {

--- a/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.ts
+++ b/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.ts
@@ -14,9 +14,12 @@ export class AddLessonButtonComponent {
 
   protected addLessonBefore(): void {
     const newLesson = this.projectService.createGroup('New Lesson');
-    const previousLessonId = this.projectService.getPreviousStepNodeId(this.lessonId);
+    const previousLessonId = this.projectService.getPreviousNodeId(this.lessonId);
     if (previousLessonId == null) {
-      this.projectService.createNodeInside(newLesson, 'group0');
+      const insertLocation = this.projectService.isActive(this.lessonId)
+        ? 'group0'
+        : 'inactiveGroups';
+      this.projectService.createNodeInside(newLesson, insertLocation);
     } else {
       this.projectService.createNodeAfter(newLesson, previousLessonId);
     }

--- a/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.ts
+++ b/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.ts
@@ -54,7 +54,10 @@ export class AddLessonButtonComponent {
   private updateProject(newNodeId: string): void {
     this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
       this.projectService.refreshProject();
-      temporarilyHighlightElement(newNodeId);
+      // This timeout is used to allow the lesson to be added to the DOM before we highlight it
+      setTimeout(() => {
+        temporarilyHighlightElement(newNodeId);
+      });
     });
   }
 }

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -73,10 +73,7 @@ export class ProjectAuthoringLessonComponent {
     if (this.projectService.isFirstStepInLesson(nodeId)) {
       this.projectService.createNodeInside(newStep, this.projectService.getParentGroupId(nodeId));
     } else {
-      this.projectService.createNodeAfter(
-        newStep,
-        this.projectService.getPreviousStepNodeId(nodeId)
-      );
+      this.projectService.createNodeAfter(newStep, this.projectService.getPreviousNodeId(nodeId));
     }
     this.updateProject(newStep.id);
   }

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -77,16 +77,7 @@
 <div class="all-nodes-div">
   <div *ngIf="lessons.length === 0" fxLayout="row" fxLayoutAlign="start center">
     <div i18n>There are no lessons</div>
-    <button
-      mat-icon-button
-      color="primary"
-      (click)="addLesson()"
-      matTooltip="Add lesson"
-      matTooltipPosition="above"
-      i18n-matTooltip
-    >
-      <mat-icon>add_circle</mat-icon>
-    </button>
+    <add-lesson-button [active]="true"></add-lesson-button>
   </div>
   <div *ngFor="let lesson of lessons" fxLayout="row">
     <project-authoring-lesson
@@ -98,22 +89,17 @@
       (onExpandedChanged)="onExpandedChanged($event)"
       fxFlex
     ></project-authoring-lesson>
-    <add-lesson-button [lessonId]="lesson.id"></add-lesson-button>
+    <add-lesson-button
+      class="add-lesson-button-next-to-lesson"
+      [active]="true"
+      [lessonId]="lesson.id"
+    ></add-lesson-button>
   </div>
   <div>
     <h6 class="unused-header" i18n>Unused Lessons</h6>
     <div *ngIf="inactiveGroupNodes.length === 0" fxLayout="row" fxLayoutAlign="start center">
       <div i18n>There are no unused lessons</div>
-      <button
-        mat-icon-button
-        color="primary"
-        (click)="addUnusedLesson()"
-        matTooltip="Add lesson"
-        matTooltipPosition="above"
-        i18n-matTooltip
-      >
-        <mat-icon>add_circle</mat-icon>
-      </button>
+      <add-lesson-button [active]="false"></add-lesson-button>
     </div>
     <div *ngFor="let inactiveGroupNode of inactiveGroupNodes" fxLayout="row">
       <project-authoring-lesson
@@ -125,7 +111,11 @@
         (onExpandedChanged)="onExpandedChanged($event)"
         fxFlex
       ></project-authoring-lesson>
-      <add-lesson-button [lessonId]="inactiveGroupNode.id"></add-lesson-button>
+      <add-lesson-button
+        class="add-lesson-button-next-to-lesson"
+        [active]="false"
+        [lessonId]="inactiveGroupNode.id"
+      ></add-lesson-button>
     </div>
     <div>
       <h6 class="unused-header" i18n>Unused Steps</h6>

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -75,7 +75,7 @@
   </button>
 </div>
 <div class="all-nodes-div">
-  <div *ngFor="let lesson of lessons">
+  <div *ngFor="let lesson of lessons" fxLayout="row">
     <project-authoring-lesson
       [lesson]="lesson"
       (selectNodeEvent)="selectNode($event)"
@@ -83,7 +83,30 @@
       [projectId]="projectId"
       [expanded]="lessonIdToExpanded()[lesson.id]"
       (onExpandedChanged)="onExpandedChanged($event)"
+      fxFlex
     ></project-authoring-lesson>
+    <button
+      mat-icon-button
+      color="primary"
+      class="add-lesson-button"
+      [matMenuTriggerFor]="lessonMenu"
+      #menuTrigger="matMenuTrigger"
+      matTooltip="Add lesson"
+      matTooltipPosition="above"
+      i18n-matTooltip
+    >
+      <mat-icon>add_circle</mat-icon>
+    </button>
+    <mat-menu #lessonMenu="matMenu">
+      <button mat-menu-item (click)="addLessonBefore(lesson.id)">
+        <mat-icon class="add-lesson-menu-icon">add_circle</mat-icon
+        ><span i18n>Add Lesson Before</span>
+      </button>
+      <button mat-menu-item (click)="addLessonAfter(lesson.id)">
+        <mat-icon class="add-lesson-menu-icon">add_circle</mat-icon
+        ><span i18n>Add Lesson After</span>
+      </button>
+    </mat-menu>
   </div>
   <div>
     <h6 class="unused-header" i18n>Unused Lessons</h6>

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -99,7 +99,7 @@
     <h6 class="unused-header" i18n>Unused Lessons</h6>
     <div *ngIf="inactiveGroupNodes.length === 0" fxLayout="row" fxLayoutAlign="start center">
       <div i18n>There are no unused lessons</div>
-      <add-lesson-button [active]="false"></add-lesson-button>
+      <add-lesson-button></add-lesson-button>
     </div>
     <div *ngFor="let inactiveGroupNode of inactiveGroupNodes" fxLayout="row">
       <project-authoring-lesson
@@ -113,7 +113,6 @@
       ></project-authoring-lesson>
       <add-lesson-button
         class="add-lesson-button-next-to-lesson"
-        [active]="false"
         [lessonId]="inactiveGroupNode.id"
       ></add-lesson-button>
     </div>

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -85,28 +85,7 @@
       (onExpandedChanged)="onExpandedChanged($event)"
       fxFlex
     ></project-authoring-lesson>
-    <button
-      mat-icon-button
-      color="primary"
-      class="add-lesson-button"
-      [matMenuTriggerFor]="lessonMenu"
-      #menuTrigger="matMenuTrigger"
-      matTooltip="Add lesson"
-      matTooltipPosition="above"
-      i18n-matTooltip
-    >
-      <mat-icon>add_circle</mat-icon>
-    </button>
-    <mat-menu #lessonMenu="matMenu">
-      <button mat-menu-item (click)="addLessonBefore(lesson.id)">
-        <mat-icon class="add-lesson-menu-icon">add_circle</mat-icon
-        ><span i18n>Add Lesson Before</span>
-      </button>
-      <button mat-menu-item (click)="addLessonAfter(lesson.id)">
-        <mat-icon class="add-lesson-menu-icon">add_circle</mat-icon
-        ><span i18n>Add Lesson After</span>
-      </button>
-    </mat-menu>
+    <add-lesson-button [lessonId]="lesson.id"></add-lesson-button>
   </div>
   <div>
     <h6 class="unused-header" i18n>Unused Lessons</h6>

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -75,6 +75,19 @@
   </button>
 </div>
 <div class="all-nodes-div">
+  <div *ngIf="lessons.length === 0" fxLayout="row" fxLayoutAlign="start center">
+    <div i18n>There are no lessons</div>
+    <button
+      mat-icon-button
+      color="primary"
+      (click)="addLesson()"
+      matTooltip="Add lesson"
+      matTooltipPosition="above"
+      i18n-matTooltip
+    >
+      <mat-icon>add_circle</mat-icon>
+    </button>
+  </div>
   <div *ngFor="let lesson of lessons" fxLayout="row">
     <project-authoring-lesson
       [lesson]="lesson"
@@ -89,8 +102,20 @@
   </div>
   <div>
     <h6 class="unused-header" i18n>Unused Lessons</h6>
-    <div *ngIf="inactiveGroupNodes.length === 0" i18n>There are no Unused Lessons</div>
-    <div *ngFor="let inactiveGroupNode of inactiveGroupNodes">
+    <div *ngIf="inactiveGroupNodes.length === 0" fxLayout="row" fxLayoutAlign="start center">
+      <div i18n>There are no unused lessons</div>
+      <button
+        mat-icon-button
+        color="primary"
+        (click)="addUnusedLesson()"
+        matTooltip="Add lesson"
+        matTooltipPosition="above"
+        i18n-matTooltip
+      >
+        <mat-icon>add_circle</mat-icon>
+      </button>
+    </div>
+    <div *ngFor="let inactiveGroupNode of inactiveGroupNodes" fxLayout="row">
       <project-authoring-lesson
         [lesson]="inactiveGroupNode"
         (selectNodeEvent)="selectNode($event)"
@@ -98,11 +123,13 @@
         [projectId]="projectId"
         [expanded]="lessonIdToExpanded()[inactiveGroupNode.id]"
         (onExpandedChanged)="onExpandedChanged($event)"
+        fxFlex
       ></project-authoring-lesson>
+      <add-lesson-button [lessonId]="inactiveGroupNode.id"></add-lesson-button>
     </div>
     <div>
       <h6 class="unused-header" i18n>Unused Steps</h6>
-      <div *ngIf="inactiveStepNodes.length === 0" i18n>There are no Unused Steps</div>
+      <div *ngIf="inactiveStepNodes.length === 0" i18n>There are no unused steps</div>
       <ng-container *ngFor="let inactiveStepNode of inactiveStepNodes">
         <project-authoring-step
           *ngIf="getParentGroup(inactiveStepNode.id) == null"

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.scss
@@ -36,3 +36,11 @@
 .mat-icon {
   margin: 0px;
 }
+
+.add-lesson-button {
+  margin-top: 20px;
+}
+
+.add-lesson-menu-icon {
+  margin-right: 16px;
+}

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.scss
@@ -36,11 +36,3 @@
 .mat-icon {
   margin: 0px;
 }
-
-.add-lesson-button {
-  margin-top: 20px;
-}
-
-.add-lesson-menu-icon {
-  margin-right: 16px;
-}

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.scss
@@ -36,3 +36,7 @@
 .mat-icon {
   margin: 0px;
 }
+
+.add-lesson-button-next-to-lesson {
+  margin-top: 20px;
+}

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
@@ -36,6 +36,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { ConfigService } from '../../services/configService';
 import { of } from 'rxjs/internal/observable/of';
 import { HttpClient } from '@angular/common/http';
+import { AddLessonButtonComponent } from '../add-lesson-button/add-lesson-button.component';
 
 let configService: ConfigService;
 let component: ProjectAuthoringComponent;
@@ -51,6 +52,7 @@ describe('ProjectAuthoringComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [
+        AddLessonButtonComponent,
         ConcurrentAuthorsMessageComponent,
         NodeAuthoringComponent,
         NodeIconComponent,

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
@@ -38,6 +38,8 @@ import { of } from 'rxjs/internal/observable/of';
 import { HttpClient } from '@angular/common/http';
 import { AddLessonButtonComponent } from '../add-lesson-button/add-lesson-button.component';
 
+const addLessonAfterRegex = /Add Lesson After/;
+const addLessonBeforeRegex = /Add Lesson Before/;
 let configService: ConfigService;
 let component: ProjectAuthoringComponent;
 let getConfigParamSpy: jasmine.Spy;
@@ -298,6 +300,9 @@ function addLesson() {
   addLessonBefore();
   addLessonBeforeFirstLesson();
   addLessonAfter();
+  addInactiveLessonBefore();
+  addInactiveLessonBeforeFirstLesson();
+  addInactiveLessonAfter();
 }
 
 function addLessonBeforeFirstLesson() {
@@ -307,7 +312,7 @@ function addLessonBeforeFirstLesson() {
         const addLessonButtons = await harness.getAddLessonButtons();
         addLessonButtons[0].click();
         const addLessonMenu = await harness.getOpenedAddStepMenu();
-        await addLessonMenu.clickItem({ text: /Add Lesson Before/ });
+        await addLessonMenu.clickItem({ text: addLessonBeforeRegex });
         const newLesson = await harness.getLesson('1: New Lesson');
         expect(newLesson).not.toEqual(null);
       });
@@ -322,7 +327,7 @@ function addLessonBefore() {
         const addLessonButtons = await harness.getAddLessonButtons();
         addLessonButtons[1].click();
         const addLessonMenu = await harness.getOpenedAddStepMenu();
-        await addLessonMenu.clickItem({ text: /Add Lesson Before/ });
+        await addLessonMenu.clickItem({ text: addLessonBeforeRegex });
         const newLesson = await harness.getLesson('2: New Lesson');
         expect(newLesson).not.toEqual(null);
       });
@@ -337,9 +342,66 @@ function addLessonAfter() {
         const addLessonButtons = await harness.getAddLessonButtons();
         addLessonButtons[0].click();
         const addLessonMenu = await harness.getOpenedAddStepMenu();
-        await addLessonMenu.clickItem({ text: /Add Lesson After/ });
+        await addLessonMenu.clickItem({ text: addLessonAfterRegex });
         const newLesson = await harness.getLesson('2: New Lesson');
         expect(newLesson).not.toEqual(null);
+      });
+    });
+  });
+}
+
+function addInactiveLessonBeforeFirstLesson() {
+  describe('add lesson button is clicked on an inactive lesson that is the first inactive lesson', () => {
+    describe('add lesson before is chosen on the menu', () => {
+      it('adds a lesson before the chosen lesson', async () => {
+        const addLessonButtons = await harness.getAddLessonButtons();
+        addLessonButtons[5].click();
+        const addLessonMenu = await harness.getOpenedAddStepMenu();
+        await addLessonMenu.clickItem({ text: addLessonBeforeRegex });
+        const unusedLessonTitles = await harness.getUnusedLessonTitles();
+        expect(unusedLessonTitles).toEqual([
+          'New Lesson',
+          'Inactive Lesson One',
+          'Inactive Lesson Two'
+        ]);
+      });
+    });
+  });
+}
+
+function addInactiveLessonBefore() {
+  describe('add lesson button is clicked on an inactive lesson that is not the first inactive lesson', () => {
+    describe('add lesson before is chosen on the menu', () => {
+      it('adds a lesson before the chosen lesson', async () => {
+        const addLessonButtons = await harness.getAddLessonButtons();
+        addLessonButtons[6].click();
+        const addLessonMenu = await harness.getOpenedAddStepMenu();
+        await addLessonMenu.clickItem({ text: addLessonBeforeRegex });
+        const unusedLessonTitles = await harness.getUnusedLessonTitles();
+        expect(unusedLessonTitles).toEqual([
+          'Inactive Lesson One',
+          'New Lesson',
+          'Inactive Lesson Two'
+        ]);
+      });
+    });
+  });
+}
+
+function addInactiveLessonAfter() {
+  describe('add lesson button is clicked next to an inactive lesson', () => {
+    describe('add lesson after is chosen on the menu', () => {
+      it('adds a lesson after the chosen lesson', async () => {
+        const addLessonButtons = await harness.getAddLessonButtons();
+        addLessonButtons[6].click();
+        const addLessonMenu = await harness.getOpenedAddStepMenu();
+        await addLessonMenu.clickItem({ text: addLessonAfterRegex });
+        const unusedLessonTitles = await harness.getUnusedLessonTitles();
+        expect(unusedLessonTitles).toEqual([
+          'Inactive Lesson One',
+          'Inactive Lesson Two',
+          'New Lesson'
+        ]);
       });
     });
   });

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
@@ -39,6 +39,7 @@ import { HttpClient } from '@angular/common/http';
 
 let configService: ConfigService;
 let component: ProjectAuthoringComponent;
+let getConfigParamSpy: jasmine.Spy;
 let fixture: ComponentFixture<ProjectAuthoringComponent>;
 let harness: ProjectAuthoringHarness;
 let http: HttpClient;
@@ -91,6 +92,17 @@ describe('ProjectAuthoringComponent', () => {
     route = TestBed.inject(ActivatedRoute);
     router = TestBed.inject(Router);
     window.history.pushState({}, '', '');
+    getConfigParamSpy = spyOn(configService, 'getConfigParam');
+    getConfigParamSpy.withArgs('canEditProject').and.returnValue(true);
+    getConfigParamSpy.withArgs('mode').and.returnValue('author');
+    getConfigParamSpy.withArgs('saveProjectURL').and.returnValue('/api/author/project/save/1');
+    spyOn(configService, 'getMyUserInfo').and.returnValue({
+      userId: 4,
+      firstName: 'Spongebob',
+      lastName: 'Squarepants',
+      username: 'spongebobsquarepants'
+    });
+    spyOn(http, 'post').and.returnValue(of({ status: 'success' }) as any);
     fixture = TestBed.createComponent(ProjectAuthoringComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -105,6 +117,7 @@ describe('ProjectAuthoringComponent', () => {
   deleteSpecificLesson();
   moveSpecificLesson();
   addStep();
+  addLesson();
 });
 
 function collapseAllButtonClicked() {
@@ -229,19 +242,6 @@ function moveSpecificLesson() {
 }
 
 function addStep() {
-  beforeEach(() => {
-    const getConfigParamSpy = spyOn(configService, 'getConfigParam');
-    getConfigParamSpy.withArgs('canEditProject').and.returnValue(true);
-    getConfigParamSpy.withArgs('mode').and.returnValue('author');
-    getConfigParamSpy.withArgs('saveProjectURL').and.returnValue('/api/author/project/save/1');
-    spyOn(configService, 'getMyUserInfo').and.returnValue({
-      userId: 4,
-      firstName: 'Spongebob',
-      lastName: 'Squarepants',
-      username: 'spongebobsquarepants'
-    });
-    spyOn(http, 'post').and.returnValue(of({ status: 'success' }) as any);
-  });
   addStepBefore();
   addStepBeforeFirstStepInLesson();
   addStepAfter();
@@ -287,6 +287,57 @@ function addStepAfter() {
         await addStepMenu.clickItem({ text: /Add Step After/ });
         const newStep = await harness.getStep('1.3: New Step');
         expect(newStep).not.toEqual(null);
+      });
+    });
+  });
+}
+
+function addLesson() {
+  addLessonBefore();
+  addLessonBeforeFirstLesson();
+  addLessonAfter();
+}
+
+function addLessonBeforeFirstLesson() {
+  describe('add lesson button is clicked on a lesson that is the first lesson', () => {
+    describe('add lesson before is chosen on the menu', () => {
+      it('adds a lesson before the chosen lesson', async () => {
+        const addLessonButtons = await harness.getAddLessonButtons();
+        addLessonButtons[0].click();
+        const addLessonMenu = await harness.getOpenedAddStepMenu();
+        await addLessonMenu.clickItem({ text: /Add Lesson Before/ });
+        const newLesson = await harness.getLesson('1: New Lesson');
+        expect(newLesson).not.toEqual(null);
+      });
+    });
+  });
+}
+
+function addLessonBefore() {
+  describe('add lesson button is clicked on a lesson that is not the first lesson', () => {
+    describe('add lesson before is chosen on the menu', () => {
+      it('adds a lesson before the chosen lesson', async () => {
+        const addLessonButtons = await harness.getAddLessonButtons();
+        addLessonButtons[1].click();
+        const addLessonMenu = await harness.getOpenedAddStepMenu();
+        await addLessonMenu.clickItem({ text: /Add Lesson Before/ });
+        const newLesson = await harness.getLesson('2: New Lesson');
+        expect(newLesson).not.toEqual(null);
+      });
+    });
+  });
+}
+
+function addLessonAfter() {
+  describe('add lesson button is clicked', () => {
+    describe('add lesson after is chosen on the menu', () => {
+      it('adds a lesson after the chosen lesson', async () => {
+        const addLessonButtons = await harness.getAddLessonButtons();
+        addLessonButtons[0].click();
+        const addLessonMenu = await harness.getOpenedAddStepMenu();
+        await addLessonMenu.clickItem({ text: /Add Lesson After/ });
+        const newLesson = await harness.getLesson('2: New Lesson');
+        expect(newLesson).not.toEqual(null);
       });
     });
   });

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -236,4 +236,28 @@ export class ProjectAuthoringComponent implements OnInit {
     });
     this.projectService.setNodeTypeSelected(nodeTypeSelected);
   }
+
+  protected addLessonBefore(nodeId: string): void {
+    const newLesson = this.projectService.createGroup('New Lesson');
+    const previousLessonId = this.projectService.getPreviousStepNodeId(nodeId);
+    if (previousLessonId == null) {
+      this.projectService.createNodeInside(newLesson, 'group0');
+    } else {
+      this.projectService.createNodeAfter(newLesson, previousLessonId);
+    }
+    this.updateProject(newLesson.id);
+  }
+
+  protected addLessonAfter(nodeId: string): void {
+    const newLesson = this.projectService.createGroup('New Lesson');
+    this.projectService.createNodeAfter(newLesson, nodeId);
+    this.updateProject(newLesson.id);
+  }
+
+  private updateProject(newNodeId: string): void {
+    this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
+      this.projectService.refreshProject();
+      temporarilyHighlightElement(newNodeId);
+    });
+  }
 }

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -236,4 +236,23 @@ export class ProjectAuthoringComponent implements OnInit {
     });
     this.projectService.setNodeTypeSelected(nodeTypeSelected);
   }
+
+  protected addLesson(): void {
+    const newLesson = this.projectService.createGroup('New Lesson');
+    this.projectService.createNodeInside(newLesson, 'group0');
+    this.updateProject(newLesson.id);
+  }
+
+  protected addUnusedLesson(): void {
+    const newLesson = this.projectService.createGroup('New Lesson');
+    this.projectService.createNodeInside(newLesson, 'inactiveGroups');
+    this.updateProject(newLesson.id);
+  }
+
+  private updateProject(newNodeId: string): void {
+    this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
+      this.projectService.refreshProject();
+      temporarilyHighlightElement(newNodeId);
+    });
+  }
 }

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -236,28 +236,4 @@ export class ProjectAuthoringComponent implements OnInit {
     });
     this.projectService.setNodeTypeSelected(nodeTypeSelected);
   }
-
-  protected addLessonBefore(nodeId: string): void {
-    const newLesson = this.projectService.createGroup('New Lesson');
-    const previousLessonId = this.projectService.getPreviousStepNodeId(nodeId);
-    if (previousLessonId == null) {
-      this.projectService.createNodeInside(newLesson, 'group0');
-    } else {
-      this.projectService.createNodeAfter(newLesson, previousLessonId);
-    }
-    this.updateProject(newLesson.id);
-  }
-
-  protected addLessonAfter(nodeId: string): void {
-    const newLesson = this.projectService.createGroup('New Lesson');
-    this.projectService.createNodeAfter(newLesson, nodeId);
-    this.updateProject(newLesson.id);
-  }
-
-  private updateProject(newNodeId: string): void {
-    this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
-      this.projectService.refreshProject();
-      temporarilyHighlightElement(newNodeId);
-    });
-  }
 }

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -236,23 +236,4 @@ export class ProjectAuthoringComponent implements OnInit {
     });
     this.projectService.setNodeTypeSelected(nodeTypeSelected);
   }
-
-  protected addLesson(): void {
-    const newLesson = this.projectService.createGroup('New Lesson');
-    this.projectService.createNodeInside(newLesson, 'group0');
-    this.updateProject(newLesson.id);
-  }
-
-  protected addUnusedLesson(): void {
-    const newLesson = this.projectService.createGroup('New Lesson');
-    this.projectService.createNodeInside(newLesson, 'inactiveGroups');
-    this.updateProject(newLesson.id);
-  }
-
-  private updateProject(newNodeId: string): void {
-    this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
-      this.projectService.refreshProject();
-      temporarilyHighlightElement(newNodeId);
-    });
-  }
 }

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.harness.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.harness.ts
@@ -6,6 +6,9 @@ import { ProjectAuthoringStepHarness } from '../project-authoring-step/project-a
 
 export class ProjectAuthoringHarness extends ComponentHarness {
   static hostSelector = 'project-authoring';
+  getAddLessonButtons = this.locatorForAll(
+    MatButtonHarness.with({ selector: '[matTooltip="Add lesson"]' })
+  );
   getAddStepButtons = this.locatorForAll(
     MatButtonHarness.with({ selector: '[matTooltip="Add step"]' })
   );

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.harness.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.harness.ts
@@ -22,6 +22,18 @@ export class ProjectAuthoringHarness extends ComponentHarness {
     return this.locatorForOptional(ProjectAuthoringLessonHarness.with({ title: title }))();
   }
 
+  getUnusedLessons(): Promise<ProjectAuthoringLessonHarness[]> {
+    return this.locatorForAll(ProjectAuthoringLessonHarness.with({ title: /^(?!\d*: ).*/ }))();
+  }
+
+  async getUnusedLessonTitles(): Promise<string[]> {
+    const unusedLessonTitles = [];
+    for (const unusedLesson of await this.getUnusedLessons()) {
+      unusedLessonTitles.push(await unusedLesson.getTitle());
+    }
+    return unusedLessonTitles;
+  }
+
   getStep(title: string): Promise<ProjectAuthoringStepHarness> {
     return this.locatorForOptional(ProjectAuthoringStepHarness.with({ title: title }))();
   }

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -2003,10 +2003,20 @@ export class ProjectService {
     return this.project.speechToText;
   }
 
-  getPreviousStepNodeId(nodeId: string): string {
-    const parentGroup = this.getParentGroup(nodeId);
-    const childIds = parentGroup.ids;
-    return childIds[childIds.indexOf(nodeId) - 1];
+  getPreviousNodeId(nodeId: string): string {
+    if (this.isActive(nodeId)) {
+      const parentGroup = this.getParentGroup(nodeId);
+      const childIds = parentGroup.ids;
+      return childIds[childIds.indexOf(nodeId) - 1];
+    } else {
+      const inactiveGroupNodes = this.getInactiveGroupNodes();
+      for (let i = 0; i < inactiveGroupNodes.length; i++) {
+        if (inactiveGroupNodes[i].id === nodeId) {
+          return inactiveGroupNodes[i - 1]?.id;
+        }
+      }
+    }
+    return null;
   }
 
   isFirstStepInLesson(nodeId: string): boolean {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1145,11 +1145,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">83</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">93</context>
+          <context context-type="linenumber">80</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/top-bar/top-bar.component.html</context>
@@ -1547,7 +1543,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-raw-data/export-raw-data.component.html</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">49</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-step-visits/export-step-visits.component.html</context>
@@ -5196,25 +5192,25 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Account avatar</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="linenumber">13</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">19</context>
+          <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c48210e0360714d757f8286144200648dc140e30" datatype="html">
         <source>Switch back to original user</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c4e3e4170654ee5a353d29a0c34b8008cd25a635" datatype="html">
         <source>Student Home</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">33</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/student/student-home/student-home.component.html</context>
@@ -5225,7 +5221,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Teacher Home</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">43</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-home/teacher-home.component.html</context>
@@ -5236,11 +5232,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Edit Profile</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">55</context>
+          <context context-type="linenumber">53</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">65</context>
+          <context context-type="linenumber">63</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/student/account/edit/edit.component.html</context>
@@ -5255,21 +5251,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Researcher Tools</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">69</context>
+          <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="593d1ae1c4b71457eda8476df2bb52624a3c6e74" datatype="html">
         <source>Admin Tools</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">73</context>
+          <context context-type="linenumber">71</context>
         </context-group>
       </trans-unit>
       <trans-unit id="640eec093c685babaa3265137215e3cc92ad704d" datatype="html">
         <source>Sign Out</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/header/header-account-menu/header-account-menu.component.html</context>
-          <context context-type="linenumber">98</context>
+          <context context-type="linenumber">85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="17f37e96c7b8059b23c07791dca1bdb3f3f6853f" datatype="html">
@@ -9193,7 +9189,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">89</context>
+          <context context-type="linenumber">112</context>
         </context-group>
       </trans-unit>
       <trans-unit id="24b2aed16c8aef6c967fb04c48adde152cf40193" datatype="html">
@@ -9758,7 +9754,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">90</context>
+          <context context-type="linenumber">113</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a10dba8eb1f22a5f90f90e79b8305963eec3ee38" datatype="html">
@@ -9773,7 +9769,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">102</context>
+          <context context-type="linenumber">125</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0217500199a3e48a7b95762b14b79dad49e76beb" datatype="html">
@@ -9788,7 +9784,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">103</context>
+          <context context-type="linenumber">126</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f951d80b53d5536f79142285e8ba09f190a3c723" datatype="html">
@@ -12359,6 +12355,27 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">73,75</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="f6b8c00d13eab40bfcae19bec9a2c7698d943715" datatype="html">
+        <source>Add lesson</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
+          <context context-type="linenumber">94</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="d0486a16c279a8f3cf447b35c0bb3ebafff545e0" datatype="html">
+        <source>Add Lesson Before</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
+          <context context-type="linenumber">103</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="af0c4734813fe3427d3723ae7369483ffd2142c6" datatype="html">
+        <source>Add Lesson After</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
+          <context context-type="linenumber">107</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="791981839110791639" datatype="html">
         <source>Are you sure you want to delete the selected item?</source>
         <context-group purpose="location">
@@ -14296,6 +14313,10 @@ Are you sure you want to proceed?</source>
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
           <context context-type="linenumber">138</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-raw-data/export-raw-data.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="20bbb22e352d5d032b13110d7fc111db453051ff" datatype="html">
         <source> Include Student Work </source>
@@ -14414,7 +14435,7 @@ Are you sure you want to proceed?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-raw-data/export-raw-data.component.html</context>
-          <context context-type="linenumber">44</context>
+          <context context-type="linenumber">42</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-step-visits/export-step-visits.component.html</context>
@@ -14493,7 +14514,7 @@ Are you sure you want to proceed?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-raw-data/export-raw-data.component.html</context>
-          <context context-type="linenumber">26,28</context>
+          <context context-type="linenumber">24,26</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8ceab0a9b07bda5bc01732412828ffc8272d1352" datatype="html">
@@ -14531,32 +14552,25 @@ Are you sure you want to proceed?</source>
           <context context-type="linenumber">98</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="9387b6a5443aa7f4f1b86c41fb821509258a068b" datatype="html">
-        <source> Everything </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-raw-data/export-raw-data.component.html</context>
-          <context context-type="linenumber">16,18</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="230255460fb90e84a3fd489ec7b2761169aad59a" datatype="html">
         <source> Include Student Work </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-raw-data/export-raw-data.component.html</context>
-          <context context-type="linenumber">21,23</context>
+          <context context-type="linenumber">19,21</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1430340d92f413a1cbe8f67c1c263dba644bd134" datatype="html">
         <source> Include Annotations </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-raw-data/export-raw-data.component.html</context>
-          <context context-type="linenumber">31,33</context>
+          <context context-type="linenumber">29,31</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bd5b585853f6216ebf24b880288018643e4da2b7" datatype="html">
         <source>Include Events</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-raw-data/export-raw-data.component.html</context>
-          <context context-type="linenumber">36</context>
+          <context context-type="linenumber">34</context>
         </context-group>
       </trans-unit>
       <trans-unit id="18a393cd6211a7e1f51159db6b49637ee7c61490" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9092,29 +9092,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Add lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
-          <context context-type="linenumber">7</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">84</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">111</context>
+          <context context-type="linenumber">8</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d0486a16c279a8f3cf447b35c0bb3ebafff545e0" datatype="html">
         <source>Add Lesson Before</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="linenumber">16</context>
         </context-group>
       </trans-unit>
       <trans-unit id="af0c4734813fe3427d3723ae7369483ffd2142c6" datatype="html">
         <source>Add Lesson After</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
-          <context context-type="linenumber">18</context>
+          <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="372e176e8ed50173e0caa989d8c5b7ff750c4d58" datatype="html">
@@ -9218,7 +9210,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">104</context>
+          <context context-type="linenumber">99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="24b2aed16c8aef6c967fb04c48adde152cf40193" datatype="html">
@@ -9794,7 +9786,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">131</context>
+          <context context-type="linenumber">121</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0217500199a3e48a7b95762b14b79dad49e76beb" datatype="html">
@@ -12387,14 +12379,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>There are no unused lessons</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">106</context>
+          <context context-type="linenumber">101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1f244812aec621e93ca22f9e72ba88ffe13bb354" datatype="html">
         <source>There are no unused steps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">132</context>
+          <context context-type="linenumber">122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="791981839110791639" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9094,6 +9094,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
           <context context-type="linenumber">7</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
+          <context context-type="linenumber">84</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
+          <context context-type="linenumber">111</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="d0486a16c279a8f3cf447b35c0bb3ebafff545e0" datatype="html">
         <source>Add Lesson Before</source>
@@ -9210,7 +9218,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">91</context>
+          <context context-type="linenumber">104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="24b2aed16c8aef6c967fb04c48adde152cf40193" datatype="html">
@@ -9773,10 +9781,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/assets/wise5/authoringTool/choose-node-location/choose-move-node-location/choose-move-node-location.component.html</context>
           <context context-type="linenumber">41</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">92</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="a10dba8eb1f22a5f90f90e79b8305963eec3ee38" datatype="html">
         <source>Unused Steps</source>
@@ -9790,7 +9794,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">104</context>
+          <context context-type="linenumber">131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0217500199a3e48a7b95762b14b79dad49e76beb" datatype="html">
@@ -9802,10 +9806,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/choose-node-location/choose-move-node-location/choose-move-node-location.component.html</context>
           <context context-type="linenumber">81</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f951d80b53d5536f79142285e8ba09f190a3c723" datatype="html">
@@ -12374,6 +12374,27 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
           <context context-type="linenumber">73,75</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="064120d68b9435e460f4e279c5e61bbebae375eb" datatype="html">
+        <source>There are no lessons</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
+          <context context-type="linenumber">79</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="916f9b62ed7c33eba9be8517d84288d762048cfa" datatype="html">
+        <source>There are no unused lessons</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1f244812aec621e93ca22f9e72ba88ffe13bb354" datatype="html">
+        <source>There are no unused steps</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
+          <context context-type="linenumber">132</context>
         </context-group>
       </trans-unit>
       <trans-unit id="791981839110791639" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9088,6 +9088,27 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">69</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="f6b8c00d13eab40bfcae19bec9a2c7698d943715" datatype="html">
+        <source>Add lesson</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="d0486a16c279a8f3cf447b35c0bb3ebafff545e0" datatype="html">
+        <source>Add Lesson Before</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="af0c4734813fe3427d3723ae7369483ffd2142c6" datatype="html">
+        <source>Add Lesson After</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="372e176e8ed50173e0caa989d8c5b7ff750c4d58" datatype="html">
         <source>Enter a title for the new unit</source>
         <context-group purpose="location">
@@ -9189,7 +9210,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">112</context>
+          <context context-type="linenumber">91</context>
         </context-group>
       </trans-unit>
       <trans-unit id="24b2aed16c8aef6c967fb04c48adde152cf40193" datatype="html">
@@ -9754,7 +9775,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">113</context>
+          <context context-type="linenumber">92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a10dba8eb1f22a5f90f90e79b8305963eec3ee38" datatype="html">
@@ -9769,7 +9790,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">125</context>
+          <context context-type="linenumber">104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0217500199a3e48a7b95762b14b79dad49e76beb" datatype="html">
@@ -9784,7 +9805,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">126</context>
+          <context context-type="linenumber">105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f951d80b53d5536f79142285e8ba09f190a3c723" datatype="html">
@@ -12353,27 +12374,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
           <context context-type="linenumber">73,75</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="f6b8c00d13eab40bfcae19bec9a2c7698d943715" datatype="html">
-        <source>Add lesson</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">94</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="d0486a16c279a8f3cf447b35c0bb3ebafff545e0" datatype="html">
-        <source>Add Lesson Before</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">103</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="af0c4734813fe3427d3723ae7369483ffd2142c6" datatype="html">
-        <source>Add Lesson After</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">107</context>
         </context-group>
       </trans-unit>
       <trans-unit id="791981839110791639" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9092,21 +9092,28 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Add lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
-          <context context-type="linenumber">8</context>
+          <context context-type="linenumber">7</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d0486a16c279a8f3cf447b35c0bb3ebafff545e0" datatype="html">
         <source>Add Lesson Before</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
-          <context context-type="linenumber">16</context>
+          <context context-type="linenumber">15</context>
         </context-group>
       </trans-unit>
       <trans-unit id="af0c4734813fe3427d3723ae7369483ffd2142c6" datatype="html">
         <source>Add Lesson After</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
-          <context context-type="linenumber">19</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="97251568662383277" datatype="html">
+        <source>New Lesson</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.ts</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="372e176e8ed50173e0caa989d8c5b7ff750c4d58" datatype="html">
@@ -9786,7 +9793,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">120</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0217500199a3e48a7b95762b14b79dad49e76beb" datatype="html">
@@ -12386,7 +12393,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>There are no unused steps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">122</context>
+          <context context-type="linenumber">121</context>
         </context-group>
       </trans-unit>
       <trans-unit id="791981839110791639" datatype="html">


### PR DESCRIPTION
## Changes
- Added an add button next to all active lessons in the project view
- Clicking on the add button will open a menu that has the options "Add Lesson Before" and "Add Lesson After"
- Clicking on either of the options will create a new lesson named "New Lesson"
- The new lesson will have no steps

## Test
- Use the new add lesson button menus to add a lesson
  - before the first lesson
  - before a lesson that is not the first lesson
  - after a lesson
 - Add an unused lesson when there are no unused lessons
 - Add an active lesson when there are no active lessons

Closes #1671
