### PR TITLE
fix(Authoring): Fix moving lesson above first empty lesson breaks unit

### DIFF
--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -2267,18 +2267,9 @@ export class TeacherProjectService extends ProjectService {
                 const oldToGroup = this.getNodeById(oldToGroupId);
                 if (oldToGroup != null) {
                   const oldToGroupStartId = oldToGroup.startId;
-                  const transition = {};
-                  let toNodeId = '';
-                  if (oldToGroupStartId == null) {
-                    // there is no start node id so we will just point to the group
-                    toNodeId = oldToGroup;
-                  } else {
-                    // there is a start node id so we will point to it
-                    toNodeId = oldToGroupStartId;
+                  if (oldToGroupStartId != null && oldToGroupStartId !== '') {
+                    this.addToTransition(child, oldToGroupStartId);
                   }
-
-                  // create the transition from the child to the old group
-                  this.addToTransition(child, toNodeId);
                 }
               }
             }


### PR DESCRIPTION
## Changes
- Authors can now move a lesson that contains steps above the first empty lesson without breaking the unit
- After this action is performed, for the lesson that contains steps, the last step in the lesson will have no transitions. Everything still works because the lesson that has steps still has a transition to the empty lesson.

## Test
1. Open or create a unit in the Authoring Tool
2. Create a lesson with no steps and make it the first lesson in the unit
3. Move a lesson that contains at least one step and make it the first lesson in the unit. This used to immediately break the Authoring Tool but now it should not.

Closes #1673
