### PR TITLE
fix(Authoring): Fix deleting first lesson when second lesson is empty

### DIFF
--- a/src/assets/wise5/services/deleteNodeService.ts
+++ b/src/assets/wise5/services/deleteNodeService.ts
@@ -83,7 +83,7 @@ export class DeleteNodeService {
       let nextNodeId = transitions[0].to;
       if (this.ProjectService.isGroupNode(nextNodeId)) {
         const nextGroupStartId = this.ProjectService.getGroupStartId(nextNodeId);
-        if (nextGroupStartId == null) {
+        if (nextGroupStartId == null || nextGroupStartId === '') {
           this.ProjectService.setStartNodeId(nextNodeId);
         } else {
           this.ProjectService.setStartNodeId(nextGroupStartId);


### PR DESCRIPTION
## Changes
- Fix deleting first lesson when second lesson is empty. This used to break the unit.

## Test
1. Create a new unit
2. Add a new empty lesson after the first default lesson
3. Select both lessons and click the global delete icon in the top row. This used to break the unit but now it should not.

Closes #1676