### PR TITLE
refactor(Archive): Make archive unit menu items use archive service

### DIFF
--- a/src/app/modules/library/library-project-menu/library-project-menu.component.ts
+++ b/src/app/modules/library/library-project-menu/library-project-menu.component.ts
@@ -7,7 +7,6 @@ import { UserService } from '../../../services/user.service';
 import { ConfigService } from '../../../services/config.service';
 import { EditRunWarningDialogComponent } from '../../../teacher/edit-run-warning-dialog/edit-run-warning-dialog.component';
 import { ArchiveProjectService } from '../../../services/archive-project.service';
-import { ArchiveProjectResponse } from '../../../domain/archiveProjectResponse';
 
 @Component({
   selector: 'app-library-project-menu',
@@ -88,16 +87,6 @@ export class LibraryProjectMenuComponent {
   }
 
   protected archive(archive: boolean): void {
-    this.archiveProjectService[archive ? 'archiveProject' : 'unarchiveProject'](
-      this.project
-    ).subscribe({
-      next: (response: ArchiveProjectResponse) => {
-        this.archiveProjectService.updateProjectArchivedStatus(this.project, response.archived);
-        this.archiveProjectService.showArchiveProjectSuccessMessage(this.project, archive);
-      },
-      error: () => {
-        this.archiveProjectService.showArchiveProjectErrorMessage(archive);
-      }
-    });
+    this.archiveProjectService.archiveProject(this.project, archive);
   }
 }

--- a/src/app/modules/library/personal-library/personal-library.component.ts
+++ b/src/app/modules/library/personal-library/personal-library.component.ts
@@ -143,11 +143,6 @@ export class PersonalLibraryComponent extends LibraryComponent {
     }
   }
 
-  protected refreshProjects(): void {
-    this.unselectAllProjects();
-    this.archiveProjectService.refreshProjects();
-  }
-
   protected unselectAllProjects(): void {
     this.projects.forEach((project) => (project.selected = false));
     this.selectedProjects.set([]);

--- a/src/app/services/archive-project.service.ts
+++ b/src/app/services/archive-project.service.ts
@@ -12,43 +12,44 @@ export class ArchiveProjectService {
 
   constructor(private http: HttpClient, private snackBar: MatSnackBar) {}
 
-  archiveProject(project: Project): Observable<ArchiveProjectResponse> {
-    return this.http.put<ArchiveProjectResponse>(`/api/project/${project.id}/archived`, null);
-  }
-
-  private makeArchiveProjectsRequest(projects: Project[]): Observable<ArchiveProjectResponse[]> {
-    const projectIds = projects.map((project) => project.id);
-    return this.http.put<ArchiveProjectResponse[]>(`/api/projects/archived`, projectIds);
-  }
-
-  unarchiveProject(project: Project): Observable<ArchiveProjectResponse> {
-    return this.http.delete<ArchiveProjectResponse>(`/api/project/${project.id}/archived`);
-  }
-
-  private makeUnarchiveProjectsRequest(projects: Project[]): Observable<ArchiveProjectResponse[]> {
-    let params = new HttpParams();
-    for (const project of projects) {
-      params = params.append('projectIds', project.id);
-    }
-    return this.http.delete<ArchiveProjectResponse[]>(`/api/projects/archived`, {
-      params: params
+  archiveProject(project: Project, archive: boolean): void {
+    this[archive ? 'makeArchiveProjectRequest' : 'makeUnarchiveProjectRequest'](project).subscribe({
+      next: (response: ArchiveProjectResponse) => {
+        this.updateProjectArchivedStatus(project, response.archived);
+        this.showArchiveProjectSuccessMessage(project, archive);
+      },
+      error: () => {
+        this.showArchiveProjectErrorMessage(archive);
+      }
     });
   }
 
-  refreshProjects(): void {
-    this.refreshProjectsEventSource.next();
+  private makeArchiveProjectRequest(project: Project): Observable<ArchiveProjectResponse> {
+    return this.http.put<ArchiveProjectResponse>(`/api/project/${project.id}/archived`, null);
   }
 
-  showArchiveProjectSuccessMessage(project: Project, archive: boolean): void {
+  private makeUnarchiveProjectRequest(project: Project): Observable<ArchiveProjectResponse> {
+    return this.http.delete<ArchiveProjectResponse>(`/api/project/${project.id}/archived`);
+  }
+
+  private updateProjectArchivedStatus(project: Project, archived: boolean): void {
+    project.updateArchivedStatus(archived);
+    this.refreshProjects();
+  }
+
+  private showArchiveProjectSuccessMessage(project: Project, archive: boolean): void {
     this.snackBar
       .open($localize`Successfully ${archive ? 'archived' : 'restored'} unit.`, $localize`Undo`)
       .onAction()
       .subscribe(() => {
-        this.undoArchiveProjectAction(project, archive ? 'unarchiveProject' : 'archiveProject');
+        this.undoArchiveProjectAction(
+          project,
+          archive ? 'makeUnarchiveProjectRequest' : 'makeArchiveProjectRequest'
+        );
       });
   }
 
-  undoArchiveProjectAction(project: Project, archiveFunctionName: string): void {
+  private undoArchiveProjectAction(project: Project, archiveFunctionName: string): void {
     this[archiveFunctionName](project).subscribe({
       next: (response: ArchiveProjectResponse) => {
         this.updateProjectArchivedStatus(project, response.archived);
@@ -60,44 +61,7 @@ export class ArchiveProjectService {
     });
   }
 
-  updateProjectArchivedStatus(project: Project, archived: boolean): void {
-    project.updateArchivedStatus(archived);
-    this.refreshProjects();
-  }
-
-  showArchiveProjectsSuccessMessage(projects: Project[], archived: boolean): void {
-    this.snackBar
-      .open(
-        archived
-          ? $localize`Successfully archived ${projects.length} unit(s).`
-          : $localize`Successfully restored ${projects.length} unit(s).`,
-        $localize`Undo`
-      )
-      .onAction()
-      .subscribe(() => {
-        this.undoArchiveProjects(
-          projects,
-          archived ? 'makeUnarchiveProjectsRequest' : 'makeArchiveProjectsRequest'
-        );
-      });
-  }
-
-  undoArchiveProjects(projects: Project[], archiveFunctionName: string): void {
-    this[archiveFunctionName](projects).subscribe({
-      next: (response: ArchiveProjectResponse[]) => {
-        for (const projectResponse of response) {
-          const project = projects.find((project) => project.id === projectResponse.id);
-          this.updateProjectArchivedStatus(project, projectResponse.archived);
-        }
-        this.snackBar.open($localize`Action undone.`);
-      },
-      error: () => {
-        this.snackBar.open($localize`Error undoing action.`);
-      }
-    });
-  }
-
-  showArchiveProjectErrorMessage(archive: boolean): void {
+  private showArchiveProjectErrorMessage(archive: boolean): void {
     this.snackBar.open(
       archive ? $localize`Error archiving unit.` : $localize`Error restoring unit.`
     );
@@ -114,6 +78,21 @@ export class ArchiveProjectService {
       error: () => {
         this.showErrorSnackBar(archive);
       }
+    });
+  }
+
+  private makeArchiveProjectsRequest(projects: Project[]): Observable<ArchiveProjectResponse[]> {
+    const projectIds = projects.map((project) => project.id);
+    return this.http.put<ArchiveProjectResponse[]>(`/api/projects/archived`, projectIds);
+  }
+
+  private makeUnarchiveProjectsRequest(projects: Project[]): Observable<ArchiveProjectResponse[]> {
+    let params = new HttpParams();
+    for (const project of projects) {
+      params = params.append('projectIds', project.id);
+    }
+    return this.http.delete<ArchiveProjectResponse[]>(`/api/projects/archived`, {
+      params: params
     });
   }
 
@@ -152,12 +131,6 @@ export class ArchiveProjectService {
       });
   }
 
-  private showErrorSnackBar(archive: boolean): void {
-    this.snackBar.open(
-      archive ? $localize`Error archiving unit(s).` : $localize`Error restoring unit(s).`
-    );
-  }
-
   private undoArchiveAction(projects: Project[], archiveFunctionName: string): void {
     this[archiveFunctionName](projects).subscribe({
       next: (archiveProjectsResponse: ArchiveProjectResponse[]) => {
@@ -169,5 +142,15 @@ export class ArchiveProjectService {
         this.snackBar.open($localize`Error undoing action.`);
       }
     });
+  }
+
+  private showErrorSnackBar(archive: boolean): void {
+    this.snackBar.open(
+      archive ? $localize`Error archiving unit(s).` : $localize`Error restoring unit(s).`
+    );
+  }
+
+  private refreshProjects(): void {
+    this.refreshProjectsEventSource.next();
   }
 }

--- a/src/app/teacher/run-menu/run-menu.component.spec.ts
+++ b/src/app/teacher/run-menu/run-menu.component.spec.ts
@@ -128,7 +128,8 @@ function setRun(archived: boolean): void {
       archived: archived,
       id: 1,
       owner: owner,
-      sharedOwners: []
+      sharedOwners: [],
+      tags: []
     }
   });
 }

--- a/src/app/teacher/run-menu/run-menu.component.ts
+++ b/src/app/teacher/run-menu/run-menu.component.ts
@@ -8,9 +8,7 @@ import { ConfigService } from '../../services/config.service';
 import { RunSettingsDialogComponent } from '../run-settings-dialog/run-settings-dialog.component';
 import { EditRunWarningDialogComponent } from '../edit-run-warning-dialog/edit-run-warning-dialog.component';
 import { Router } from '@angular/router';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { ArchiveProjectService } from '../../services/archive-project.service';
-import { ArchiveProjectResponse } from '../../domain/archiveProjectResponse';
 
 @Component({
   selector: 'app-run-menu',
@@ -28,8 +26,7 @@ export class RunMenuComponent implements OnInit {
     private dialog: MatDialog,
     private userService: UserService,
     private configService: ConfigService,
-    private router: Router,
-    private snackBar: MatSnackBar
+    private router: Router
   ) {}
 
   ngOnInit() {
@@ -85,55 +82,6 @@ export class RunMenuComponent implements OnInit {
   }
 
   protected archive(archive: boolean): void {
-    this.archiveProjectService[archive ? 'archiveProject' : 'unarchiveProject'](
-      this.run.project
-    ).subscribe({
-      next: (response: ArchiveProjectResponse) => {
-        this.updateArchivedStatus(this.run, response.archived);
-        this.showSuccessMessage(this.run, archive);
-      },
-      error: () => {
-        this.showErrorMessage(archive);
-      }
-    });
-  }
-
-  private showSuccessMessage(run: TeacherRun, archive: boolean): void {
-    this.openSnackBar(
-      run,
-      $localize`Successfully ${archive ? 'archived' : 'restored'} unit.`,
-      archive ? 'unarchiveProject' : 'archiveProject'
-    );
-  }
-
-  private showErrorMessage(archive: boolean): void {
-    this.snackBar.open($localize`Error ${archive ? 'archiving' : 'unarchiving'} unit.`);
-  }
-
-  private updateArchivedStatus(run: TeacherRun, archived: boolean): void {
-    run.project.archived = archived;
-    this.runArchiveStatusChangedEvent.emit();
-  }
-
-  private openSnackBar(run: TeacherRun, message: string, undoFunctionName: string): void {
-    this.snackBar
-      .open(message, $localize`Undo`)
-      .onAction()
-      .subscribe(() => {
-        this.undoArchiveAction(run, undoFunctionName);
-      });
-  }
-
-  private undoArchiveAction(run: TeacherRun, archiveFunctionName: string): void {
-    this.archiveProjectService[archiveFunctionName](run.project).subscribe({
-      next: (response: ArchiveProjectResponse) => {
-        run.project.archived = response.archived;
-        this.archiveProjectService.refreshProjects();
-        this.snackBar.open($localize`Action undone.`);
-      },
-      error: () => {
-        this.snackBar.open($localize`Error undoing action.`);
-      }
-    });
+    this.archiveProjectService.archiveProject(this.run.project, archive);
   }
 }

--- a/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.spec.ts
+++ b/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.spec.ts
@@ -118,14 +118,10 @@ function render() {
 function runArchiveStatusChanged() {
   describe('run is not archived and archive menu button is clicked', () => {
     it('should archive run and emit events', async () => {
-      const runSelectedSpy = spyOn(component.runSelectedStatusChangedEvent, 'emit');
-      const runArchiveSpy = spyOn(component.runArchiveStatusChangedEvent, 'emit');
       expect(await runListItemHarness.isArchived()).toBeFalse();
       spyOn(http, 'put').and.returnValue(of(new ArchiveProjectResponse(1, true)));
       await runListItemHarness.clickArchiveMenuButton();
       expect(await runListItemHarness.isArchived()).toBeTrue();
-      expect(runSelectedSpy).toHaveBeenCalled();
-      expect(runArchiveSpy).toHaveBeenCalled();
     });
   });
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -5873,7 +5873,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>units</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library.component.ts</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="413346167952108153" datatype="html">
@@ -7408,118 +7408,82 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Successfully <x id="PH" equiv-text="archive ? &apos;archived&apos; : &apos;restored&apos;"/> unit.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">44</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/run-menu/run-menu.component.ts</context>
-          <context context-type="linenumber">104</context>
+          <context context-type="linenumber">42</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5775346636203685655" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">44</context>
+          <context context-type="linenumber">42</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">74</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">144</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/run-menu/run-menu.component.ts</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1866036816253590803" datatype="html">
         <source>Action undone.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">55</context>
+          <context context-type="linenumber">56</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">92</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">166</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/run-menu/run-menu.component.ts</context>
-          <context context-type="linenumber">132</context>
+          <context context-type="linenumber">139</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8310924106294815391" datatype="html">
         <source>Error undoing action.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">58</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">95</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">169</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/run-menu/run-menu.component.ts</context>
-          <context context-type="linenumber">135</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4446500764298446942" datatype="html">
-        <source>Successfully archived <x id="PH" equiv-text="projects.length"/> unit(s).</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">59</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
           <context context-type="linenumber">142</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6233410407787231949" datatype="html">
-        <source>Successfully restored <x id="PH" equiv-text="projects.length"/> unit(s).</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">73</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">143</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="4649373271512187502" datatype="html">
         <source>Error archiving unit.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">102</context>
+          <context context-type="linenumber">66</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3781019523543102447" datatype="html">
         <source>Error restoring unit.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">102</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4446500764298446942" datatype="html">
+        <source>Successfully archived <x id="PH" equiv-text="count"/> unit(s).</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
+          <context context-type="linenumber">121</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6233410407787231949" datatype="html">
+        <source>Successfully restored <x id="PH" equiv-text="count"/> unit(s).</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
+          <context context-type="linenumber">122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3755123516042132329" datatype="html">
         <source>Error archiving unit(s).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">157</context>
+          <context context-type="linenumber">149</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3419148337120710852" datatype="html">
         <source>Error restoring unit(s).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">157</context>
+          <context context-type="linenumber">149</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e931f6b80399785ea1647269f43ffeea54327cb6" datatype="html">
@@ -8443,21 +8407,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Run Settings</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-menu/run-menu.component.ts</context>
-          <context context-type="linenumber">68</context>
+          <context context-type="linenumber">65</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8421677200321603991" datatype="html">
         <source>Edit Classroom Unit Warning</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-menu/run-menu.component.ts</context>
-          <context context-type="linenumber">78</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2351493690393455691" datatype="html">
-        <source>Error <x id="PH" equiv-text="archive ? &apos;archiving&apos; : &apos;unarchiving&apos;"/> unit.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/run-menu/run-menu.component.ts</context>
-          <context context-type="linenumber">110</context>
+          <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9cce5b778a46771992b9753e43f7f3dbcc8c322a" datatype="html">


### PR DESCRIPTION
## Changes
- Moved archive single unit code into the archive service
- Made the run list item menu and library project menu use the archive service to archive projects

## Test
- Make sure archiving, restoring, and undoing a single unit using the menu item works in
  - Run List
  - Unit Library
