### PR TITLE
feat(Translation): Make embedded component authoring inputs translatable

### DIFF
--- a/src/assets/wise5/components/embedded/edit-embedded-advanced/edit-embedded-advanced.component.html
+++ b/src/assets/wise5/components/embedded/edit-embedded-advanced/edit-embedded-advanced.component.html
@@ -1,12 +1,12 @@
 <div>
-  <mat-form-field class="model-parameters">
-    <mat-label i18n>Model Parameters</mat-label>
-    <input
-      matInput
-      [(ngModel)]="componentContent.parameters"
-      (ngModelChange)="componentChanged()"
-    />
-  </mat-form-field>
+  <translatable-input
+    [content]="componentContent"
+    key="parameters"
+    label="Model Parameters"
+    i18n-label
+    (defaultLanguageTextChanged)="componentChanged()"
+    class="model-parameters"
+  />
 </div>
 <div *ngIf="isNotebookEnabled()">
   <edit-component-add-to-notebook-button [componentContent]="componentContent">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -17878,7 +17878,7 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Model Parameters</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/embedded/edit-embedded-advanced/edit-embedded-advanced.component.html</context>
-          <context context-type="linenumber">3</context>
+          <context context-type="linenumber">5</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1d3911009f4b8bea155d7d4f87812066abaa614b" datatype="html">


### PR DESCRIPTION
## Changes
- Convert authoring input for Model Parameters field in advanced authoring for embedded components to translatable input.

Note: The Model File Name field should also be translatable, but it is tied to a file chooser, which doesn't yet work with translatable inputs. This will be made translatable in a separate PR.

## Test
- Author an embedded component and make sure the "Model Parameters" field in the advanced authoring is translatable.