### PR TITLE
feat(Tag): Implement manage tags dialog

### DIFF
--- a/src/app/services/tagService.spec.ts
+++ b/src/app/services/tagService.spec.ts
@@ -36,7 +36,7 @@ function retrieveRunTags() {
     const req = http.expectOne(`/api/tag/run/${configService.getRunId()}`);
     expect(req.request.method).toEqual('GET');
     req.flush(response);
-    expect(service.tags).toEqual(response);
+    expect(service.getTags()).toEqual(response);
   });
 }
 

--- a/src/app/teacher/apply-tags-button/apply-tags-button.component.html
+++ b/src/app/teacher/apply-tags-button/apply-tags-button.component.html
@@ -20,4 +20,6 @@
       {{ tag.text }}
     </mat-checkbox>
   </div>
+  <mat-divider></mat-divider>
+  <div (click)="manageTags(); $event.stopPropagation()" mat-menu-item i18n>Manage Tags</div>
 </mat-menu>

--- a/src/app/teacher/apply-tags-button/apply-tags-button.component.ts
+++ b/src/app/teacher/apply-tags-button/apply-tags-button.component.ts
@@ -2,6 +2,8 @@ import { Component, Input, OnInit } from '@angular/core';
 import { Project } from '../../domain/project';
 import { TagService } from '../../../assets/wise5/services/tagService';
 import { Tag } from '../../domain/tag';
+import { MatDialog } from '@angular/material/dialog';
+import { ManageTagsDialogComponent } from '../manage-tags-dialog/manage-tags-dialog.component';
 
 @Component({
   selector: 'apply-tags-button',
@@ -12,7 +14,7 @@ export class ApplyTagsButtonComponent implements OnInit {
   @Input() selectedProjects: Project[] = [];
   protected tags: Tag[] = [];
 
-  constructor(private tagService: TagService) {}
+  constructor(private dialog: MatDialog, private tagService: TagService) {}
 
   ngOnInit(): void {
     this.tagService.retrieveUserTags().subscribe((tags: Tag[]) => {
@@ -20,6 +22,10 @@ export class ApplyTagsButtonComponent implements OnInit {
         tag.checked = this.doesAnyProjectHaveTag(tag);
       }
       this.tags = tags;
+    });
+    this.tagService.tagChanged$.subscribe((tagThatChanged: Tag) => {
+      const tag = this.tags.find((t: Tag) => t.id === tagThatChanged.id);
+      tag.text = tagThatChanged.text;
     });
   }
 
@@ -54,5 +60,11 @@ export class ApplyTagsButtonComponent implements OnInit {
       project.tags = project.tags.filter((projectTag: string) => projectTag !== tag.text);
       project.tags.sort();
     }
+  }
+
+  protected manageTags(): void {
+    this.dialog.open(ManageTagsDialogComponent, {
+      panelClass: 'dialog-md'
+    });
   }
 }

--- a/src/app/teacher/apply-tags-button/apply-tags-button.module.ts
+++ b/src/app/teacher/apply-tags-button/apply-tags-button.module.ts
@@ -11,6 +11,7 @@ import { CommonModule } from '@angular/common';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
 import { MatDividerModule } from '@angular/material/divider';
+import { ManageTagsDialogComponent } from '../manage-tags-dialog/manage-tags-dialog.component';
 
 @NgModule({
   declarations: [ApplyTagsButtonComponent],
@@ -19,6 +20,7 @@ import { MatDividerModule } from '@angular/material/divider';
     CommonModule,
     FlexLayoutModule,
     FormsModule,
+    ManageTagsDialogComponent,
     MatButtonModule,
     MatCheckboxModule,
     MatDividerModule,

--- a/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.html
+++ b/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.html
@@ -1,0 +1,18 @@
+<h2 mat-dialog-title i18n>Manage Tags</h2>
+<mat-dialog-content>
+  <div fxLayout="column" fxLayoutGap="12px">
+    <div *ngFor="let tag of tags" fxLayout="row" fxLayoutAlign="start center">
+      <mat-form-field subscriptSizing="dynamic" fxFlex>
+        <input
+          matInput
+          type="text"
+          [(ngModel)]="tag.text"
+          (ngModelChange)="inputChanged.next({ tag: tag, text: $event })"
+        />
+      </mat-form-field>
+    </div>
+  </div>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button cdkFocusInitial mat-dialog-close i18n>Close</button>
+</mat-dialog-actions>

--- a/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.spec.ts
+++ b/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.spec.ts
@@ -3,6 +3,7 @@ import { ManageTagsDialogComponent } from './manage-tags-dialog.component';
 import { TagService } from '../../../assets/wise5/services/tagService';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { StudentTeacherCommonServicesModule } from '../../student-teacher-common-services.module';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 describe('ManageTagsDialogComponent', () => {
   let component: ManageTagsDialogComponent;
@@ -13,6 +14,7 @@ describe('ManageTagsDialogComponent', () => {
       imports: [
         HttpClientTestingModule,
         ManageTagsDialogComponent,
+        MatSnackBarModule,
         StudentTeacherCommonServicesModule
       ],
       providers: [TagService]

--- a/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.spec.ts
+++ b/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ManageTagsDialogComponent } from './manage-tags-dialog.component';
+import { TagService } from '../../../assets/wise5/services/tagService';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { StudentTeacherCommonServicesModule } from '../../student-teacher-common-services.module';
+
+describe('ManageTagsDialogComponent', () => {
+  let component: ManageTagsDialogComponent;
+  let fixture: ComponentFixture<ManageTagsDialogComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        ManageTagsDialogComponent,
+        StudentTeacherCommonServicesModule
+      ],
+      providers: [TagService]
+    });
+    fixture = TestBed.createComponent(ManageTagsDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts
+++ b/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts
@@ -1,0 +1,53 @@
+import { Component, OnInit } from '@angular/core';
+import { TagService } from '../../../assets/wise5/services/tagService';
+import { Tag } from '../../domain/tag';
+import { Subject, Subscription, debounceTime, distinctUntilChanged } from 'rxjs';
+import { CommonModule } from '@angular/common';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+
+@Component({
+  selector: 'manage-tags-dialog',
+  templateUrl: './manage-tags-dialog.component.html',
+  styleUrls: ['./manage-tags-dialog.component.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    FlexLayoutModule,
+    FormsModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatInputModule,
+    MatFormFieldModule
+  ]
+})
+export class ManageTagsDialogComponent implements OnInit {
+  inputChanged: Subject<string> = new Subject<string>();
+  inputChangedSubscription: Subscription;
+  protected tags: Tag[] = [];
+
+  constructor(private tagService: TagService) {}
+
+  ngOnInit(): void {
+    this.tagService.retrieveUserTags().subscribe((tags: Tag[]) => {
+      this.tags = tags;
+    });
+    this.inputChangedSubscription = this.inputChanged
+      .pipe(debounceTime(1000), distinctUntilChanged())
+      .subscribe(({ tag }: any) => {
+        this.updateTag(tag);
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.inputChangedSubscription.unsubscribe();
+  }
+
+  private updateTag(tag: Tag): void {
+    this.tagService.updateTag(tag);
+  }
+}

--- a/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts
+++ b/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts
@@ -26,28 +26,28 @@ import { MatInputModule } from '@angular/material/input';
   ]
 })
 export class ManageTagsDialogComponent implements OnInit {
-  inputChanged: Subject<string> = new Subject<string>();
-  inputChangedSubscription: Subscription;
+  protected inputChanged: Subject<string> = new Subject<any>();
+  private subscriptions: Subscription = new Subscription();
   protected tags: Tag[] = [];
 
   constructor(private tagService: TagService) {}
 
   ngOnInit(): void {
-    this.tagService.retrieveUserTags().subscribe((tags: Tag[]) => {
-      this.tags = tags;
-    });
-    this.inputChangedSubscription = this.inputChanged
-      .pipe(debounceTime(1000), distinctUntilChanged())
-      .subscribe(({ tag }: any) => {
-        this.updateTag(tag);
-      });
+    this.subscriptions.add(
+      this.tagService.retrieveUserTags().subscribe((tags: Tag[]) => {
+        this.tags = tags;
+      })
+    );
+    this.subscriptions.add(
+      this.inputChanged
+        .pipe(debounceTime(1000), distinctUntilChanged())
+        .subscribe(({ tag }: any) => {
+          this.tagService.updateTag(tag);
+        })
+    );
   }
 
   ngOnDestroy(): void {
-    this.inputChangedSubscription.unsubscribe();
-  }
-
-  private updateTag(tag: Tag): void {
-    this.tagService.updateTag(tag);
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts
+++ b/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts
@@ -27,7 +27,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
   ]
 })
 export class ManageTagsDialogComponent implements OnInit {
-  protected inputChanged: Subject<string> = new Subject<any>();
+  protected inputChanged: Subject<any> = new Subject<any>();
   private subscriptions: Subscription = new Subscription();
   protected tags: Tag[] = [];
 

--- a/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts
+++ b/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts
@@ -9,6 +9,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'manage-tags-dialog',
@@ -30,7 +31,7 @@ export class ManageTagsDialogComponent implements OnInit {
   private subscriptions: Subscription = new Subscription();
   protected tags: Tag[] = [];
 
-  constructor(private tagService: TagService) {}
+  constructor(private snackBar: MatSnackBar, private tagService: TagService) {}
 
   ngOnInit(): void {
     this.subscriptions.add(
@@ -43,6 +44,7 @@ export class ManageTagsDialogComponent implements OnInit {
         .pipe(debounceTime(1000), distinctUntilChanged())
         .subscribe(({ tag }: any) => {
           this.tagService.updateTag(tag);
+          this.snackBar.open($localize`Tag updated`);
         })
     );
   }

--- a/src/assets/wise5/services/tagService.ts
+++ b/src/assets/wise5/services/tagService.ts
@@ -5,13 +5,15 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { ConfigService } from './configService';
 import { map } from 'rxjs/operators';
 import { ProjectService } from './projectService';
-import { Observable, Subscription } from 'rxjs';
+import { Observable, Subject, Subscription } from 'rxjs';
 import { Project } from '../../../app/domain/project';
 import { Tag } from '../../../app/domain/tag';
 
 @Injectable()
 export class TagService {
-  tags: any[] = [];
+  private tagChangedSource: Subject<Tag> = new Subject<Tag>();
+  public tagChanged$: Observable<Tag> = this.tagChangedSource.asObservable();
+  private tags: any[] = [];
 
   constructor(
     protected http: HttpClient,
@@ -99,5 +101,11 @@ export class TagService {
       params = params.append('projectIds', project.id);
     }
     return this.http.delete(`/api/projects/tag/${tag.text}`, { params: params }).subscribe();
+  }
+
+  updateTag(tag: Tag): Subscription {
+    return this.http.put<Tag>(`/api/user/tag/${tag.id}`, tag).subscribe((tag) => {
+      this.tagChangedSource.next(tag);
+    });
   }
 }

--- a/src/assets/wise5/services/tagService.ts
+++ b/src/assets/wise5/services/tagService.ts
@@ -11,8 +11,8 @@ import { Tag } from '../../../app/domain/tag';
 
 @Injectable()
 export class TagService {
-  private tagChangedSource: Subject<Tag> = new Subject<Tag>();
-  public tagChanged$: Observable<Tag> = this.tagChangedSource.asObservable();
+  private tagUpdatedSource: Subject<Tag> = new Subject<Tag>();
+  public tagUpdated$: Observable<Tag> = this.tagUpdatedSource.asObservable();
   private tags: any[] = [];
 
   constructor(
@@ -103,9 +103,9 @@ export class TagService {
     return this.http.delete(`/api/projects/tag/${tag.text}`, { params: params }).subscribe();
   }
 
-  updateTag(tag: Tag): Subscription {
-    return this.http.put<Tag>(`/api/user/tag/${tag.id}`, tag).subscribe((tag) => {
-      this.tagChangedSource.next(tag);
+  updateTag(tag: Tag): void {
+    this.http.put<Tag>(`/api/user/tag/${tag.id}`, tag).subscribe((tag) => {
+      this.tagUpdatedSource.next(tag);
     });
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -290,6 +290,10 @@
           <context context-type="linenumber">15</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/share-run-code-dialog/share-run-code-dialog.component.html</context>
           <context context-type="linenumber">61</context>
         </context-group>
@@ -8019,6 +8023,17 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/apply-tags-button/apply-tags-button.component.html</context>
           <context context-type="linenumber">11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="dfbc2318c9fccb8087026673bfd89a13ef2284de" datatype="html">
+        <source>Manage Tags</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/apply-tags-button/apply-tags-button.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.html</context>
+          <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a2d9400df68d9f4e89fe24f6a3f40bc5322f19f2" datatype="html">


### PR DESCRIPTION
## Changes
- Implemented manage tags dialog
- Tag text can now be edited

## Test
- Test with https://github.com/WISE-Community/WISE-API/pull/261
- In the Class Schedule view, select some units by clicking on their checkbox
- Click the "Apply Tags" button
- Click the "Manage Tags" menu item
- Change the text for a tag. The tag text should immediately update in the "Apply tags" menu but not in the unit cards. I'll fix immediately updating in the unit cards in another PR.

