### PR TITLE
refactor(Multiple Languages): Change TranslationText from signal<string> to string

### DIFF
--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
@@ -11,7 +11,7 @@
   <mat-label>{{ label }} ({{ currentLanguage().language }})</mat-label>
   <input
     matInput
-    [ngModel]="translationText()"
+    [ngModel]="translationText"
     (ngModelChange)="translationTextChanged.next($event)"
     placeholder="{{ placeholder }}"
   />

--- a/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html
@@ -4,16 +4,12 @@
   (modelChange)="saveDefaultLanguageText()"
 >
 </wise-authoring-tinymce-editor>
-<mat-tab-group
-  *ngIf="showTranslationInput()"
-  mat-stretch-tabs="false"
-  (selectedTabChange)="setLanguage($event)"
->
+<mat-tab-group *ngIf="showTranslationInput()" mat-stretch-tabs="false">
   <mat-tab label="{{ currentLanguage().language }}"
     ><ng-template matTabContent
       ><wise-authoring-tinymce-editor
         [language]="currentLanguage()"
-        [model]="translationText()"
+        [(model)]="translationText"
         (modelChange)="translationTextChanged.next($event)"
       >
       </wise-authoring-tinymce-editor></ng-template

--- a/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.ts
@@ -1,7 +1,7 @@
-import { Component, computed } from '@angular/core';
+import { Component } from '@angular/core';
 import { AbstractTranslatableFieldComponent } from '../abstract-translatable-field/abstract-translatable-field.component';
 import { WiseTinymceEditorModule } from '../../../directives/wise-tinymce-editor/wise-tinymce-editor.module';
-import { MatTabChangeEvent, MatTabsModule } from '@angular/material/tabs';
+import { MatTabsModule } from '@angular/material/tabs';
 import { insertWiseLinks, replaceWiseLinks } from '../../../common/wise-link/wise-link';
 import { ConfigService } from '../../../services/configService';
 import { EditProjectTranslationService } from '../../../services/editProjectTranslationService';
@@ -31,19 +31,10 @@ export class TranslatableRichTextEditorComponent extends AbstractTranslatableFie
   ngOnInit(): void {
     super.ngOnInit();
     this.html = this.projectService.replaceAssetPaths(replaceWiseLinks(this.content[this.key]));
-    this.translationText = computed(() =>
-      this.projectService.replaceAssetPaths(
-        replaceWiseLinks(this.translateProjectService.currentTranslations()[this.i18nId]?.value)
-      )
-    );
   }
 
-  protected setLanguage(event: MatTabChangeEvent): void {
-    // this call is required to fetch and keep the translations for the
-    // current language up-to-date when switching between language tabs
-    if (event.index === 0) {
-      this.projectService.setCurrentLanguage(this.projectService.currentLanguage());
-    }
+  protected setTranslationText(text: string): void {
+    this.translationText = this.projectService.replaceAssetPaths(replaceWiseLinks(text));
   }
 
   protected saveDefaultLanguageText(): void {

--- a/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.html
@@ -13,7 +13,7 @@
   <mat-label>{{ label }} ({{ currentLanguage().language }})</mat-label>
   <textarea
     matInput
-    [ngModel]="translationText()"
+    [ngModel]="translationText"
     (ngModelChange)="translationTextChanged.next($event)"
     placeholder="{{ placeholder }}"
     cdkTextareaAutosize

--- a/src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts
+++ b/src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts
@@ -114,7 +114,10 @@ export class WiseTinymceEditorComponent {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (this.editorComponent) {
-      if (changes.model) {
+      if (
+        changes.model &&
+        changes.model.currentValue !== this.editorComponent.editor.getContent()
+      ) {
         this.editorComponent.editor.setContent(changes.model.currentValue ?? '');
       }
       if (changes.language && !this.model) {

--- a/src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts
+++ b/src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts
@@ -114,7 +114,7 @@ export class WiseTinymceEditorComponent {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (this.editorComponent) {
-      if (changes.model && changes.model.currentValue !== this.model) {
+      if (changes.model) {
         this.editorComponent.editor.setContent(changes.model.currentValue ?? '');
       }
       if (changes.language && !this.model) {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10153,7 +10153,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Editing is disabled. Please switch back to <x id="INTERPOLATION" equiv-text="{{ defaultLanguage.language }}"/> if you want to edit.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html</context>
-          <context context-type="linenumber">24,25</context>
+          <context context-type="linenumber">20,21</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1318680729593701201" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -21417,28 +21417,28 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>File</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts</context>
-          <context context-type="linenumber">171</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3075681036535086015" datatype="html">
         <source>Insert from Notebook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts</context>
-          <context context-type="linenumber">185</context>
+          <context context-type="linenumber">188</context>
         </context-group>
       </trans-unit>
       <trans-unit id="535405804327281099" datatype="html">
         <source>Insert note +</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts</context>
-          <context context-type="linenumber">186</context>
+          <context context-type="linenumber">189</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7138428925866529608" datatype="html">
         <source>Image from notebook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts</context>
-          <context context-type="linenumber">212</context>
+          <context context-type="linenumber">215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3570422532828875517" datatype="html">


### PR DESCRIPTION
## Changes
- Change ```AbstractTranslatableFieldComponent.translationText``` type from ```signal<string>``` to just ```string```. This will make the field easier to maintain when the languages are switched in the language chooser and in the tab in the HTML authoring. 
   - For example, we no longer need the ```TranslatableRichTextEditorComponent.setLanguage()``` function.
- Convert ```TranslateProjectService.currentTranslations``` signal to an observable to know when to update the ```translationText``` model.

## Test
- Translating the input, textarea, and RichTextarea (in HTML authoring) fields work as before
