### PR TITLE
feat(AI Chat): Restrict authors to admin, researcher, and trusted authors

### DIFF
--- a/src/app/classroom-monitor/show-node-info-dialog/show-node-info-dialog.component.spec.ts
+++ b/src/app/classroom-monitor/show-node-info-dialog/show-node-info-dialog.component.spec.ts
@@ -16,6 +16,7 @@ import { TeacherProjectService } from '../../../assets/wise5/services/teacherPro
 import { VLEProjectService } from '../../../assets/wise5/vle/vleProjectService';
 import { ShowNodeInfoDialogComponent } from './show-node-info-dialog.component';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentTypeServiceModule } from '../../../assets/wise5/services/componentTypeService.module';
 
 let component: ShowNodeInfoDialogComponent;
 const componentRubric: string = 'This is the component rubric.';
@@ -52,6 +53,7 @@ describe('ShowNodeInfoDialogComponent', () => {
       ],
       imports: [
         ClassroomMonitorTestingModule,
+        ComponentTypeServiceModule,
         MatCardModule,
         MatDialogModule,
         MatIconModule,

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -38,11 +38,27 @@ export class UserService {
   }
 
   isStudent(): boolean {
-    return this.isAuthenticated && this.getRoles().includes('student');
+    return this.isRole('student');
   }
 
   isTeacher(): boolean {
-    return this.isAuthenticated && this.getRoles().includes('teacher');
+    return this.isRole('teacher');
+  }
+
+  isTrustedAuthor(): boolean {
+    return this.isRole('trustedAuthor');
+  }
+
+  isResearcher(): boolean {
+    return this.isRole('researcher');
+  }
+
+  isAdmin(): boolean {
+    return this.isRole('admin');
+  }
+
+  private isRole(role: string): boolean {
+    return this.isAuthenticated && this.getRoles().includes(role);
   }
 
   getRoles(): string[] {

--- a/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.spec.ts
+++ b/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.spec.ts
@@ -21,6 +21,7 @@ import { OutsideUrlInfo } from '../../../components/outsideURL/OutsideUrlInfo';
 import { OpenResponseInfo } from '../../../components/openResponse/OpenResponseInfo';
 import { ComponentInfo } from '../../../components/ComponentInfo';
 import { MatCardModule } from '@angular/material/card';
+import { ComponentTypeServiceModule } from '../../../services/componentTypeService.module';
 
 let component: ComponentInfoDialogComponent;
 let fixture: ComponentFixture<ComponentInfoDialogComponent>;
@@ -39,6 +40,7 @@ describe('ComponentInfoDialogComponent', () => {
       ],
       imports: [
         BrowserAnimationsModule,
+        ComponentTypeServiceModule,
         HttpClientTestingModule,
         MatButtonModule,
         MatCardModule,

--- a/src/assets/wise5/authoringTool/components/component-type-selector/component-type-selector.component.spec.ts
+++ b/src/assets/wise5/authoringTool/components/component-type-selector/component-type-selector.component.spec.ts
@@ -8,10 +8,13 @@ import { MatSelectModule } from '@angular/material/select';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ComponentTypeSelectorHarness } from './component-type-selector.harness';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentTypeServiceModule } from '../../../services/componentTypeService.module';
+import { UserService } from '../../../../../app/services/user.service';
 
 let component: ComponentTypeSelectorComponent;
 let componentTypeSelectorHarness: ComponentTypeSelectorHarness;
 let fixture: ComponentFixture<ComponentTypeSelectorComponent>;
+let userService: UserService;
 
 describe('ComponentTypeSelectorComponent', () => {
   beforeEach(async () => {
@@ -19,6 +22,7 @@ describe('ComponentTypeSelectorComponent', () => {
       declarations: [ComponentTypeSelectorComponent],
       imports: [
         BrowserAnimationsModule,
+        ComponentTypeServiceModule,
         HttpClientTestingModule,
         MatFormFieldModule,
         MatIconModule,
@@ -28,6 +32,9 @@ describe('ComponentTypeSelectorComponent', () => {
       providers: []
     });
     fixture = TestBed.createComponent(ComponentTypeSelectorComponent);
+    userService = TestBed.inject(UserService);
+    userService.isAuthenticated = true;
+    spyOn(userService, 'getRoles').and.returnValue(['researcher', 'teacher']);
     component = fixture.componentInstance;
     component.componentType = 'OpenResponse';
     fixture.detectChanges();

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
@@ -25,6 +25,7 @@ import { TeacherNodeService } from '../../../services/teacherNodeService';
 import { EditNodeTitleComponent } from '../edit-node-title/edit-node-title.component';
 import { AddComponentButtonComponent } from '../add-component-button/add-component-button.component';
 import { CopyComponentButtonComponent } from '../copy-component-button/copy-component-button.component';
+import { ComponentTypeServiceModule } from '../../../services/componentTypeService.module';
 
 let component: NodeAuthoringComponent;
 let component1: any;
@@ -50,6 +51,7 @@ describe('NodeAuthoringComponent', () => {
       imports: [
         BrowserAnimationsModule,
         ComponentAuthoringModule,
+        ComponentTypeServiceModule,
         DragDropModule,
         FormsModule,
         HttpClientTestingModule,

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading-view/node-grading-view.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading-view/node-grading-view.component.spec.ts
@@ -19,6 +19,7 @@ import { CommonModule } from '@angular/common';
 import { NodeGradingViewComponentTestHelper } from '../../nodeGrading/node-grading-view/node-grading-view.component.test.helper';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { of } from 'rxjs';
+import { ComponentTypeServiceModule } from '../../../../services/componentTypeService.module';
 
 let component: NodeGradingViewComponent;
 let fixture: ComponentFixture<NodeGradingViewComponent>;
@@ -36,6 +37,7 @@ describe('NodeGradingViewComponent', () => {
         BrowserAnimationsModule,
         ClassroomMonitorTestingModule,
         CommonModule,
+        ComponentTypeServiceModule,
         FlexLayoutModule,
         FormsModule,
         MatAutocompleteModule,

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.spec.ts
@@ -3,6 +3,7 @@ import { ClassroomMonitorTestingModule } from '../../../classroom-monitor-testin
 import { WorkgroupItemComponent } from './workgroup-item.component';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentTypeServiceModule } from '../../../../services/componentTypeService.module';
 
 let component: WorkgroupItemComponent;
 let fixture: ComponentFixture<WorkgroupItemComponent>;
@@ -13,7 +14,7 @@ describe('WorkgroupItemComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [WorkgroupItemComponent],
-      imports: [ClassroomMonitorTestingModule],
+      imports: [ClassroomMonitorTestingModule, ComponentTypeServiceModule],
       providers: [TeacherProjectService],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/assets/wise5/services/componentTypeService.module.ts
+++ b/src/assets/wise5/services/componentTypeService.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { ComponentServiceLookupService } from './componentServiceLookupService';
+import { UserService } from '../../../app/services/user.service';
+import { ComponentTypeService } from './componentTypeService';
+import { ConfigService } from '../../../app/services/config.service';
+
+@NgModule({
+  providers: [ComponentServiceLookupService, ComponentTypeService, ConfigService, UserService]
+})
+export class ComponentTypeServiceModule {}

--- a/src/assets/wise5/services/componentTypeService.ts
+++ b/src/assets/wise5/services/componentTypeService.ts
@@ -1,13 +1,16 @@
 import { Injectable } from '@angular/core';
 import { ComponentServiceLookupService } from './componentServiceLookupService';
+import { UserService } from '../../../app/services/user.service';
 
 @Injectable()
 export class ComponentTypeService {
-  constructor(private componentServiceLookupService: ComponentServiceLookupService) {}
+  constructor(
+    private componentServiceLookupService: ComponentServiceLookupService,
+    private userService: UserService
+  ) {}
 
   getComponentTypes(): any[] {
-    return [
-      { type: 'AiChat', name: this.getComponentTypeLabel('AiChat') },
+    const componentTypes = [
       { type: 'Animation', name: this.getComponentTypeLabel('Animation') },
       { type: 'AudioOscillator', name: this.getComponentTypeLabel('AudioOscillator') },
       { type: 'ConceptMap', name: this.getComponentTypeLabel('ConceptMap') },
@@ -28,6 +31,14 @@ export class ComponentTypeService {
       { type: 'Summary', name: this.getComponentTypeLabel('Summary') },
       { type: 'Table', name: this.getComponentTypeLabel('Table') }
     ];
+    if (
+      this.userService.isAdmin() ||
+      this.userService.isResearcher() ||
+      this.userService.isTrustedAuthor()
+    ) {
+      componentTypes.unshift({ type: 'AiChat', name: this.getComponentTypeLabel('AiChat') });
+    }
+    return componentTypes;
   }
 
   getComponentTypeLabel(componentType: string): string {


### PR DESCRIPTION
## Changes
- Only allow admin, researcher, and trusted authors to add AI Chat items in the Authoring Tool

## Test
- Test with https://github.com/WISE-Community/WISE-API/pull/252 (make sure to pull for latest code)
1. Teacher not allowed to author AI Chat
   - Sign in as a teacher that is not an admin, researcher, or trusted author
   - Go to the Authoring Tool and go to the view where you add a step or item
   - You should not see AI Chat as an item that you can add

2. Teacher allowed to author AI Chat
   - Sign in as a teacher that is an admin, researcher, or trusted author
   - Go to the Authoring Tool and go to the view where you add a step or item
   - You should see AI Chat as an item that you can add

