### PR TITLE
fix(Authoring): Fix add assessment and add simulation

### DIFF
--- a/src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.ts
@@ -96,7 +96,7 @@ export class ChooseSimulationComponent {
   }
 
   protected next(): void {
-    this.router.navigate(['../../../import-step/choose-location'], {
+    this.router.navigate(['../../import-step/choose-location'], {
       relativeTo: this.route,
       state: {
         importFromProjectId: this.simulationProjectId,

--- a/src/assets/wise5/authoringTool/addNode/configure-automated-assessment/configure-automated-assessment.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/configure-automated-assessment/configure-automated-assessment.component.ts
@@ -20,7 +20,7 @@ export class ConfigureAutomatedAssessmentComponent {
   }
 
   protected next(): void {
-    this.router.navigate(['../../../import-step/choose-location'], {
+    this.router.navigate(['../../import-step/choose-location'], {
       relativeTo: this.route,
       state: {
         importFromProjectId: this.importFromProjectId,


### PR DESCRIPTION
## Changes
- Fixed routing for add assessment and add simulation

## Test
Automated Assessment
1. Open a unit in the Authoring Tool
2. Click the "Add New Step" button
3. Select "Automated Assessment"
4. Choose any item and click "Next"
5. At the "Customize Feedback" view, click "Next". An error used to occur and you would not be able to choose where to put the step. Now you should be able to choose where to put the step.

Interactive Simulation
1. Open a unit in the Authoring Tool
2. Click the "Add New Step" button
3. Select "Interactive Simulation"
4. Click "Select" on any simulation
5. Click "Next".  An error used to occur and you would not be able to choose where to put the step. Now you should be able to choose where to put the step.

Closes #1700
