### PR TITLE
refactor(Multiple Languages): Extract ProjectTranslationService

### DIFF
--- a/src/app/services/editProjectTranslationService.spec.ts
+++ b/src/app/services/editProjectTranslationService.spec.ts
@@ -4,6 +4,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { TeacherProjectService } from '../../assets/wise5/services/teacherProjectService';
 import { ConfigService } from '../../assets/wise5/services/configService';
 import { signal } from '@angular/core';
+import { ProjectService } from '../../assets/wise5/services/projectService';
 
 class ConfigServiceStub {
   getProjectId() {
@@ -28,6 +29,7 @@ describe('EditProjectTranslationService', () => {
         EditProjectTranslationService,
         HttpClientTestingModule,
         { provide: ConfigService, useClass: ConfigServiceStub },
+        { provide: ProjectService, useClass: TeacherProjectServiceStub },
         { provide: TeacherProjectService, useClass: TeacherProjectServiceStub }
       ],
       imports: [HttpClientTestingModule]

--- a/src/assets/wise5/authoringTool/components/abstract-translatable-field/abstract-translatable-field.component.ts
+++ b/src/assets/wise5/authoringTool/components/abstract-translatable-field/abstract-translatable-field.component.ts
@@ -3,7 +3,6 @@ import { Subject, Subscription, debounceTime, distinctUntilChanged } from 'rxjs'
 import { Language } from '../../../../../app/domain/language';
 import { EditProjectTranslationService } from '../../../services/editProjectTranslationService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
-import { TranslateProjectService } from '../../../services/translateProjectService';
 import { generateRandomKey } from '../../../common/string/string';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { Translations } from '../../../../../app/domain/translations';
@@ -12,7 +11,7 @@ import { Translations } from '../../../../../app/domain/translations';
 export abstract class AbstractTranslatableFieldComponent {
   @Input() content: object;
   protected currentLanguage: Signal<Language> = this.projectService.currentLanguage;
-  private currentTranslations$ = toObservable(this.translateProjectService.currentTranslations);
+  private currentTranslations$ = toObservable(this.projectTranslationService.currentTranslations);
   protected defaultLanguage: Language = this.projectService.getLocale().getDefaultLanguage();
   @Output() defaultLanguageTextChanged: Subject<string> = new Subject<string>();
   protected i18nId: string;
@@ -26,9 +25,8 @@ export abstract class AbstractTranslatableFieldComponent {
   protected translationText: string;
   protected translationTextChanged: Subject<string> = new Subject<string>();
   constructor(
-    protected editProjectTranslationService: EditProjectTranslationService,
     protected projectService: TeacherProjectService,
-    protected translateProjectService: TranslateProjectService
+    protected projectTranslationService: EditProjectTranslationService
   ) {}
 
   ngOnInit(): void {
@@ -66,12 +64,10 @@ export abstract class AbstractTranslatableFieldComponent {
 
   protected saveTranslationText(text: string): void {
     this.projectService.broadcastSavingProject();
-    const currentTranslations = this.translateProjectService.currentTranslations();
+    const currentTranslations = this.projectTranslationService.currentTranslations();
     currentTranslations[this.i18nId] = { value: text, modified: new Date().getTime() };
-    this.editProjectTranslationService
-      .saveCurrentTranslations(currentTranslations)
-      .subscribe(() => {
-        this.projectService.broadcastProjectSaved();
-      });
+    this.projectTranslationService.saveCurrentTranslations(currentTranslations).subscribe(() => {
+      this.projectService.broadcastProjectSaved();
+    });
   }
 }

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.spec.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.spec.ts
@@ -5,6 +5,7 @@ import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ProjectLocale } from '../../../../../app/domain/projectLocale';
+import { EditProjectTranslationService } from '../../../services/editProjectTranslationService';
 
 describe('TranslatableInputComponent', () => {
   let component: TranslatableInputComponent;
@@ -18,7 +19,7 @@ describe('TranslatableInputComponent', () => {
         StudentTeacherCommonServicesModule,
         TranslatableInputComponent
       ],
-      providers: [TeacherProjectService]
+      providers: [EditProjectTranslationService, TeacherProjectService]
     });
     spyOn(TestBed.inject(TeacherProjectService), 'getLocale').and.returnValue(
       new ProjectLocale({ default: 'en-US' })

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { EditProjectTranslationService } from '../../../services/editProjectTranslationService';
 import { CommonModule } from '@angular/common';
 import { MatInputModule } from '@angular/material/input';
 import { FormsModule } from '@angular/forms';
@@ -9,7 +8,6 @@ import { AbstractTranslatableFieldComponent } from '../abstract-translatable-fie
   standalone: true,
   selector: 'translatable-input',
   imports: [CommonModule, FormsModule, MatInputModule],
-  providers: [EditProjectTranslationService],
   styleUrls: ['./translatable-input.component.scss'],
   templateUrl: './translatable-input.component.html'
 })

--- a/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.ts
@@ -6,7 +6,6 @@ import { insertWiseLinks, replaceWiseLinks } from '../../../common/wise-link/wis
 import { ConfigService } from '../../../services/configService';
 import { EditProjectTranslationService } from '../../../services/editProjectTranslationService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
-import { TranslateProjectService } from '../../../services/translateProjectService';
 import { CommonModule } from '@angular/common';
 import { MatDialogModule } from '@angular/material/dialog';
 
@@ -21,11 +20,10 @@ export class TranslatableRichTextEditorComponent extends AbstractTranslatableFie
 
   constructor(
     private configService: ConfigService,
-    protected editProjectTranslationService: EditProjectTranslationService,
     protected projectService: TeacherProjectService,
-    protected translateProjectService: TranslateProjectService
+    protected projectTranslationService: EditProjectTranslationService
   ) {
-    super(editProjectTranslationService, projectService, translateProjectService);
+    super(projectService, projectTranslationService);
   }
 
   ngOnInit(): void {

--- a/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.spec.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.spec.ts
@@ -5,6 +5,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { ProjectLocale } from '../../../../../app/domain/projectLocale';
+import { EditProjectTranslationService } from '../../../services/editProjectTranslationService';
 
 describe('TranslatableTextareaComponent', () => {
   let component: TranslatableTextareaComponent;
@@ -18,7 +19,7 @@ describe('TranslatableTextareaComponent', () => {
         StudentTeacherCommonServicesModule,
         TranslatableTextareaComponent
       ],
-      providers: [TeacherProjectService]
+      providers: [EditProjectTranslationService, TeacherProjectService]
     });
     spyOn(TestBed.inject(TeacherProjectService), 'getLocale').and.returnValue(
       new ProjectLocale({ default: 'en-US' })

--- a/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { EditProjectTranslationService } from '../../../services/editProjectTranslationService';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
@@ -9,7 +8,6 @@ import { AbstractTranslatableFieldComponent } from '../abstract-translatable-fie
   standalone: true,
   selector: 'translatable-textarea',
   imports: [CommonModule, FormsModule, MatInputModule],
-  providers: [EditProjectTranslationService],
   templateUrl: './translatable-textarea.component.html'
 })
 export class TranslatableTextareaComponent extends AbstractTranslatableFieldComponent {}

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
@@ -26,6 +26,7 @@ import { EditNodeTitleComponent } from '../edit-node-title/edit-node-title.compo
 import { AddComponentButtonComponent } from '../add-component-button/add-component-button.component';
 import { CopyComponentButtonComponent } from '../copy-component-button/copy-component-button.component';
 import { ProjectLocale } from '../../../../../app/domain/projectLocale';
+import { EditProjectTranslationService } from '../../../services/editProjectTranslationService';
 
 let component: NodeAuthoringComponent;
 let component1: any;
@@ -63,6 +64,7 @@ describe('NodeAuthoringComponent', () => {
       ],
       providers: [
         ClassroomStatusService,
+        EditProjectTranslationService,
         ProjectAssetService,
         TeacherDataService,
         TeacherNodeService,

--- a/src/assets/wise5/services/editProjectTranslationService.ts
+++ b/src/assets/wise5/services/editProjectTranslationService.ts
@@ -1,17 +1,26 @@
-import { Injectable } from '@angular/core';
-import { Observable, catchError, throwError } from 'rxjs';
-import { HttpClient } from '@angular/common/http';
-import { ConfigService } from './configService';
+import { Injectable, WritableSignal, signal } from '@angular/core';
+import { Observable, catchError, lastValueFrom, map, throwError } from 'rxjs';
 import { TeacherProjectService } from './teacherProjectService';
 import { Translations } from '../../../app/domain/translations';
+import { ProjectTranslationService } from './projectTranslationService';
+import { HttpClient } from '@angular/common/http';
+import { ConfigService } from './configService';
+import { ProjectService } from './projectService';
+import { toObservable } from '@angular/core/rxjs-interop';
 
 @Injectable()
-export class EditProjectTranslationService {
+export class EditProjectTranslationService extends ProjectTranslationService {
+  currentTranslations: WritableSignal<Translations> = signal({});
   constructor(
-    private configService: ConfigService,
-    private http: HttpClient,
-    private projectService: TeacherProjectService
-  ) {}
+    protected configService: ConfigService,
+    protected http: HttpClient,
+    protected projectService: ProjectService
+  ) {
+    super(configService, http, projectService);
+    toObservable(this.projectService.currentLanguage).subscribe(async (language) => {
+      this.currentTranslations.set(await lastValueFrom(this.fetchTranslations(language.locale)));
+    });
+  }
 
   saveCurrentTranslations(translations: Translations): Observable<void> {
     return this.http
@@ -22,8 +31,11 @@ export class EditProjectTranslationService {
         translations
       )
       .pipe(
+        map(() => {
+          this.currentTranslations.set(translations);
+        }),
         catchError(() => {
-          this.projectService.broadcastErrorSavingProject();
+          (this.projectService as TeacherProjectService).broadcastErrorSavingProject();
           return throwError(
             () => new Error($localize`Error saving translation. Please try again later.`)
           );

--- a/src/assets/wise5/services/editProjectTranslationService.ts
+++ b/src/assets/wise5/services/editProjectTranslationService.ts
@@ -5,7 +5,6 @@ import { Translations } from '../../../app/domain/translations';
 import { ProjectTranslationService } from './projectTranslationService';
 import { HttpClient } from '@angular/common/http';
 import { ConfigService } from './configService';
-import { ProjectService } from './projectService';
 import { toObservable } from '@angular/core/rxjs-interop';
 
 @Injectable()
@@ -14,7 +13,7 @@ export class EditProjectTranslationService extends ProjectTranslationService {
   constructor(
     protected configService: ConfigService,
     protected http: HttpClient,
-    protected projectService: ProjectService
+    protected projectService: TeacherProjectService
   ) {
     super(configService, http, projectService);
     toObservable(this.projectService.currentLanguage).subscribe(async (language) => {
@@ -35,7 +34,7 @@ export class EditProjectTranslationService extends ProjectTranslationService {
           this.currentTranslations.set(translations);
         }),
         catchError(() => {
-          (this.projectService as TeacherProjectService).broadcastErrorSavingProject();
+          this.projectService.broadcastErrorSavingProject();
           return throwError(
             () => new Error($localize`Error saving translation. Please try again later.`)
           );

--- a/src/assets/wise5/services/projectTranslationService.ts
+++ b/src/assets/wise5/services/projectTranslationService.ts
@@ -1,0 +1,27 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ConfigService } from './configService';
+import { ProjectService } from './projectService';
+import { Translations } from '../../../app/domain/translations';
+
+@Injectable()
+export class ProjectTranslationService {
+  constructor(
+    protected configService: ConfigService,
+    protected http: HttpClient,
+    protected projectService: ProjectService
+  ) {}
+
+  protected fetchTranslations(locale: string): Observable<Translations> {
+    return this.http.get<Translations>(this.getTranslationMappingURL(locale), {
+      headers: new HttpHeaders().set('cache-control', 'no-cache')
+    });
+  }
+
+  private getTranslationMappingURL(locale: string): string {
+    return this.configService
+      .getConfigParam('projectURL')
+      .replace('project.json', `translations.${locale}.json`);
+  }
+}

--- a/src/assets/wise5/services/translateProjectService.ts
+++ b/src/assets/wise5/services/translateProjectService.ts
@@ -1,14 +1,12 @@
 import { Injectable } from '@angular/core';
-import { ProjectService } from './projectService';
-import { ConfigService } from './configService';
-import { Observable, lastValueFrom, of, switchMap, tap } from 'rxjs';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { lastValueFrom, of, switchMap, tap } from 'rxjs';
 import { copy } from '../common/object/object';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { Translations } from '../../../app/domain/translations';
+import { ProjectTranslationService } from './projectTranslationService';
+import { toSignal, toObservable } from '@angular/core/rxjs-interop';
 
 @Injectable()
-export class TranslateProjectService {
+export class TranslateProjectService extends ProjectTranslationService {
   currentTranslations = toSignal(
     toObservable(this.projectService.currentLanguage).pipe(
       switchMap((language) =>
@@ -19,12 +17,6 @@ export class TranslateProjectService {
     ),
     { initialValue: {} }
   );
-
-  constructor(
-    private configService: ConfigService,
-    private http: HttpClient,
-    private projectService: ProjectService
-  ) {}
 
   translate(locale = 'en_US'): Promise<any> {
     const project = this.revertToOriginalProject();
@@ -44,18 +36,6 @@ export class TranslateProjectService {
     const project = copy(this.projectService.getOriginalProject());
     this.projectService.setProject(project);
     return project;
-  }
-
-  private fetchTranslations(locale: string): Observable<Translations> {
-    return this.http.get<Translations>(this.getTranslationMappingURL(locale), {
-      headers: new HttpHeaders().set('cache-control', 'no-cache')
-    });
-  }
-
-  private getTranslationMappingURL(locale: string): string {
-    return this.configService
-      .getConfigParam('projectURL')
-      .replace('project.json', `translations.${locale}.json`);
   }
 
   private applyTranslations(projectElement: object, translations: Translations): void {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -21532,7 +21532,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Error saving translation. Please try again later.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/editProjectTranslationService.ts</context>
-          <context context-type="linenumber">40</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1384916903989385807" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -21532,7 +21532,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Error saving translation. Please try again later.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/editProjectTranslationService.ts</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">40</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1384916903989385807" datatype="html">


### PR DESCRIPTION
## Changes
- Extract common translation functionality to ProjectTranslationService
- Separate author and student-specific functions to services
   - Author: EditProjectTranslationService
   - Student: TranslateProjectService 

## Test Prep
- Test with ```at-units-in-multiple-languages``` branch in API

## Test
- Translating unit works as before
- Previewing translations in the student view works as before