### PR TITLE
feat(Multiple languages): Copy default language in HTML component

### DIFF
--- a/src/assets/wise5/authoringTool/components/abstract-translatable-field/abstract-translatable-field.component.ts
+++ b/src/assets/wise5/authoringTool/components/abstract-translatable-field/abstract-translatable-field.component.ts
@@ -1,5 +1,5 @@
 import { Input, Signal, Output, computed, Directive } from '@angular/core';
-import { Subject, Subscription, debounceTime, distinctUntilChanged } from 'rxjs';
+import { Subject, Subscription, debounceTime } from 'rxjs';
 import { Language } from '../../../../../app/domain/language';
 import { TeacherProjectTranslationService } from '../../../services/teacherProjectTranslationService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
@@ -37,14 +37,12 @@ export abstract class AbstractTranslatableFieldComponent {
       })
     );
     this.subscriptions.add(
-      this.translationTextChanged
-        .pipe(debounceTime(1000), distinctUntilChanged())
-        .subscribe(async (text: string) => {
-          if (this.i18nId == null) {
-            await this.createI18NField();
-          }
-          this.saveTranslationText(text);
-        })
+      this.translationTextChanged.pipe(debounceTime(1000)).subscribe(async (text: string) => {
+        if (this.i18nId == null) {
+          await this.createI18NField();
+        }
+        this.saveTranslationText(text);
+      })
     );
   }
 

--- a/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html
@@ -5,26 +5,32 @@
 >
 </wise-authoring-tinymce-editor>
 <mat-tab-group *ngIf="showTranslationInput()" mat-stretch-tabs="false">
-  <mat-tab label="{{ currentLanguage().language }}"
-    ><ng-template matTabContent
-      ><button mat-button color="primary" (click)="copyDefaultLanguageText()" i18n>
-        Copy content from {{ defaultLanguage.language }}</button
-      ><wise-authoring-tinymce-editor
+  <mat-tab label="{{ currentLanguage().language }}">
+    <ng-template matTabContent>
+      <div class="translation-tools">
+        <button mat-stroked-button color="primary" (click)="copyDefaultLanguageText()" i18n>
+          Copy content from {{ defaultLanguage.language }}
+        </button>
+      </div>
+      <wise-authoring-tinymce-editor
         [language]="currentLanguage()"
         [(model)]="translationText"
         (modelChange)="translationTextChanged.next($event)"
       >
-      </wise-authoring-tinymce-editor></ng-template
-  ></mat-tab>
+      </wise-authoring-tinymce-editor>
+    </ng-template>
+  </mat-tab>
   <mat-tab label="{{ defaultLanguage.language }}">
     <ng-template matTabContent>
-      <span i18n
-        >Editing is disabled. Please switch back to {{ defaultLanguage.language }} if you want to
-        edit.</span
-      >
-      <button mat-button color="primary" (click)="copyDefaultLanguageText()" i18n>
-        Copy content to {{ currentLanguage().language }}
-      </button>
+      <div class="translation-tools" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
+        <span class="info mat-caption" i18n
+          >Note: Editing is disabled. Please switch back to {{ defaultLanguage.language }} if you
+          want to edit.</span
+        >
+        <button mat-stroked-button color="primary" (click)="copyDefaultLanguageText()" i18n>
+          Copy content to {{ currentLanguage().language }}
+        </button>
+      </div>
       <wise-authoring-tinymce-editor [model]="html" disabled="true"></wise-authoring-tinymce-editor>
     </ng-template>
   </mat-tab>

--- a/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html
@@ -7,6 +7,8 @@
 <mat-tab-group *ngIf="showTranslationInput()" mat-stretch-tabs="false">
   <mat-tab label="{{ currentLanguage().language }}"
     ><ng-template matTabContent
+      ><button mat-button color="primary" (click)="copyDefaultLanguageText()" i18n>
+        Copy content from {{ defaultLanguage.language }}</button
       ><wise-authoring-tinymce-editor
         [language]="currentLanguage()"
         [(model)]="translationText"
@@ -20,6 +22,9 @@
         >Editing is disabled. Please switch back to {{ defaultLanguage.language }} if you want to
         edit.</span
       >
+      <button mat-button color="primary" (click)="copyDefaultLanguageText()" i18n>
+        Copy content to {{ currentLanguage().language }}
+      </button>
       <wise-authoring-tinymce-editor [model]="html" disabled="true"></wise-authoring-tinymce-editor>
     </ng-template>
   </mat-tab>

--- a/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.scss
+++ b/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.scss
@@ -1,0 +1,3 @@
+.translation-tools {
+  padding: 8px 0;
+}

--- a/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.ts
@@ -1,22 +1,24 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { AbstractTranslatableFieldComponent } from '../abstract-translatable-field/abstract-translatable-field.component';
 import { WiseTinymceEditorModule } from '../../../directives/wise-tinymce-editor/wise-tinymce-editor.module';
-import { MatTabsModule } from '@angular/material/tabs';
+import { MatTabGroup, MatTabsModule } from '@angular/material/tabs';
 import { insertWiseLinks, replaceWiseLinks } from '../../../common/wise-link/wise-link';
 import { ConfigService } from '../../../services/configService';
 import { TeacherProjectTranslationService } from '../../../services/teacherProjectTranslationService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { CommonModule } from '@angular/common';
 import { MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
 
 @Component({
   standalone: true,
   selector: 'translatable-rich-text-editor',
-  imports: [CommonModule, MatDialogModule, MatTabsModule, WiseTinymceEditorModule],
+  imports: [CommonModule, MatButtonModule, MatDialogModule, MatTabsModule, WiseTinymceEditorModule],
   templateUrl: './translatable-rich-text-editor.component.html'
 })
 export class TranslatableRichTextEditorComponent extends AbstractTranslatableFieldComponent {
   protected html: string = '';
+  @ViewChild(MatTabGroup) private tabs: MatTabGroup;
 
   constructor(
     private configService: ConfigService,
@@ -40,6 +42,21 @@ export class TranslatableRichTextEditorComponent extends AbstractTranslatableFie
       this.configService.removeAbsoluteAssetPaths(this.html)
     );
     this.defaultLanguageTextChanged.next(this.content[this.key]);
+  }
+
+  protected copyDefaultLanguageText(): void {
+    if (
+      this.translationText == undefined ||
+      this.translationText === '' ||
+      confirm(
+        $localize`Are you sure you want to replace the content in ${
+          this.currentLanguage().language
+        } with content in ${this.defaultLanguage.language} for this item?`
+      )
+    ) {
+      this.translationTextChanged.next(this.html);
+      this.tabs.selectedIndex = 0;
+    }
   }
 
   protected saveTranslationText(text: string): void {

--- a/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.ts
@@ -9,12 +9,21 @@ import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { CommonModule } from '@angular/common';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
+import { FlexLayoutModule } from '@angular/flex-layout';
 
 @Component({
   standalone: true,
   selector: 'translatable-rich-text-editor',
-  imports: [CommonModule, MatButtonModule, MatDialogModule, MatTabsModule, WiseTinymceEditorModule],
-  templateUrl: './translatable-rich-text-editor.component.html'
+  imports: [
+    CommonModule,
+    FlexLayoutModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatTabsModule,
+    WiseTinymceEditorModule
+  ],
+  templateUrl: './translatable-rich-text-editor.component.html',
+  styleUrls: ['./translatable-rich-text-editor.component.scss']
 })
 export class TranslatableRichTextEditorComponent extends AbstractTranslatableFieldComponent {
   protected html: string = '';

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10149,32 +10149,32 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7ed3343749b3a6cff42de1bb3f3ca7d6acf1e000" datatype="html">
-        <source> Copy content from <x id="INTERPOLATION" equiv-text="{{ defaultLanguage.language }}"/></source>
+      <trans-unit id="48a41ede1e77cc856b4db02992364495fff66794" datatype="html">
+        <source> Copy content from <x id="INTERPOLATION" equiv-text="{{ defaultLanguage.language }}"/> </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html</context>
-          <context context-type="linenumber">10,11</context>
+          <context context-type="linenumber">11,13</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="9c87505361726ff6c363fb8e19efe9832f666c14" datatype="html">
-        <source>Editing is disabled. Please switch back to <x id="INTERPOLATION" equiv-text="{{ defaultLanguage.language }}"/> if you want to edit.</source>
+      <trans-unit id="640c45ed65607e87581aabc5cfce2ccf3942bac9" datatype="html">
+        <source>Note: Editing is disabled. Please switch back to <x id="INTERPOLATION" equiv-text="{{ defaultLanguage.language }}"/> if you want to edit.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html</context>
-          <context context-type="linenumber">22,23</context>
+          <context context-type="linenumber">27,28</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="be56318bfd9f0ff179d4389466d7a39b58079a88" datatype="html">
+      <trans-unit id="ea247b9f655d6860ba5938acc13f2a10c49b0f75" datatype="html">
         <source> Copy content to <x id="INTERPOLATION" equiv-text="{{ currentLanguage().language }}"/> </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html</context>
-          <context context-type="linenumber">25,27</context>
+          <context context-type="linenumber">30,32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5046317553228226783" datatype="html">
         <source>Are you sure you want to replace the content in <x id="PH" equiv-text="this.currentLanguage().language"/> with content in <x id="PH_1" equiv-text="this.defaultLanguage.language"/> for this item?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.ts</context>
-          <context context-type="linenumber">51,53</context>
+          <context context-type="linenumber">61,63</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1318680729593701201" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10149,11 +10149,32 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="7ed3343749b3a6cff42de1bb3f3ca7d6acf1e000" datatype="html">
+        <source> Copy content from <x id="INTERPOLATION" equiv-text="{{ defaultLanguage.language }}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html</context>
+          <context context-type="linenumber">10,11</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="9c87505361726ff6c363fb8e19efe9832f666c14" datatype="html">
         <source>Editing is disabled. Please switch back to <x id="INTERPOLATION" equiv-text="{{ defaultLanguage.language }}"/> if you want to edit.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html</context>
-          <context context-type="linenumber">20,21</context>
+          <context context-type="linenumber">22,23</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="be56318bfd9f0ff179d4389466d7a39b58079a88" datatype="html">
+        <source> Copy content to <x id="INTERPOLATION" equiv-text="{{ currentLanguage().language }}"/> </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.html</context>
+          <context context-type="linenumber">25,27</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5046317553228226783" datatype="html">
+        <source>Are you sure you want to replace the content in <x id="PH" equiv-text="this.currentLanguage().language"/> with content in <x id="PH_1" equiv-text="this.defaultLanguage.language"/> for this item?</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component.ts</context>
+          <context context-type="linenumber">51,53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1318680729593701201" datatype="html">


### PR DESCRIPTION
## Changes
- Allow translator to copy content from default language in HTML component authoring

## Notes
- Please style the button as you see fit

## Test Prep
- Test with ```at-units-in-multiple-languages``` branch in API


## Test (in HTML component authoring for a translated unit)
- "Copy content from [default language]" and "Copy content to [translation language]" buttons appear in the translation tab and default language tab and correctly shows the languages
- Click on the "Copy content from [default language]" button in the translation tab
   - If the translation language text is empty, it should copy the text
   - If the translation language text is not empty, it should confirm with the author before copying
- Click on the "Copy content to [translation language]" button in the default language tab
   - If the translation language text is empty, it should copy the text and switch to the translation tab
   - If the translation language text is not empty, it should confirm with the author before copying and switching to the translation tab