### PR TITLE
feat(Tag): Implement create tag dialog

### DIFF
--- a/src/app/teacher/apply-tags-button/apply-tags-button.component.ts
+++ b/src/app/teacher/apply-tags-button/apply-tags-button.component.ts
@@ -33,6 +33,11 @@ export class ApplyTagsButtonComponent implements OnInit {
         tag.text = tagThatChanged.text;
       })
     );
+    this.subscriptions.add(
+      this.tagService.newTag$.subscribe((tag: Tag) => {
+        this.tags.push(tag);
+      })
+    );
   }
 
   ngOnDestroy(): void {

--- a/src/app/teacher/create-tag-dialog/create-tag-dialog.component.html
+++ b/src/app/teacher/create-tag-dialog/create-tag-dialog.component.html
@@ -1,0 +1,11 @@
+<h2 mat-dialog-title i18n>Create New Tag</h2>
+<mat-dialog-content>
+  <mat-form-field class="tag-name">
+    <mat-label i18n>Tag Name</mat-label>
+    <input matInput [(ngModel)]="tagName" (keypress)="keyPressed($event)" autofocus />
+  </mat-form-field>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close i18n>Cancel</button>
+  <button mat-raised-button color="primary" (click)="create()" i18n>Create</button>
+</mat-dialog-actions>

--- a/src/app/teacher/create-tag-dialog/create-tag-dialog.component.scss
+++ b/src/app/teacher/create-tag-dialog/create-tag-dialog.component.scss
@@ -1,0 +1,3 @@
+.tag-name {
+  width: 100%;
+}

--- a/src/app/teacher/create-tag-dialog/create-tag-dialog.component.spec.ts
+++ b/src/app/teacher/create-tag-dialog/create-tag-dialog.component.spec.ts
@@ -1,0 +1,31 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CreateTagDialogComponent } from './create-tag-dialog.component';
+import { TagService } from '../../../assets/wise5/services/tagService';
+import { MatDialogRef } from '@angular/material/dialog';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { StudentTeacherCommonServicesModule } from '../../student-teacher-common-services.module';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('CreateTagDialogComponent', () => {
+  let component: CreateTagDialogComponent;
+  let fixture: ComponentFixture<CreateTagDialogComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CreateTagDialogComponent,
+        BrowserAnimationsModule,
+        HttpClientTestingModule,
+        StudentTeacherCommonServicesModule
+      ],
+      providers: [{ provide: MatDialogRef, useValue: { close() {} } }, TagService]
+    });
+    fixture = TestBed.createComponent(CreateTagDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/teacher/create-tag-dialog/create-tag-dialog.component.spec.ts
+++ b/src/app/teacher/create-tag-dialog/create-tag-dialog.component.spec.ts
@@ -5,6 +5,7 @@ import { MatDialogRef } from '@angular/material/dialog';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { StudentTeacherCommonServicesModule } from '../../student-teacher-common-services.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 describe('CreateTagDialogComponent', () => {
   let component: CreateTagDialogComponent;
@@ -16,6 +17,7 @@ describe('CreateTagDialogComponent', () => {
         CreateTagDialogComponent,
         BrowserAnimationsModule,
         HttpClientTestingModule,
+        MatSnackBarModule,
         StudentTeacherCommonServicesModule
       ],
       providers: [{ provide: MatDialogRef, useValue: { close() {} } }, TagService]

--- a/src/app/teacher/create-tag-dialog/create-tag-dialog.component.ts
+++ b/src/app/teacher/create-tag-dialog/create-tag-dialog.component.ts
@@ -1,0 +1,42 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { TagService } from '../../../assets/wise5/services/tagService';
+
+@Component({
+  selector: 'create-tag-dialog',
+  templateUrl: './create-tag-dialog.component.html',
+  styleUrls: ['./create-tag-dialog.component.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule
+  ]
+})
+export class CreateTagDialogComponent {
+  protected tagName: string = '';
+
+  constructor(
+    private dialogRef: MatDialogRef<CreateTagDialogComponent>,
+    private tagService: TagService
+  ) {}
+
+  protected keyPressed(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      this.create();
+    }
+  }
+
+  protected create(): void {
+    this.tagService.createTag(this.tagName);
+    this.dialogRef.close();
+  }
+}

--- a/src/app/teacher/create-tag-dialog/create-tag-dialog.component.ts
+++ b/src/app/teacher/create-tag-dialog/create-tag-dialog.component.ts
@@ -1,11 +1,13 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { TagService } from '../../../assets/wise5/services/tagService';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'create-tag-dialog',
@@ -21,13 +23,27 @@ import { TagService } from '../../../assets/wise5/services/tagService';
     MatInputModule
   ]
 })
-export class CreateTagDialogComponent {
+export class CreateTagDialogComponent implements OnInit {
+  private subscriptions: Subscription = new Subscription();
   protected tagName: string = '';
 
   constructor(
     private dialogRef: MatDialogRef<CreateTagDialogComponent>,
+    private snackBar: MatSnackBar,
     private tagService: TagService
   ) {}
+
+  ngOnInit(): void {
+    this.subscriptions.add(
+      this.tagService.newTag$.subscribe(() => {
+        this.snackBar.open($localize`Tag created`);
+      })
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
 
   protected keyPressed(event: KeyboardEvent): void {
     if (event.key === 'Enter') {

--- a/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.html
+++ b/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.html
@@ -1,6 +1,11 @@
 <h2 mat-dialog-title i18n>Manage Tags</h2>
-<mat-dialog-content>
+<mat-dialog-content class="dialog-content-scroll">
   <div fxLayout="column" fxLayoutGap="12px">
+    <div>
+      <button mat-raised-button color="primary" (click)="openCreateTagDialog()" i18n>
+        + New Tag
+      </button>
+    </div>
     <div *ngFor="let tag of tags" fxLayout="row" fxLayoutAlign="start center">
       <mat-form-field subscriptSizing="dynamic" fxFlex>
         <input

--- a/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts
+++ b/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts
@@ -6,10 +6,11 @@ import { CommonModule } from '@angular/common';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
-import { MatDialogModule } from '@angular/material/dialog';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { CreateTagDialogComponent } from '../create-tag-dialog/create-tag-dialog.component';
 
 @Component({
   selector: 'manage-tags-dialog',
@@ -17,13 +18,14 @@ import { MatSnackBar } from '@angular/material/snack-bar';
   styleUrls: ['./manage-tags-dialog.component.scss'],
   standalone: true,
   imports: [
+    CreateTagDialogComponent,
     CommonModule,
     FlexLayoutModule,
     FormsModule,
     MatButtonModule,
     MatDialogModule,
-    MatInputModule,
-    MatFormFieldModule
+    MatFormFieldModule,
+    MatInputModule
   ]
 })
 export class ManageTagsDialogComponent implements OnInit {
@@ -31,7 +33,11 @@ export class ManageTagsDialogComponent implements OnInit {
   private subscriptions: Subscription = new Subscription();
   protected tags: Tag[] = [];
 
-  constructor(private snackBar: MatSnackBar, private tagService: TagService) {}
+  constructor(
+    private dialog: MatDialog,
+    private snackBar: MatSnackBar,
+    private tagService: TagService
+  ) {}
 
   ngOnInit(): void {
     this.subscriptions.add(
@@ -47,9 +53,20 @@ export class ManageTagsDialogComponent implements OnInit {
           this.snackBar.open($localize`Tag updated`);
         })
     );
+    this.subscriptions.add(
+      this.tagService.newTag$.subscribe((tag: Tag) => {
+        this.tags.push(tag);
+      })
+    );
   }
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
+  }
+
+  protected openCreateTagDialog(): void {
+    this.dialog.open(CreateTagDialogComponent, {
+      panelClass: 'dialog-md'
+    });
   }
 }

--- a/src/assets/wise5/services/tagService.ts
+++ b/src/assets/wise5/services/tagService.ts
@@ -11,6 +11,8 @@ import { Tag } from '../../../app/domain/tag';
 
 @Injectable()
 export class TagService {
+  private newTagSource: Subject<Tag> = new Subject<Tag>();
+  public newTag$: Observable<Tag> = this.newTagSource.asObservable();
   private tagUpdatedSource: Subject<Tag> = new Subject<Tag>();
   public tagUpdated$: Observable<Tag> = this.tagUpdatedSource.asObservable();
   private tags: any[] = [];
@@ -106,6 +108,13 @@ export class TagService {
   updateTag(tag: Tag): void {
     this.http.put<Tag>(`/api/user/tag/${tag.id}`, tag).subscribe((tag) => {
       this.tagUpdatedSource.next(tag);
+    });
+  }
+
+  createTag(tagName: string): Subscription {
+    return this.http.post(`/api/user/tag`, { text: tagName }).subscribe((tag: Tag) => {
+      this.tags.push(tag);
+      this.newTagSource.next(tag);
     });
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -291,7 +291,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.html</context>
-          <context context-type="linenumber">17</context>
+          <context context-type="linenumber">22</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/share-run-code-dialog/share-run-code-dialog.component.html</context>
@@ -434,6 +434,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/create-run-dialog/create-run-dialog.component.html</context>
           <context context-type="linenumber">91</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/create-tag-dialog/create-tag-dialog.component.html</context>
+          <context context-type="linenumber">9</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/edit-run-warning-dialog/edit-run-warning-dialog.component.html</context>
@@ -1040,6 +1044,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-component-tags/edit-component-tags.component.html</context>
           <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/create-tag-dialog/create-tag-dialog.component.html</context>
+          <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9001940350011393028" datatype="html">
@@ -8185,6 +8193,32 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">128,130</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="e1b8c658165692659d6ad0a7eb28f782cb011dda" datatype="html">
+        <source>Create New Tag</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/create-tag-dialog/create-tag-dialog.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="70a67e04629f6d412db0a12d51820b480788d795" datatype="html">
+        <source>Create</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/create-tag-dialog/create-tag-dialog.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/create-new-peer-grouping-dialog/create-new-peer-grouping-dialog.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/wise-link-authoring-dialog/wise-link-authoring-dialog.component.html</context>
+          <context context-type="linenumber">51</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/add-team-dialog/add-team-dialog.component.html</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="22003a1edfc137e76879183acaaea45adf8452fa" datatype="html">
         <source>Latest from the WISE Community</source>
         <context-group purpose="location">
@@ -8369,6 +8403,20 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/list-classroom-courses-dialog/list-classroom-courses-dialog.component.ts</context>
           <context context-type="linenumber">123</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="dea691b1f946f0b5e4bf750b4cfc30098c784fe0" datatype="html">
+        <source> + New Tag </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.html</context>
+          <context context-type="linenumber">5,7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1772313028295081091" datatype="html">
+        <source>Tag updated</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts</context>
+          <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9008968878373693685" datatype="html">
@@ -11922,21 +11970,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/edit-peer-grouping-dialog/edit-peer-grouping-dialog.component.html</context>
           <context context-type="linenumber">38</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="70a67e04629f6d412db0a12d51820b480788d795" datatype="html">
-        <source>Create</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/create-new-peer-grouping-dialog/create-new-peer-grouping-dialog.component.html</context>
-          <context context-type="linenumber">53</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/wise-link-authoring-dialog/wise-link-authoring-dialog.component.html</context>
-          <context context-type="linenumber">51</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/add-team-dialog/add-team-dialog.component.html</context>
-          <context context-type="linenumber">63</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f49dc696db7f816c672e23d20e563dd132a8e714" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -8219,6 +8219,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">63</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="5325249077056620539" datatype="html">
+        <source>Tag created</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/create-tag-dialog/create-tag-dialog.component.ts</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="22003a1edfc137e76879183acaaea45adf8452fa" datatype="html">
         <source>Latest from the WISE Community</source>
         <context-group purpose="location">


### PR DESCRIPTION
## Changes
- Implemented create tag dialog

## Test
- Test with https://github.com/WISE-Community/WISE-API/pull/262
- In the Class Schedule view, select some units by clicking on their checkbox
- Click the "Apply Tags" button
- Click the "Manage Tags" menu item
- Click the "+ New Tag" button
- Enter a name for the new tag
- Click "Create". The new tag should be added to the end of the tags list.