### PR TITLE
feat(Authoring): Remove add step before option on steps after the first

### DIFF
--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -70,7 +70,6 @@ import { AddStepButtonComponent } from '../../assets/wise5/authoringTool/add-ste
     AddLessonChooseTemplateComponent,
     AddLessonConfigureComponent,
     AddProjectComponent,
-    AddStepButtonComponent,
     AddYourOwnNode,
     AdvancedProjectAuthoringComponent,
     AuthoringToolComponent,
@@ -114,6 +113,7 @@ import { AddStepButtonComponent } from '../../assets/wise5/authoringTool/add-ste
     ProjectListComponent
   ],
   imports: [
+    AddStepButtonComponent,
     StudentTeacherCommonModule,
     ComponentAuthoringModule,
     ComponentStudentModule,

--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -60,6 +60,7 @@ import { SaveIndicatorComponent } from '../../assets/wise5/common/save-indicator
 import { ProjectAuthoringLessonComponent } from '../../assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component';
 import { ProjectAuthoringStepComponent } from '../../assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component';
 import { AddLessonButtonComponent } from '../../assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component';
+import { AddStepButtonComponent } from '../../assets/wise5/authoringTool/add-step-button/add-step-button.component';
 
 @NgModule({
   declarations: [
@@ -69,6 +70,7 @@ import { AddLessonButtonComponent } from '../../assets/wise5/authoringTool/add-l
     AddLessonChooseTemplateComponent,
     AddLessonConfigureComponent,
     AddProjectComponent,
+    AddStepButtonComponent,
     AddYourOwnNode,
     AdvancedProjectAuthoringComponent,
     AuthoringToolComponent,

--- a/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.html
+++ b/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.html
@@ -1,0 +1,33 @@
+<ng-container *ngIf="first">
+  <button
+    mat-icon-button
+    color="primary"
+    [matMenuTriggerFor]="step"
+    #menuTrigger="matMenuTrigger"
+    matTooltip="Add step"
+    matTooltipPosition="above"
+    i18n-matTooltip
+  >
+    <mat-icon>add_circle</mat-icon>
+  </button>
+  <mat-menu #step="matMenu">
+    <button mat-menu-item (click)="addStepBefore()">
+      <mat-icon>add_circle</mat-icon><span i18n>Add Step Before</span>
+    </button>
+    <button mat-menu-item (click)="addStepAfter()">
+      <mat-icon>add_circle</mat-icon><span i18n>Add Step After</span>
+    </button>
+  </mat-menu>
+</ng-container>
+<ng-container *ngIf="!first">
+  <button
+    mat-icon-button
+    color="primary"
+    (click)="addStepAfter()"
+    matTooltip="Add step after"
+    matTooltipPosition="above"
+    i18n-matTooltip
+  >
+    <mat-icon>add_circle</mat-icon>
+  </button>
+</ng-container>

--- a/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.html
+++ b/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.html
@@ -12,10 +12,10 @@
   </button>
   <mat-menu #step="matMenu">
     <button mat-menu-item (click)="addStepBefore()">
-      <mat-icon>add_circle</mat-icon><span i18n>Add Step Before</span>
+      <mat-icon>add_circle</mat-icon><span i18n>Add step before</span>
     </button>
     <button mat-menu-item (click)="addStepAfter()">
-      <mat-icon>add_circle</mat-icon><span i18n>Add Step After</span>
+      <mat-icon>add_circle</mat-icon><span i18n>Add step after</span>
     </button>
   </mat-menu>
 </ng-container>

--- a/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.spec.ts
+++ b/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.spec.ts
@@ -1,0 +1,32 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AddStepButtonComponent } from './add-step-button.component';
+import { TeacherProjectService } from '../../services/teacherProjectService';
+import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatIconModule } from '@angular/material/icon';
+
+describe('AddStepButtonComponent', () => {
+  let component: AddStepButtonComponent;
+  let fixture: ComponentFixture<AddStepButtonComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [AddStepButtonComponent],
+      imports: [
+        HttpClientTestingModule,
+        MatIconModule,
+        RouterTestingModule,
+        StudentTeacherCommonServicesModule
+      ],
+      providers: [TeacherProjectService]
+    });
+    fixture = TestBed.createComponent(AddStepButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.spec.ts
+++ b/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.spec.ts
@@ -12,8 +12,8 @@ describe('AddStepButtonComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [AddStepButtonComponent],
       imports: [
+        AddStepButtonComponent,
         HttpClientTestingModule,
         MatIconModule,
         RouterTestingModule,

--- a/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.ts
+++ b/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.ts
@@ -1,0 +1,41 @@
+import { Component, Input } from '@angular/core';
+import { TeacherProjectService } from '../../services/teacherProjectService';
+import { ActivatedRoute, Router } from '@angular/router';
+
+@Component({
+  selector: 'add-step-button',
+  templateUrl: './add-step-button.component.html',
+  styleUrls: ['./add-step-button.component.scss']
+})
+export class AddStepButtonComponent {
+  @Input() first: boolean;
+  @Input() nodeId: string;
+
+  constructor(
+    private projectService: TeacherProjectService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {}
+
+  protected addStepBefore(): void {
+    this.addStepInside(this.projectService.getParentGroupId(this.nodeId));
+  }
+
+  private addStepInside(nodeId: string): void {
+    this.router.navigate(['add-node', 'choose-template'], {
+      relativeTo: this.route,
+      state: {
+        nodeIdToInsertInsideOrAfter: nodeId
+      }
+    });
+  }
+
+  protected addStepAfter(): void {
+    this.router.navigate(['add-node', 'choose-template'], {
+      relativeTo: this.route,
+      state: {
+        nodeIdToInsertInsideOrAfter: this.nodeId
+      }
+    });
+  }
+}

--- a/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.ts
+++ b/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.ts
@@ -10,7 +10,6 @@ import { MatMenuModule } from '@angular/material/menu';
 @Component({
   selector: 'add-step-button',
   templateUrl: './add-step-button.component.html',
-  styleUrls: ['./add-step-button.component.scss'],
   standalone: true,
   imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule, MatTooltipModule]
 })

--- a/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.ts
+++ b/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.ts
@@ -1,11 +1,18 @@
 import { Component, Input } from '@angular/core';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { ActivatedRoute, Router } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatButtonModule } from '@angular/material/button';
+import { MatMenuModule } from '@angular/material/menu';
 
 @Component({
   selector: 'add-step-button',
   templateUrl: './add-step-button.component.html',
-  styleUrls: ['./add-step-button.component.scss']
+  styleUrls: ['./add-step-button.component.scss'],
+  standalone: true,
+  imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule, MatTooltipModule]
 })
 export class AddStepButtonComponent {
   @Input() first: boolean;
@@ -18,23 +25,18 @@ export class AddStepButtonComponent {
   ) {}
 
   protected addStepBefore(): void {
-    this.addStepInside(this.projectService.getParentGroupId(this.nodeId));
+    this.goToAddStepView(this.projectService.getParentGroupId(this.nodeId));
   }
 
-  private addStepInside(nodeId: string): void {
+  protected addStepAfter(): void {
+    this.goToAddStepView(this.nodeId);
+  }
+
+  private goToAddStepView(nodeId: string): void {
     this.router.navigate(['add-node', 'choose-template'], {
       relativeTo: this.route,
       state: {
         nodeIdToInsertInsideOrAfter: nodeId
-      }
-    });
-  }
-
-  protected addStepAfter(): void {
-    this.router.navigate(['add-node', 'choose-template'], {
-      relativeTo: this.route,
-      state: {
-        nodeIdToInsertInsideOrAfter: this.nodeId
       }
     });
   }

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -64,7 +64,7 @@
   </div>
   <div *ngIf="expanded" fxLayout="column">
     <div
-      *ngFor="let childId of lesson.ids"
+      *ngFor="let childId of lesson.ids; let first = first"
       class="step-div"
       fxLayout="row wrap"
       fxLayoutAlign="start center"
@@ -76,30 +76,7 @@
         [projectId]="projectId"
         fxFlex
       ></project-authoring-step>
-      <button
-        mat-icon-button
-        color="primary"
-        [matMenuTriggerFor]="step"
-        #menuTrigger="matMenuTrigger"
-        matTooltip="Add step"
-        matTooltipPosition="above"
-        i18n-matTooltip
-      >
-        <mat-icon>add_circle</mat-icon>
-      </button>
-      <mat-menu #step="matMenu">
-        <button
-          mat-menu-item
-          (click)="addStepBefore(childId)"
-          [disabled]="isFirstNodeInBranchPath(childId)"
-          i18n
-        >
-          <mat-icon>add_circle</mat-icon>Add Step Before
-        </button>
-        <button mat-menu-item (click)="addStepAfter(childId)" i18n>
-          <mat-icon>add_circle</mat-icon>Add Step After
-        </button>
-      </mat-menu>
+      <add-step-button [nodeId]="childId" [first]="first"></add-step-button>
     </div>
     <div *ngIf="lesson.ids.length === 0" class="no-steps-message" fxLayoutAlign="start center">
       <div i18n>This lesson has no steps</div>

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
@@ -19,6 +19,7 @@ import { DeleteNodeService } from '../../services/deleteNodeService';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CopyNodesService } from '../../services/copyNodesService';
 import { MatMenuModule } from '@angular/material/menu';
+import { AddStepButtonComponent } from '../add-step-button/add-step-button.component';
 
 let component: ProjectAuthoringLessonComponent;
 let fixture: ComponentFixture<ProjectAuthoringLessonComponent>;
@@ -35,6 +36,7 @@ describe('ProjectAuthoringLessonComponent', () => {
   beforeEach(async () => {
     TestBed.configureTestingModule({
       declarations: [
+        AddStepButtonComponent,
         NodeIconComponent,
         NodeIconAndTitleComponent,
         ProjectAuthoringLessonComponent,

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
@@ -36,13 +36,13 @@ describe('ProjectAuthoringLessonComponent', () => {
   beforeEach(async () => {
     TestBed.configureTestingModule({
       declarations: [
-        AddStepButtonComponent,
         NodeIconComponent,
         NodeIconAndTitleComponent,
         ProjectAuthoringLessonComponent,
         ProjectAuthoringStepComponent
       ],
       imports: [
+        AddStepButtonComponent,
         FormsModule,
         HttpClientTestingModule,
         MatCheckboxModule,

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -63,27 +63,6 @@ export class ProjectAuthoringLessonComponent {
     }
   }
 
-  protected isFirstNodeInBranchPath(nodeId: string): boolean {
-    return this.projectService.isFirstNodeInBranchPath(nodeId);
-  }
-
-  protected addStepBefore(nodeId: string): void {
-    if (this.projectService.isFirstStepInLesson(nodeId)) {
-      this.addStepInside(this.projectService.getParentGroupId(nodeId));
-    } else {
-      this.addStepAfter(this.projectService.getPreviousNodeId(nodeId));
-    }
-  }
-
-  protected addStepAfter(nodeId: string): void {
-    this.router.navigate(['add-node', 'choose-template'], {
-      relativeTo: this.route,
-      state: {
-        nodeIdToInsertInsideOrAfter: nodeId
-      }
-    });
-  }
-
   protected addStepInside(nodeId: string): void {
     this.router.navigate(['add-node', 'choose-template'], {
       relativeTo: this.route,

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
@@ -37,6 +37,7 @@ import { ConfigService } from '../../services/configService';
 import { of } from 'rxjs/internal/observable/of';
 import { HttpClient } from '@angular/common/http';
 import { AddLessonButtonComponent } from '../add-lesson-button/add-lesson-button.component';
+import { AddStepButtonComponent } from '../add-step-button/add-step-button.component';
 
 const addLessonAfterRegex = /Add Lesson After/;
 const addLessonBeforeRegex = /Add Lesson Before/;
@@ -55,6 +56,7 @@ describe('ProjectAuthoringComponent', () => {
     await TestBed.configureTestingModule({
       declarations: [
         AddLessonButtonComponent,
+        AddStepButtonComponent,
         ConcurrentAuthorsMessageComponent,
         NodeAuthoringComponent,
         NodeIconComponent,

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
@@ -56,7 +56,6 @@ describe('ProjectAuthoringComponent', () => {
     await TestBed.configureTestingModule({
       declarations: [
         AddLessonButtonComponent,
-        AddStepButtonComponent,
         ConcurrentAuthorsMessageComponent,
         NodeAuthoringComponent,
         NodeIconComponent,
@@ -67,6 +66,7 @@ describe('ProjectAuthoringComponent', () => {
         TeacherNodeIconComponent
       ],
       imports: [
+        AddStepButtonComponent,
         BrowserAnimationsModule,
         FormsModule,
         HttpClientTestingModule,

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1393,8 +1393,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2d00759dc177baeb48ce2f3092f5a350caf51b86" datatype="html">
-        <source>Selected unit: <x id="INTERPOLATION" equiv-text="{{ project.metadata.title }}"/></source>
+      <trans-unit id="cf540b0175594b4ab4215257835c477a2fe4cb5f" datatype="html">
+        <source>Selected unit: <x id="INTERPOLATION" equiv-text="{{ project?.metadata.title }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
           <context context-type="linenumber">3</context>
@@ -9072,6 +9072,38 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">52</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="3f3eed30db20799da458408b4d53206e5c8c8684" datatype="html">
+        <source>Add step</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/add-step-button/add-step-button.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
+          <context context-type="linenumber">87</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="a4f285203b0b63fd0791a62c1ca404c90e1b5c50" datatype="html">
+        <source>Add Step Before</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/add-step-button/add-step-button.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="a15d82403ab103b4c4d110d1d6bbb1a0860678e9" datatype="html">
+        <source>Add Step After</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/add-step-button/add-step-button.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="d59263511cd8dbe0a1eb9bd829aac8d827d8fd83" datatype="html">
+        <source>Add step after</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/add-step-button/add-step-button.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="fe6e2f065cc702b14273855c483508aedc35a279" datatype="html">
         <source>Choose a location for the new lesson: <x id="INTERPOLATION" equiv-text="{{ title }}"/></source>
         <context-group purpose="location">
@@ -12141,36 +12173,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3f3eed30db20799da458408b4d53206e5c8c8684" datatype="html">
-        <source>Add step</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">84</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">110</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="f28facec49bae19961cf1c78a7e6e2c0fcf1e617" datatype="html">
-        <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon&gt;"/>add_circle<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/>Add Step Before </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">97,98</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="b954bd44d8e965f064fddd3ebbf401b71786535d" datatype="html">
-        <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon&gt;"/>add_circle<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/>Add Step After </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">100,101</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="66084384cb169b4f9d7836c16f37b8b9dfc5a049" datatype="html">
         <source>This lesson has no steps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">105</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2751426191436053350" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9083,22 +9083,19 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="a4f285203b0b63fd0791a62c1ca404c90e1b5c50" datatype="html">
-        <source>Add Step Before</source>
+      <trans-unit id="abeeca08450df34a78cb591b634d6d16ef5b7dad" datatype="html">
+        <source>Add step before</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-step-button/add-step-button.component.html</context>
           <context context-type="linenumber">15</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="a15d82403ab103b4c4d110d1d6bbb1a0860678e9" datatype="html">
-        <source>Add Step After</source>
+      <trans-unit id="d59263511cd8dbe0a1eb9bd829aac8d827d8fd83" datatype="html">
+        <source>Add step after</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-step-button/add-step-button.component.html</context>
           <context context-type="linenumber">18</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="d59263511cd8dbe0a1eb9bd829aac8d827d8fd83" datatype="html">
-        <source>Add step after</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-step-button/add-step-button.component.html</context>
           <context context-type="linenumber">27</context>


### PR DESCRIPTION
## Changes
- Created add step button component
- If the step is the first in a lesson, clicking the button will show a menu with the options "Add Step Before" and "Add Step After"
- If the step is not the first in a lesson, clicking the button will go directly to the add step route

## Test
- Open a unit in the Authoring Tool
- If the step is the first in a lesson, clicking the button shows a menu with the options "Add Step Before" and "Add Step After"
- If the step is not the first in a lesson, clicking the button will go directly to the add step route
- If a lesson has no steps, clicking the "Add Step" button will go directly to the add step route

Closes #1710