### PR TITLE
feat(Authoring): Remove add lesson before option on lessons after first

### DIFF
--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -65,7 +65,6 @@ import { AddStepButtonComponent } from '../../assets/wise5/authoringTool/add-ste
 @NgModule({
   declarations: [
     AddComponentButtonComponent,
-    AddLessonButtonComponent,
     AddLessonChooseLocationComponent,
     AddLessonChooseTemplateComponent,
     AddLessonConfigureComponent,
@@ -113,6 +112,7 @@ import { AddStepButtonComponent } from '../../assets/wise5/authoringTool/add-ste
     ProjectListComponent
   ],
   imports: [
+    AddLessonButtonComponent,
     AddStepButtonComponent,
     StudentTeacherCommonModule,
     ComponentAuthoringModule,

--- a/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html
+++ b/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html
@@ -1,20 +1,47 @@
-<button
-  mat-icon-button
-  color="primary"
-  (click)="addLesson()"
-  [matMenuTriggerFor]="lessonId == null ? null : lessonMenu"
-  #menuTrigger
-  matTooltip="Add lesson"
-  matTooltipPosition="above"
-  i18n-matTooltip
->
-  <mat-icon>add_circle</mat-icon>
-</button>
-<mat-menu #lessonMenu="matMenu">
-  <button mat-menu-item (click)="addLessonBefore()">
-    <mat-icon>add_circle</mat-icon><span i18n>Add Lesson Before</span>
+<ng-container *ngIf="lessonId == null">
+  <button
+    mat-icon-button
+    color="primary"
+    (click)="addFirstLesson()"
+    matTooltip="Add lesson"
+    matTooltipPosition="above"
+    i18n-matTooltip
+  >
+    <mat-icon>add_circle</mat-icon>
   </button>
-  <button mat-menu-item (click)="addLessonAfter()">
-    <mat-icon>add_circle</mat-icon><span i18n>Add Lesson After</span>
-  </button>
-</mat-menu>
+</ng-container>
+<ng-container *ngIf="lessonId != null">
+  <ng-container *ngIf="first">
+    <button
+      mat-icon-button
+      color="primary"
+      [matMenuTriggerFor]="lessonMenu"
+      #menuTrigger
+      matTooltip="Add lesson"
+      matTooltipPosition="above"
+      i18n-matTooltip
+    >
+      <mat-icon>add_circle</mat-icon>
+    </button>
+    <mat-menu #lessonMenu="matMenu">
+      <button mat-menu-item (click)="addLessonBefore()">
+        <mat-icon>add_circle</mat-icon><span i18n>Add lesson before</span>
+      </button>
+      <button mat-menu-item (click)="addLessonAfter()">
+        <mat-icon>add_circle</mat-icon><span i18n>Add lesson after</span>
+      </button>
+    </mat-menu>
+  </ng-container>
+  <ng-container *ngIf="!first">
+    <button
+      mat-icon-button
+      color="primary"
+      (click)="addLessonAfter()"
+      matTooltip="Add lesson after"
+      matTooltipPosition="above"
+      i18n-matTooltip
+    >
+      <mat-icon>add_circle</mat-icon>
+    </button>
+  </ng-container>
+</ng-container>

--- a/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.spec.ts
+++ b/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.spec.ts
@@ -12,8 +12,8 @@ describe('AddLessonButtonComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [AddLessonButtonComponent],
       imports: [
+        AddLessonButtonComponent,
         HttpClientTestingModule,
         StudentTeacherCommonServicesModule,
         MatIconModule,

--- a/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.ts
+++ b/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.ts
@@ -1,26 +1,31 @@
 import { Component, Input, ViewChild } from '@angular/core';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { temporarilyHighlightElement } from '../../common/dom/dom';
-import { MatMenuTrigger } from '@angular/material/menu';
+import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
   selector: 'add-lesson-button',
   templateUrl: './add-lesson-button.component.html',
-  styleUrls: ['./add-lesson-button.component.scss']
+  standalone: true,
+  imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule, MatTooltipModule]
 })
 export class AddLessonButtonComponent {
   @Input() active: boolean;
+  @Input() first: boolean;
   @Input() lessonId: string;
   @ViewChild(MatMenuTrigger) menuTrigger: MatMenuTrigger;
 
   constructor(private projectService: TeacherProjectService) {}
 
-  protected addLesson(): void {
-    if (this.lessonId == null) {
-      this.addFirstLesson();
-    } else {
-      this.menuTrigger.openMenu();
-    }
+  protected addFirstLesson(): void {
+    const newLesson = this.createNewLesson();
+    const insertLocation = this.active ? 'group0' : 'inactiveGroups';
+    this.projectService.createNodeInside(newLesson, insertLocation);
+    this.updateProject(newLesson.id);
   }
 
   protected addLessonBefore(): void {
@@ -32,13 +37,6 @@ export class AddLessonButtonComponent {
       this.projectService.createNodeAfter(newLesson, previousLessonId);
       this.updateProject(newLesson.id);
     }
-  }
-
-  private addFirstLesson(): void {
-    const newLesson = this.createNewLesson();
-    const insertLocation = this.active ? 'group0' : 'inactiveGroups';
-    this.projectService.createNodeInside(newLesson, insertLocation);
-    this.updateProject(newLesson.id);
   }
 
   protected addLessonAfter(): void {

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -68,7 +68,7 @@
     <div i18n>There are no lessons</div>
     <add-lesson-button [active]="true"></add-lesson-button>
   </div>
-  <div *ngFor="let lesson of lessons" fxLayout="row">
+  <div *ngFor="let lesson of lessons; let first = first" fxLayout="row">
     <project-authoring-lesson
       [lesson]="lesson"
       (selectNodeEvent)="selectNode($event)"
@@ -81,6 +81,7 @@
     <add-lesson-button
       class="add-lesson-button-next-to-lesson"
       [active]="true"
+      [first]="first"
       [lessonId]="lesson.id"
     ></add-lesson-button>
   </div>
@@ -90,7 +91,7 @@
       <div i18n>There are no unused lessons</div>
       <add-lesson-button></add-lesson-button>
     </div>
-    <div *ngFor="let inactiveGroupNode of inactiveGroupNodes" fxLayout="row">
+    <div *ngFor="let inactiveGroupNode of inactiveGroupNodes; let first = first" fxLayout="row">
       <project-authoring-lesson
         [lesson]="inactiveGroupNode"
         (selectNodeEvent)="selectNode($event)"
@@ -102,6 +103,7 @@
       ></project-authoring-lesson>
       <add-lesson-button
         class="add-lesson-button-next-to-lesson"
+        [first]="first"
         [lessonId]="inactiveGroupNode.id"
       ></add-lesson-button>
     </div>

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
@@ -39,8 +39,6 @@ import { HttpClient } from '@angular/common/http';
 import { AddLessonButtonComponent } from '../add-lesson-button/add-lesson-button.component';
 import { AddStepButtonComponent } from '../add-step-button/add-step-button.component';
 
-const addLessonAfterRegex = /Add Lesson After/;
-const addLessonBeforeRegex = /Add Lesson Before/;
 let configService: ConfigService;
 let component: ProjectAuthoringComponent;
 let getConfigParamSpy: jasmine.Spy;
@@ -55,7 +53,6 @@ describe('ProjectAuthoringComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [
-        AddLessonButtonComponent,
         ConcurrentAuthorsMessageComponent,
         NodeAuthoringComponent,
         NodeIconComponent,
@@ -66,6 +63,7 @@ describe('ProjectAuthoringComponent', () => {
         TeacherNodeIconComponent
       ],
       imports: [
+        AddLessonButtonComponent,
         AddStepButtonComponent,
         BrowserAnimationsModule,
         FormsModule,
@@ -122,7 +120,6 @@ describe('ProjectAuthoringComponent', () => {
   moveSpecificStep();
   deleteSpecificLesson();
   moveSpecificLesson();
-  addLesson();
 });
 
 function collapseAllButtonClicked() {
@@ -241,117 +238,6 @@ function moveSpecificLesson() {
         state: {
           selectedNodeIds: ['group1']
         }
-      });
-    });
-  });
-}
-
-function addLesson() {
-  addLessonBefore();
-  addLessonBeforeFirstLesson();
-  addLessonAfter();
-  addInactiveLessonBefore();
-  addInactiveLessonBeforeFirstLesson();
-  addInactiveLessonAfter();
-}
-
-function addLessonBeforeFirstLesson() {
-  describe('add lesson button is clicked on a lesson that is the first lesson', () => {
-    describe('add lesson before is chosen on the menu', () => {
-      it('adds a lesson before the chosen lesson', async () => {
-        const addLessonButtons = await harness.getAddLessonButtons();
-        addLessonButtons[0].click();
-        const addLessonMenu = await harness.getOpenedAddStepMenu();
-        await addLessonMenu.clickItem({ text: addLessonBeforeRegex });
-        const newLesson = await harness.getLesson('1: New Lesson');
-        expect(newLesson).not.toEqual(null);
-      });
-    });
-  });
-}
-
-function addLessonBefore() {
-  describe('add lesson button is clicked on a lesson that is not the first lesson', () => {
-    describe('add lesson before is chosen on the menu', () => {
-      it('adds a lesson before the chosen lesson', async () => {
-        const addLessonButtons = await harness.getAddLessonButtons();
-        addLessonButtons[1].click();
-        const addLessonMenu = await harness.getOpenedAddStepMenu();
-        await addLessonMenu.clickItem({ text: addLessonBeforeRegex });
-        const newLesson = await harness.getLesson('2: New Lesson');
-        expect(newLesson).not.toEqual(null);
-      });
-    });
-  });
-}
-
-function addLessonAfter() {
-  describe('add lesson button is clicked', () => {
-    describe('add lesson after is chosen on the menu', () => {
-      it('adds a lesson after the chosen lesson', async () => {
-        const addLessonButtons = await harness.getAddLessonButtons();
-        addLessonButtons[0].click();
-        const addLessonMenu = await harness.getOpenedAddStepMenu();
-        await addLessonMenu.clickItem({ text: addLessonAfterRegex });
-        const newLesson = await harness.getLesson('2: New Lesson');
-        expect(newLesson).not.toEqual(null);
-      });
-    });
-  });
-}
-
-function addInactiveLessonBeforeFirstLesson() {
-  describe('add lesson button is clicked on an inactive lesson that is the first inactive lesson', () => {
-    describe('add lesson before is chosen on the menu', () => {
-      it('adds a lesson before the chosen lesson', async () => {
-        const addLessonButtons = await harness.getAddLessonButtons();
-        addLessonButtons[5].click();
-        const addLessonMenu = await harness.getOpenedAddStepMenu();
-        await addLessonMenu.clickItem({ text: addLessonBeforeRegex });
-        const unusedLessonTitles = await harness.getUnusedLessonTitles();
-        expect(unusedLessonTitles).toEqual([
-          'New Lesson',
-          'Inactive Lesson One',
-          'Inactive Lesson Two'
-        ]);
-      });
-    });
-  });
-}
-
-function addInactiveLessonBefore() {
-  describe('add lesson button is clicked on an inactive lesson that is not the first inactive lesson', () => {
-    describe('add lesson before is chosen on the menu', () => {
-      it('adds a lesson before the chosen lesson', async () => {
-        const addLessonButtons = await harness.getAddLessonButtons();
-        addLessonButtons[6].click();
-        const addLessonMenu = await harness.getOpenedAddStepMenu();
-        await addLessonMenu.clickItem({ text: addLessonBeforeRegex });
-        const unusedLessonTitles = await harness.getUnusedLessonTitles();
-        expect(unusedLessonTitles).toEqual([
-          'Inactive Lesson One',
-          'New Lesson',
-          'Inactive Lesson Two'
-        ]);
-      });
-    });
-  });
-}
-
-function addInactiveLessonAfter() {
-  describe('add lesson button is clicked next to an inactive lesson', () => {
-    describe('add lesson after is chosen on the menu', () => {
-      it('adds a lesson after the chosen lesson', async () => {
-        const addLessonButtons = await harness.getAddLessonButtons();
-        addLessonButtons[6].click();
-        const addLessonMenu = await harness.getOpenedAddStepMenu();
-        await addLessonMenu.clickItem({ text: addLessonAfterRegex });
-        const unusedLessonTitles = await harness.getUnusedLessonTitles();
-        expect(unusedLessonTitles).toEqual([
-          'Inactive Lesson One',
-          'Inactive Lesson Two',
-          'New Lesson'
-        ]);
       });
     });
   });

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -8981,28 +8981,36 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Add lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
-          <context context-type="linenumber">7</context>
+          <context context-type="linenumber">6</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="d0486a16c279a8f3cf447b35c0bb3ebafff545e0" datatype="html">
-        <source>Add Lesson Before</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="linenumber">20</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="af0c4734813fe3427d3723ae7369483ffd2142c6" datatype="html">
-        <source>Add Lesson After</source>
+      <trans-unit id="f00499cc318eb0e75bbd9f6a08f409e3ed806c5b" datatype="html">
+        <source>Add lesson before</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
-          <context context-type="linenumber">18</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7c096031ae7c24c22f80edb62bd25896a4cbd2e6" datatype="html">
+        <source>Add lesson after</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
+          <context context-type="linenumber">40</context>
         </context-group>
       </trans-unit>
       <trans-unit id="97251568662383277" datatype="html">
         <source>New Lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.ts</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="372e176e8ed50173e0caa989d8c5b7ff750c4d58" datatype="html">
@@ -9131,7 +9139,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">88</context>
+          <context context-type="linenumber">89</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1e9b22a987b26586870bb920525f8062d24c6267" datatype="html">
@@ -9729,7 +9737,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0217500199a3e48a7b95762b14b79dad49e76beb" datatype="html">
@@ -12290,14 +12298,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>There are no unused lessons</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">90</context>
+          <context context-type="linenumber">91</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1f244812aec621e93ca22f9e72ba88ffe13bb354" datatype="html">
         <source>There are no unused steps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">110</context>
+          <context context-type="linenumber">112</context>
         </context-group>
       </trans-unit>
       <trans-unit id="791981839110791639" datatype="html">


### PR DESCRIPTION
## Changes
- If the lesson is the first in the unit, clicking the add lesson button will show a menu with the options "Add lesson before" and "Add lesson after"
- If the lesson is not the first in the unit, clicking the add lesson after button will immediately add a lesson after

## Test
- Open a unit in the Authoring Tool
- If the lesson is the first in the unit, clicking the add lesson button will show a menu with the options "Add lesson before" and "Add lesson after"
- If the lesson is not the first in the unit, clicking the add lesson after button will immediately add a lesson after
- If there are no lessons, clicking the add lesson button will immediately add a lesson

Closes #1712
