### PR TITLE
feat(Tag): Use tag objects instead of strings in project

### DIFF
--- a/src/app/domain/archiveProjectResponse.ts
+++ b/src/app/domain/archiveProjectResponse.ts
@@ -1,9 +1,13 @@
+import { Tag } from './tag';
+
 export class ArchiveProjectResponse {
   archived: boolean;
   id: number;
+  tag: Tag;
 
-  constructor(id: number, archived: boolean) {
+  constructor(id: number, archived: boolean, tag: Tag) {
     this.id = id;
     this.archived = archived;
+    this.tag = tag;
   }
 }

--- a/src/app/domain/project.ts
+++ b/src/app/domain/project.ts
@@ -1,5 +1,6 @@
 import { Run } from './run';
 import { User } from '../domain/user';
+import { Tag } from './tag';
 
 export class Project {
   archived: boolean;
@@ -17,7 +18,7 @@ export class Project {
   run: Run;
   sharedOwners: User[] = [];
   selected: boolean;
-  tags: string[];
+  tags: Tag[];
   thumbStyle: any;
   uri: String;
   wiseVersion: number;
@@ -93,16 +94,21 @@ export class Project {
     return metadata;
   }
 
-  hasTag(tag: string): boolean {
-    return this.tags.includes(tag);
+  hasTag(tagText: string): boolean {
+    return this.tags.some((tag: Tag) => tag.text === tagText);
   }
 
-  updateArchivedStatus(archived: boolean): void {
+  updateArchivedStatus(archived: boolean, tag: Tag): void {
     this.archived = archived;
-    if (archived) {
-      this.tags.push('archived');
-    } else {
-      this.tags.splice(this.tags.indexOf('archived'), 1);
-    }
+    archived ? this.addTag(tag) : this.removeTag(tag);
+  }
+
+  addTag(tag: Tag): void {
+    this.tags.push(tag);
+    this.tags.sort((a, b) => a.text.toLowerCase().localeCompare(b.text.toLowerCase()));
+  }
+
+  removeTag(tag: Tag): void {
+    this.tags = this.tags.filter((projectTag: Tag) => projectTag.id !== tag.id);
   }
 }

--- a/src/app/modules/library/library-project-menu/library-project-menu.component.spec.ts
+++ b/src/app/modules/library/library-project-menu/library-project-menu.component.spec.ts
@@ -49,6 +49,7 @@ export class MockConfigService {
   }
 }
 
+const archivedTag = { id: 1, text: 'archived' };
 let component: LibraryProjectMenuComponent;
 let fixture: ComponentFixture<LibraryProjectMenuComponent>;
 let harness: LibraryProjectMenuHarness;
@@ -108,7 +109,7 @@ function showsArchiveButton() {
 function showsRestoreButton() {
   describe('project has archived tag', () => {
     beforeEach(() => {
-      component.project.tags = ['archived'];
+      component.project.tags = [archivedTag];
       component.ngOnInit();
     });
     it('shows restore button', async () => {

--- a/src/app/modules/library/personal-library/personal-library.component.spec.ts
+++ b/src/app/modules/library/personal-library/personal-library.component.spec.ts
@@ -25,6 +25,7 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { ArchiveProjectsButtonComponent } from '../../../teacher/archive-projects-button/archive-projects-button.component';
 import { HttpClient } from '@angular/common/http';
 
+const archivedTag = { id: 1, text: 'archived' };
 let archiveProjectService: ArchiveProjectService;
 let component: PersonalLibraryComponent;
 let fixture: ComponentFixture<PersonalLibraryComponent>;
@@ -92,12 +93,12 @@ function setUpFiveProjects() {
     new LibraryProject({
       id: projectId1,
       metadata: { title: 'Hello' },
-      tags: ['archived']
+      tags: [archivedTag]
     }),
     new LibraryProject({
       id: projectId2,
       metadata: { title: 'Hello World' },
-      tags: ['archived']
+      tags: [archivedTag]
     }),
     new LibraryProject({
       id: projectId3,
@@ -150,7 +151,10 @@ function archiveMultipleProjects() {
       it('archives multiple projects', async () => {
         await harness.selectProjects([projectId4, projectId3]);
         spyOn(http, 'put').and.returnValue(
-          of([new ArchiveProjectResponse(4, true), new ArchiveProjectResponse(3, true)])
+          of([
+            new ArchiveProjectResponse(4, true, archivedTag),
+            new ArchiveProjectResponse(3, true, archivedTag)
+          ])
         );
         await (await harness.getArchiveButton()).click();
         expect(await harness.getProjectIdsInView()).toEqual([projectId5]);
@@ -166,7 +170,10 @@ function restoreMultipleProjects() {
         await harness.showArchivedView();
         await harness.selectProjects([projectId2, projectId1]);
         spyOn(http, 'delete').and.returnValue(
-          of([new ArchiveProjectResponse(2, false), new ArchiveProjectResponse(1, false)])
+          of([
+            new ArchiveProjectResponse(2, false, archivedTag),
+            new ArchiveProjectResponse(1, false, archivedTag)
+          ])
         );
         await (await harness.getUnarchiveButton()).click();
         expect(await harness.getProjectIdsInView()).toEqual([]);

--- a/src/app/services/archive-project.service.ts
+++ b/src/app/services/archive-project.service.ts
@@ -4,6 +4,7 @@ import { Observable, Subject, Subscription } from 'rxjs';
 import { Project } from '../domain/project';
 import { ArchiveProjectResponse } from '../domain/archiveProjectResponse';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Tag } from '../domain/tag';
 
 @Injectable()
 export class ArchiveProjectService {
@@ -15,7 +16,7 @@ export class ArchiveProjectService {
   archiveProject(project: Project, archive: boolean): void {
     this[archive ? 'makeArchiveProjectRequest' : 'makeUnarchiveProjectRequest'](project).subscribe({
       next: (response: ArchiveProjectResponse) => {
-        this.updateProjectArchivedStatus(project, response.archived);
+        this.updateProjectArchivedStatus(project, response.archived, response.tag);
         this.showArchiveProjectSuccessMessage(project, archive);
       },
       error: () => {
@@ -32,8 +33,8 @@ export class ArchiveProjectService {
     return this.http.delete<ArchiveProjectResponse>(`/api/project/${project.id}/archived`);
   }
 
-  private updateProjectArchivedStatus(project: Project, archived: boolean): void {
-    project.updateArchivedStatus(archived);
+  private updateProjectArchivedStatus(project: Project, archived: boolean, tag: Tag): void {
+    project.updateArchivedStatus(archived, tag);
     this.refreshProjects();
   }
 
@@ -52,7 +53,7 @@ export class ArchiveProjectService {
   private undoArchiveProjectAction(project: Project, archiveFunctionName: string): void {
     this[archiveFunctionName](project).subscribe({
       next: (response: ArchiveProjectResponse) => {
-        this.updateProjectArchivedStatus(project, response.archived);
+        this.updateProjectArchivedStatus(project, response.archived, response.tag);
         this.snackBar.open($localize`Action undone.`);
       },
       error: () => {
@@ -102,7 +103,7 @@ export class ArchiveProjectService {
   ): void {
     for (const archiveProjectResponse of archiveProjectsResponse) {
       const project = projects.find((project: Project) => project.id === archiveProjectResponse.id);
-      project.updateArchivedStatus(archiveProjectResponse.archived);
+      project.updateArchivedStatus(archiveProjectResponse.archived, archiveProjectResponse.tag);
     }
     this.refreshProjects();
   }

--- a/src/app/teacher/apply-tags-button/apply-tags-button.component.ts
+++ b/src/app/teacher/apply-tags-button/apply-tags-button.component.ts
@@ -31,6 +31,7 @@ export class ApplyTagsButtonComponent implements OnInit {
       this.projectTagService.tagUpdated$.subscribe((tagThatChanged: Tag) => {
         const tag = this.tags.find((t: Tag) => t.id === tagThatChanged.id);
         tag.text = tagThatChanged.text;
+        this.projectTagService.sortTags(this.tags);
       })
     );
     this.subscriptions.add(

--- a/src/app/teacher/apply-tags-button/apply-tags-button.component.ts
+++ b/src/app/teacher/apply-tags-button/apply-tags-button.component.ts
@@ -36,6 +36,7 @@ export class ApplyTagsButtonComponent implements OnInit {
     this.subscriptions.add(
       this.projectTagService.newTag$.subscribe((tag: Tag) => {
         this.tags.push(tag);
+        this.projectTagService.sortTags(this.tags);
       })
     );
   }
@@ -46,7 +47,7 @@ export class ApplyTagsButtonComponent implements OnInit {
 
   private doesAnyProjectHaveTag(tag: Tag): boolean {
     for (const project of this.selectedProjects) {
-      if (project.tags.includes(tag.text)) {
+      if (project.tags.some((projectTag) => projectTag.id === tag.id)) {
         return true;
       }
     }
@@ -65,15 +66,13 @@ export class ApplyTagsButtonComponent implements OnInit {
 
   private addTagToProjects(tag: Tag, projects: Project[]): void {
     for (const project of projects) {
-      project.tags.push(tag.text);
-      project.tags.sort();
+      project.addTag(tag);
     }
   }
 
   private removeTagFromProjects(tag: Tag, projects: Project[]): void {
     for (const project of projects) {
-      project.tags = project.tags.filter((projectTag: string) => projectTag !== tag.text);
-      project.tags.sort();
+      project.tags = project.tags.filter((projectTag: Tag) => projectTag.id !== tag.id);
     }
   }
 

--- a/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts
+++ b/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts
@@ -56,6 +56,7 @@ export class ManageTagsDialogComponent implements OnInit {
     this.subscriptions.add(
       this.projectTagService.newTag$.subscribe((tag: Tag) => {
         this.tags.push(tag);
+        this.projectTagService.sortTags(this.tags);
       })
     );
   }

--- a/src/app/teacher/run-menu/run-menu.component.spec.ts
+++ b/src/app/teacher/run-menu/run-menu.component.spec.ts
@@ -67,6 +67,7 @@ export class MockConfigService {
   }
 }
 
+const archivedTag = { id: 1, text: 'archived' };
 let archiveProjectService: ArchiveProjectService;
 let component: RunMenuComponent;
 let fixture: ComponentFixture<RunMenuComponent>;
@@ -137,20 +138,22 @@ function setRun(archived: boolean): void {
 function archive() {
   describe('archive()', () => {
     it('should archive a run', async () => {
-      spyOn(http, 'put').and.returnValue(of(new ArchiveProjectResponse(runId1, true)));
+      spyOn(http, 'put').and.returnValue(of(new ArchiveProjectResponse(runId1, true, archivedTag)));
       await runMenuHarness.clickArchiveMenuButton();
       expect(component.run.project.archived).toEqual(true);
       const snackBar = await getSnackBar();
       expect(await snackBar.getMessage()).toEqual('Successfully archived unit.');
     });
     it('should archive a run and then undo', async () => {
-      spyOn(http, 'put').and.returnValue(of(new ArchiveProjectResponse(runId1, true)));
+      spyOn(http, 'put').and.returnValue(of(new ArchiveProjectResponse(runId1, true, archivedTag)));
       await runMenuHarness.clickArchiveMenuButton();
       expect(component.run.project.archived).toEqual(true);
       let snackBar = await getSnackBar();
       expect(await snackBar.getMessage()).toEqual('Successfully archived unit.');
       expect(await snackBar.getActionDescription()).toEqual('Undo');
-      spyOn(http, 'delete').and.returnValue(of(new ArchiveProjectResponse(runId1, false)));
+      spyOn(http, 'delete').and.returnValue(
+        of(new ArchiveProjectResponse(runId1, false, archivedTag))
+      );
       await snackBar.dismissWithAction();
       expect(component.run.project.archived).toEqual(false);
       snackBar = await getSnackBar();
@@ -164,7 +167,9 @@ function unarchive() {
     it('should unarchive a run', async () => {
       setRun(true);
       component.ngOnInit();
-      spyOn(http, 'delete').and.returnValue(of(new ArchiveProjectResponse(runId1, false)));
+      spyOn(http, 'delete').and.returnValue(
+        of(new ArchiveProjectResponse(runId1, false, archivedTag))
+      );
       await runMenuHarness.clickUnarchiveMenuButton();
       expect(component.run.project.archived).toEqual(false);
       const snackBar = await getSnackBar();
@@ -173,13 +178,15 @@ function unarchive() {
     it('should unarchive a run and then undo', async () => {
       setRun(true);
       component.ngOnInit();
-      spyOn(http, 'delete').and.returnValue(of(new ArchiveProjectResponse(runId1, false)));
+      spyOn(http, 'delete').and.returnValue(
+        of(new ArchiveProjectResponse(runId1, false, archivedTag))
+      );
       await runMenuHarness.clickUnarchiveMenuButton();
       expect(component.run.project.archived).toEqual(false);
       let snackBar = await getSnackBar();
       expect(await snackBar.getMessage()).toEqual('Successfully restored unit.');
       expect(await snackBar.getActionDescription()).toEqual('Undo');
-      spyOn(http, 'put').and.returnValue(of(new ArchiveProjectResponse(runId1, true)));
+      spyOn(http, 'put').and.returnValue(of(new ArchiveProjectResponse(runId1, true, archivedTag)));
       await snackBar.dismissWithAction();
       expect(component.run.project.archived).toEqual(true);
       snackBar = await getSnackBar();

--- a/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html
+++ b/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html
@@ -48,7 +48,7 @@
     Shared by {{ run.owner.firstName }} {{ run.owner.lastName }}
   </div>
   <div fxLayout="row">
-    <div *ngFor="let tag of run.project.tags" class="tag">{{ tag }}</div>
+    <div *ngFor="let tag of run.project.tags" class="tag">{{ tag.text }}</div>
   </div>
 </ng-template>
 

--- a/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.spec.ts
+++ b/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.spec.ts
@@ -21,6 +21,7 @@ import { User } from '../../domain/user';
 import { HttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 import { ArchiveProjectResponse } from '../../domain/archiveProjectResponse';
+import { ProjectTagService } from '../../../assets/wise5/services/projectTagService';
 
 export class MockTeacherService {}
 
@@ -36,6 +37,7 @@ export class MockConfigService {
   }
 }
 
+const archivedTag = { id: 1, text: 'archived' };
 let component: TeacherRunListItemComponent;
 let fixture: ComponentFixture<TeacherRunListItemComponent>;
 let http: HttpClient;
@@ -64,6 +66,7 @@ describe('TeacherRunListItemComponent', () => {
       providers: [
         ArchiveProjectService,
         { provide: ConfigService, useClass: MockConfigService },
+        ProjectTagService,
         { provide: TeacherService, useClass: MockTeacherService },
         UserService
       ],
@@ -119,7 +122,7 @@ function runArchiveStatusChanged() {
   describe('run is not archived and archive menu button is clicked', () => {
     it('should archive run and emit events', async () => {
       expect(await runListItemHarness.isArchived()).toBeFalse();
-      spyOn(http, 'put').and.returnValue(of(new ArchiveProjectResponse(1, true)));
+      spyOn(http, 'put').and.returnValue(of(new ArchiveProjectResponse(1, true, archivedTag)));
       await runListItemHarness.clickArchiveMenuButton();
       expect(await runListItemHarness.isArchived()).toBeTrue();
     });

--- a/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
+++ b/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
@@ -58,6 +58,7 @@ export class TeacherRunListItemComponent implements OnInit {
         const tagOnProject = this.run.project.tags.find((tag: Tag) => tag.id === tagThatChanged.id);
         if (tagOnProject != null) {
           tagOnProject.text = tagThatChanged.text;
+          this.projectTagService.sortTags(this.run.project.tags);
         }
       })
     );

--- a/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
+++ b/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
@@ -52,7 +52,7 @@ export class TeacherRunListItemComponent implements OnInit {
     this.subscribeToTagUpdated();
   }
 
-  subscribeToTagUpdated(): void {
+  private subscribeToTagUpdated(): void {
     this.subscriptions.add(
       this.projectTagService.tagUpdated$.subscribe((tagThatChanged: Tag) => {
         const tagOnProject = this.run.project.tags.find((tag: Tag) => tag.id === tagThatChanged.id);

--- a/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
+++ b/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
@@ -78,7 +78,7 @@ export class TeacherRunListComponent implements OnInit {
     this.runs = runs.map((run) => {
       const teacherRun = new TeacherRun(run);
       teacherRun.shared = !teacherRun.isOwner(userId);
-      teacherRun.project.archived = teacherRun.project.tags.includes('archived');
+      teacherRun.project.archived = teacherRun.project.hasTag('archived');
       return teacherRun;
     });
     this.filteredRuns = this.runs;

--- a/src/assets/wise5/services/projectTagService.ts
+++ b/src/assets/wise5/services/projectTagService.ts
@@ -41,4 +41,8 @@ export class ProjectTagService {
       this.newTagSource.next(tag);
     });
   }
+
+  sortTags(tags: Tag[]): Tag[] {
+    return tags.sort((a, b) => a.text.toLowerCase().localeCompare(b.text.toLowerCase()));
+  }
 }


### PR DESCRIPTION
## Changes
- Changed project tags to be objects instead of just the string text
- Sort tags alphabetically
- Update tags on run cards when a tag is applied or edited
- Archiving or restoring a run now receives the archived tag object

## Test
- Test with https://github.com/WISE-Community/WISE-API/pull/264
- Make sure tags show up properly on run cards
- Apply a tag to a run and make sure it immediately appears on the run card
- Edit a tag that is applied to a run and make sure it immediately updates on the run card
- Make sure archiving or restoring a run properly shows or removes the archived tag
