### PR TITLE
feat(Tag): Implement delete tag

### DIFF
--- a/src/app/domain/project.ts
+++ b/src/app/domain/project.ts
@@ -94,8 +94,12 @@ export class Project {
     return metadata;
   }
 
-  hasTag(tagText: string): boolean {
+  hasTagWithText(tagText: string): boolean {
     return this.tags.some((tag: Tag) => tag.text === tagText);
+  }
+
+  hasTag(tag: Tag): boolean {
+    return this.tags.some((projectTag: Tag) => projectTag.id === tag.id);
   }
 
   updateArchivedStatus(archived: boolean, tag: Tag): void {

--- a/src/app/modules/library/library-project-menu/library-project-menu.component.ts
+++ b/src/app/modules/library/library-project-menu/library-project-menu.component.ts
@@ -40,7 +40,7 @@ export class LibraryProjectMenuComponent {
     this.isCanShare = this.isOwner() && !this.isRun;
     this.editLink = `${this.configService.getContextPath()}/teacher/edit/unit/${this.project.id}`;
     this.isChild = this.project.isChild();
-    this.archived = this.project.hasTag('archived');
+    this.archived = this.project.hasTagWithText('archived');
   }
 
   isOwner() {

--- a/src/app/modules/library/personal-library/personal-library.component.ts
+++ b/src/app/modules/library/personal-library/personal-library.component.ts
@@ -113,7 +113,7 @@ export class PersonalLibraryComponent extends LibraryComponent {
   public filterUpdated(filterValues: ProjectFilterValues = null): void {
     super.filterUpdated(filterValues);
     this.filteredProjects = this.filteredProjects.filter(
-      (project) => project.hasTag('archived') == this.showArchivedView
+      (project) => project.hasTagWithText('archived') == this.showArchivedView
     );
     this.numProjectsInView = this.getProjectsInView().length;
     this.unselectAllProjects();

--- a/src/app/teacher/apply-tags-button/apply-tags-button.component.ts
+++ b/src/app/teacher/apply-tags-button/apply-tags-button.component.ts
@@ -19,14 +19,22 @@ export class ApplyTagsButtonComponent implements OnInit {
   constructor(private dialog: MatDialog, private projectTagService: ProjectTagService) {}
 
   ngOnInit(): void {
-    this.subscriptions.add(
-      this.projectTagService.retrieveUserTags().subscribe((tags: Tag[]) => {
-        for (const tag of tags) {
-          tag.checked = this.doesAnyProjectHaveTag(tag);
-        }
-        this.tags = tags;
-      })
-    );
+    this.retrieveUserTags();
+    this.subscribeToTagUpdated();
+    this.subscribeToNewTag();
+    this.subscribeToTagDeleted();
+  }
+
+  private retrieveUserTags(): void {
+    this.projectTagService.retrieveUserTags().subscribe((tags: Tag[]) => {
+      for (const tag of tags) {
+        tag.checked = this.doesAnyProjectHaveTag(tag);
+      }
+      this.tags = tags;
+    });
+  }
+
+  private subscribeToTagUpdated(): void {
     this.subscriptions.add(
       this.projectTagService.tagUpdated$.subscribe((tagThatChanged: Tag) => {
         const tag = this.tags.find((t: Tag) => t.id === tagThatChanged.id);
@@ -34,10 +42,21 @@ export class ApplyTagsButtonComponent implements OnInit {
         this.projectTagService.sortTags(this.tags);
       })
     );
+  }
+
+  private subscribeToNewTag(): void {
     this.subscriptions.add(
       this.projectTagService.newTag$.subscribe((tag: Tag) => {
         this.tags.push(tag);
         this.projectTagService.sortTags(this.tags);
+      })
+    );
+  }
+
+  private subscribeToTagDeleted(): void {
+    this.subscriptions.add(
+      this.projectTagService.tagDeleted$.subscribe((deletedTag: Tag) => {
+        this.tags = this.tags.filter((tag: Tag) => tag.id !== deletedTag.id);
       })
     );
   }

--- a/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.html
+++ b/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.html
@@ -6,7 +6,7 @@
         + New Tag
       </button>
     </div>
-    <div *ngFor="let tag of tags" fxLayout="row" fxLayoutAlign="start center">
+    <div *ngFor="let tag of tags" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="12px">
       <mat-form-field subscriptSizing="dynamic" fxFlex>
         <input
           matInput
@@ -15,6 +15,9 @@
           (ngModelChange)="inputChanged.next({ tag: tag, text: $event })"
         />
       </mat-form-field>
+      <button mat-icon-button color="primary" (click)="delete(tag)">
+        <mat-icon>close</mat-icon>
+      </button>
     </div>
   </div>
 </mat-dialog-content>

--- a/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.scss
+++ b/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.scss
@@ -1,0 +1,3 @@
+.mat-icon {
+  margin: 0px;
+}

--- a/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.spec.ts
+++ b/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.spec.ts
@@ -4,6 +4,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { StudentTeacherCommonServicesModule } from '../../student-teacher-common-services.module';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { ProjectTagService } from '../../../assets/wise5/services/projectTagService';
+import { TeacherService } from '../teacher.service';
 
 describe('ManageTagsDialogComponent', () => {
   let component: ManageTagsDialogComponent;
@@ -17,7 +18,7 @@ describe('ManageTagsDialogComponent', () => {
         MatSnackBarModule,
         StudentTeacherCommonServicesModule
       ],
-      providers: [ProjectTagService]
+      providers: [ProjectTagService, TeacherService]
     });
     fixture = TestBed.createComponent(ManageTagsDialogComponent);
     component = fixture.componentInstance;

--- a/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts
+++ b/src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts
@@ -91,18 +91,13 @@ export class ManageTagsDialogComponent implements OnInit {
   }
 
   private getDeleteMessage(runs: Run[], tag: Tag): string {
-    const numberOfProjectsWithTag = this.getNumberOfProjectsWithTag(runs, tag);
-    const numberOfProjectsMessage =
-      numberOfProjectsWithTag === 1
-        ? $localize`There is ${numberOfProjectsWithTag} unit with this tag.`
-        : $localize`There are ${numberOfProjectsWithTag} units with this tag.`;
-    return $localize`Are you sure you want to delete this tag? ` + numberOfProjectsMessage;
-  }
-
-  private getNumberOfProjectsWithTag(runs: Run[], tag: Tag) {
-    const projectsWithTag = runs.filter((run: Run) =>
+    const numProjectsWithTag = runs.filter((run: Run) =>
       run.project.tags.some((projectTag: Tag) => projectTag.id === tag.id)
-    );
-    return projectsWithTag.length;
+    ).length;
+    const numberOfProjectsMessage =
+      numProjectsWithTag === 1
+        ? $localize`There is ${numProjectsWithTag} unit with this tag.`
+        : $localize`There are ${numProjectsWithTag} units with this tag.`;
+    return $localize`Are you sure you want to delete this tag? ` + numberOfProjectsMessage;
   }
 }

--- a/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
+++ b/src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts
@@ -50,6 +50,7 @@ export class TeacherRunListItemComponent implements OnInit {
       }, 7000);
     }
     this.subscribeToTagUpdated();
+    this.subscribeToTagDeleted();
   }
 
   private subscribeToTagUpdated(): void {
@@ -59,6 +60,16 @@ export class TeacherRunListItemComponent implements OnInit {
         if (tagOnProject != null) {
           tagOnProject.text = tagThatChanged.text;
           this.projectTagService.sortTags(this.run.project.tags);
+        }
+      })
+    );
+  }
+
+  private subscribeToTagDeleted(): void {
+    this.subscriptions.add(
+      this.projectTagService.tagDeleted$.subscribe((tag: Tag) => {
+        if (this.run.project.hasTag(tag)) {
+          this.run.project.removeTag(tag);
         }
       })
     );

--- a/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
+++ b/src/app/teacher/teacher-run-list/teacher-run-list.component.ts
@@ -78,7 +78,7 @@ export class TeacherRunListComponent implements OnInit {
     this.runs = runs.map((run) => {
       const teacherRun = new TeacherRun(run);
       teacherRun.shared = !teacherRun.isOwner(userId);
-      teacherRun.project.archived = teacherRun.project.hasTag('archived');
+      teacherRun.project.archived = teacherRun.project.hasTagWithText('archived');
       return teacherRun;
     });
     this.filteredRuns = this.runs;

--- a/src/assets/wise5/services/projectTagService.ts
+++ b/src/assets/wise5/services/projectTagService.ts
@@ -8,6 +8,8 @@ import { Tag } from '../../../app/domain/tag';
 export class ProjectTagService {
   private newTagSource: Subject<Tag> = new Subject<Tag>();
   public newTag$: Observable<Tag> = this.newTagSource.asObservable();
+  private tagDeletedSource: Subject<Tag> = new Subject<Tag>();
+  public tagDeleted$: Observable<Tag> = this.tagDeletedSource.asObservable();
   private tagUpdatedSource: Subject<Tag> = new Subject<Tag>();
   public tagUpdated$: Observable<Tag> = this.tagUpdatedSource.asObservable();
 
@@ -44,5 +46,11 @@ export class ProjectTagService {
 
   sortTags(tags: Tag[]): Tag[] {
     return tags.sort((a, b) => a.text.toLowerCase().localeCompare(b.text.toLowerCase()));
+  }
+
+  deleteTag(tag: Tag): void {
+    this.http.delete(`/api/user/tag/${tag.id}`).subscribe((tag: Tag) => {
+      this.tagDeletedSource.next(tag);
+    });
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -291,7 +291,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.html</context>
-          <context context-type="linenumber">22</context>
+          <context context-type="linenumber">25</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/share-run-code-dialog/share-run-code-dialog.component.html</context>
@@ -7420,82 +7420,82 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Successfully <x id="PH" equiv-text="archive ? &apos;archived&apos; : &apos;restored&apos;"/> unit.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5775346636203685655" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">43</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">123</context>
+          <context context-type="linenumber">124</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1866036816253590803" datatype="html">
         <source>Action undone.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">57</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">139</context>
+          <context context-type="linenumber">140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8310924106294815391" datatype="html">
         <source>Error undoing action.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">59</context>
+          <context context-type="linenumber">60</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">142</context>
+          <context context-type="linenumber">143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4649373271512187502" datatype="html">
         <source>Error archiving unit.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3781019523543102447" datatype="html">
         <source>Error restoring unit.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4446500764298446942" datatype="html">
         <source>Successfully archived <x id="PH" equiv-text="count"/> unit(s).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6233410407787231949" datatype="html">
         <source>Successfully restored <x id="PH" equiv-text="count"/> unit(s).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">122</context>
+          <context context-type="linenumber">123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3755123516042132329" datatype="html">
         <source>Error archiving unit(s).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">149</context>
+          <context context-type="linenumber">150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3419148337120710852" datatype="html">
         <source>Error restoring unit(s).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/archive-project.service.ts</context>
-          <context context-type="linenumber">149</context>
+          <context context-type="linenumber">150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e931f6b80399785ea1647269f43ffeea54327cb6" datatype="html">
@@ -8423,7 +8423,35 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Tag updated</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts</context>
-          <context context-type="linenumber">53</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8663242190095976332" datatype="html">
+        <source>Tag deleted</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="9151762754681070291" datatype="html">
+        <source>There is <x id="PH" equiv-text="numberOfProjectsWithTag"/> unit with this tag.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts</context>
+          <context context-type="linenumber">97</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2021640020415028727" datatype="html">
+        <source>There are <x id="PH" equiv-text="numberOfProjectsWithTag"/> units with this tag.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1288226131735320264" datatype="html">
+        <source>Are you sure you want to delete this tag? </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts</context>
+          <context context-type="linenumber">99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9008968878373693685" datatype="html">
@@ -9064,7 +9092,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Class Periods:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.ts</context>
-          <context context-type="linenumber">82</context>
+          <context context-type="linenumber">115</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dc4130f5eb9a8c04d1b3734d36f745db855fe90f" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -8434,24 +8434,24 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
       </trans-unit>
       <trans-unit id="9151762754681070291" datatype="html">
-        <source>There is <x id="PH" equiv-text="numberOfProjectsWithTag"/> unit with this tag.</source>
+        <source>There is <x id="PH" equiv-text="numProjectsWithTag"/> unit with this tag.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts</context>
-          <context context-type="linenumber">97</context>
+          <context context-type="linenumber">99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2021640020415028727" datatype="html">
-        <source>There are <x id="PH" equiv-text="numberOfProjectsWithTag"/> units with this tag.</source>
+        <source>There are <x id="PH" equiv-text="numProjectsWithTag"/> units with this tag.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts</context>
-          <context context-type="linenumber">98</context>
+          <context context-type="linenumber">100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1288226131735320264" datatype="html">
         <source>Are you sure you want to delete this tag? </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/manage-tags-dialog/manage-tags-dialog.component.ts</context>
-          <context context-type="linenumber">99</context>
+          <context context-type="linenumber">101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9008968878373693685" datatype="html">


### PR DESCRIPTION
## Changes
- In the Manage Tags dialog, added delete button next to each tag

## Test
- Test with https://github.com/WISE-Community/WISE-API/pull/266
- Go to the teacher run list
- Click the checkbox for a run
- Click the "Apply Tags" button
- Click "Manage Tags"
- Click on a delete button next to a tag
- A confirm message should pop up saying how many units use that tag
- Click "OK"
- The tag should immediately disappear from the "Manage Tags" popup
- The tag should immediately disappear from the "Apply Tags" menu
- If the tag was on any runs, it should immediately disappear from the run card

