### PR TITLE
feat(Translation): Make embedded authoring inputs translatable

### DIFF
--- a/src/assets/wise5/authoringTool/components/translatable-asset-chooser/translatable-asset-chooser.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-asset-chooser/translatable-asset-chooser.component.html
@@ -2,9 +2,8 @@
   mat-raised-button
   color="primary"
   (click)="chooseAsset()"
-  matTooltip="Choose an image"
+  [matTooltip]="tooltip"
   matTooltipPosition="above"
-  i18n-matTooltip
 >
   <mat-icon>insert_photo</mat-icon>
 </button>

--- a/src/assets/wise5/authoringTool/components/translatable-asset-chooser/translatable-asset-chooser.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-asset-chooser/translatable-asset-chooser.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
@@ -18,6 +18,8 @@ import { TeacherProjectTranslationService } from '../../../services/teacherProje
   styleUrls: ['./translatable-asset-chooser.component.scss']
 })
 export class TranslatableAssetChooserComponent extends AbstractTranslatableFieldComponent {
+  @Input() tooltip: String = $localize`Choose image`;
+
   constructor(
     private dialog: MatDialog,
     protected projectService: TeacherProjectService,

--- a/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.html
+++ b/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.html
@@ -1,19 +1,18 @@
 <div>
-  <mat-form-field class="model-file">
-    <mat-label i18n>Model File Name</mat-label>
-    <input matInput [(ngModel)]="componentContent.url" (ngModelChange)="inputChange.next($event)" />
-  </mat-form-field>
-  <button
-    mat-raised-button
-    color="primary"
-    class="button"
-    (click)="chooseModelFile()"
-    matTooltip="Choose Model File"
-    matTooltipPosition="above"
-    i18n-matTooltip
-  >
-    <mat-icon>insert_photo</mat-icon>
-  </button>
+  <translatable-input
+    [content]="componentContent"
+    key="url"
+    label="Model file name"
+    i18n-label
+    (defaultLanguageTextChanged)="inputChange.next($event)"
+  />
+  <translatable-asset-chooser
+    [content]="componentContent"
+    key="url"
+    tooltip="Choose model file"
+    i18n-tooltip
+    (defaultLanguageTextChanged)="componentChanged()"
+  />
 </div>
 <author-url-parameters
   [url]="componentContent.url"

--- a/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.html
+++ b/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.html
@@ -1,10 +1,11 @@
-<div>
+<div fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="8px">
   <translatable-input
     [content]="componentContent"
     key="url"
     label="Model file name"
     i18n-label
     (defaultLanguageTextChanged)="inputChange.next($event)"
+    fxFlex="auto"
   />
   <translatable-asset-chooser
     [content]="componentContent"

--- a/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.spec.ts
+++ b/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.spec.ts
@@ -7,6 +7,7 @@ import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { EmbeddedAuthoring } from './embedded-authoring.component';
 import { EmbeddedAuthoringModule } from './embedded-authoring.module';
 import { TeacherNodeService } from '../../../services/teacherNodeService';
+import { ProjectLocale } from '../../../../../app/domain/projectLocale';
 
 let component: EmbeddedAuthoring;
 let fixture: ComponentFixture<EmbeddedAuthoring>;
@@ -22,9 +23,22 @@ describe('EmbeddedAuthoringComponent', () => {
       ],
       providers: [TeacherNodeService]
     });
+    spyOn(TestBed.inject(TeacherProjectService), 'getLocale').and.returnValue(
+      new ProjectLocale({ default: 'en-US' })
+    );
     fixture = TestBed.createComponent(EmbeddedAuthoring);
     component = fixture.componentInstance;
-    const componentContent = createComponentContent();
+    const componentContent = {
+      id: '86fel4wjm4',
+      type: 'Embedded',
+      prompt: '',
+      showSaveButton: false,
+      showSubmitButton: false,
+      url: 'glucose.html',
+      showAddToNotebookButton: true,
+      width: null
+    };
+    spyOn(TestBed.inject(TeacherProjectService), 'isDefaultLocale').and.returnValue(true);
     spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue(
       copy(componentContent)
     );
@@ -32,38 +46,7 @@ describe('EmbeddedAuthoringComponent', () => {
     fixture.detectChanges();
   });
 
-  shouldSelectTheModelFile();
-});
-
-function createComponentContent() {
-  return {
-    id: '86fel4wjm4',
-    type: 'Embedded',
-    prompt: '',
-    showSaveButton: false,
-    showSubmitButton: false,
-    url: 'glucose.html',
-    showAddToNotebookButton: true,
-    width: null
-  };
-}
-
-function shouldSelectTheModelFile() {
-  it('should select the model file', () => {
-    component.nodeId = 'node1';
-    component.componentId = 'component1';
-    expect(component.componentContent.url).toEqual('glucose.html');
-    spyOn(component, 'componentChanged').and.callFake(() => {});
-    const args = {
-      nodeId: 'node1',
-      componentId: 'component1',
-      target: 'modelFile',
-      targetObject: {},
-      assetItem: {
-        fileName: 'thermo.html'
-      }
-    };
-    component.assetSelected(args);
-    expect(component.componentContent.url).toEqual('thermo.html');
+  it('should create', () => {
+    expect(component).toBeTruthy();
   });
-}
+});

--- a/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.ts
+++ b/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.ts
@@ -6,9 +6,6 @@ import { AbstractComponentAuthoring } from '../../../authoringTool/components/Ab
 import { ConfigService } from '../../../services/configService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { EmbeddedService } from '../embeddedService';
-import { MatDialog } from '@angular/material/dialog';
-import { AssetChooser } from '../../../authoringTool/project-asset-authoring/asset-chooser';
-import { filter } from 'rxjs/operators';
 import { TeacherNodeService } from '../../../services/teacherNodeService';
 
 @Component({
@@ -21,7 +18,6 @@ export class EmbeddedAuthoring extends AbstractComponentAuthoring {
 
   constructor(
     protected ConfigService: ConfigService,
-    private dialog: MatDialog,
     private EmbeddedService: EmbeddedService,
     protected NodeService: TeacherNodeService,
     protected ProjectAssetService: ProjectAssetService,
@@ -37,14 +33,6 @@ export class EmbeddedAuthoring extends AbstractComponentAuthoring {
     );
   }
 
-  assetSelected({ nodeId, componentId, assetItem, target }): void {
-    super.assetSelected({ nodeId, componentId, assetItem, target });
-    if (target === 'modelFile') {
-      this.componentContent.url = assetItem.fileName;
-      this.componentChanged();
-    }
-  }
-
   reloadModel(): void {
     const iframe: any = document.getElementById(this.embeddedApplicationIFrameId);
     const src = iframe.src;
@@ -55,15 +43,5 @@ export class EmbeddedAuthoring extends AbstractComponentAuthoring {
   updateUrl(url: string): void {
     this.componentContent.url = url;
     this.componentChanged();
-  }
-
-  chooseModelFile(): void {
-    new AssetChooser(this.dialog, this.nodeId, this.componentId)
-      .open('modelFile')
-      .afterClosed()
-      .pipe(filter((data) => data != null))
-      .subscribe((data: any) => {
-        return this.assetSelected(data);
-      });
   }
 }

--- a/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.module.ts
+++ b/src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.module.ts
@@ -21,18 +21,22 @@ import { TagService } from '../../../services/tagService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { EmbeddedService } from '../embeddedService';
 import { EmbeddedAuthoring } from './embedded-authoring.component';
+import { ComponentAuthoringModule } from '../../component-authoring.module';
+import { TranslatableAssetChooserComponent } from '../../../authoringTool/components/translatable-asset-chooser/translatable-asset-chooser.component';
 
 @NgModule({
   declarations: [EmbeddedAuthoring, EditComponentPrompt, AuthorUrlParametersComponent],
   imports: [
     CommonModule,
+    ComponentAuthoringModule,
     FormsModule,
     MatCheckboxModule,
     MatDialogModule,
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
-    MatRadioModule
+    MatRadioModule,
+    TranslatableAssetChooserComponent
   ],
   providers: [
     AnnotationService,

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -17905,14 +17905,14 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Choose model file</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.html</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">13</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a6b43c2ea6f759a9be7fab85583d99fb03f439ca" datatype="html">
         <source>Width (px) (optional)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">26</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component.html</context>
@@ -17923,7 +17923,7 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Height (px)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.html</context>
-          <context context-type="linenumber">34</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component.html</context>
@@ -17937,18 +17937,18 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
       &gt;"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.html</context>
-          <context context-type="linenumber">48,54</context>
+          <context context-type="linenumber">49,55</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b2a497bce327b6c20cc9969b0bad0b1470fcccd5" datatype="html">
         <source>Reload Model</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.html</context>
-          <context context-type="linenumber">62</context>
+          <context context-type="linenumber">63</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.html</context>
-          <context context-type="linenumber">65</context>
+          <context context-type="linenumber">66</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7956799829776596403" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10142,11 +10142,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="c84903b02fcad0b9ab897b080e38e0bddc2b1aa7" datatype="html">
-        <source>Choose an image</source>
+      <trans-unit id="1572694953180596523" datatype="html">
+        <source>Choose image</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-asset-chooser/translatable-asset-chooser.component.html</context>
-          <context context-type="linenumber">5</context>
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/components/translatable-asset-chooser/translatable-asset-chooser.component.ts</context>
+          <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
       <trans-unit id="48a41ede1e77cc856b4db02992364495fff66794" datatype="html">
@@ -17894,25 +17894,25 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">5</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1d3911009f4b8bea155d7d4f87812066abaa614b" datatype="html">
-        <source>Model File Name</source>
+      <trans-unit id="c5929c4661e8359e3e9c9ca7a2b6a7fa1cb30719" datatype="html">
+        <source>Model file name</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.html</context>
-          <context context-type="linenumber">3</context>
+          <context context-type="linenumber">5</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="83813fc16c9097856819be3462a0f06ccf97f525" datatype="html">
-        <source>Choose Model File</source>
+      <trans-unit id="9c8ffd36c79fe1af07822eb27393673bc5d29dc3" datatype="html">
+        <source>Choose model file</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.html</context>
-          <context context-type="linenumber">11</context>
+          <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a6b43c2ea6f759a9be7fab85583d99fb03f439ca" datatype="html">
         <source>Width (px) (optional)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.html</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">25</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component.html</context>
@@ -17923,7 +17923,7 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Height (px)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.html</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">34</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component.html</context>
@@ -17937,18 +17937,18 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
       &gt;"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.html</context>
-          <context context-type="linenumber">49,55</context>
+          <context context-type="linenumber">48,54</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b2a497bce327b6c20cc9969b0bad0b1470fcccd5" datatype="html">
         <source>Reload Model</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.html</context>
-          <context context-type="linenumber">63</context>
+          <context context-type="linenumber">62</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/embedded/embedded-authoring/embedded-authoring.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">65</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7956799829776596403" datatype="html">


### PR DESCRIPTION
## Notes
- Please style as you see fit. The url input and the asset choose button used to be on the same line (see production), but I couldn't figure out how to do that easily with the new elements.
- When you are translating to another language, the changes are saved, but the input field does not immediately update with the newly-selected asset at the moment. It takes a second or so to update.

## Changes
- Parameterize TranslatableAssetChooser button tooltip
- Convert embedded authoring
   - url input to TranslatableInput
   - asset chooser to TranslatableAssetChooser
   - Note: these changes removed the need to define ```assetSelected()``` and ```chooseModelFile()``` in EmbeddedAuthoringComponent

## Test Prep
- Test with the ```at-units-in-multiple-languages``` branch on API

## Test (In embedded component authoring)
- The tooltip text on the button for choosing model should say "Choose model file"
- Choosing asset in both non-multi-lingual unit and multi-lingual unit work when: 
   - typing in the asset url string in the input
   - using the "Choose model file" asset chooser
