### PR TITLE
feat(Translation): Convert notebook authoring to translatable

### DIFF
--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -65,6 +65,9 @@ import { SaveIndicatorComponent } from '../../assets/wise5/common/save-indicator
 import { ProjectAuthoringLessonComponent } from '../../assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component';
 import { ProjectAuthoringStepComponent } from '../../assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component';
 import { AddLessonButtonComponent } from '../../assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component';
+import { TranslatableInputComponent } from '../../assets/wise5/authoringTool/components/translatable-input/translatable-input.component';
+import { TranslatableTextareaComponent } from '../../assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component';
+import { TranslatableRichTextEditorComponent } from '../../assets/wise5/authoringTool/components/translatable-rich-text-editor/translatable-rich-text-editor.component';
 
 @NgModule({
   declarations: [
@@ -135,6 +138,9 @@ import { AddLessonButtonComponent } from '../../assets/wise5/authoringTool/add-l
     SaveIndicatorComponent,
     StepToolsModule,
     StructureAuthoringModule,
+    TranslatableInputComponent,
+    TranslatableRichTextEditorComponent,
+    TranslatableTextareaComponent,
     WiseTinymceEditorModule
   ]
 })

--- a/src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html
+++ b/src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html
@@ -13,7 +13,7 @@
   </mat-slide-toggle>
 </div>
 <div *ngIf="project.notebook.enabled" class="notebook-div">
-  <div class="small-width">
+  <div class="notebook-input">
     <translatable-input
       [content]="project.notebook"
       key="label"
@@ -35,33 +35,30 @@
   </div>
   <div *ngIf="project.notebook.itemTypes.note.enabled" class="notebook-child-div">
     <div fxLayout="row wrap" fxLayoutGap="20px">
-      <div class="small-width">
-        <translatable-input
-          [content]="project.notebook.itemTypes.note.label"
-          key="singular"
-          label="Label (Singular)"
-          i18n-label
-          (defaultLanguageTextChanged)="contentChanged()"
-        ></translatable-input>
-      </div>
-      <div class="small-width">
-        <translatable-input
-          [content]="project.notebook.itemTypes.note.label"
-          key="plural"
-          label="Label (Plural)"
-          i18n-label
-          (defaultLanguageTextChanged)="contentChanged()"
-        ></translatable-input>
-      </div>
-      <div class="small-width">
-        <translatable-input
-          [content]="project.notebook.itemTypes.note.label"
-          key="link"
-          label="Label (Link)"
-          i18n-label
-          (defaultLanguageTextChanged)="contentChanged()"
-        ></translatable-input>
-      </div>
+      <translatable-input
+        [content]="project.notebook.itemTypes.note.label"
+        key="singular"
+        label="Label (Singular)"
+        i18n-label
+        (defaultLanguageTextChanged)="contentChanged()"
+        class="notebook-input"
+      ></translatable-input>
+      <translatable-input
+        [content]="project.notebook.itemTypes.note.label"
+        key="plural"
+        label="Label (Plural)"
+        i18n-label
+        (defaultLanguageTextChanged)="contentChanged()"
+        class="notebook-input"
+      ></translatable-input>
+      <translatable-input
+        [content]="project.notebook.itemTypes.note.label"
+        key="link"
+        label="Label (Link)"
+        i18n-label
+        (defaultLanguageTextChanged)="contentChanged()"
+        class="notebook-input"
+      ></translatable-input>
     </div>
     <mat-checkbox
       color="primary"
@@ -111,36 +108,32 @@
   </mat-slide-toggle>
   <div *ngIf="project.notebook.itemTypes.report.enabled" class="notebook-child-div">
     <div fxLayout="row wrap" fxLayoutGap="20px">
-      <div class="small-width">
-        <translatable-input
-          [content]="project.notebook.itemTypes.report.label"
-          key="singular"
-          label="Label (Singular)"
-          i18n-label
-          (defaultLanguageTextChanged)="contentChanged()"
-        ></translatable-input>
-      </div>
-      <div class="small-width">
-        <translatable-input
-          [content]="project.notebook.itemTypes.report.label"
-          key="plural"
-          label="Label (Plural)"
-          i18n-label
-          (defaultLanguageTextChanged)="contentChanged()"
-        ></translatable-input>
-      </div>
-      <div class="small-width">
-        <translatable-input
-          [content]="project.notebook.itemTypes.report.label"
-          key="link"
-          label="Label (Link)"
-          i18n-label
-          (defaultLanguageTextChanged)="contentChanged()"
-        ></translatable-input>
-      </div>
+      <translatable-input
+        [content]="project.notebook.itemTypes.report.label"
+        key="singular"
+        label="Label (Singular)"
+        i18n-label
+        (defaultLanguageTextChanged)="contentChanged()"
+        class="notebook-input"
+      ></translatable-input>
+      <translatable-input
+        [content]="project.notebook.itemTypes.report.label"
+        key="plural"
+        label="Label (Plural)"
+        i18n-label
+        (defaultLanguageTextChanged)="contentChanged()"
+        class="notebook-input"
+      ></translatable-input>
+      <translatable-input
+        [content]="project.notebook.itemTypes.report.label"
+        key="link"
+        label="Label (Link)"
+        i18n-label
+        (defaultLanguageTextChanged)="contentChanged()"
+      ></translatable-input>
     </div>
     <div *ngFor="let reportNote of project.notebook.itemTypes.report.notes">
-      <div class="small-width">
+      <div class="notebook-input">
         <translatable-input
           [content]="reportNote"
           key="title"
@@ -195,7 +188,7 @@
   </mat-slide-toggle>
 </div>
 <div *ngIf="project.teacherNotebook.enabled" class="notebook-div">
-  <div class="small-width">
+  <div class="notebook-input">
     <translatable-input
       [content]="project.teacherNotebook"
       key="label"
@@ -215,44 +208,40 @@
   </mat-slide-toggle>
   <div *ngIf="project.teacherNotebook.itemTypes.report.enabled" class="notebook-child-div">
     <div fxLayout="row wrap" fxLayoutGap="20px">
-      <div class="small-width">
-        <translatable-input
-          [content]="project.teacherNotebook.itemTypes.report.label"
-          key="singular"
-          label="Label (Singular)"
-          i18n-label
-          (defaultLanguageTextChanged)="contentChanged()"
-        ></translatable-input>
-      </div>
-      <div class="small-width">
-        <translatable-input
-          [content]="project.teacherNotebook.itemTypes.report.label"
-          key="plural"
-          label="Label (Plural)"
-          i18n-label
-          (defaultLanguageTextChanged)="contentChanged()"
-        ></translatable-input>
-      </div>
-      <div class="small-width">
-        <translatable-input
-          [content]="project.teacherNotebook.itemTypes.report.label"
-          key="link"
-          label="Label (Link)"
-          i18n-label
-          (defaultLanguageTextChanged)="contentChanged()"
-        ></translatable-input>
-      </div>
+      <translatable-input
+        [content]="project.teacherNotebook.itemTypes.report.label"
+        key="singular"
+        label="Label (Singular)"
+        i18n-label
+        (defaultLanguageTextChanged)="contentChanged()"
+        class="notebook-input"
+      ></translatable-input>
+      <translatable-input
+        [content]="project.teacherNotebook.itemTypes.report.label"
+        key="plural"
+        label="Label (Plural)"
+        i18n-label
+        (defaultLanguageTextChanged)="contentChanged()"
+        class="notebook-input"
+      ></translatable-input>
+      <translatable-input
+        [content]="project.teacherNotebook.itemTypes.report.label"
+        key="link"
+        label="Label (Link)"
+        i18n-label
+        (defaultLanguageTextChanged)="contentChanged()"
+        class="notebook-input"
+      ></translatable-input>
     </div>
     <div *ngFor="let reportNote of project.teacherNotebook.itemTypes.report.notes">
-      <div class="small-width">
-        <translatable-input
-          [content]="reportNote"
-          key="title"
-          label="Title"
-          i18n-label
-          (defaultLanguageTextChanged)="contentChanged()"
-        ></translatable-input>
-      </div>
+      <translatable-input
+        [content]="reportNote"
+        key="title"
+        label="Title"
+        i18n-label
+        (defaultLanguageTextChanged)="contentChanged()"
+        class="notebook-input"
+      ></translatable-input>
       <translatable-textarea
         [content]="reportNote"
         key="description"

--- a/src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html
+++ b/src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html
@@ -188,14 +188,15 @@
   </mat-slide-toggle>
 </div>
 <div *ngIf="project.teacherNotebook.enabled" class="notebook-div">
-  <div class="notebook-input">
-    <translatable-input
-      [content]="project.teacherNotebook"
-      key="label"
-      label="Notebook Label"
-      i18n-label
-      (defaultLanguageTextChanged)="contentChanged()"
-    ></translatable-input>
+  <div>
+    <mat-form-field>
+      <mat-label i18n>Notebook Label</mat-label>
+      <input
+        matInput
+        [(ngModel)]="project.teacherNotebook.label"
+        (ngModelChange)="contentChanged()"
+      />
+    </mat-form-field>
   </div>
   <mat-slide-toggle
     color="primary"
@@ -207,61 +208,64 @@
     Enable Report
   </mat-slide-toggle>
   <div *ngIf="project.teacherNotebook.itemTypes.report.enabled" class="notebook-child-div">
-    <div fxLayout="row wrap" fxLayoutGap="20px">
-      <translatable-input
-        [content]="project.teacherNotebook.itemTypes.report.label"
-        key="singular"
-        label="Label (Singular)"
-        i18n-label
-        (defaultLanguageTextChanged)="contentChanged()"
-        class="notebook-input"
-      ></translatable-input>
-      <translatable-input
-        [content]="project.teacherNotebook.itemTypes.report.label"
-        key="plural"
-        label="Label (Plural)"
-        i18n-label
-        (defaultLanguageTextChanged)="contentChanged()"
-        class="notebook-input"
-      ></translatable-input>
-      <translatable-input
-        [content]="project.teacherNotebook.itemTypes.report.label"
-        key="link"
-        label="Label (Link)"
-        i18n-label
-        (defaultLanguageTextChanged)="contentChanged()"
-        class="notebook-input"
-      ></translatable-input>
+    <div fxLayoutGap="20px">
+      <mat-form-field>
+        <mat-label i18n>Label (Singular)</mat-label>
+        <input
+          matInput
+          [(ngModel)]="project.teacherNotebook.itemTypes.report.label.singular"
+          (ngModelChange)="contentChanged()"
+        />
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label i18n>Label (Plural)</mat-label>
+        <input
+          matInput
+          [(ngModel)]="project.teacherNotebook.itemTypes.report.label.plural"
+          (ngModelChange)="contentChanged()"
+        />
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label i18n>Label (Link)</mat-label>
+        <input
+          matInput
+          [(ngModel)]="project.teacherNotebook.itemTypes.report.label.link"
+          (ngModelChange)="contentChanged()"
+        />
+      </mat-form-field>
     </div>
     <div *ngFor="let reportNote of project.teacherNotebook.itemTypes.report.notes">
-      <translatable-input
-        [content]="reportNote"
-        key="title"
-        label="Title"
-        i18n-label
-        (defaultLanguageTextChanged)="contentChanged()"
-        class="notebook-input"
-      ></translatable-input>
-      <translatable-textarea
-        [content]="reportNote"
-        key="description"
-        label="Description"
-        i18n-label
-        (defaultLanguageTextChanged)="contentChanged()"
-      ></translatable-textarea>
-      <translatable-textarea
-        [content]="reportNote"
-        key="prompt"
-        label="Prompt"
-        i18n-label
-        (defaultLanguageTextChanged)="contentChanged()"
-      ></translatable-textarea>
+      <mat-form-field>
+        <mat-label i18n>Title</mat-label>
+        <input matInput [(ngModel)]="reportNote.title" (ngModelChange)="contentChanged()" />
+      </mat-form-field>
+      <br />
+      <mat-form-field class="textarea">
+        <mat-label i18n>Description</mat-label>
+        <textarea
+          matInput
+          cdkTextareaAutosize
+          [(ngModel)]="reportNote.description"
+          (ngModelChange)="contentChanged()"
+        ></textarea>
+      </mat-form-field>
+      <br />
+      <mat-form-field class="textarea">
+        <mat-label i18n>Prompt</mat-label>
+        <textarea
+          matInput
+          cdkTextareaAutosize
+          [(ngModel)]="reportNote.prompt"
+          (ngModelChange)="contentChanged()"
+        ></textarea>
+      </mat-form-field>
+      <br />
       <mat-label i18n>Starter Text</mat-label>
-      <translatable-rich-text-editor
-        [content]="reportNote"
-        key="content"
-        (defaultLanguageTextChanged)="save()"
-      ></translatable-rich-text-editor>
+      <wise-authoring-tinymce-editor
+        [(model)]="reportIdToAuthoringNote[reportNote.reportId].html"
+        (modelChange)="reportStarterTextChanged(reportNote.reportId)"
+      >
+      </wise-authoring-tinymce-editor>
     </div>
   </div>
 </div>

--- a/src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html
+++ b/src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html
@@ -13,11 +13,14 @@
   </mat-slide-toggle>
 </div>
 <div *ngIf="project.notebook.enabled" class="notebook-div">
-  <div>
-    <mat-form-field>
-      <mat-label i18n>Notebook Label</mat-label>
-      <input matInput [(ngModel)]="project.notebook.label" (ngModelChange)="contentChanged()" />
-    </mat-form-field>
+  <div class="small-width">
+    <translatable-input
+      [content]="project.notebook"
+      key="label"
+      label="Notebook Label"
+      i18n-label
+      (defaultLanguageTextChanged)="contentChanged()"
+    ></translatable-input>
   </div>
   <div>
     <mat-slide-toggle
@@ -31,31 +34,34 @@
     </mat-slide-toggle>
   </div>
   <div *ngIf="project.notebook.itemTypes.note.enabled" class="notebook-child-div">
-    <div fxLayoutGap="20px">
-      <mat-form-field>
-        <mat-label i18n>Label (Singular)</mat-label>
-        <input
-          matInput
-          [(ngModel)]="project.notebook.itemTypes.note.label.singular"
-          (ngModelChange)="contentChanged()"
-        />
-      </mat-form-field>
-      <mat-form-field>
-        <mat-label i18n>Label (Plural)</mat-label>
-        <input
-          matInput
-          [(ngModel)]="project.notebook.itemTypes.note.label.plural"
-          (ngModelChange)="contentChanged()"
-        />
-      </mat-form-field>
-      <mat-form-field>
-        <mat-label i18n>Label (Link)</mat-label>
-        <input
-          matInput
-          [(ngModel)]="project.notebook.itemTypes.note.label.link"
-          (ngModelChange)="contentChanged()"
-        />
-      </mat-form-field>
+    <div fxLayout="row wrap" fxLayoutGap="20px">
+      <div class="small-width">
+        <translatable-input
+          [content]="project.notebook.itemTypes.note.label"
+          key="singular"
+          label="Label (Singular)"
+          i18n-label
+          (defaultLanguageTextChanged)="contentChanged()"
+        ></translatable-input>
+      </div>
+      <div class="small-width">
+        <translatable-input
+          [content]="project.notebook.itemTypes.note.label"
+          key="plural"
+          label="Label (Plural)"
+          i18n-label
+          (defaultLanguageTextChanged)="contentChanged()"
+        ></translatable-input>
+      </div>
+      <div class="small-width">
+        <translatable-input
+          [content]="project.notebook.itemTypes.note.label"
+          key="link"
+          label="Label (Link)"
+          i18n-label
+          (defaultLanguageTextChanged)="contentChanged()"
+        ></translatable-input>
+      </div>
     </div>
     <mat-checkbox
       color="primary"
@@ -104,74 +110,76 @@
     Enable Report
   </mat-slide-toggle>
   <div *ngIf="project.notebook.itemTypes.report.enabled" class="notebook-child-div">
-    <div fxLayoutGap="20px">
-      <mat-form-field>
-        <mat-label i18n>Label (Singular)</mat-label>
-        <input
-          matInput
-          [(ngModel)]="project.notebook.itemTypes.report.label.singular"
-          (ngModelChange)="contentChanged()"
-        />
-      </mat-form-field>
-      <mat-form-field>
-        <mat-label i18n>Label (Plural)</mat-label>
-        <input
-          matInput
-          [(ngModel)]="project.notebook.itemTypes.report.label.plural"
-          (ngModelChange)="contentChanged()"
-        />
-      </mat-form-field>
-      <mat-form-field>
-        <mat-label i18n>Label (Link)</mat-label>
-        <input
-          matInput
-          [(ngModel)]="project.notebook.itemTypes.report.label.link"
-          (ngModelChange)="contentChanged()"
-        />
-      </mat-form-field>
+    <div fxLayout="row wrap" fxLayoutGap="20px">
+      <div class="small-width">
+        <translatable-input
+          [content]="project.notebook.itemTypes.report.label"
+          key="singular"
+          label="Label (Singular)"
+          i18n-label
+          (defaultLanguageTextChanged)="contentChanged()"
+        ></translatable-input>
+      </div>
+      <div class="small-width">
+        <translatable-input
+          [content]="project.notebook.itemTypes.report.label"
+          key="plural"
+          label="Label (Plural)"
+          i18n-label
+          (defaultLanguageTextChanged)="contentChanged()"
+        ></translatable-input>
+      </div>
+      <div class="small-width">
+        <translatable-input
+          [content]="project.notebook.itemTypes.report.label"
+          key="link"
+          label="Label (Link)"
+          i18n-label
+          (defaultLanguageTextChanged)="contentChanged()"
+        ></translatable-input>
+      </div>
     </div>
     <div *ngFor="let reportNote of project.notebook.itemTypes.report.notes">
-      <mat-form-field>
-        <mat-label i18n>Title</mat-label>
-        <input matInput [(ngModel)]="reportNote.title" (ngModelChange)="contentChanged()" />
-      </mat-form-field>
-      <br />
-      <mat-form-field>
-        <mat-label i18n>Max Score</mat-label>
-        <input
-          matInput
-          [(ngModel)]="reportNote.maxScore"
-          type="number"
-          (ngModelChange)="contentChanged()"
-        />
-      </mat-form-field>
-      <br />
-      <mat-form-field class="textarea">
-        <mat-label i18n>Description</mat-label>
-        <textarea
-          matInput
-          cdkTextareaAutosize
-          [(ngModel)]="reportNote.description"
-          (ngModelChange)="contentChanged()"
-        ></textarea>
-      </mat-form-field>
-      <br />
-      <mat-form-field class="textarea">
-        <mat-label i18n>Prompt</mat-label>
-        <textarea
-          matInput
-          cdkTextareaAutosize
-          [(ngModel)]="reportNote.prompt"
-          (ngModelChange)="contentChanged()"
-        ></textarea>
-      </mat-form-field>
-      <br />
+      <div class="small-width">
+        <translatable-input
+          [content]="reportNote"
+          key="title"
+          label="Title"
+          i18n-label
+          (defaultLanguageTextChanged)="contentChanged()"
+        ></translatable-input>
+      </div>
+      <div>
+        <mat-form-field>
+          <mat-label i18n>Max Score</mat-label>
+          <input
+            matInput
+            [(ngModel)]="reportNote.maxScore"
+            type="number"
+            (ngModelChange)="contentChanged()"
+          />
+        </mat-form-field>
+      </div>
+      <translatable-textarea
+        [content]="reportNote"
+        key="description"
+        label="Description"
+        i18n-label
+        (defaultLanguageTextChanged)="contentChanged()"
+      ></translatable-textarea>
+      <translatable-textarea
+        [content]="reportNote"
+        key="prompt"
+        label="Prompt"
+        i18n-label
+        (defaultLanguageTextChanged)="contentChanged()"
+      ></translatable-textarea>
       <mat-label i18n>Starter Text</mat-label>
-      <wise-authoring-tinymce-editor
-        [(model)]="reportIdToAuthoringNote[reportNote.reportId].html"
-        (modelChange)="reportStarterTextChanged(reportNote.reportId)"
-      >
-      </wise-authoring-tinymce-editor>
+      <translatable-rich-text-editor
+        [content]="reportNote"
+        key="content"
+        (defaultLanguageTextChanged)="save()"
+      ></translatable-rich-text-editor>
     </div>
   </div>
 </div>
@@ -187,15 +195,14 @@
   </mat-slide-toggle>
 </div>
 <div *ngIf="project.teacherNotebook.enabled" class="notebook-div">
-  <div>
-    <mat-form-field>
-      <mat-label i18n>Notebook Label</mat-label>
-      <input
-        matInput
-        [(ngModel)]="project.teacherNotebook.label"
-        (ngModelChange)="contentChanged()"
-      />
-    </mat-form-field>
+  <div class="small-width">
+    <translatable-input
+      [content]="project.teacherNotebook"
+      key="label"
+      label="Notebook Label"
+      i18n-label
+      (defaultLanguageTextChanged)="contentChanged()"
+    ></translatable-input>
   </div>
   <mat-slide-toggle
     color="primary"
@@ -207,64 +214,65 @@
     Enable Report
   </mat-slide-toggle>
   <div *ngIf="project.teacherNotebook.itemTypes.report.enabled" class="notebook-child-div">
-    <div fxLayoutGap="20px">
-      <mat-form-field>
-        <mat-label i18n>Label (Singular)</mat-label>
-        <input
-          matInput
-          [(ngModel)]="project.teacherNotebook.itemTypes.report.label.singular"
-          (ngModelChange)="contentChanged()"
-        />
-      </mat-form-field>
-      <mat-form-field>
-        <mat-label i18n>Label (Plural)</mat-label>
-        <input
-          matInput
-          [(ngModel)]="project.teacherNotebook.itemTypes.report.label.plural"
-          (ngModelChange)="contentChanged()"
-        />
-      </mat-form-field>
-      <mat-form-field>
-        <mat-label i18n>Label (Link)</mat-label>
-        <input
-          matInput
-          [(ngModel)]="project.teacherNotebook.itemTypes.report.label.link"
-          (ngModelChange)="contentChanged()"
-        />
-      </mat-form-field>
+    <div fxLayout="row wrap" fxLayoutGap="20px">
+      <div class="small-width">
+        <translatable-input
+          [content]="project.teacherNotebook.itemTypes.report.label"
+          key="singular"
+          label="Label (Singular)"
+          i18n-label
+          (defaultLanguageTextChanged)="contentChanged()"
+        ></translatable-input>
+      </div>
+      <div class="small-width">
+        <translatable-input
+          [content]="project.teacherNotebook.itemTypes.report.label"
+          key="plural"
+          label="Label (Plural)"
+          i18n-label
+          (defaultLanguageTextChanged)="contentChanged()"
+        ></translatable-input>
+      </div>
+      <div class="small-width">
+        <translatable-input
+          [content]="project.teacherNotebook.itemTypes.report.label"
+          key="link"
+          label="Label (Link)"
+          i18n-label
+          (defaultLanguageTextChanged)="contentChanged()"
+        ></translatable-input>
+      </div>
     </div>
     <div *ngFor="let reportNote of project.teacherNotebook.itemTypes.report.notes">
-      <mat-form-field>
-        <mat-label i18n>Title</mat-label>
-        <input matInput [(ngModel)]="reportNote.title" (ngModelChange)="contentChanged()" />
-      </mat-form-field>
-      <br />
-      <mat-form-field class="textarea">
-        <mat-label i18n>Description</mat-label>
-        <textarea
-          matInput
-          cdkTextareaAutosize
-          [(ngModel)]="reportNote.description"
-          (ngModelChange)="contentChanged()"
-        ></textarea>
-      </mat-form-field>
-      <br />
-      <mat-form-field class="textarea">
-        <mat-label i18n>Prompt</mat-label>
-        <textarea
-          matInput
-          cdkTextareaAutosize
-          [(ngModel)]="reportNote.prompt"
-          (ngModelChange)="contentChanged()"
-        ></textarea>
-      </mat-form-field>
-      <br />
+      <div class="small-width">
+        <translatable-input
+          [content]="reportNote"
+          key="title"
+          label="Title"
+          i18n-label
+          (defaultLanguageTextChanged)="contentChanged()"
+        ></translatable-input>
+      </div>
+      <translatable-textarea
+        [content]="reportNote"
+        key="description"
+        label="Description"
+        i18n-label
+        (defaultLanguageTextChanged)="contentChanged()"
+      ></translatable-textarea>
+      <translatable-textarea
+        [content]="reportNote"
+        key="prompt"
+        label="Prompt"
+        i18n-label
+        (defaultLanguageTextChanged)="contentChanged()"
+      ></translatable-textarea>
       <mat-label i18n>Starter Text</mat-label>
-      <wise-authoring-tinymce-editor
-        [(model)]="reportIdToAuthoringNote[reportNote.reportId].html"
-        (modelChange)="reportStarterTextChanged(reportNote.reportId)"
-      >
-      </wise-authoring-tinymce-editor>
+      <translatable-rich-text-editor
+        [content]="reportNote"
+        key="content"
+        (defaultLanguageTextChanged)="save()"
+      ></translatable-rich-text-editor>
     </div>
   </div>
 </div>

--- a/src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.scss
+++ b/src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.scss
@@ -14,6 +14,10 @@
   padding: 20px 20px 10px 20px;
 }
 
+.textarea {
+  width: 100%;
+}
+
 .notebook-input {
   width: 240px;
 }

--- a/src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.scss
+++ b/src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.scss
@@ -14,6 +14,6 @@
   padding: 20px 20px 10px 20px;
 }
 
-.small-width {
-  width: 20%;
+.notebook-input {
+  width: 240px;
 }

--- a/src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.scss
+++ b/src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.scss
@@ -14,6 +14,6 @@
   padding: 20px 20px 10px 20px;
 }
 
-.textarea {
-  width: 100%;
+.small-width {
+  width: 20%;
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -979,7 +979,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">255</context>
+          <context context-type="linenumber">254</context>
         </context-group>
       </trans-unit>
       <trans-unit id="495b53dee6164e1c3ec7d95ee3527bb23b62a8c2" datatype="html">
@@ -2074,7 +2074,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">248</context>
+          <context context-type="linenumber">244</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
@@ -11750,7 +11750,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">240</context>
+          <context context-type="linenumber">239</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.html</context>
@@ -11887,7 +11887,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">195</context>
+          <context context-type="linenumber">193</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8d39e7a8a3bd007e5e2d7849161f5b889f0dcaf5" datatype="html">
@@ -11909,7 +11909,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">214</context>
+          <context context-type="linenumber">213</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8a47226bd3bdacc082629e439e94e09f34dc6e49" datatype="html">
@@ -11924,7 +11924,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">222</context>
+          <context context-type="linenumber">221</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2c660aa7c76de50c1b41d2ebd298c915d9ec5014" datatype="html">
@@ -11939,7 +11939,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">230</context>
+          <context context-type="linenumber">229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8939b0942e4470509efee81a517a37ed0172c6e3" datatype="html">
@@ -11978,7 +11978,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">206,208</context>
+          <context context-type="linenumber">207,209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="814bb9115573edc442f7afdafa03c3e46cbc0ddc" datatype="html">
@@ -11989,7 +11989,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">259</context>
+          <context context-type="linenumber">263</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c5f210eb923dd7a5eaf665c440fdf98cd541508a" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -953,7 +953,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">147</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e5bfb1c8202a7255708c24e046e647ccbdd95693" datatype="html">
@@ -975,11 +975,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">173</context>
+          <context context-type="linenumber">166</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">266</context>
+          <context context-type="linenumber">255</context>
         </context-group>
       </trans-unit>
       <trans-unit id="495b53dee6164e1c3ec7d95ee3527bb23b62a8c2" datatype="html">
@@ -2070,11 +2070,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">166</context>
+          <context context-type="linenumber">159</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">259</context>
+          <context context-type="linenumber">248</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
@@ -11746,11 +11746,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">147</context>
+          <context context-type="linenumber">140</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">251</context>
+          <context context-type="linenumber">240</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.html</context>
@@ -11887,7 +11887,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">202</context>
+          <context context-type="linenumber">195</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8d39e7a8a3bd007e5e2d7849161f5b889f0dcaf5" datatype="html">
@@ -11901,102 +11901,102 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Label (Singular)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">41</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">118</context>
+          <context context-type="linenumber">114</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">222</context>
+          <context context-type="linenumber">214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8a47226bd3bdacc082629e439e94e09f34dc6e49" datatype="html">
         <source>Label (Plural)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">49</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">127</context>
+          <context context-type="linenumber">122</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">231</context>
+          <context context-type="linenumber">222</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2c660aa7c76de50c1b41d2ebd298c915d9ec5014" datatype="html">
         <source>Label (Link)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">57</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">136</context>
+          <context context-type="linenumber">130</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">240</context>
+          <context context-type="linenumber">230</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8939b0942e4470509efee81a517a37ed0172c6e3" datatype="html">
         <source> Enable Add Note Button </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">71,73</context>
+          <context context-type="linenumber">68,70</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2171379d08d0377804e100f871c8e96ff20c5239" datatype="html">
         <source> Require students to write text on every note </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">81,83</context>
+          <context context-type="linenumber">78,80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f0c7f017ce69101e8b7b60163c94e05292175b7d" datatype="html">
         <source> Enable Clipping </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">90,92</context>
+          <context context-type="linenumber">87,89</context>
         </context-group>
       </trans-unit>
       <trans-unit id="881f27fd5138b6c7c0b3402575377b552606abfd" datatype="html">
         <source> Enable Student Uploads </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">99,101</context>
+          <context context-type="linenumber">96,98</context>
         </context-group>
       </trans-unit>
       <trans-unit id="00d9fa046e02414bb4726dc04aeeff2429203220" datatype="html">
         <source> Enable Report </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">109,111</context>
+          <context context-type="linenumber">106,108</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">213,215</context>
+          <context context-type="linenumber">206,208</context>
         </context-group>
       </trans-unit>
       <trans-unit id="814bb9115573edc442f7afdafa03c3e46cbc0ddc" datatype="html">
         <source>Starter Text</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">177</context>
+          <context context-type="linenumber">170</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">270</context>
+          <context context-type="linenumber">259</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c5f210eb923dd7a5eaf665c440fdf98cd541508a" datatype="html">
         <source> Teacher Notebook </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">193,195</context>
+          <context context-type="linenumber">186,188</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4199930238964775542" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -953,7 +953,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">140</context>
+          <context context-type="linenumber">154</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e5bfb1c8202a7255708c24e046e647ccbdd95693" datatype="html">
@@ -975,11 +975,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">160</context>
+          <context context-type="linenumber">173</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">253</context>
+          <context context-type="linenumber">266</context>
         </context-group>
       </trans-unit>
       <trans-unit id="495b53dee6164e1c3ec7d95ee3527bb23b62a8c2" datatype="html">
@@ -2070,11 +2070,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">166</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">243</context>
+          <context context-type="linenumber">259</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
@@ -11746,11 +11746,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">135</context>
+          <context context-type="linenumber">147</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">238</context>
+          <context context-type="linenumber">251</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.html</context>
@@ -11883,120 +11883,120 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Notebook Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">18</context>
+          <context context-type="linenumber">20</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">192</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8d39e7a8a3bd007e5e2d7849161f5b889f0dcaf5" datatype="html">
         <source> Enable Note </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">29,31</context>
+          <context context-type="linenumber">32,34</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d68f1b31f3cbd1b30b3636d345a39fa325147196" datatype="html">
         <source>Label (Singular)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">36</context>
+          <context context-type="linenumber">42</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">118</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">212</context>
+          <context context-type="linenumber">222</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8a47226bd3bdacc082629e439e94e09f34dc6e49" datatype="html">
         <source>Label (Plural)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">44</context>
+          <context context-type="linenumber">51</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">117</context>
+          <context context-type="linenumber">127</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">220</context>
+          <context context-type="linenumber">231</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2c660aa7c76de50c1b41d2ebd298c915d9ec5014" datatype="html">
         <source>Label (Link)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">60</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">125</context>
+          <context context-type="linenumber">136</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">228</context>
+          <context context-type="linenumber">240</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8939b0942e4470509efee81a517a37ed0172c6e3" datatype="html">
         <source> Enable Add Note Button </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">65,67</context>
+          <context context-type="linenumber">71,73</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2171379d08d0377804e100f871c8e96ff20c5239" datatype="html">
         <source> Require students to write text on every note </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">75,77</context>
+          <context context-type="linenumber">81,83</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f0c7f017ce69101e8b7b60163c94e05292175b7d" datatype="html">
         <source> Enable Clipping </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">84,86</context>
+          <context context-type="linenumber">90,92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="881f27fd5138b6c7c0b3402575377b552606abfd" datatype="html">
         <source> Enable Student Uploads </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">93,95</context>
+          <context context-type="linenumber">99,101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="00d9fa046e02414bb4726dc04aeeff2429203220" datatype="html">
         <source> Enable Report </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">103,105</context>
+          <context context-type="linenumber">109,111</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">206,208</context>
+          <context context-type="linenumber">213,215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="814bb9115573edc442f7afdafa03c3e46cbc0ddc" datatype="html">
         <source>Starter Text</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">169</context>
+          <context context-type="linenumber">177</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">262</context>
+          <context context-type="linenumber">270</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c5f210eb923dd7a5eaf665c440fdf98cd541508a" datatype="html">
         <source> Teacher Notebook </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">185,187</context>
+          <context context-type="linenumber">193,195</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4199930238964775542" datatype="html">


### PR DESCRIPTION
## Changes
- Convert notebook authoring to translatable
- Deleted a lot of code in notebook-authoring.component.ts because that logic is now handled in translatable-rich-text-editor.component.ts

## Test
- Make sure all the relevant notebook authoring fields are translatable