### PR TITLE
feat(AI Chat): Check if chat gpt is enabled when adding items

### DIFF
--- a/src/assets/wise5/authoringTool/components/component-type-selector/component-type-selector.component.spec.ts
+++ b/src/assets/wise5/authoringTool/components/component-type-selector/component-type-selector.component.spec.ts
@@ -10,9 +10,11 @@ import { ComponentTypeSelectorHarness } from './component-type-selector.harness'
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentTypeServiceModule } from '../../../services/componentTypeService.module';
 import { UserService } from '../../../../../app/services/user.service';
+import { ConfigService } from '../../../services/configService';
 
 let component: ComponentTypeSelectorComponent;
 let componentTypeSelectorHarness: ComponentTypeSelectorHarness;
+let configService: ConfigService;
 let fixture: ComponentFixture<ComponentTypeSelectorComponent>;
 let userService: UserService;
 
@@ -32,6 +34,8 @@ describe('ComponentTypeSelectorComponent', () => {
       providers: []
     });
     fixture = TestBed.createComponent(ComponentTypeSelectorComponent);
+    configService = TestBed.inject(ConfigService);
+    spyOn(configService, 'getConfigParam').and.returnValue(true);
     userService = TestBed.inject(UserService);
     userService.isAuthenticated = true;
     spyOn(userService, 'getRoles').and.returnValue(['researcher', 'teacher']);

--- a/src/assets/wise5/services/componentTypeService.ts
+++ b/src/assets/wise5/services/componentTypeService.ts
@@ -1,11 +1,13 @@
 import { Injectable } from '@angular/core';
 import { ComponentServiceLookupService } from './componentServiceLookupService';
 import { UserService } from '../../../app/services/user.service';
+import { ConfigService } from './configService';
 
 @Injectable()
 export class ComponentTypeService {
   constructor(
     private componentServiceLookupService: ComponentServiceLookupService,
+    private configService: ConfigService,
     private userService: UserService
   ) {}
 
@@ -31,11 +33,7 @@ export class ComponentTypeService {
       { type: 'Summary', name: this.getComponentTypeLabel('Summary') },
       { type: 'Table', name: this.getComponentTypeLabel('Table') }
     ];
-    if (
-      this.userService.isAdmin() ||
-      this.userService.isResearcher() ||
-      this.userService.isTrustedAuthor()
-    ) {
+    if (this.isAiChatAllowed()) {
       componentTypes.unshift({ type: 'AiChat', name: this.getComponentTypeLabel('AiChat') });
     }
     return componentTypes;
@@ -43,5 +41,14 @@ export class ComponentTypeService {
 
   getComponentTypeLabel(componentType: string): string {
     return this.componentServiceLookupService.getService(componentType).getComponentTypeLabel();
+  }
+
+  private isAiChatAllowed(): boolean {
+    return (
+      this.configService.getConfigParam('chatGptEnabled') &&
+      (this.userService.isAdmin() ||
+        this.userService.isResearcher() ||
+        this.userService.isTrustedAuthor())
+    );
   }
 }


### PR DESCRIPTION
## Changes
- Check authoring config param "chatGptEnabled" to determine whether to show the AI Chat item when an author adds items

## Test
- Test with https://github.com/WISE-Community/WISE-API/pull/271
- If chat gpt is enabled, you should be able to add AI Chat items in the authoring
- If chat gpt is not enabled, you should not be able to add AI Chat items in the authoring
