### PR TITLE
fix(Application): Retrieve config during app initialization

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -30,9 +30,13 @@ export function initialize(
   userService: UserService
 ): () => Promise<any> {
   return (): Promise<any> => {
-    return userService.retrieveUserPromise().then((user) => {
-      userService.getUser().subscribe((user) => {
-        configService.retrieveConfig();
+    return new Promise((resolve) => {
+      userService.retrieveUserPromise().then(() => {
+        return userService.getUser().subscribe(() => {
+          return configService.retrieveConfig().subscribe((config) => {
+            resolve(config);
+          });
+        });
       });
     });
   };

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, tap } from 'rxjs';
 import { Config } from '../domain/config';
 import { Announcement } from '../domain/announcement';
 
@@ -17,14 +17,16 @@ export class ConfigService {
     return this.config$;
   }
 
-  retrieveConfig() {
+  retrieveConfig(): Observable<Config> {
     const headers = new HttpHeaders({ 'Cache-Control': 'no-cache' });
-    this.http
+    return this.http
       .get<Config>(this.userConfigUrl, { headers: headers })
-      .subscribe((config) => {
-        this.config$.next(config);
-        this.timeDiff = Date.now() - config.currentTime;
-      });
+      .pipe(
+        tap((config) => {
+          this.config$.next(config);
+          this.timeDiff = Date.now() - config.currentTime;
+        })
+      );
   }
 
   getContextPath() {


### PR DESCRIPTION
## Changes
- Use promise and resolve() to ensure that the config object is retrieved during APP_INITIALIZATION. This was causing issues in pages that required the config object to be present but the API was slow to respond due to network latency.

## Test
1. Add a breakpoint at the top of UserAPIController.getConfig() function and start a debugging session on API
2. Go directly to the login page by copying&pasting this url to the browser: http://localhost/login
   - This should break at the UserAPIController.getConfig() breakpoint
   - You should not see any js errors
3. Release the breakpoint
   - The login page should load 
   - You should not see any js errors

Test that directly going to other pages work as before, like register student/teacher form pages.

Closes #1747 
