### PR TITLE
feat(Tag): Add search input to the apply tags menu

### DIFF
--- a/src/app/modules/shared/search-bar/search-bar.component.html
+++ b/src/app/modules/shared/search-bar/search-bar.component.html
@@ -1,12 +1,12 @@
-<mat-form-field class="search-bar" appearance="fill">
+<mat-form-field class="search-bar" appearance="fill" (click)="$event.stopPropagation()">
   <mat-label>{{ placeholderText }}</mat-label>
   <mat-icon matPrefix>search</mat-icon>
-  <input matInput [formControl]="searchField" />
+  <input matInput [formControl]="searchField" (keydown)="$event.stopPropagation()" />
   <button
     mat-icon-button
     matSuffix
     [disabled]="disable"
-    [ngClass]="{ invisible: !value }"
+    [ngClass]="{ invisible: !searchField.value }"
     i18n-aria-label
     aria-label="Clear"
     (click)="clear()"

--- a/src/app/teacher/apply-tags-button/apply-tags-button.component.html
+++ b/src/app/teacher/apply-tags-button/apply-tags-button.component.html
@@ -8,9 +8,9 @@
   <mat-icon>sell</mat-icon>
 </button>
 <mat-menu #applyTagsMenu>
-  <div class="menu-info secondary-text" i18n>Apply tags</div>
-  <mat-divider></mat-divider>
-  <div *ngFor="let tag of tags" (click)="$event.stopPropagation()" mat-menu-item>
+  <div class="menu-info secondary-text" (click)="$event.stopPropagation()" i18n>Apply tags</div>
+  <app-search-bar (update)="filterTags($event)"></app-search-bar>
+  <div *ngFor="let tag of filteredTags" (click)="$event.stopPropagation()" mat-menu-item>
     <select-all-items-checkbox
       [numAllItems]="selectedProjects.length"
       [numSelectedItems]="tag.numProjectsWithTag"

--- a/src/app/teacher/apply-tags-button/apply-tags-button.component.html
+++ b/src/app/teacher/apply-tags-button/apply-tags-button.component.html
@@ -7,7 +7,7 @@
 >
   <mat-icon>sell</mat-icon>
 </button>
-<mat-menu #applyTagsMenu (closed)="menuClosed()">
+<mat-menu #applyTagsMenu (closed)="searchText = ''">
   <div class="menu-info secondary-text" (click)="$event.stopPropagation()" i18n>Apply tags</div>
   <app-search-bar [value]="searchText" (update)="filterTags($event)"></app-search-bar>
   <div *ngFor="let tag of filteredTags" (click)="$event.stopPropagation()" mat-menu-item>

--- a/src/app/teacher/apply-tags-button/apply-tags-button.component.html
+++ b/src/app/teacher/apply-tags-button/apply-tags-button.component.html
@@ -7,9 +7,9 @@
 >
   <mat-icon>sell</mat-icon>
 </button>
-<mat-menu #applyTagsMenu>
+<mat-menu #applyTagsMenu (closed)="menuClosed()">
   <div class="menu-info secondary-text" (click)="$event.stopPropagation()" i18n>Apply tags</div>
-  <app-search-bar (update)="filterTags($event)"></app-search-bar>
+  <app-search-bar [value]="searchText" (update)="filterTags($event)"></app-search-bar>
   <div *ngFor="let tag of filteredTags" (click)="$event.stopPropagation()" mat-menu-item>
     <select-all-items-checkbox
       [numAllItems]="selectedProjects.length"

--- a/src/app/teacher/apply-tags-button/apply-tags-button.component.scss
+++ b/src/app/teacher/apply-tags-button/apply-tags-button.component.scss
@@ -1,3 +1,3 @@
 .menu-info {
-  margin: 0 16px;
+  margin: 16px;
 }

--- a/src/app/teacher/apply-tags-button/apply-tags-button.component.spec.ts
+++ b/src/app/teacher/apply-tags-button/apply-tags-button.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ApplyTagsButtonComponent } from './apply-tags-button.component';
 import { ApplyTagsButtonModule } from './apply-tags-button.module';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('ApplyTagsButtonComponent', () => {
   let component: ApplyTagsButtonComponent;
@@ -10,7 +11,7 @@ describe('ApplyTagsButtonComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [ApplyTagsButtonComponent],
-      imports: [ApplyTagsButtonModule, HttpClientTestingModule]
+      imports: [ApplyTagsButtonModule, BrowserAnimationsModule, HttpClientTestingModule]
     });
     fixture = TestBed.createComponent(ApplyTagsButtonComponent);
     component = fixture.componentInstance;

--- a/src/app/teacher/apply-tags-button/apply-tags-button.component.ts
+++ b/src/app/teacher/apply-tags-button/apply-tags-button.component.ts
@@ -14,6 +14,7 @@ import { MAT_CHECKBOX_DEFAULT_OPTIONS } from '@angular/material/checkbox';
   providers: [{ provide: MAT_CHECKBOX_DEFAULT_OPTIONS, useValue: { clickAction: 'noop' } }]
 })
 export class ApplyTagsButtonComponent implements OnInit {
+  protected filteredTags: Tag[] = [];
   @Input() selectedProjects: Project[] = [];
   private subscriptions: Subscription = new Subscription();
   protected tags: Tag[] = [];
@@ -34,6 +35,7 @@ export class ApplyTagsButtonComponent implements OnInit {
   private retrieveUserTags(): void {
     this.projectTagService.retrieveUserTags().subscribe((tags: Tag[]) => {
       this.tags = tags;
+      this.filteredTags = tags;
       this.updateAllTagsCheckedValues();
     });
   }
@@ -99,6 +101,12 @@ export class ApplyTagsButtonComponent implements OnInit {
       }
       this.updateTagCheckedValue(tag);
     });
+  }
+
+  protected filterTags(searchText: string): void {
+    this.filteredTags = this.tags.filter((tag: Tag) =>
+      tag.text.toLowerCase().includes(searchText.trim().toLowerCase())
+    );
   }
 
   protected manageTags(): void {

--- a/src/app/teacher/apply-tags-button/apply-tags-button.component.ts
+++ b/src/app/teacher/apply-tags-button/apply-tags-button.component.ts
@@ -15,6 +15,7 @@ import { MAT_CHECKBOX_DEFAULT_OPTIONS } from '@angular/material/checkbox';
 })
 export class ApplyTagsButtonComponent implements OnInit {
   protected filteredTags: Tag[] = [];
+  protected searchText: string = '';
   @Input() selectedProjects: Project[] = [];
   private subscriptions: Subscription = new Subscription();
   protected tags: Tag[] = [];
@@ -104,6 +105,7 @@ export class ApplyTagsButtonComponent implements OnInit {
   }
 
   protected filterTags(searchText: string): void {
+    this.searchText = searchText;
     this.filteredTags = this.tags.filter((tag: Tag) =>
       tag.text.toLowerCase().includes(searchText.trim().toLowerCase())
     );
@@ -113,5 +115,9 @@ export class ApplyTagsButtonComponent implements OnInit {
     this.dialog.open(ManageTagsDialogComponent, {
       panelClass: 'dialog-md'
     });
+  }
+
+  protected menuClosed(): void {
+    this.searchText = '';
   }
 }

--- a/src/app/teacher/apply-tags-button/apply-tags-button.component.ts
+++ b/src/app/teacher/apply-tags-button/apply-tags-button.component.ts
@@ -116,8 +116,4 @@ export class ApplyTagsButtonComponent implements OnInit {
       panelClass: 'dialog-md'
     });
   }
-
-  protected menuClosed(): void {
-    this.searchText = '';
-  }
 }

--- a/src/app/teacher/apply-tags-button/apply-tags-button.module.ts
+++ b/src/app/teacher/apply-tags-button/apply-tags-button.module.ts
@@ -13,6 +13,9 @@ import { MatDividerModule } from '@angular/material/divider';
 import { ManageTagsDialogComponent } from '../manage-tags-dialog/manage-tags-dialog.component';
 import { ProjectTagService } from '../../../assets/wise5/services/projectTagService';
 import { SelectAllItemsCheckboxComponent } from '../../modules/library/select-all-items-checkbox/select-all-items-checkbox.component';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { SharedModule } from '../../modules/shared/shared.module';
 
 @NgModule({
   declarations: [ApplyTagsButtonComponent],
@@ -25,10 +28,13 @@ import { SelectAllItemsCheckboxComponent } from '../../modules/library/select-al
     MatButtonModule,
     MatCheckboxModule,
     MatDividerModule,
+    MatFormFieldModule,
     MatIconModule,
+    MatInputModule,
     MatMenuModule,
     MatTooltipModule,
     SelectAllItemsCheckboxComponent,
+    SharedModule,
     StudentTeacherCommonServicesModule
   ],
   providers: [ProjectTagService]


### PR DESCRIPTION
## Changes
- Added search input to the apply tags menu
- Added $event.stopPropagation() to the search bar when clicking on the mat-form-field and when typing in the input

## Test
- Make sure the apply tags search filters the tags
- Make sure search still works in
  - Unit library
  - Teacher run list
  - Student run list