### PR TITLE
refactor(HeaderSignInComponent): Convert to standalone

### DIFF
--- a/src/app/modules/header/header-signin/header-signin.component.spec.ts
+++ b/src/app/modules/header/header-signin/header-signin.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { HeaderSigninComponent } from './header-signin.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { provideRouter } from '@angular/router';
 
 describe('HeaderSigninComponent', () => {
   let component: HeaderSigninComponent;
   let fixture: ComponentFixture<HeaderSigninComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [HeaderSigninComponent],
-      imports: [],
-      providers: [],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [HeaderSigninComponent],
+        providers: [provideRouter([])]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HeaderSigninComponent);

--- a/src/app/modules/header/header-signin/header-signin.component.ts
+++ b/src/app/modules/header/header-signin/header-signin.component.ts
@@ -1,12 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-header-signin',
+  standalone: true,
+  imports: [RouterModule],
   templateUrl: './header-signin.component.html',
   styleUrls: ['./header-signin.component.scss']
 })
-export class HeaderSigninComponent implements OnInit {
-  constructor() {}
-
-  ngOnInit() {}
-}
+export class HeaderSigninComponent {}

--- a/src/app/modules/header/header.module.ts
+++ b/src/app/modules/header/header.module.ts
@@ -23,13 +23,14 @@ const materialModules = [
 ];
 
 @NgModule({
-  imports: [CommonModule, FlexLayoutModule, AppRoutingModule, materialModules],
-  declarations: [
-    HeaderComponent,
+  imports: [
+    CommonModule,
     HeaderSigninComponent,
-    HeaderLinksComponent,
-    HeaderAccountMenuComponent
+    FlexLayoutModule,
+    AppRoutingModule,
+    materialModules
   ],
+  declarations: [HeaderComponent, HeaderLinksComponent, HeaderAccountMenuComponent],
   providers: [ConfigService, UserService],
   exports: [HeaderComponent]
 })


### PR DESCRIPTION
## Changes
- Convert HeaderSignInComponent to standalone component
- Clean up HeaderSignInComponent and spec file by removing unused code

## Test
- On the homepage, the "Register or Sign in" links appear (when not signed in), and take you to the right pages