### PR TITLE
fix(Authoring): Peer Chat authoring error when peer grouping is null

### DIFF
--- a/src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-authoring/select-peer-grouping-authoring.component.html
+++ b/src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-authoring/select-peer-grouping-authoring.component.html
@@ -1,9 +1,7 @@
 <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="10px" class="bottom-spacing">
   <mat-label class="bold" i18n>Grouping Logic:</mat-label>
-  <ng-container [ngSwitch]="peerGrouping">
-    <span *ngSwitchCase="null" i18n>(None Selected)</span>
-    <span *ngSwitchDefault>{{ peerGrouping.name }}</span>
-  </ng-container>
+  <span *ngIf="peerGrouping == null" i18n>(None Selected)</span>
+  <span *ngIf="peerGrouping != null">{{ peerGrouping.name }}</span>
   <button
     mat-raised-button
     color="primary"

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -11989,21 +11989,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>(None Selected)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-authoring/select-peer-grouping-authoring.component.html</context>
-          <context context-type="linenumber">4</context>
+          <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit>
       <trans-unit id="12fcaa2cb1d9e1fa4bfd1ff394784a6e9431241e" datatype="html">
         <source>Select Grouping Logic</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-authoring/select-peer-grouping-authoring.component.html</context>
-          <context context-type="linenumber">11</context>
+          <context context-type="linenumber">9</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ea2045d6b234ad874045e888ba18a749149a4f94" datatype="html">
         <source> Select </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-authoring/select-peer-grouping-authoring.component.html</context>
-          <context context-type="linenumber">15,17</context>
+          <context context-type="linenumber">13,15</context>
         </context-group>
       </trans-unit>
       <trans-unit id="17315c72b1b5a693dc4992a961e0b0330f958851" datatype="html">


### PR DESCRIPTION
## Changes
- Fixed a null pointer error in Peer Chat authoring when peer grouping is null
- I think this was introduced when upgrading to Angular 17

## Test
1. Open a unit in the Authoring Tool
2. Create a step with a Peer Chat item
3. Go into the step
4. Expand the Peer Chat item. The Peer Chat authoring UI should render properly. It used to not render properly and would show this error in the console
```
core.mjs:6531 ERROR TypeError: Cannot read properties of undefined (reading 'name')
    at Tv (select-peer-grouping-authoring.component.html:5:28)
```

Closes #1759
