### PR TITLE
refactor(HeaderLinksComponent): Convert to standalone component

### DIFF
--- a/src/app/modules/header/header-links/header-links.component.spec.ts
+++ b/src/app/modules/header/header-links/header-links.component.spec.ts
@@ -1,7 +1,7 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HeaderLinksComponent } from './header-links.component';
 import { User } from '../../../domain/user';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { provideRouter } from '@angular/router';
 
 describe('HeaderLinksComponent', () => {
   let component: HeaderLinksComponent;
@@ -9,9 +9,8 @@ describe('HeaderLinksComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [HeaderLinksComponent],
-      imports: [],
-      schemas: [NO_ERRORS_SCHEMA]
+      imports: [HeaderLinksComponent],
+      providers: [provideRouter([])]
     });
     fixture = TestBed.createComponent(HeaderLinksComponent);
     component = fixture.componentInstance;

--- a/src/app/modules/header/header-links/header-links.component.ts
+++ b/src/app/modules/header/header-links/header-links.component.ts
@@ -1,24 +1,23 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, Input, SimpleChanges } from '@angular/core';
 import { User } from '../../../domain/user';
+import { CommonModule } from '@angular/common';
+import { HeaderSigninComponent } from '../header-signin/header-signin.component';
+import { MatButtonModule } from '@angular/material/button';
+import { FlexLayoutModule } from '@angular/flex-layout';
+
 @Component({
+  standalone: true,
   selector: 'app-header-links',
+  imports: [CommonModule, FlexLayoutModule, HeaderSigninComponent, MatButtonModule],
   templateUrl: './header-links.component.html',
-  styleUrls: ['./header-links.component.scss']
+  styleUrl: './header-links.component.scss'
 })
-export class HeaderLinksComponent implements OnInit {
-  @Input()
-  user: User;
+export class HeaderLinksComponent {
+  @Input() location: string;
+  protected roles: string[] = [];
+  @Input() user: User;
 
-  @Input()
-  location: string;
-
-  roles: string[] = [];
-
-  constructor() {}
-
-  ngOnInit() {}
-
-  ngOnChanges(changes) {
+  ngOnChanges(changes: SimpleChanges): void {
     if (changes.user) {
       let user = changes.user.currentValue;
       this.roles = user.roles ? user.roles : [];

--- a/src/app/modules/header/header.module.ts
+++ b/src/app/modules/header/header.module.ts
@@ -8,7 +8,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { HeaderComponent } from './header.component';
-import { HeaderSigninComponent } from './header-signin/header-signin.component';
 import { HeaderLinksComponent } from './header-links/header-links.component';
 import { HeaderAccountMenuComponent } from './header-account-menu/header-account-menu.component';
 import { ConfigService } from '../../services/config.service';
@@ -25,12 +24,12 @@ const materialModules = [
 @NgModule({
   imports: [
     CommonModule,
-    HeaderSigninComponent,
+    HeaderLinksComponent,
     FlexLayoutModule,
     AppRoutingModule,
     materialModules
   ],
-  declarations: [HeaderComponent, HeaderLinksComponent, HeaderAccountMenuComponent],
+  declarations: [HeaderComponent, HeaderAccountMenuComponent],
   providers: [ConfigService, UserService],
   exports: [HeaderComponent]
 })


### PR DESCRIPTION
## Changes
- Convert HeaderLinksComponent to standalone
- Clean up HeaderLinks component and spec files

## Test
- Header links displays and works as before
   - not signed in: should show "Features", "About Us", "Community", "Research", "Register" and "Sign in" links
   - signed in: should show "Welcome, {first name}" and the account menu button

## Note
It looks like ```<app-header-signin>``` block could (and should?) be move out of HeaderLinksComponent template and into the header component template instead? It's not really a link. We can discuss and address this in a separate task.