### PR TITLE
feat(MultipleLanguages): Delete translations when steps and lessons are deleted

### DIFF
--- a/src/app/services/deleteTranslationsService.spec.ts
+++ b/src/app/services/deleteTranslationsService.spec.ts
@@ -23,18 +23,18 @@ describe('DeleteTranslationsService', () => {
     projectService = TestBed.inject(TeacherProjectService);
     service = TestBed.inject(DeleteTranslationsService);
   });
-  deleteComponents();
+  tryDeleteComponents();
 });
 
-function deleteComponents() {
-  describe('deleteComponents()', () => {
+function tryDeleteComponents() {
+  describe('tryDeleteComponents()', () => {
     it('fetches all supported translations', () => {
       spyOn(projectService, 'getLocale').and.returnValue(
         new ProjectLocale({ default: 'en_us', supported: ['es', 'ja'] })
       );
       spyOn(configService, 'getProjectId').and.returnValue('123');
       spyOn(configService, 'getConfigParam').and.returnValue('/123/project.json');
-      service.deleteComponents([
+      service.tryDeleteComponents([
         {
           id: 'abc',
           type: 'OpenResponse',

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
@@ -207,7 +207,7 @@ export class NodeAuthoringComponent implements OnInit {
         this.componentsToChecked.mutate((obj) => delete obj[component.id]);
         delete this.componentsToExpanded[component.id];
       }
-      this.deleteTranslations(components);
+      this.deleteTranslationsService.tryDeleteComponents(components);
     });
   }
 
@@ -221,12 +221,6 @@ export class NodeAuthoringComponent implements OnInit {
         this.nodeJson.showSaveButton = false;
         this.nodeJson.showSubmitButton = false;
       }
-    }
-  }
-
-  private deleteTranslations(components: ComponentContent[]): void {
-    if (this.projectService.getLocale().hasTranslations()) {
-      this.deleteTranslationsService.deleteComponents(components);
     }
   }
 

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
@@ -20,6 +20,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { CopyNodesService } from '../../services/copyNodesService';
 import { MatMenuModule } from '@angular/material/menu';
 import { AddStepButtonComponent } from '../add-step-button/add-step-button.component';
+import { DeleteTranslationsService } from '../../services/deleteTranslationsService';
 
 let component: ProjectAuthoringLessonComponent;
 let fixture: ComponentFixture<ProjectAuthoringLessonComponent>;
@@ -56,6 +57,7 @@ describe('ProjectAuthoringLessonComponent', () => {
         ClassroomStatusService,
         CopyNodesService,
         DeleteNodeService,
+        DeleteTranslationsService,
         TeacherDataService,
         TeacherProjectService,
         TeacherWebSocketService

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -6,6 +6,7 @@ import { NodeTypeSelected } from '../domain/node-type-selected';
 import { ExpandEvent } from '../domain/expand-event';
 import { DeleteNodeService } from '../../services/deleteNodeService';
 import { ActivatedRoute, Router } from '@angular/router';
+import { DeleteTranslationsService } from '../../services/deleteTranslationsService';
 
 @Component({
   selector: 'project-authoring-lesson',
@@ -25,6 +26,7 @@ export class ProjectAuthoringLessonComponent {
   constructor(
     private dataService: TeacherDataService,
     private deleteNodeService: DeleteNodeService,
+    private deleteTranslationsService: DeleteTranslationsService,
     private projectService: TeacherProjectService,
     private route: ActivatedRoute,
     private router: Router
@@ -58,8 +60,14 @@ export class ProjectAuthoringLessonComponent {
 
   protected delete(): void {
     if (confirm($localize`Are you sure you want to delete this lesson?`)) {
+      const components = this.lesson.ids.flatMap(
+        (nodeId) => this.projectService.getNodeById(nodeId).components
+      ); // get the components before they're removed by the following line
       this.deleteNodeService.deleteNode(this.lesson.id);
       this.saveAndRefreshProject();
+      if (this.projectService.getLocale().hasTranslations()) {
+        this.deleteTranslationsService.deleteComponents(components);
+      }
     }
   }
 

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -60,15 +60,10 @@ export class ProjectAuthoringLessonComponent {
 
   protected delete(): void {
     if (confirm($localize`Are you sure you want to delete this lesson?`)) {
-      // get the components before they're removed by the following line
-      const components = this.lesson.ids.flatMap(
-        (nodeId) => this.projectService.getNodeById(nodeId).components
-      );
+      const components = this.projectService.getComponentsFromLesson(this.lesson.id);
       this.deleteNodeService.deleteNode(this.lesson.id);
       this.saveAndRefreshProject();
-      if (this.projectService.getLocale().hasTranslations()) {
-        this.deleteTranslationsService.deleteComponents(components);
-      }
+      this.deleteTranslationsService.tryDeleteComponents(components);
     }
   }
 

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -60,9 +60,10 @@ export class ProjectAuthoringLessonComponent {
 
   protected delete(): void {
     if (confirm($localize`Are you sure you want to delete this lesson?`)) {
+      // get the components before they're removed by the following line
       const components = this.lesson.ids.flatMap(
         (nodeId) => this.projectService.getNodeById(nodeId).components
-      ); // get the components before they're removed by the following line
+      );
       this.deleteNodeService.deleteNode(this.lesson.id);
       this.saveAndRefreshProject();
       if (this.projectService.getLocale().hasTranslations()) {

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.spec.ts
@@ -15,6 +15,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { DeleteNodeService } from '../../services/deleteNodeService';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CopyNodesService } from '../../services/copyNodesService';
+import { DeleteTranslationsService } from '../../services/deleteTranslationsService';
 
 const nodeId1 = 'nodeId1';
 const node = { id: nodeId1 };
@@ -39,6 +40,7 @@ describe('ProjectAuthoringStepComponent', () => {
         ClassroomStatusService,
         CopyNodesService,
         DeleteNodeService,
+        DeleteTranslationsService,
         TeacherDataService,
         TeacherProjectService,
         TeacherWebSocketService

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
@@ -24,7 +24,7 @@ export class ProjectAuthoringStepComponent {
     private copyNodesService: CopyNodesService,
     private dataService: TeacherDataService,
     private deleteNodeService: DeleteNodeService,
-    private deleteTranslationService: DeleteTranslationsService,
+    private deleteTranslationsService: DeleteTranslationsService,
     private projectService: TeacherProjectService,
     private route: ActivatedRoute,
     private router: Router
@@ -116,9 +116,7 @@ export class ProjectAuthoringStepComponent {
       const components = this.step.components;
       this.deleteNodeService.deleteNode(this.step.id);
       this.saveAndRefreshProject();
-      if (this.projectService.getLocale().hasTranslations()) {
-        this.deleteTranslationService.deleteComponents(components);
-      }
+      this.deleteTranslationsService.tryDeleteComponents(components);
     }
   }
 

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
@@ -6,6 +6,7 @@ import { SelectNodeEvent } from '../domain/select-node-event';
 import { NodeTypeSelected } from '../domain/node-type-selected';
 import { DeleteNodeService } from '../../services/deleteNodeService';
 import { CopyNodesService } from '../../services/copyNodesService';
+import { DeleteTranslationsService } from '../../services/deleteTranslationsService';
 
 @Component({
   selector: 'project-authoring-step',
@@ -23,6 +24,7 @@ export class ProjectAuthoringStepComponent {
     private copyNodesService: CopyNodesService,
     private dataService: TeacherDataService,
     private deleteNodeService: DeleteNodeService,
+    private deleteTranslationService: DeleteTranslationsService,
     private projectService: TeacherProjectService,
     private route: ActivatedRoute,
     private router: Router
@@ -110,8 +112,12 @@ export class ProjectAuthoringStepComponent {
 
   protected delete(): void {
     if (confirm($localize`Are you sure you want to delete this step?`)) {
+      const components = this.step.components; // get the components before they're removed by the following line
       this.deleteNodeService.deleteNode(this.step.id);
       this.saveAndRefreshProject();
+      if (this.projectService.getLocale().hasTranslations()) {
+        this.deleteTranslationService.deleteComponents(components);
+      }
     }
   }
 

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
@@ -112,7 +112,8 @@ export class ProjectAuthoringStepComponent {
 
   protected delete(): void {
     if (confirm($localize`Are you sure you want to delete this step?`)) {
-      const components = this.step.components; // get the components before they're removed by the following line
+      // get the components before they're removed by the following line
+      const components = this.step.components;
       this.deleteNodeService.deleteNode(this.step.id);
       this.saveAndRefreshProject();
       if (this.projectService.getLocale().hasTranslations()) {

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
@@ -38,6 +38,7 @@ import { of } from 'rxjs/internal/observable/of';
 import { HttpClient } from '@angular/common/http';
 import { AddLessonButtonComponent } from '../add-lesson-button/add-lesson-button.component';
 import { AddStepButtonComponent } from '../add-step-button/add-step-button.component';
+import { DeleteTranslationsService } from '../../services/deleteTranslationsService';
 
 let configService: ConfigService;
 let component: ProjectAuthoringComponent;
@@ -83,6 +84,7 @@ describe('ProjectAuthoringComponent', () => {
         ClassroomStatusService,
         CopyNodesService,
         DeleteNodeService,
+        DeleteTranslationsService,
         MoveNodesService,
         TeacherDataService,
         TeacherProjectService,

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -87,10 +87,7 @@ export class ProjectAuthoringComponent implements OnInit {
 
   protected deleteSelectedNodes(): void {
     const selectedNodeIds = this.getSelectedNodeIds();
-    const confirmMessage =
-      selectedNodeIds.length === 1
-        ? $localize`Are you sure you want to delete the selected item?`
-        : $localize`Are you sure you want to delete the ${selectedNodeIds.length} selected items?`;
+    const confirmMessage = $localize`Are you sure you want to delete the ${selectedNodeIds.length} selected item(s)?`;
     if (confirm(confirmMessage)) {
       // get the components before they're removed by the following line
       const components = this.getComponents(selectedNodeIds);
@@ -98,18 +95,15 @@ export class ProjectAuthoringComponent implements OnInit {
       this.removeLessonIdToExpandedEntries(selectedNodeIds);
       this.projectService.saveProject();
       this.refreshProject();
-      if (this.projectService.getLocale().hasTranslations()) {
-        this.deleteTranslationsService.deleteComponents(components);
-      }
+      this.deleteTranslationsService.tryDeleteComponents(components);
     }
   }
 
   private getComponents(nodeIds: string[]): ComponentContent[] {
-    return nodeIds.flatMap((nodeId) => {
-      const node = this.projectService.getNodeById(nodeId);
+    return nodeIds.flatMap((nodeId: string) => {
       return this.projectService.isGroupNode(nodeId)
-        ? node.ids.flatMap((nodeId) => this.projectService.getNodeById(nodeId).components)
-        : node.components;
+        ? this.projectService.getComponentsFromLesson(nodeId)
+        : this.projectService.getComponentsFromStep(nodeId);
     });
   }
 

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -92,7 +92,8 @@ export class ProjectAuthoringComponent implements OnInit {
         ? $localize`Are you sure you want to delete the selected item?`
         : $localize`Are you sure you want to delete the ${selectedNodeIds.length} selected items?`;
     if (confirm(confirmMessage)) {
-      const components = this.getComponents(selectedNodeIds); // get the components before they're removed by the following line
+      // get the components before they're removed by the following line
+      const components = this.getComponents(selectedNodeIds);
       selectedNodeIds.forEach((nodeId) => this.deleteNodeService.deleteNode(nodeId));
       this.removeLessonIdToExpandedEntries(selectedNodeIds);
       this.projectService.saveProject();

--- a/src/assets/wise5/services/deleteTranslationsService.ts
+++ b/src/assets/wise5/services/deleteTranslationsService.ts
@@ -18,7 +18,13 @@ export class DeleteTranslationsService extends ProjectTranslationService {
     super(configService, http, projectService);
   }
 
-  async deleteComponents(components: ComponentContent[]): Promise<void> {
+  tryDeleteComponents(components: ComponentContent[]): void {
+    if (this.projectService.getLocale().hasTranslations()) {
+      this.deleteComponents(components);
+    }
+  }
+
+  private async deleteComponents(components: ComponentContent[]): Promise<void> {
     const allTranslations = await this.fetchAllTranslations();
     const i18nKeys = components.flatMap((component) => this.getI18NKeys(component));
     const saveTranslationRequests: Observable<Object>[] = [];

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -12,6 +12,7 @@ import { generateRandomKey } from '../common/string/string';
 import { branchPathBackgroundColors } from '../common/color/color';
 import { reduceByUniqueId } from '../common/array/array';
 import { NodeTypeSelected } from '../authoringTool/domain/node-type-selected';
+import { ComponentContent } from '../common/ComponentContent';
 
 @Injectable()
 export class TeacherProjectService extends ProjectService {
@@ -3089,5 +3090,15 @@ export class TeacherProjectService extends ProjectService {
 
   getNodeTypeSelected(): Signal<NodeTypeSelected> {
     return this.nodeTypeSelected.asReadonly();
+  }
+
+  getComponentsFromStep(nodeId: string): ComponentContent[] {
+    return this.getNodeById(nodeId).components;
+  }
+
+  getComponentsFromLesson(lessonId: string): ComponentContent[] {
+    return this.getNodeById(lessonId).ids.flatMap((nodeId: string) =>
+      this.getComponentsFromStep(nodeId)
+    );
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12479,18 +12479,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">101</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="791981839110791639" datatype="html">
-        <source>Are you sure you want to delete the selected item?</source>
+      <trans-unit id="5775641662261420108" datatype="html">
+        <source>Are you sure you want to delete the <x id="PH" equiv-text="selectedNodeIds.length"/> selected item(s)?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">92</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1189930234736223663" datatype="html">
-        <source>Are you sure you want to delete the <x id="PH" equiv-text="selectedNodeIds.length"/> selected items?</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">93</context>
+          <context context-type="linenumber">90</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e8fb2ceb6f8d4c3e90a6a688e9024461e67f44f0" datatype="html">
@@ -21480,7 +21473,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">97</context>
+          <context context-type="linenumber">98</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7975589013595125523" datatype="html">
@@ -21491,11 +21484,11 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">110</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">151</context>
+          <context context-type="linenumber">152</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5946383547512220582" datatype="html">
@@ -21506,11 +21499,11 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">110</context>
+          <context context-type="linenumber">111</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">152</context>
+          <context context-type="linenumber">153</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3177789104763917185" datatype="html">
@@ -21528,7 +21521,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">119</context>
+          <context context-type="linenumber">120</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6590475405017990661" datatype="html">
@@ -21539,7 +21532,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">121</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7008439939460403347" datatype="html">
@@ -21550,7 +21543,7 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4200122564420479235" datatype="html">
@@ -21767,145 +21760,145 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>First Lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2017855920890197640" datatype="html">
         <source>First Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">75</context>
+          <context context-type="linenumber">76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8104421162933956065" datatype="html">
         <source>Notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">111</context>
+          <context context-type="linenumber">112</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">153</context>
+          <context context-type="linenumber">154</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5668531960608480573" datatype="html">
         <source>Final Report</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">128</context>
+          <context context-type="linenumber">129</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8604167983715964004" datatype="html">
         <source>Final summary report of what you learned in this unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">129</context>
+          <context context-type="linenumber">130</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4419148705442508208" datatype="html">
         <source>Use this space to write your final report using evidence from your notebook.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">130</context>
+          <context context-type="linenumber">131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2128364009265696768" datatype="html">
         <source>&lt;h3&gt;This is a heading&lt;/h3&gt;&lt;p&gt;This is a paragraph.&lt;/p&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">131</context>
+          <context context-type="linenumber">132</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3712572360135341203" datatype="html">
         <source>Teacher Notebook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">139</context>
+          <context context-type="linenumber">140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3422550137142657635" datatype="html">
         <source>teacher notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">161</context>
+          <context context-type="linenumber">162</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">162</context>
+          <context context-type="linenumber">163</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2558301014879118031" datatype="html">
         <source>Teacher Notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">163</context>
+          <context context-type="linenumber">164</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">170</context>
+          <context context-type="linenumber">171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2841850575512700640" datatype="html">
         <source>Notes for the teacher as they&apos;re running the WISE unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">171</context>
+          <context context-type="linenumber">172</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4383493915104232758" datatype="html">
         <source>Use this space to take notes for this unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">172</context>
+          <context context-type="linenumber">173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8373748870534083811" datatype="html">
         <source>&lt;p&gt;Use this space to take notes for this unit&lt;/p&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">173</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4358283284933461426" datatype="html">
         <source>All steps after this one will not be visitable until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">945</context>
+          <context context-type="linenumber">946</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5548702737138673668" datatype="html">
         <source>All steps after this one will not be visible until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">948</context>
+          <context context-type="linenumber">949</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3112051127445790513" datatype="html">
         <source>All other steps will not be visitable until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">951</context>
+          <context context-type="linenumber">952</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2264443134334419091" datatype="html">
         <source>All other steps will not be visible until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">954</context>
+          <context context-type="linenumber">955</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6819040711904864999" datatype="html">
         <source>This step will not be visitable until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">957</context>
+          <context context-type="linenumber">958</context>
         </context-group>
       </trans-unit>
       <trans-unit id="816962217622004346" datatype="html">
         <source>This step will not be visible until </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherProjectService.ts</context>
-          <context context-type="linenumber">960</context>
+          <context context-type="linenumber">961</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6103908175957925049" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12367,7 +12367,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete this lesson?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0788cea8f340f4f5399901765d2003f90af76669" datatype="html">
@@ -12434,7 +12434,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete this step?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts</context>
-          <context context-type="linenumber">112</context>
+          <context context-type="linenumber">114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="57cf305f9bfd681c70dc26e914108d06384ade9f" datatype="html">
@@ -12483,14 +12483,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete the selected item?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">89</context>
+          <context context-type="linenumber">92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1189930234736223663" datatype="html">
         <source>Are you sure you want to delete the <x id="PH" equiv-text="selectedNodeIds.length"/> selected items?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">90</context>
+          <context context-type="linenumber">93</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e8fb2ceb6f8d4c3e90a6a688e9024461e67f44f0" datatype="html">


### PR DESCRIPTION
## Changes
- Delete translations associated with deleted step(s) and lesson(s). 

## Test Prep
- Test with ```issue-259-implement-unit-tagging``` API branch

## Test
- Multilingual unit:
   - Associated translation entries are deleted from translations.[language].json files (for all supported languages) when you delete 
      - one step 
      - multiple steps together
      - one lesson
      - multiple lessons together
- Non-multilingual unit:
   - Deleting steps and lessons work as before 
