### PR TITLE
refactor(SearchBarComponent): convert to standalone

### DIFF
--- a/src/app/modules/library/library.module.ts
+++ b/src/app/modules/library/library.module.ts
@@ -50,6 +50,7 @@ import { LibraryPaginatorIntl } from './libraryPaginatorIntl';
 import { DiscourseCategoryActivityComponent } from './discourse-category-activity/discourse-category-activity.component';
 import { SelectAllItemsCheckboxComponent } from './select-all-items-checkbox/select-all-items-checkbox.component';
 import { ArchiveProjectsButtonComponent } from '../../teacher/archive-projects-button/archive-projects-button.component';
+import { SearchBarComponent } from '../shared/search-bar/search-bar.component';
 
 const materialModules = [
   MatAutocompleteModule,
@@ -81,6 +82,7 @@ const materialModules = [
     ReactiveFormsModule,
     RouterModule,
     materialModules,
+    SearchBarComponent,
     SharedModule,
     TimelineModule
   ],

--- a/src/app/modules/shared/search-bar/search-bar.component.spec.ts
+++ b/src/app/modules/shared/search-bar/search-bar.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { SearchBarComponent } from './search-bar.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('SearchBarComponent', () => {
   let component: SearchBarComponent;
   let fixture: ComponentFixture<SearchBarComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [SearchBarComponent],
-      imports: [],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [BrowserAnimationsModule, SearchBarComponent]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SearchBarComponent);

--- a/src/app/modules/shared/search-bar/search-bar.component.ts
+++ b/src/app/modules/shared/search-bar/search-bar.component.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import {
   Component,
   EventEmitter,
@@ -7,61 +8,61 @@ import {
   SimpleChanges,
   ViewEncapsulation
 } from '@angular/core';
-import { FormControl } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 
 @Component({
+  encapsulation: ViewEncapsulation.None,
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    ReactiveFormsModule
+  ],
   selector: 'app-search-bar',
-  templateUrl: './search-bar.component.html',
-  styleUrls: ['./search-bar.component.scss'],
-  encapsulation: ViewEncapsulation.None
+  standalone: true,
+  styleUrl: './search-bar.component.scss',
+  templateUrl: './search-bar.component.html'
 })
 export class SearchBarComponent implements OnInit {
-  @Input()
-  placeholderText: string = $localize`Search`; // placeholder text
+  @Output('update') change: EventEmitter<string> = new EventEmitter<string>();
+  @Input() debounce: number = 250;
+  @Input() disable: boolean;
+  @Input() placeholderText: string = $localize`Search`;
+  protected searchField = new FormControl('');
+  @Input() value: string = '';
 
-  @Input()
-  disable: boolean = false; // whether input is disabled
-
-  @Input()
-  value: string = ''; // search string
-
-  @Input()
-  debounce: number = 250; // time to wait for changes (milliseconds)
-
-  @Output('update')
-  change: EventEmitter<string> = new EventEmitter<string>(); // change event emitter
-
-  searchField = new FormControl(''); // form control for the search input
-
-  constructor() {}
-
-  ngOnInit() {
+  ngOnInit(): void {
     this.searchField = new FormControl({
       value: this.value,
       disabled: this.disable
     });
     this.searchField.valueChanges
-      .pipe(debounceTime(this.debounce)) // wait specified interval for any changes
-      .pipe(distinctUntilChanged()) // only emit event if search string has changed
+      .pipe(debounceTime(this.debounce))
+      .pipe(distinctUntilChanged())
       .subscribe((value) => {
         this.change.emit(this.searchField.value);
       });
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges): void {
     if (changes.value) {
       this.value = changes.value.currentValue;
       this.searchField.setValue(this.value);
     }
-
     if (changes.disable) {
       this.disable = changes.disable.currentValue;
       this.disable ? this.searchField.disable() : this.searchField.enable();
     }
   }
 
-  clear() {
+  protected clear(): void {
     this.searchField.setValue('');
   }
 }

--- a/src/app/modules/shared/shared.module.ts
+++ b/src/app/modules/shared/shared.module.ts
@@ -25,7 +25,6 @@ const materialModules = [
 import { BlurbComponent } from './blurb/blurb.component';
 import { CallToActionComponent } from './call-to-action/call-to-action.component';
 import { HeroSectionComponent } from './hero-section/hero-section.component';
-import { SearchBarComponent } from './search-bar/search-bar.component';
 import { SelectMenuComponent } from './select-menu/select-menu.component';
 import { EditPasswordComponent } from './edit-password/edit-password.component';
 import { UnlinkGoogleAccountConfirmComponent } from './unlink-google-account-confirm/unlink-google-account-confirm.component';
@@ -49,7 +48,6 @@ import { PasswordModule } from '../../password/password.module';
     BlurbComponent,
     CallToActionComponent,
     HeroSectionComponent,
-    SearchBarComponent,
     SelectMenuComponent,
     EditPasswordComponent
   ],
@@ -57,13 +55,11 @@ import { PasswordModule } from '../../password/password.module';
     BlurbComponent,
     CallToActionComponent,
     HeroSectionComponent,
-    SearchBarComponent,
     SelectMenuComponent,
     EditPasswordComponent,
     UnlinkGoogleAccountConfirmComponent,
     UnlinkGoogleAccountPasswordComponent,
     UnlinkGoogleAccountSuccessComponent
-  ],
-  providers: []
+  ]
 })
 export class SharedModule {}

--- a/src/app/student/student.module.ts
+++ b/src/app/student/student.module.ts
@@ -37,6 +37,7 @@ import { StudentEditProfileComponent } from './account/edit-profile/edit-profile
 import { TimelineModule } from '../modules/timeline/timeline.module';
 import { TeamSignInDialogComponent } from './team-sign-in-dialog/team-sign-in-dialog.component';
 import { GoogleSignInModule } from '../modules/google-sign-in/google-sign-in.module';
+import { SearchBarComponent } from '../modules/shared/search-bar/search-bar.component';
 
 @NgModule({
   imports: [
@@ -46,6 +47,7 @@ import { GoogleSignInModule } from '../modules/google-sign-in/google-sign-in.mod
     GoogleSignInModule,
     ReactiveFormsModule,
     materialModules,
+    SearchBarComponent,
     SharedModule,
     StudentRoutingModule,
     TimelineModule

--- a/src/app/teacher/teacher-run-list/teacher-run-list.component.spec.ts
+++ b/src/app/teacher/teacher-run-list/teacher-run-list.component.spec.ts
@@ -5,7 +5,6 @@ import { TeacherService } from '../teacher.service';
 import { TeacherRun } from '../teacher-run';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ConfigService } from '../../services/config.service';
-import { RouterTestingModule } from '@angular/router/testing';
 import { UserService } from '../../services/user.service';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { User } from '../../domain/user';
@@ -31,6 +30,7 @@ import { Project } from '../../domain/project';
 import { SearchBarComponent } from '../../modules/shared/search-bar/search-bar.component';
 import { HttpClient } from '@angular/common/http';
 import { ArchiveProjectResponse } from '../../domain/archiveProjectResponse';
+import { provideRouter } from '@angular/router';
 
 class TeacherScheduleStubComponent {}
 
@@ -81,12 +81,7 @@ describe('TeacherRunListComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [
-          RunMenuComponent,
-          SearchBarComponent,
-          TeacherRunListComponent,
-          TeacherRunListItemComponent
-        ],
+        declarations: [RunMenuComponent, TeacherRunListComponent, TeacherRunListItemComponent],
         imports: [
           ArchiveProjectsButtonComponent,
           BrowserAnimationsModule,
@@ -102,12 +97,18 @@ describe('TeacherRunListComponent', () => {
           MatSelectModule,
           MatSnackBarModule,
           ReactiveFormsModule,
-          RouterTestingModule.withRoutes([
-            { path: 'teacher/home/schedule', component: TeacherScheduleStubComponent }
-          ]),
+          SearchBarComponent,
           SelectRunsControlsModule
         ],
-        providers: [ArchiveProjectService, ConfigService, TeacherService, UserService],
+        providers: [
+          ArchiveProjectService,
+          ConfigService,
+          provideRouter([
+            { path: 'teacher/home/schedule', component: TeacherScheduleStubComponent }
+          ]),
+          TeacherService,
+          UserService
+        ],
         schemas: [NO_ERRORS_SCHEMA]
       });
     })

--- a/src/app/teacher/teacher.module.ts
+++ b/src/app/teacher/teacher.module.ts
@@ -42,6 +42,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatListModule } from '@angular/material/list';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { SelectRunsControlsModule } from './select-runs-controls/select-runs-controls.module';
+import { SearchBarComponent } from '../modules/shared/search-bar/search-bar.component';
 
 const materialModules = [
   MatAutocompleteModule,
@@ -71,6 +72,7 @@ const materialModules = [
     FormsModule,
     LibraryModule,
     materialModules,
+    SearchBarComponent,
     SharedModule,
     SelectRunsControlsModule,
     TeacherRoutingModule,

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -6161,7 +6161,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Search</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/shared/search-bar/search-bar.component.ts</context>
-          <context context-type="linenumber">21</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7f32abe3fc638f65c0d3eb269d478ee49ad41ebe" datatype="html">


### PR DESCRIPTION
## Changes
- Convert SearchBarComponent to standalone component
- Clean up SearchBarComponent and spec file by removing unused code
- Remove SearchBarComponent from SharedModule and import SearchBarComponent in places where they're used

## Test
- SearchBarComponent displays and works as before in
   - Unit library
   - Teacher run list
   - Student run list