### PR TITLE
refactor(BlurbComponent): Convert to standalone

### DIFF
--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -1,15 +1,22 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-
 import { HomeComponent } from './home.component';
 import { HomeRoutingModule } from './home-routing.module';
 import { LibraryModule } from '../modules/library/library.module';
 import { SharedModule } from '../modules/shared/shared.module';
 import { DiscourseLatestNewsComponent } from './discourse-latest-news/discourse-latest-news.component';
+import { BlurbComponent } from '../modules/shared/blurb/blurb.component';
 
 @NgModule({
-  imports: [CommonModule, HomeRoutingModule, LibraryModule, SharedModule, RouterModule],
+  imports: [
+    BlurbComponent,
+    CommonModule,
+    HomeRoutingModule,
+    LibraryModule,
+    SharedModule,
+    RouterModule
+  ],
   declarations: [HomeComponent, DiscourseLatestNewsComponent],
   exports: [HomeComponent, SharedModule]
 })

--- a/src/app/modules/shared/blurb/blurb.component.spec.ts
+++ b/src/app/modules/shared/blurb/blurb.component.spec.ts
@@ -1,24 +1,20 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { BlurbComponent } from './blurb.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 describe('BlurbComponent', () => {
   let component: BlurbComponent;
   let fixture: ComponentFixture<BlurbComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [BlurbComponent],
-      imports: [],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(BlurbComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [BlurbComponent]
+      }).compileComponents();
+      fixture = TestBed.createComponent(BlurbComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    })
+  );
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/src/app/modules/shared/blurb/blurb.component.ts
+++ b/src/app/modules/shared/blurb/blurb.component.ts
@@ -1,31 +1,19 @@
-import { Component, ContentChild, Input, OnInit, TemplateRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, ContentChild, Input, TemplateRef } from '@angular/core';
 
 @Component({
+  imports: [CommonModule],
   selector: 'app-blurb',
-  templateUrl: './blurb.component.html',
-  styleUrls: ['./blurb.component.scss']
+  standalone: true,
+  styleUrl: './blurb.component.scss',
+  templateUrl: './blurb.component.html'
 })
-export class BlurbComponent implements OnInit {
-  @Input()
-  imgSrc: string;
-
-  @Input()
-  imgDescription: string;
-
-  @Input()
-  imgSources: Object;
-
-  @Input()
-  headline: string;
-
-  @ContentChild('headlineTemplate', { static: false }) headlineRef: TemplateRef<any>;
-
-  @Input()
-  content: string;
-
+export class BlurbComponent {
+  @Input() content: string;
   @ContentChild('contentTemplate', { static: false }) contentRef: TemplateRef<any>;
-
-  constructor() {}
-
-  ngOnInit() {}
+  @Input() headline: string;
+  @ContentChild('headlineTemplate', { static: false }) headlineRef: TemplateRef<any>;
+  @Input() imgDescription: string;
+  @Input() imgSources: Object;
+  @Input() imgSrc: string;
 }

--- a/src/app/modules/shared/shared.module.ts
+++ b/src/app/modules/shared/shared.module.ts
@@ -22,7 +22,6 @@ const materialModules = [
   MatProgressBarModule
 ];
 
-import { BlurbComponent } from './blurb/blurb.component';
 import { CallToActionComponent } from './call-to-action/call-to-action.component';
 import { HeroSectionComponent } from './hero-section/hero-section.component';
 import { SelectMenuComponent } from './select-menu/select-menu.component';
@@ -45,14 +44,12 @@ import { PasswordModule } from '../../password/password.module';
   exports: [
     materialModules,
     FlexLayoutModule,
-    BlurbComponent,
     CallToActionComponent,
     HeroSectionComponent,
     SelectMenuComponent,
     EditPasswordComponent
   ],
   declarations: [
-    BlurbComponent,
     CallToActionComponent,
     HeroSectionComponent,
     SelectMenuComponent,


### PR DESCRIPTION
## Changes
- Convert BlurbComponent to standalone component
- Clean up BlurbComponent and spec file by removing unused code
- Move BlurbComponent from SharedModule to HomeModule

## Test
- On the homepage, the blurbs (3 boxes under the "The WISE Advantage" section) appear as before and the "NGSS 3D proficiency" link works