### PR TITLE
feat(Translation): Make source language text display more visible

### DIFF
--- a/src/assets/wise5/authoringTool/components/abstract-translatable-field/abstract-translatable-field.component.scss
+++ b/src/assets/wise5/authoringTool/components/abstract-translatable-field/abstract-translatable-field.component.scss
@@ -1,0 +1,16 @@
+.translatable {
+  width: 100%;
+
+  .mat-mdc-form-field-hint-wrapper {
+    position: relative;
+    margin: -16px 0 4px;
+  }
+
+  .mat-mdc-form-field-hint-spacer {
+    display: none;
+  }
+
+  .source-language {
+    padding: 4px 8px;
+  }
+}

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
@@ -7,7 +7,7 @@
     placeholder="{{ placeholder }}"
   />
 </mat-form-field>
-<mat-form-field *ngIf="showTranslationInput()">
+<mat-form-field *ngIf="showTranslationInput()" class="translatable">
   <mat-label>{{ label }} ({{ currentLanguage().language }})</mat-label>
   <input
     matInput
@@ -15,5 +15,8 @@
     (ngModelChange)="translationTextChanged.next($event)"
     placeholder="{{ placeholder }}"
   />
-  <mat-hint>[{{ defaultLanguage.language }}] {{ content[key] }}</mat-hint>
+  <mat-hint class="source-language selected-bg-bg">
+    <strong><mat-icon>translate</mat-icon> {{ defaultLanguage.language }}:</strong>
+    {{ content[key] }}
+  </mat-hint>
 </mat-form-field>

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.scss
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.scss
@@ -1,3 +1,0 @@
-mat-form-field {
-  width: 100%;
-}

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
@@ -9,10 +9,7 @@ import { MatIconModule } from '@angular/material/icon';
   standalone: true,
   selector: 'translatable-input',
   imports: [CommonModule, FormsModule, MatIconModule, MatInputModule],
-  styleUrls: [
-    '../abstract-translatable-field/abstract-translatable-field.component.scss',
-    './translatable-input.component.scss'
-  ],
+  styleUrls: ['../abstract-translatable-field/abstract-translatable-field.component.scss'],
   templateUrl: './translatable-input.component.html',
   encapsulation: ViewEncapsulation.None
 })

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.ts
@@ -1,14 +1,19 @@
-import { Component } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatInputModule } from '@angular/material/input';
 import { FormsModule } from '@angular/forms';
 import { AbstractTranslatableFieldComponent } from '../abstract-translatable-field/abstract-translatable-field.component';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   standalone: true,
   selector: 'translatable-input',
-  imports: [CommonModule, FormsModule, MatInputModule],
-  styleUrls: ['./translatable-input.component.scss'],
-  templateUrl: './translatable-input.component.html'
+  imports: [CommonModule, FormsModule, MatIconModule, MatInputModule],
+  styleUrls: [
+    '../abstract-translatable-field/abstract-translatable-field.component.scss',
+    './translatable-input.component.scss'
+  ],
+  templateUrl: './translatable-input.component.html',
+  encapsulation: ViewEncapsulation.None
 })
 export class TranslatableInputComponent extends AbstractTranslatableFieldComponent {}

--- a/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.html
@@ -9,7 +9,7 @@
   >
   </textarea>
 </mat-form-field>
-<mat-form-field *ngIf="showTranslationInput()">
+<mat-form-field *ngIf="showTranslationInput()" class="translatable">
   <mat-label>{{ label }} ({{ currentLanguage().language }})</mat-label>
   <textarea
     matInput
@@ -18,5 +18,8 @@
     placeholder="{{ placeholder }}"
     cdkTextareaAutosize
   ></textarea>
-  <mat-hint>[{{ defaultLanguage.language }}] {{ content[key] }}</mat-hint>
+  <mat-hint class="source-language selected-bg-bg">
+    <strong><mat-icon>translate</mat-icon> {{ defaultLanguage.language }}:</strong>
+    {{ content[key] }}
+  </mat-hint>
 </mat-form-field>

--- a/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.scss
+++ b/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.scss
@@ -1,3 +1,0 @@
-mat-form-field {
-  width: 100%;
-}

--- a/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.ts
@@ -9,10 +9,7 @@ import { MatIconModule } from '@angular/material/icon';
   standalone: true,
   selector: 'translatable-textarea',
   imports: [CommonModule, FormsModule, MatIconModule, MatInputModule],
-  styleUrls: [
-    '../abstract-translatable-field/abstract-translatable-field.component.scss',
-    './translatable-textarea.component.scss'
-  ],
+  styleUrls: ['../abstract-translatable-field/abstract-translatable-field.component.scss'],
   templateUrl: './translatable-textarea.component.html',
   encapsulation: ViewEncapsulation.None
 })

--- a/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.ts
+++ b/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.ts
@@ -1,14 +1,19 @@
-import { Component } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { AbstractTranslatableFieldComponent } from '../abstract-translatable-field/abstract-translatable-field.component';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   standalone: true,
   selector: 'translatable-textarea',
-  imports: [CommonModule, FormsModule, MatInputModule],
-  styleUrls: ['./translatable-textarea.component.scss'],
-  templateUrl: './translatable-textarea.component.html'
+  imports: [CommonModule, FormsModule, MatIconModule, MatInputModule],
+  styleUrls: [
+    '../abstract-translatable-field/abstract-translatable-field.component.scss',
+    './translatable-textarea.component.scss'
+  ],
+  templateUrl: './translatable-textarea.component.html',
+  encapsulation: ViewEncapsulation.None
 })
 export class TranslatableTextareaComponent extends AbstractTranslatableFieldComponent {}

--- a/src/assets/wise5/components/conceptMap/concept-map-authoring/concept-map-authoring.component.html
+++ b/src/assets/wise5/components/conceptMap/concept-map-authoring/concept-map-authoring.component.html
@@ -87,7 +87,7 @@
         "
         class="content-item"
         fxLayout="row wrap"
-        fxLayoutAlign="start center"
+        fxLayoutAlign="start start"
       >
         <translatable-input
           fxFlex="100"
@@ -102,7 +102,7 @@
         />
         <div
           class="content-item-setting"
-          fxLayoutAlign="start center"
+          fxLayoutAlign="start start"
           fxLayoutGap="8px"
           fxFlex="100"
           fxFlex.sm="60"
@@ -233,7 +233,7 @@
         "
         class="content-item"
         fxLayout="row wrap"
-        fxLayoutAlign="start center"
+        fxLayoutAlign="start start"
         fxLayouGap="16px"
       >
         <translatable-input

--- a/src/assets/wise5/components/label/label-authoring/label-authoring.component.html
+++ b/src/assets/wise5/components/label/label-authoring/label-authoring.component.html
@@ -125,7 +125,7 @@
     *ngFor="let label of componentContent.labels; index as labelIndex"
     class="starter-label-container"
   >
-    <div fxLayout="row">
+    <div fxLayout="row wrap" fxLayoutAlign="start start">
       <translatable-input
         [content]="label"
         key="text"

--- a/src/assets/wise5/components/match/match-authoring/match-authoring.component.html
+++ b/src/assets/wise5/components/match/match-authoring/match-authoring.component.html
@@ -256,7 +256,7 @@
           Is Correct
         </mat-checkbox>
       </div>
-      <div *ngIf="componentContent.ordered && choiceFeedback.isCorrect" fxLayout="row">
+      <div *ngIf="componentContent.ordered && choiceFeedback.isCorrect" fxLayout="row" fxLayoutAlign="start start">
         <mat-form-field class="position">
           <mat-label i18n>Position</mat-label>
           <input


### PR DESCRIPTION
## Changes
- Add translation icon and give source language text a background to make more visible to translators
- Fix long source language text overlapping content below

## Test
- Make sure source language text still displays properly when in translation mode in the AT.
- Try adding some source language text content that is long so that the mat-hint element takes up multiple lines. Ensure that the source language mat-hint pushes content below down and doesn't overlap.
