### PR TITLE
feat(Tag): Add tag functionality to personal library

### DIFF
--- a/src/app/modules/library/home-page-project-library/home-page-project-library.component.html
+++ b/src/app/modules/library/home-page-project-library/home-page-project-library.component.html
@@ -1,6 +1,6 @@
 <div class="library library-home notice-bg-bg">
   <div fxLayout="column" fxLayout.gt-sm="row">
-    <div class="content-block controls dark-theme library__header primary-bg" fxFlex.gt-sm="33">
+    <div class="content-block dark-theme library__header primary-bg" fxFlex.gt-sm="33">
       <app-library-filters [isSplitScreen]="true"></app-library-filters>
     </div>
     <div class="library__content library-home__content content-block" fxFlex.gt-sm="67">

--- a/src/app/modules/library/home-page-project-library/home-page-project-library.component.scss
+++ b/src/app/modules/library/home-page-project-library/home-page-project-library.component.scss
@@ -18,3 +18,8 @@
   max-width: none;
 }
 
+.content-block {
+  padding: 16px;
+  border-radius: 0;
+}
+

--- a/src/app/modules/library/library-filters/library-filters.component.html
+++ b/src/app/modules/library/library-filters/library-filters.component.html
@@ -32,12 +32,7 @@
       (NGSS).</ng-container
     >&nbsp;<a *ngIf="hasFilters()" href="#" (click)="!!clearFilterValues()" i18n>Reset</a>
   </div>
-  <div
-    fxLayout="column"
-    fxLayout.gt-sm="{{ isSplitScreen ? 'column' : 'row' }}"
-    fxLayoutGap="0"
-    fxLayoutGap.gt-sm="{{ isSplitScreen ? '0' : '8px' }}"
-  >
+  <div fxLayout="column" fxLayout.gt-sm="{{ isSplitScreen ? 'column' : 'row' }}" fxLayoutGap="8px">
     <div
       *ngIf="disciplineOptions.length > 0"
       class="library-filter"

--- a/src/app/modules/library/library-project/library-project.component.html
+++ b/src/app/modules/library/library-project/library-project.component.html
@@ -42,5 +42,12 @@
     <p *ngIf="project.shared" class="info mat-caption" i18n>
       Shared by {{ project.owner.displayName }}
     </p>
+    <mat-chip-set aria-label="Unit tags" i18n-aria-label>
+      <ng-container *ngFor="let tag of project.tags">
+        <mat-chip *ngIf="tag.text !== 'archived'" [ngStyle]="{ 'background-color': tag.color }">
+          {{ tag.text }}
+        </mat-chip>
+      </ng-container>
+    </mat-chip-set>
   </div>
 </mat-card>

--- a/src/app/modules/library/library.module.ts
+++ b/src/app/modules/library/library.module.ts
@@ -50,6 +50,10 @@ import { LibraryPaginatorIntl } from './libraryPaginatorIntl';
 import { DiscourseCategoryActivityComponent } from './discourse-category-activity/discourse-category-activity.component';
 import { ArchiveProjectsButtonComponent } from '../../teacher/archive-projects-button/archive-projects-button.component';
 import { SelectAllItemsCheckboxComponent } from './select-all-items-checkbox/select-all-items-checkbox.component';
+import { ApplyTagsButtonComponent } from '../../teacher/apply-tags-button/apply-tags-button.component';
+import { SelectTagsComponent } from '../../teacher/select-tags/select-tags.component';
+import { MatChipsModule } from '@angular/material/chips';
+import { SelectedTagsListComponent } from '../../teacher/selected-tags-list/selected-tags-list.component';
 
 const materialModules = [
   MatAutocompleteModule,
@@ -57,6 +61,7 @@ const materialModules = [
   MatButtonModule,
   MatCardModule,
   MatCheckboxModule,
+  MatChipsModule,
   MatDialogModule,
   MatDividerModule,
   MatExpansionModule,
@@ -74,6 +79,7 @@ const materialModules = [
 
 @NgModule({
   imports: [
+    ApplyTagsButtonComponent,
     ArchiveProjectsButtonComponent,
     CommonModule,
     FlexLayoutModule,
@@ -82,6 +88,8 @@ const materialModules = [
     RouterModule,
     materialModules,
     SelectAllItemsCheckboxComponent,
+    SelectTagsComponent,
+    SelectedTagsListComponent,
     SharedModule,
     TimelineModule
   ],

--- a/src/app/modules/library/personal-library/personal-library.component.html
+++ b/src/app/modules/library/personal-library/personal-library.component.html
@@ -2,14 +2,20 @@
   <div class="personal-library-header" fxLayoutAlign="center center" fxLayoutGap="8px">
     <a class="mat-caption" href="#" (click)="showInfo($event)" i18n>What are My Units?</a>
     <span fxFlex></span>
+    <select-tags [selectedTags]="selectedTags" (selectTagEvent)="selectTags($event)"></select-tags>
     <mat-form-field [subscriptSizing]="'dynamic'">
-      <mat-label>View</mat-label>
+      <mat-label i18n>View</mat-label>
       <mat-select [(ngModel)]="showArchivedView" (selectionChange)="switchActiveArchivedView()">
         <mat-option [value]="false" i18n>Active</mat-option>
         <mat-option [value]="true" i18n>Archived</mat-option>
       </mat-select>
     </mat-form-field>
   </div>
+  <selected-tags-list
+    *ngIf="selectedTags.length > 0"
+    [tags]="selectedTags"
+    (removeTagEvent)="removeTag($event)"
+  ></selected-tags-list>
   <mat-divider></mat-divider>
   <div fxLayoutAlign="start center" fxLayout.xs="column" fxLayoutGap="8px">
     <div fxLayoutAlign="center center" fxLayoutGap="4px" fxFlexAlign.xs="start" fxFlexOrder.xs="1">
@@ -28,6 +34,10 @@
         [showArchive]="!showArchivedView"
         (archiveProjectsEvent)="archiveProjects($event)"
       ></archive-projects-button>
+      <apply-tags-button
+        *ngIf="selectedProjects().length > 0"
+        [selectedProjects]="selectedProjects()"
+      ></apply-tags-button>
     </div>
     <span fxFlex fxHide.xs></span>
     <mat-paginator

--- a/src/app/modules/library/personal-library/personal-library.component.html
+++ b/src/app/modules/library/personal-library/personal-library.component.html
@@ -14,6 +14,7 @@
   <selected-tags-list
     *ngIf="selectedTags.length > 0"
     [tags]="selectedTags"
+    [showClearButton]="true"
     (removeTagEvent)="removeTag($event)"
   ></selected-tags-list>
   <mat-divider></mat-divider>

--- a/src/app/modules/library/personal-library/personal-library.component.ts
+++ b/src/app/modules/library/personal-library/personal-library.component.ts
@@ -138,17 +138,14 @@ export class PersonalLibraryComponent extends LibraryComponent {
   }
 
   protected updateSelectedProjects(event: ProjectSelectionEvent): void {
+    const selectedProjects = this.selectedProjects();
     if (event.selected) {
-      this.selectedProjects.update((selectedProjects) => {
-        selectedProjects.push(event.project);
-        return selectedProjects;
-      });
+      selectedProjects.push(event.project);
     } else {
-      this.selectedProjects.update((selectedProjects) => {
-        selectedProjects.splice(selectedProjects.indexOf(event.project), 1);
-        return selectedProjects;
-      });
+      selectedProjects.splice(selectedProjects.indexOf(event.project), 1);
     }
+    // create a new array to trigger change detection
+    this.selectedProjects.set([...selectedProjects]);
   }
 
   protected unselectAllProjects(): void {

--- a/src/app/modules/library/personal-library/personal-library.component.ts
+++ b/src/app/modules/library/personal-library/personal-library.component.ts
@@ -7,6 +7,8 @@ import { ProjectFilterValues } from '../../../domain/projectFilterValues';
 import { ArchiveProjectService } from '../../../services/archive-project.service';
 import { PageEvent } from '@angular/material/paginator';
 import { ProjectSelectionEvent } from '../../../domain/projectSelectionEvent';
+import { Tag } from '../../../domain/tag';
+import { Project } from '../../../domain/project';
 
 @Component({
   selector: 'app-personal-library',
@@ -27,6 +29,7 @@ export class PersonalLibraryComponent extends LibraryComponent {
   projects: LibraryProject[] = [];
   protected projectsLabel: string = $localize`Select all units`;
   protected selectedProjects: WritableSignal<LibraryProject[]> = signal([]);
+  protected selectedTags: Tag[] = [];
   protected sharedProjects: LibraryProject[] = [];
   protected showArchivedView: boolean = false;
 
@@ -115,6 +118,11 @@ export class PersonalLibraryComponent extends LibraryComponent {
     this.filteredProjects = this.filteredProjects.filter(
       (project) => project.hasTagWithText('archived') == this.showArchivedView
     );
+    if (this.selectedTags.length > 0) {
+      this.filteredProjects = this.filteredProjects.filter((project: Project) =>
+        this.selectedTags.some((tag: Tag) => project.hasTag(tag))
+      );
+    }
     this.numProjectsInView = this.getProjectsInView().length;
     this.unselectAllProjects();
   }
@@ -162,6 +170,16 @@ export class PersonalLibraryComponent extends LibraryComponent {
 
   protected archiveProjects(archive: boolean): void {
     this.archiveProjectService.archiveProjects(this.selectedProjects(), archive);
+  }
+
+  protected selectTags(tags: Tag[]): void {
+    this.selectedTags = tags;
+    this.filterUpdated();
+  }
+
+  protected removeTag(tag: Tag): void {
+    this.selectedTags = this.selectedTags.filter((selectedTag: Tag) => selectedTag.id !== tag.id);
+    this.filterUpdated();
   }
 }
 

--- a/src/app/modules/library/teacher-project-library/teacher-project-library.component.html
+++ b/src/app/modules/library/teacher-project-library/teacher-project-library.component.html
@@ -1,5 +1,5 @@
 <div class="library library-teacher notice-bg-bg">
-  <div class="content-block controls dark-theme library__header library-teacher__header primary-bg">
+  <div class="content-block filters dark-theme library__header library-teacher__header primary-bg">
     <app-library-filters></app-library-filters>
   </div>
   <div class="library__content library-teacher__content">

--- a/src/app/modules/library/teacher-project-library/teacher-project-library.component.scss
+++ b/src/app/modules/library/teacher-project-library/teacher-project-library.component.scss
@@ -12,6 +12,12 @@
   }
 }
 
+.filters {
+  padding: 16px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
 .library-teacher__header {
   h3 {
     font-weight: 500;

--- a/src/app/modules/shared/search-bar/search-bar.component.html
+++ b/src/app/modules/shared/search-bar/search-bar.component.html
@@ -1,4 +1,9 @@
-<mat-form-field class="search-bar" appearance="fill" (click)="$event.stopPropagation()">
+<mat-form-field
+  class="search-bar"
+  appearance="fill"
+  [subscriptSizing]="'dynamic'"
+  (click)="$event.stopPropagation()"
+>
   <mat-label>{{ placeholderText }}</mat-label>
   <mat-icon matPrefix>search</mat-icon>
   <input matInput [formControl]="searchField" (keydown)="$event.stopPropagation()" />

--- a/src/app/modules/shared/select-menu/select-menu.component.html
+++ b/src/app/modules/shared/select-menu/select-menu.component.html
@@ -1,4 +1,4 @@
-<mat-form-field class="select-menu" appearance="fill">
+<mat-form-field class="select-menu" appearance="fill" [subscriptSizing]="'dynamic'">
   <mat-label>{{ placeholderText }}</mat-label>
   <mat-select
     [formControl]="selectField"

--- a/src/app/teacher/select-tags/select-tags.component.html
+++ b/src/app/teacher/select-tags/select-tags.component.html
@@ -1,5 +1,5 @@
-<mat-form-field>
-  <mat-label i18n>Tags</mat-label>
+<mat-form-field [subscriptSizing]="'dynamic'">
+  <mat-label i18n>Filter by tag</mat-label>
   <mat-select
     [(value)]="selectedTags"
     (selectionChange)="selectTagEvent.emit(selectedTags)"

--- a/src/app/teacher/selected-tags-list/selected-tags-list.component.html
+++ b/src/app/teacher/selected-tags-list/selected-tags-list.component.html
@@ -11,4 +11,12 @@
       </button>
     </mat-chip-option>
   </mat-chip-listbox>
+  <a
+    *ngIf="showClearButton && tags.length > 0"
+    href="#"
+    (click)="removeTags(); $event.preventDefault()"
+    i18n
+  >
+    Clear filters
+  </a>
 </div>

--- a/src/app/teacher/selected-tags-list/selected-tags-list.component.html
+++ b/src/app/teacher/selected-tags-list/selected-tags-list.component.html
@@ -13,6 +13,7 @@
   </mat-chip-listbox>
   <a
     *ngIf="showClearButton && tags.length > 0"
+    class="mat-caption"
     href="#"
     (click)="removeTags(); $event.preventDefault()"
     i18n

--- a/src/app/teacher/selected-tags-list/selected-tags-list.component.ts
+++ b/src/app/teacher/selected-tags-list/selected-tags-list.component.ts
@@ -14,5 +14,12 @@ import { MatChipsModule } from '@angular/material/chips';
 })
 export class SelectedTagsListComponent {
   @Output() removeTagEvent: EventEmitter<Tag> = new EventEmitter<Tag>();
+  @Input() showClearButton = false;
   @Input() tags: Tag[] = [];
+
+  protected removeTags(): void {
+    this.tags.forEach((tag: Tag) => {
+      this.removeTagEvent.emit(tag);
+    });
+  }
 }

--- a/src/app/teacher/teacher-run-list/teacher-run-list.component.html
+++ b/src/app/teacher/teacher-run-list/teacher-run-list.component.html
@@ -1,24 +1,22 @@
-<div class="content-block">
-  <div
-    class="content-block__header controls dark-theme primary-bg"
-    fxLayout="row"
-    fxLayout.xs="column"
-    fxLayoutGap="16px"
-    fxLayoutAlign="start center"
-  >
-    <app-search-bar
-      fxFlex="0 0 auto"
-      fxFlex.xs="0 0 100%"
-      fxFlex.sm="0 0 calc(50%-8px)"
-      i18n-placeholderText
-      placeholderText="Search"
-      [disable]="!recentRunsLoaded"
-      [value]="searchValue"
-      (update)="searchChanged($event)"
-    ></app-search-bar>
-    <span fxFlex="1 1 auto" fxHide fxShow.gt-sm></span>
+<div
+  class="content-block filters dark-theme primary-bg"
+  fxLayout="row"
+  fxLayout.lt-md="column"
+  fxLayoutGap="16px"
+  fxLayoutAlign="start stretch"
+>
+  <app-search-bar
+    fxFlex="0 0 auto"
+    i18n-placeholderText
+    placeholderText="Search"
+    [disable]="!recentRunsLoaded"
+    [value]="searchValue"
+    (update)="searchChanged($event)"
+  ></app-search-bar>
+  <span fxFlex="1 1 auto" fxHide fxShow.gt-sm></span>
+  <div fxLayout="row" fxLayoutAlign="center center" fxLayoutGap="16px">
     <select-tags [selectedTags]="selectedTags" (selectTagEvent)="selectTags($event)"></select-tags>
-    <mat-form-field>
+    <mat-form-field [subscriptSizing]="'dynamic'">
       <mat-label>View</mat-label>
       <mat-select [(ngModel)]="showArchivedView" (selectionChange)="refreshProjects()">
         <mat-option [value]="false" i18n>Active</mat-option>
@@ -26,6 +24,8 @@
       </mat-select>
     </mat-form-field>
   </div>
+</div>
+<div class="content-block">
   <selected-tags-list
     *ngIf="selectedTags.length > 0"
     [tags]="selectedTags"

--- a/src/app/teacher/teacher-run-list/teacher-run-list.component.scss
+++ b/src/app/teacher/teacher-run-list/teacher-run-list.component.scss
@@ -7,17 +7,11 @@ h2 {
   margin-bottom: 0;
 }
 
-.content-block {
+.filters {
   margin-top: 24px;
-  overflow: hidden;
-}
-
-.content-block__header {
-  margin: -16px -16px 16px;
-
-  @media (min-width: breakpoint('sm.min')) {
-    margin: -24px -24px 16px;
-  }
+  padding: 16px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .notice {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -5749,6 +5749,17 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">42,44</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="8e63cdbdb10c29b7ecc49caa43163fc7c800d612" datatype="html">
+        <source>Unit tags</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/library/library-project/library-project.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="7189355262232159449" datatype="html">
         <source>Unit Details</source>
         <context-group purpose="location">
@@ -5857,11 +5868,18 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="6829218544e108e152f5fa72cb79c4ccb82e0d06" datatype="html">
+        <source>View</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="b36e1450940b7f6028d8587568c7d669b53f7a06" datatype="html">
         <source>Active</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library.component.html</context>
-          <context context-type="linenumber">8</context>
+          <context context-type="linenumber">9</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list/teacher-run-list.component.html</context>
@@ -5872,7 +5890,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Archived</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library.component.html</context>
-          <context context-type="linenumber">9</context>
+          <context context-type="linenumber">10</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list/teacher-run-list.component.html</context>
@@ -5883,21 +5901,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source> <x id="INTERPOLATION" equiv-text="{{ numSelectedProjects() }}"/> selected </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library.component.html</context>
-          <context context-type="linenumber">23,25</context>
+          <context context-type="linenumber">29,31</context>
         </context-group>
       </trans-unit>
       <trans-unit id="050a0b486e807a37ee8dbeeac274d84786bffa34" datatype="html">
         <source> No owned or shared units found. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library.component.html</context>
-          <context context-type="linenumber">56,58</context>
+          <context context-type="linenumber">66,68</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4204495853509039236" datatype="html">
         <source>Select all units</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library.component.ts</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6028472408314831177" datatype="html">
@@ -9143,13 +9161,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
           <context context-type="linenumber">47,49</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8e63cdbdb10c29b7ecc49caa43163fc7c800d612" datatype="html">
-        <source>Unit tags</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/teacher-run-list-item/teacher-run-list-item.component.html</context>
-          <context context-type="linenumber">50</context>
         </context-group>
       </trans-unit>
       <trans-unit id="490233cd77b10fe95606d32aa5ed4be533645820" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -5901,14 +5901,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source> <x id="INTERPOLATION" equiv-text="{{ numSelectedProjects() }}"/> selected </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library.component.html</context>
-          <context context-type="linenumber">29,31</context>
+          <context context-type="linenumber">30,32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="050a0b486e807a37ee8dbeeac274d84786bffa34" datatype="html">
         <source> No owned or shared units found. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library.component.html</context>
-          <context context-type="linenumber">66,68</context>
+          <context context-type="linenumber">67,69</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4204495853509039236" datatype="html">
@@ -8907,6 +8907,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/selected-tags-list/selected-tags-list.component.html</context>
           <context context-type="linenumber">9</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="0f1ef37e15512702909190c08b6f79056dd5c1ae" datatype="html">
+        <source> Clear filters </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/selected-tags-list/selected-tags-list.component.html</context>
+          <context context-type="linenumber">19,21</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c76c2eeebe0adc81f3434495d189c56d70899cad" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1035,10 +1035,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/app/authoring-tool/edit-component-tags/edit-component-tags.component.html</context>
           <context context-type="linenumber">2</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/select-tags/select-tags.component.html</context>
-          <context context-type="linenumber">2</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="d9a6d2f30e57a02a6b36a7773c39a3791c42ae9c" datatype="html">
         <source>Add Tag</source>
@@ -3008,7 +3004,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list/teacher-run-list.component.html</context>
-          <context context-type="linenumber">14</context>
+          <context context-type="linenumber">11</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.html</context>
@@ -5470,21 +5466,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Discipline</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-filters/library-filters.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">45</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b26db160af51478944575eeb0137e167ab054cca" datatype="html">
         <source>DCI Arrangement</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-filters/library-filters.component.html</context>
-          <context context-type="linenumber">68</context>
+          <context context-type="linenumber">63</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b17d72cdba2d53ad1c4952c8c3ba0d70ffc7ed1d" datatype="html">
         <source>Performance Expectation</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-filters/library-filters.component.html</context>
-          <context context-type="linenumber">86</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="07ab43ffb10e6bed417b203bfdc02cdda6aa1b61" datatype="html">
@@ -5883,7 +5879,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list/teacher-run-list.component.html</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5124633f6ba30f4d9b29fd0e43c9195a6bcf0f79" datatype="html">
@@ -5894,7 +5890,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/teacher-run-list/teacher-run-list.component.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">23</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8c208095ba4dc91d0b08952326cd6eff7e781d8e" datatype="html">
@@ -5990,7 +5986,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/shared/search-bar/search-bar.component.html</context>
-          <context context-type="linenumber">11</context>
+          <context context-type="linenumber">16</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/share-run-dialog/share-run-dialog.component.html</context>
@@ -8888,6 +8884,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="bdb9a910523610254872e147222689e9a4115b84" datatype="html">
+        <source>Filter by tag</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/select-tags/select-tags.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="353c43d34a92c7a8744729bd7b3ae5d3be470ae5" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{ selectedTags.length }}"/> Tag(s)</source>
         <context-group purpose="location">
@@ -8913,7 +8916,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source> Clear filters </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/selected-tags-list/selected-tags-list.component.html</context>
-          <context context-type="linenumber">19,21</context>
+          <context context-type="linenumber">20,22</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c76c2eeebe0adc81f3434495d189c56d70899cad" datatype="html">


### PR DESCRIPTION
## Changes
- In personal library added
  - Apply tags button
  - Tags filter
  - Tags displayed in library card
- In selected tags component, added optional clear filters button

@breity The select tags filter alignment is a little off in the personal library. I tried adding `[subscriptSizing]="'dynamic'"` to the mat-form-field which fixes the problem in the personal library view but then the alignment is off in the class schedule. Can you look into figuring out a good solution for this?

## Test
- Test with https://github.com/WISE-Community/WISE-API/pull/274
- Make sure all the tag functionality works properly in the personal library
- Make sure the clear filters button works