### PR TITLE
refactor(PossibleScoresComponent): Convert to standalone

### DIFF
--- a/src/app/possible-score/possible-score.component.ts
+++ b/src/app/possible-score/possible-score.component.ts
@@ -1,21 +1,20 @@
 import { Component, Input } from '@angular/core';
 import { ProjectService } from '../../assets/wise5/services/projectService';
+import { CommonModule } from '@angular/common';
 
 @Component({
+  imports: [CommonModule],
   selector: 'possible-score',
+  standalone: true,
   templateUrl: 'possible-score.component.html'
 })
 export class PossibleScoreComponent {
-  @Input()
-  maxScore: any;
-
-  themeSettings: any;
-  hidePossibleScores: any;
+  protected hidePossibleScores: boolean;
+  @Input() maxScore: number;
 
   constructor(private projectService: ProjectService) {}
 
-  ngOnInit() {
-    this.themeSettings = this.projectService.getThemeSettings();
-    this.hidePossibleScores = this.themeSettings.hidePossibleScores;
+  ngOnInit(): void {
+    this.hidePossibleScores = this.projectService.getThemeSettings().hidePossibleScores;
   }
 }

--- a/src/app/student/student.component.module.ts
+++ b/src/app/student/student.component.module.ts
@@ -16,17 +16,15 @@ import { StudentTeacherCommonModule } from '../student-teacher-common.module';
     ComponentHeader,
     ComponentSaveSubmitButtons,
     DynamicPromptComponent,
-    PossibleScoreComponent,
     PromptComponent
   ],
-  imports: [StudentTeacherCommonModule, ComponentStateInfoModule],
+  imports: [ComponentStateInfoModule, PossibleScoreComponent, StudentTeacherCommonModule],
   exports: [
     AddToNotebookButton,
     ComponentAnnotationsComponent,
     ComponentHeader,
     ComponentSaveSubmitButtons,
     DynamicPromptComponent,
-    PossibleScoreComponent,
     PromptComponent
   ]
 })

--- a/src/assets/wise5/components/aiChat/ai-chat-student/ai-chat-student.component.spec.ts
+++ b/src/assets/wise5/components/aiChat/ai-chat-student/ai-chat-student.component.spec.ts
@@ -9,7 +9,6 @@ import { ComponentHeader } from '../../../directives/component-header/component-
 import { AiChatModule } from '../ai-chat.module';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { PromptComponent } from '../../../directives/prompt/prompt.component';
-import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
 import { AiChatComponent } from '../AiChatComponent';
 import { FormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
@@ -17,6 +16,7 @@ import { ProjectService } from '../../../services/projectService';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { ChatInputComponent } from '../../../common/chat-input/chat-input.component';
+import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
 
 describe('AiChatStudentComponent', () => {
   let component: AiChatStudentComponent;
@@ -24,12 +24,7 @@ describe('AiChatStudentComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        AiChatStudentComponent,
-        ComponentHeader,
-        PossibleScoreComponent,
-        PromptComponent
-      ],
+      declarations: [AiChatStudentComponent, ComponentHeader, PromptComponent],
       imports: [
         AiChatModule,
         BrowserAnimationsModule,
@@ -41,6 +36,7 @@ describe('AiChatStudentComponent', () => {
         MatFormFieldModule,
         MatInputModule,
         MatSnackBarModule,
+        PossibleScoreComponent,
         StudentTeacherCommonServicesModule
       ],
       providers: [AiChatService]

--- a/src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.spec.ts
+++ b/src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.spec.ts
@@ -41,10 +41,11 @@ describe('AudioOscillatorStudent', () => {
         MatInputModule,
         MatSelectModule,
         MatTooltipModule,
+        PossibleScoreComponent,
         ReactiveFormsModule,
         StudentTeacherCommonServicesModule
       ],
-      declarations: [AudioOscillatorStudent, ComponentHeader, PossibleScoreComponent],
+      declarations: [AudioOscillatorStudent, ComponentHeader],
       schemas: [NO_ERRORS_SCHEMA]
     });
     fixture = TestBed.createComponent(AudioOscillatorStudent);

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.spec.ts
@@ -7,7 +7,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { ComputerAvatar } from '../../../common/computer-avatar/ComputerAvatar';
 import { ComponentHeader } from '../../../directives/component-header/component-header.component';
@@ -27,6 +26,7 @@ import { DialogGuidanceComponent } from '../DialogGuidanceComponent';
 import { RawCRaterResponse } from '../../common/cRater/RawCRaterResponse';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ChatInputComponent } from '../../../common/chat-input/chat-input.component';
+import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
 
 let component: DialogGuidanceStudentComponent;
 let fixture: ComponentFixture<DialogGuidanceStudentComponent>;
@@ -50,12 +50,7 @@ function createDialogGuidanceComponent(isComputerAvatarEnabled: boolean): Dialog
 describe('DialogGuidanceStudentComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [
-        ComponentHeader,
-        DialogGuidanceStudentComponent,
-        DialogResponsesComponent,
-        PossibleScoreComponent
-      ],
+      declarations: [ComponentHeader, DialogGuidanceStudentComponent, DialogResponsesComponent],
       imports: [
         BrowserAnimationsModule,
         ChatInputComponent,
@@ -66,6 +61,7 @@ describe('DialogGuidanceStudentComponent', () => {
         MatFormFieldModule,
         MatIconModule,
         MatInputModule,
+        PossibleScoreComponent,
         StudentTeacherCommonServicesModule
       ],
       providers: [DialogGuidanceFeedbackService],

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.spec.ts
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.spec.ts
@@ -116,10 +116,11 @@ describe('MultipleChoiceStudentComponent', () => {
         MatCheckboxModule,
         MatDialogModule,
         MatRadioModule,
+        PossibleScoreComponent,
         ReactiveFormsModule,
         StudentTeacherCommonServicesModule
       ],
-      declarations: [ComponentHeader, MultipleChoiceStudent, PossibleScoreComponent],
+      declarations: [ComponentHeader, MultipleChoiceStudent],
       schemas: [NO_ERRORS_SCHEMA]
     });
     fixture = TestBed.createComponent(MultipleChoiceStudent);

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.spec.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.spec.ts
@@ -40,6 +40,7 @@ describe('OpenResponseStudent', () => {
         HttpClientTestingModule,
         MatDialogModule,
         MatIconModule,
+        PossibleScoreComponent,
         ReactiveFormsModule,
         StudentTeacherCommonServicesModule
       ],
@@ -47,8 +48,7 @@ describe('OpenResponseStudent', () => {
         ComponentHeader,
         ComponentSaveSubmitButtons,
         DialogWithoutCloseComponent,
-        OpenResponseStudent,
-        PossibleScoreComponent
+        OpenResponseStudent
       ],
       providers: [AudioRecorderService],
       schemas: [NO_ERRORS_SCHEMA]

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.spec.ts
@@ -130,13 +130,13 @@ describe('PeerChatStudentComponent', () => {
         MatIconModule,
         MatInputModule,
         PeerChatModule,
+        PossibleScoreComponent,
         StudentTeacherCommonServicesModule
       ],
       declarations: [
         ComponentHeader,
         DynamicPromptComponent,
         PeerChatStudentComponent,
-        PossibleScoreComponent,
         PromptComponent
       ],
       providers: [


### PR DESCRIPTION
## Changes
- Convert PossibleScoresComponent to standalone component
- Clean up PossibleScoresComponent by removing unused code and adding types

## Note
- This changes required changes in some component spec files (e.g. AudioOscillator, DialogGuidance, AiChat, ...) but not others, so we're not being consistent across all the components. I think it'd be nice if we didn't have to import the PossibleScoresComponent in the component spec files. We should take a look in a separate PR.

## Test (in student VLE)
- PossibleScoresComponent loads and displays the possible score as before in the component header, alongside the prompt
    - ex: ```Who hears Fin first? (5 points)```