### PR TITLE
refactor(SaveTimeMessageComponent): Convert to standalone

### DIFF
--- a/src/assets/wise5/common/component-state-info/component-state-info.module.ts
+++ b/src/assets/wise5/common/component-state-info/component-state-info.module.ts
@@ -1,12 +1,10 @@
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { SaveTimeMessageComponent } from '../save-time-message/save-time-message.component';
 import { ComponentStateInfoComponent } from './component-state-info.component';
 
 @NgModule({
-  declarations: [ComponentStateInfoComponent, SaveTimeMessageComponent],
-  imports: [CommonModule, MatTooltipModule],
+  declarations: [ComponentStateInfoComponent],
+  imports: [SaveTimeMessageComponent],
   exports: [ComponentStateInfoComponent, SaveTimeMessageComponent]
 })
 export class ComponentStateInfoModule {}

--- a/src/assets/wise5/common/save-time-message/save-time-message.component.ts
+++ b/src/assets/wise5/common/save-time-message/save-time-message.component.ts
@@ -1,21 +1,23 @@
-import { formatDate } from '@angular/common';
+import { CommonModule, formatDate } from '@angular/common';
 import { Component, Inject, Input, LOCALE_ID } from '@angular/core';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
+  imports: [CommonModule, MatTooltipModule],
   selector: 'save-time-message',
-  styleUrls: ['save-time-message.component.scss'],
+  standalone: true,
+  styleUrl: 'save-time-message.component.scss',
   templateUrl: 'save-time-message.component.html'
 })
 export class SaveTimeMessageComponent {
   @Input() isAutoSave: boolean;
   @Input() isInactive: boolean;
   @Input() isSubmit: boolean;
+  protected message: string;
   @Input() saveTime: number;
   @Input() timeOnly: boolean;
+  protected tooltip: string;
   @Input() tooltipPosition: 'left' | 'right' | 'above' | 'below' | 'before' | 'after';
-
-  message: string;
-  tooltip: string;
 
   constructor(@Inject(LOCALE_ID) private localeID: string) {}
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15113,21 +15113,21 @@ Are you sure you want to proceed?</source>
         <source>Submitted <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/save-time-message/save-time-message.component.ts</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5275881069346355759" datatype="html">
         <source>Auto Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/save-time-message/save-time-message.component.ts</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3124371804165766752" datatype="html">
         <source>Saved <x id="saveTime" equiv-text="saveTimeText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/save-time-message/save-time-message.component.ts</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">34</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9ba24bf3c65fed6e59c2d2264be8d104f370a69c" datatype="html">


### PR DESCRIPTION
## Changes
- Convert SaveTimeMessageComponent to standalone component
- Clean up SaveTimeMessageComponent by adding types and ordering variables

## Test
- In the VLE and the Grading Tool, SaveTimeMessageComponent 
   - correctly displays the save/submit times for students' work as before
   - tooltip appears on hover, displaying the timestamp