### PR TITLE
refactor(CallToActionComponent): Convert to standalone

### DIFF
--- a/src/app/forgot/forgot.module.ts
+++ b/src/app/forgot/forgot.module.ts
@@ -21,9 +21,11 @@ import { ForgotTeacherPasswordChangeComponent } from './teacher/forgot-teacher-p
 import { ForgotTeacherPasswordVerifyComponent } from './teacher/forgot-teacher-password-verify/forgot-teacher-password-verify.component';
 import { PasswordModule } from '../password/password.module';
 import { ForgotUserPasswordCompleteComponent } from './forgot-user-password-complete/forgot-user-password-complete.component';
+import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-action.component';
 
 @NgModule({
   imports: [
+    CallToActionComponent,
     CommonModule,
     ForgotRoutingModule,
     FormsModule,

--- a/src/app/help/help.module.ts
+++ b/src/app/help/help.module.ts
@@ -8,9 +8,10 @@ import { TeacherFaqComponent } from './faq/teacher-faq/teacher-faq.component';
 import { StudentFaqComponent } from './faq/student-faq/student-faq.component';
 import { HelpHomeComponent } from './help-home/help-home.component';
 import { MatDividerModule } from '@angular/material/divider';
+import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-action.component';
 
 @NgModule({
-  imports: [CommonModule, HelpRoutingModule, MatDividerModule, SharedModule],
+  imports: [CallToActionComponent, CommonModule, HelpRoutingModule, MatDividerModule, SharedModule],
   declarations: [
     HelpComponent,
     GettingStartedComponent,

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -8,10 +8,12 @@ import { SharedModule } from '../modules/shared/shared.module';
 import { DiscourseLatestNewsComponent } from './discourse-latest-news/discourse-latest-news.component';
 import { BlurbComponent } from '../modules/shared/blurb/blurb.component';
 import { HeroSectionComponent } from '../modules/shared/hero-section/hero-section.component';
+import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-action.component';
 
 @NgModule({
   imports: [
     BlurbComponent,
+    CallToActionComponent,
     CommonModule,
     HeroSectionComponent,
     HomeRoutingModule,

--- a/src/app/modules/shared/call-to-action/call-to-action.component.spec.ts
+++ b/src/app/modules/shared/call-to-action/call-to-action.component.spec.ts
@@ -1,18 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { CallToActionComponent } from './call-to-action.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { provideRouter } from '@angular/router';
 
 describe('CallToActionComponent', () => {
   let component: CallToActionComponent;
   let fixture: ComponentFixture<CallToActionComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [CallToActionComponent],
-      imports: [],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [CallToActionComponent],
+        providers: [provideRouter([])]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CallToActionComponent);

--- a/src/app/modules/shared/call-to-action/call-to-action.component.ts
+++ b/src/app/modules/shared/call-to-action/call-to-action.component.ts
@@ -1,48 +1,27 @@
-import {
-  Component,
-  ContentChild,
-  Input,
-  OnInit,
-  TemplateRef,
-  ViewEncapsulation
-} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, ContentChild, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { RouterModule } from '@angular/router';
 
 @Component({
+  encapsulation: ViewEncapsulation.None,
+  imports: [CommonModule, FlexLayoutModule, MatButtonModule, MatIconModule, RouterModule],
   selector: 'app-call-to-action',
-  templateUrl: './call-to-action.component.html',
-  styleUrls: ['./call-to-action.component.scss'],
-  encapsulation: ViewEncapsulation.None
+  standalone: true,
+  styleUrl: './call-to-action.component.scss',
+  templateUrl: './call-to-action.component.html'
 })
-export class CallToActionComponent implements OnInit {
-  @Input()
-  destination: string;
-
-  @Input()
-  isOutsideLink: boolean = false;
-
-  @Input()
-  linkTarget: string;
-
-  @Input()
-  icon: string;
-
-  @Input()
-  isSvgIcon: boolean = false;
-
-  @Input()
-  iconColor: string;
-
-  @Input()
-  headline: string;
-
-  @ContentChild('headlineTemplate', { static: false }) headlineRef: TemplateRef<any>;
-
-  @Input()
-  content: string;
-
+export class CallToActionComponent {
+  @Input() content: string;
   @ContentChild('contentTemplate', { static: false }) contentRef: TemplateRef<any>;
-
-  constructor() {}
-
-  ngOnInit() {}
+  @Input() destination: string;
+  @Input() headline: string;
+  @ContentChild('headlineTemplate', { static: false }) headlineRef: TemplateRef<any>;
+  @Input() icon: string;
+  @Input() iconColor: string;
+  @Input() isOutsideLink: boolean = false;
+  @Input() isSvgIcon: boolean = false;
+  @Input() linkTarget: string;
 }

--- a/src/app/modules/shared/shared.module.ts
+++ b/src/app/modules/shared/shared.module.ts
@@ -22,7 +22,6 @@ const materialModules = [
   MatProgressBarModule
 ];
 
-import { CallToActionComponent } from './call-to-action/call-to-action.component';
 import { SelectMenuComponent } from './select-menu/select-menu.component';
 import { EditPasswordComponent } from './edit-password/edit-password.component';
 import { UnlinkGoogleAccountConfirmComponent } from './unlink-google-account-confirm/unlink-google-account-confirm.component';
@@ -40,15 +39,8 @@ import { PasswordModule } from '../../password/password.module';
     RouterModule,
     materialModules
   ],
-  exports: [
-    materialModules,
-    FlexLayoutModule,
-    CallToActionComponent,
-    SelectMenuComponent,
-    EditPasswordComponent
-  ],
+  exports: [materialModules, FlexLayoutModule, SelectMenuComponent, EditPasswordComponent],
   declarations: [
-    CallToActionComponent,
     SelectMenuComponent,
     EditPasswordComponent,
     UnlinkGoogleAccountConfirmComponent,

--- a/src/app/register/register.module.ts
+++ b/src/app/register/register.module.ts
@@ -23,6 +23,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { GoogleSignInModule } from '../modules/google-sign-in/google-sign-in.module';
 import { PasswordModule } from '../password/password.module';
 import { RegisterMicrosoftUserAlreadyExistsComponent } from './register-microsoft-user-already-exists/register-microsoft-user-already-exists.component';
+import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-action.component';
 
 const materialModules = [
   MatButtonModule,
@@ -37,6 +38,7 @@ const materialModules = [
 
 @NgModule({
   imports: [
+    CallToActionComponent,
     CommonModule,
     FormsModule,
     GoogleSignInModule,


### PR DESCRIPTION
## Changes
- Convert CallToActionComponent to standalone component
- Clean up CallToActionComponent and spec file by removing unused code and ordering variables
- Import CallToActionComponent in modules that use them

## Test
- CallToActionComponent blocks display and work as before, in these places:
   - homepage
   - register account
   - help
   - getting started
   - student/teacher faq
   - forgot account pages