### PR TITLE
refactor(NodeStatusIconComponent): Convert to standalone

### DIFF
--- a/src/app/student-teacher-common.module.ts
+++ b/src/app/student-teacher-common.module.ts
@@ -15,7 +15,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatSelectModule } from '@angular/material/select';
-import { NodeStatusIcon } from '../assets/wise5/themes/default/themeComponents/nodeStatusIcon/node-status-icon.component';
+import { NodeStatusIconComponent } from '../assets/wise5/themes/default/themeComponents/nodeStatusIcon/node-status-icon.component';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { EditorModule } from '@tinymce/tinymce-angular';
@@ -45,7 +45,6 @@ import { SideMenuComponent } from '../assets/wise5/common/side-menu/side-menu.co
     DialogResponseComponent,
     DialogResponsesComponent,
     MainMenuComponent,
-    NodeStatusIcon,
     SideMenuComponent
   ],
   imports: [
@@ -80,6 +79,7 @@ import { SideMenuComponent } from '../assets/wise5/common/side-menu/side-menu.co
     MatTooltipModule,
     MathModule,
     NodeIconComponent,
+    NodeStatusIconComponent,
     NotebookModule,
     ReactiveFormsModule,
     StudentTeacherCommonServicesModule
@@ -118,7 +118,6 @@ import { SideMenuComponent } from '../assets/wise5/common/side-menu/side-menu.co
     MatTooltipModule,
     MathModule,
     NodeIconComponent,
-    NodeStatusIcon,
     NotebookModule,
     ReactiveFormsModule,
     SideMenuComponent

--- a/src/app/student/vle/student-vle.module.ts
+++ b/src/app/student/vle/student-vle.module.ts
@@ -34,6 +34,7 @@ import { GroupTabsComponent } from '../../../assets/wise5/directives/group-tabs/
 import { StudentPeerGroupService } from '../../../assets/wise5/services/studentPeerGroupService';
 import { PeerGroupService } from '../../../assets/wise5/services/peerGroupService';
 import { TopBarComponent } from '../top-bar/top-bar.component';
+import { NodeStatusIconComponent } from '../../../assets/wise5/themes/default/themeComponents/nodeStatusIcon/node-status-icon.component';
 
 @NgModule({
   declarations: [
@@ -55,6 +56,7 @@ import { TopBarComponent } from '../top-bar/top-bar.component';
     ComponentStudentModule,
     MatDialogModule,
     NodeModule,
+    NodeStatusIconComponent,
     SimpleDialogModule,
     StudentAssetsDialogModule,
     StudentComponentModule,

--- a/src/assets/wise5/themes/default/themeComponents/nodeStatusIcon/node-status-icon.component.ts
+++ b/src/assets/wise5/themes/default/themeComponents/nodeStatusIcon/node-status-icon.component.ts
@@ -1,18 +1,22 @@
 import { Component, Input } from '@angular/core';
 import { NodeStatusService } from '../../../../services/nodeStatusService';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
+  imports: [CommonModule, MatIconModule],
   selector: 'node-status-icon',
-  styleUrls: ['node-status-icon.component.scss'],
+  standalone: true,
+  styleUrl: 'node-status-icon.component.scss',
   templateUrl: 'node-status-icon.component.html'
 })
-export class NodeStatusIcon {
+export class NodeStatusIconComponent {
   @Input() nodeId: string;
-  nodeStatus: any;
+  protected nodeStatus: any;
 
   constructor(private nodeStatusService: NodeStatusService) {}
 
-  ngOnChanges() {
+  ngOnChanges(): void {
     this.nodeStatus = this.nodeStatusService.getNodeStatusByNodeId(this.nodeId);
   }
 }

--- a/src/assets/wise5/themes/default/themeComponents/stepTools/step-tools.component.spec.ts
+++ b/src/assets/wise5/themes/default/themeComponents/stepTools/step-tools.component.spec.ts
@@ -7,7 +7,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { NodeIconComponent } from '../../../../vle/node-icon/node-icon.component';
 import { ProjectService } from '../../../../services/projectService';
 import { StudentDataService } from '../../../../services/studentDataService';
-import { NodeStatusIcon } from '../nodeStatusIcon/node-status-icon.component';
+import { NodeStatusIconComponent } from '../nodeStatusIcon/node-status-icon.component';
 import { StepToolsComponent } from './step-tools.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../../app/student-teacher-common-services.module';
 import { NodeStatusService } from '../../../../services/nodeStatusService';
@@ -32,10 +32,11 @@ describe('StepToolsComponent', () => {
         MatIconModule,
         MatSelectModule,
         NodeIconComponent,
+        NodeStatusIconComponent,
         NoopAnimationsModule,
         StudentTeacherCommonServicesModule
       ],
-      declarations: [NodeStatusIcon, StepToolsComponent]
+      declarations: [StepToolsComponent]
     }).compileComponents();
   });
 

--- a/src/assets/wise5/themes/default/themeComponents/stepTools/step-tools.module.ts
+++ b/src/assets/wise5/themes/default/themeComponents/stepTools/step-tools.module.ts
@@ -10,6 +10,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { StudentTeacherCommonModule } from '../../../../../../app/student-teacher-common.module';
+import { NodeStatusIconComponent } from '../nodeStatusIcon/node-status-icon.component';
 
 @NgModule({
   declarations: [StepToolsComponent],
@@ -24,6 +25,7 @@ import { StudentTeacherCommonModule } from '../../../../../../app/student-teache
     MatInputModule,
     MatSelectModule,
     MatTooltipModule,
+    NodeStatusIconComponent,
     StudentTeacherCommonModule
   ]
 })

--- a/src/assets/wise5/vle/vle.component.spec.ts
+++ b/src/assets/wise5/vle/vle.component.spec.ts
@@ -20,7 +20,7 @@ import { MatBadgeModule } from '@angular/material/badge';
 import { NavigationComponent } from '../themes/default/navigation/navigation.component';
 import { StepToolsComponent } from '../themes/default/themeComponents/stepTools/step-tools.component';
 import { MatSelectModule } from '@angular/material/select';
-import { NodeStatusIcon } from '../themes/default/themeComponents/nodeStatusIcon/node-status-icon.component';
+import { NodeStatusIconComponent } from '../themes/default/themeComponents/nodeStatusIcon/node-status-icon.component';
 import { NodeIconComponent } from './node-icon/node-icon.component';
 import { FormsModule } from '@angular/forms';
 import { InitializeVLEService } from '../services/initializeVLEService';
@@ -52,13 +52,13 @@ describe('VLEComponent', () => {
         MatSelectModule,
         MatSidenavModule,
         NodeIconComponent,
+        NodeStatusIconComponent,
         StudentTeacherCommonServicesModule,
         TopBarComponent
       ],
       declarations: [
         NavigationComponent,
         NodeComponent,
-        NodeStatusIcon,
         NotebookNotesComponent,
         SafeUrl,
         StepToolsComponent,


### PR DESCRIPTION
## Changes
- Rename NodeStatusIcon to NodeStatusIconComponent
- Convert NodeStatusIconComponent to standalone component
- Clean up NodeStatusIconComponent

## Test
- NodeStatusIconComponent displays as before, in these places in the student VLE:
   - step tool bar. Should show check mark next to the next arrow if step is completed
   - project plan view. Should show check mark next to the step if step is completed