### PR TITLE
refactor(PrivacyComponent): Convert to standalone

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,7 +2,6 @@ import { HTTP_INTERCEPTORS, HttpRequest, HttpHandler, HttpInterceptor } from '@a
 import { Injectable, NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { PrivacyComponent } from './privacy/privacy.component';
 
 const routes: Routes = [
   { path: '', loadChildren: () => import('./home/home.module').then((m) => m.HomeModule) },
@@ -29,7 +28,10 @@ const routes: Routes = [
   },
   { path: 'login', loadChildren: () => import('./login/login.module').then((m) => m.LoginModule) },
   { path: 'news', loadChildren: () => import('./news/news.module').then((m) => m.NewsModule) },
-  { path: 'privacy', component: PrivacyComponent },
+  {
+    path: 'privacy',
+    loadComponent: () => import('./privacy/privacy.component').then((m) => m.PrivacyComponent)
+  },
   {
     path: 'preview',
     loadChildren: () => import('./student/student.module').then((m) => m.StudentModule)
@@ -55,7 +57,6 @@ export class XhrInterceptor implements HttpInterceptor {
 }
 
 @NgModule({
-  declarations: [PrivacyComponent],
   imports: [RouterModule.forRoot(routes, {}), FormsModule],
   exports: [RouterModule],
   providers: [{ provide: HTTP_INTERCEPTORS, useClass: XhrInterceptor, multi: true }]

--- a/src/app/privacy/privacy.component.spec.ts
+++ b/src/app/privacy/privacy.component.spec.ts
@@ -1,17 +1,17 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { PrivacyComponent } from './privacy.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 describe('PrivacyComponent', () => {
   let component: PrivacyComponent;
   let fixture: ComponentFixture<PrivacyComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [PrivacyComponent],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [PrivacyComponent]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PrivacyComponent);

--- a/src/app/privacy/privacy.component.ts
+++ b/src/app/privacy/privacy.component.ts
@@ -1,12 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-privacy',
-  templateUrl: './privacy.component.html',
-  styleUrls: ['./privacy.component.scss']
+  standalone: true,
+  styleUrl: './privacy.component.scss',
+  templateUrl: './privacy.component.html'
 })
-export class PrivacyComponent implements OnInit {
-  constructor() {}
-
-  ngOnInit() {}
-}
+export class PrivacyComponent {}


### PR DESCRIPTION
## Changes
- Convert PrivacyComponent to standalone component
- Clean up PrivacyComponent and spec file by removing unused code and ordering Component variables alphabetically
- Remove PrivacyComponent declaration in AppRoutingModule. Instead, lazily load the PrivacyComponent

## Test
- Privacy & Use page loads lazily and displays as before
