### PR TITLE
refactor(PromptComponent): Convert to standalone

### DIFF
--- a/src/app/classroom-monitor/show-node-info-dialog/show-node-info-dialog.component.spec.ts
+++ b/src/app/classroom-monitor/show-node-info-dialog/show-node-info-dialog.component.spec.ts
@@ -48,7 +48,6 @@ describe('ShowNodeInfoDialogComponent', () => {
         NodeInfoComponent,
         OpenResponseStudent,
         PreviewComponentComponent,
-        PromptComponent,
         ShowNodeInfoDialogComponent
       ],
       imports: [
@@ -57,7 +56,8 @@ describe('ShowNodeInfoDialogComponent', () => {
         MatCardModule,
         MatDialogModule,
         MatIconModule,
-        MatToolbarModule
+        MatToolbarModule,
+        PromptComponent
       ],
       providers: [
         { provide: MAT_DIALOG_DATA, useValue: nodeId1 },

--- a/src/app/student/student.component.module.ts
+++ b/src/app/student/student.component.module.ts
@@ -3,7 +3,6 @@ import { AddToNotebookButton } from '../../assets/wise5/directives/add-to-notebo
 import { ComponentHeader } from '../../assets/wise5/directives/component-header/component-header.component';
 import { ComponentSaveSubmitButtons } from '../../assets/wise5/directives/component-save-submit-buttons/component-save-submit-buttons.component';
 import { ComponentAnnotationsComponent } from '../../assets/wise5/directives/componentAnnotations/component-annotations.component';
-import { DynamicPromptComponent } from '../../assets/wise5/directives/dynamic-prompt/dynamic-prompt.component';
 import { PromptComponent } from '../../assets/wise5/directives/prompt/prompt.component';
 import { PossibleScoreComponent } from '../possible-score/possible-score.component';
 import { StudentTeacherCommonModule } from '../student-teacher-common.module';
@@ -14,21 +13,19 @@ import { ComponentStateInfoComponent } from '../../assets/wise5/common/component
     AddToNotebookButton,
     ComponentAnnotationsComponent,
     ComponentHeader,
-    ComponentSaveSubmitButtons,
-    PromptComponent
+    ComponentSaveSubmitButtons
   ],
   imports: [
     ComponentStateInfoComponent,
-    DynamicPromptComponent,
     PossibleScoreComponent,
+    PromptComponent,
     StudentTeacherCommonModule
   ],
   exports: [
     AddToNotebookButton,
     ComponentAnnotationsComponent,
     ComponentHeader,
-    ComponentSaveSubmitButtons,
-    PromptComponent
+    ComponentSaveSubmitButtons
   ]
 })
 export class StudentComponentModule {}

--- a/src/assets/wise5/components/aiChat/ai-chat-student/ai-chat-student.component.spec.ts
+++ b/src/assets/wise5/components/aiChat/ai-chat-student/ai-chat-student.component.spec.ts
@@ -24,7 +24,7 @@ describe('AiChatStudentComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [AiChatStudentComponent, ComponentHeader, PromptComponent],
+      declarations: [AiChatStudentComponent, ComponentHeader],
       imports: [
         AiChatModule,
         BrowserAnimationsModule,
@@ -37,6 +37,7 @@ describe('AiChatStudentComponent', () => {
         MatInputModule,
         MatSnackBarModule,
         PossibleScoreComponent,
+        PromptComponent,
         StudentTeacherCommonServicesModule
       ],
       providers: [AiChatService]

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.spec.ts
@@ -31,7 +31,6 @@ import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
 import { PauseScreenService } from '../../../services/pauseScreenService';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { FeedbackRule } from '../../common/feedbackRule/FeedbackRule';
-import { DynamicPromptComponent } from '../../../directives/dynamic-prompt/dynamic-prompt.component';
 import { PromptComponent } from '../../../directives/prompt/prompt.component';
 import { PeerChatComponent } from '../PeerChatComponent';
 
@@ -121,7 +120,6 @@ describe('PeerChatStudentComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
-        DynamicPromptComponent,
         FormsModule,
         HttpClientTestingModule,
         MatCardModule,
@@ -130,10 +128,11 @@ describe('PeerChatStudentComponent', () => {
         MatIconModule,
         MatInputModule,
         PeerChatModule,
+        PromptComponent,
         PossibleScoreComponent,
         StudentTeacherCommonServicesModule
       ],
-      declarations: [ComponentHeader, PeerChatStudentComponent, PromptComponent],
+      declarations: [ComponentHeader, PeerChatStudentComponent],
       providers: [
         AnnotationService,
         ComponentService,

--- a/src/assets/wise5/directives/component-header/component-header.component.spec.ts
+++ b/src/assets/wise5/directives/component-header/component-header.component.spec.ts
@@ -3,7 +3,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ComponentHeader } from './component-header.component';
 import { DomSanitizer } from '@angular/platform-browser';
 import { PromptComponent } from '../prompt/prompt.component';
-import { DynamicPromptComponent } from '../dynamic-prompt/dynamic-prompt.component';
 import { ComponentContent } from '../../common/ComponentContent';
 import { Component } from '../../common/Component';
 
@@ -13,8 +12,8 @@ let fixture: ComponentFixture<ComponentHeader>;
 describe('ComponentHeaderComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ComponentHeader, PromptComponent],
-      imports: [DynamicPromptComponent],
+      declarations: [ComponentHeader],
+      imports: [PromptComponent],
       providers: [
         {
           provide: DomSanitizer,

--- a/src/assets/wise5/directives/prompt/prompt.component.spec.ts
+++ b/src/assets/wise5/directives/prompt/prompt.component.spec.ts
@@ -4,7 +4,6 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
 import { ComponentContent } from '../../common/ComponentContent';
 import { ProjectService } from '../../services/projectService';
-import { DynamicPromptComponent } from '../dynamic-prompt/dynamic-prompt.component';
 import { DynamicPrompt } from '../dynamic-prompt/DynamicPrompt';
 import { PromptComponent } from './prompt.component';
 
@@ -17,11 +16,10 @@ describe('PromptComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [PromptComponent],
       imports: [
-        DynamicPromptComponent,
         HttpClientTestingModule,
         MatDialogModule,
+        PromptComponent,
         StudentTeacherCommonServicesModule
       ]
     }).compileComponents();

--- a/src/assets/wise5/directives/prompt/prompt.component.ts
+++ b/src/assets/wise5/directives/prompt/prompt.component.ts
@@ -1,24 +1,24 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { FeedbackRule } from '../../components/common/feedbackRule/FeedbackRule';
 import { DynamicPrompt } from '../dynamic-prompt/DynamicPrompt';
+import { CommonModule } from '@angular/common';
+import { DynamicPromptComponent } from '../dynamic-prompt/dynamic-prompt.component';
 
 @Component({
+  imports: [CommonModule, DynamicPromptComponent],
   selector: 'prompt',
-  templateUrl: './prompt.component.html',
-  styleUrls: ['./prompt.component.scss']
+  standalone: true,
+  styleUrl: './prompt.component.scss',
+  templateUrl: './prompt.component.html'
 })
-export class PromptComponent implements OnInit {
+export class PromptComponent {
   @Input() componentId: string;
   @Input() dynamicPrompt: DynamicPrompt;
   @Output() dynamicPromptChanged: EventEmitter<FeedbackRule> = new EventEmitter<FeedbackRule>();
   @Input() nodeId: string;
   @Input() prompt: string;
 
-  constructor() {}
-
-  ngOnInit(): void {}
-
-  onDynamicPromptChanged(feedbackRule: FeedbackRule): void {
+  protected onDynamicPromptChanged(feedbackRule: FeedbackRule): void {
     this.dynamicPromptChanged.emit(feedbackRule);
   }
 }


### PR DESCRIPTION
## Changes
- Convert PromptComponent to standalone component
- Make PromptComponent import DynamicPromptComponent and update references
- Clean up PromptComponent

## Test
- In the Student VLE, both the prompt and dynamic prompt work as before