### PR TITLE
fix(Authoring): Delete first step in branch path loses criteria

### DIFF
--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -1644,7 +1644,7 @@ export class TeacherProjectService extends ProjectService {
               }
 
               // remove the transition to the node we are removing
-              transitions.splice(t, 1);
+              const transitionRemoved = transitions.splice(t, 1)[0];
 
               if (transitionsCopy != null) {
                 let insertIndex = t;
@@ -1685,6 +1685,9 @@ export class TeacherProjectService extends ProjectService {
                     ) {
                       this.addToTransition(node, this.getGroupStartId(toNodeId));
                     } else {
+                      if (transitionRemoved.criteria != null) {
+                        transitionCopy.criteria = transitionRemoved.criteria;
+                      }
                       transitions.splice(insertIndex, 0, transitionCopy);
                       insertIndex++;
                     }


### PR DESCRIPTION
## Changes
- Keep the transition criteria when the first step in a branch path is deleted

## Test
1. Create a branch based on score or choice chosen
2. Make sure the first branch path has 2 or more steps (if it doesn't, add a step to the first branch path)
3. Delete the first step in the first branch path
4. Open the branch step authoring and look at the JSON. The first transition should still have the criteria field. Previously, the criteria field would disappear.

Bad
```
    "transitionLogic": {
        "transitions": [
            {
                "to": "node2"
            },
            {
                "criteria": [
                    {
                        "name": "score",
                        "params": {
                            "nodeId": "node823",
                            "componentId": "ufwc0dul2z",
                            "scores": [
                                "2"
                            ]
                        }
                    }
                ],
                "to": "node820"
            }
        ]
```

Good
```
    "transitionLogic": {
        "transitions": [
            {
                "criteria": [
                    {
                        "name": "score",
                        "params": {
                            "nodeId": "node823",
                            "componentId": "ufwc0dul2z",
                            "scores": [
                                "1"
                            ]
                        }
                    }
                ],
                "to": "node2"
            },
            {
                "criteria": [
                    {
                        "name": "score",
                        "params": {
                            "nodeId": "node823",
                            "componentId": "ufwc0dul2z",
                            "scores": [
                                "2"
                            ]
                        }
                    }
                ],
                "to": "node820"
            }
        ]
```

Closes #1796