### PR TITLE
refactor(ComponentHeaderComponent): Convert to standalone

### DIFF
--- a/src/app/classroom-monitor/show-node-info-dialog/show-node-info-dialog.component.spec.ts
+++ b/src/app/classroom-monitor/show-node-info-dialog/show-node-info-dialog.component.spec.ts
@@ -7,8 +7,7 @@ import { PreviewComponentComponent } from '../../../assets/wise5/authoringTool/c
 import { ClassroomMonitorTestingModule } from '../../../assets/wise5/classroomMonitor/classroom-monitor-testing.module';
 import { NodeInfoComponent } from '../../../assets/wise5/classroomMonitor/classroomMonitorComponents/shared/node-info/node-info.component';
 import { OpenResponseStudent } from '../../../assets/wise5/components/openResponse/open-response-student/open-response-student.component';
-import { ComponentHeader } from '../../../assets/wise5/directives/component-header/component-header.component';
-import { PromptComponent } from '../../../assets/wise5/directives/prompt/prompt.component';
+import { ComponentHeaderComponent } from '../../../assets/wise5/directives/component-header/component-header.component';
 import { NotebookService } from '../../../assets/wise5/services/notebookService';
 import { ProjectService } from '../../../assets/wise5/services/projectService';
 import { TeacherDataService } from '../../../assets/wise5/services/teacherDataService';
@@ -44,7 +43,6 @@ describe('ShowNodeInfoDialogComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [
-        ComponentHeader,
         NodeInfoComponent,
         OpenResponseStudent,
         PreviewComponentComponent,
@@ -52,12 +50,12 @@ describe('ShowNodeInfoDialogComponent', () => {
       ],
       imports: [
         ClassroomMonitorTestingModule,
+        ComponentHeaderComponent,
         ComponentTypeServiceModule,
         MatCardModule,
         MatDialogModule,
         MatIconModule,
-        MatToolbarModule,
-        PromptComponent
+        MatToolbarModule
       ],
       providers: [
         { provide: MAT_DIALOG_DATA, useValue: nodeId1 },

--- a/src/app/student/student.component.module.ts
+++ b/src/app/student/student.component.module.ts
@@ -1,30 +1,18 @@
 import { NgModule } from '@angular/core';
 import { AddToNotebookButton } from '../../assets/wise5/directives/add-to-notebook-button/add-to-notebook-button.component';
-import { ComponentHeader } from '../../assets/wise5/directives/component-header/component-header.component';
+import { ComponentHeaderComponent } from '../../assets/wise5/directives/component-header/component-header.component';
 import { ComponentSaveSubmitButtons } from '../../assets/wise5/directives/component-save-submit-buttons/component-save-submit-buttons.component';
 import { ComponentAnnotationsComponent } from '../../assets/wise5/directives/componentAnnotations/component-annotations.component';
-import { PromptComponent } from '../../assets/wise5/directives/prompt/prompt.component';
-import { PossibleScoreComponent } from '../possible-score/possible-score.component';
 import { StudentTeacherCommonModule } from '../student-teacher-common.module';
 import { ComponentStateInfoComponent } from '../../assets/wise5/common/component-state-info/component-state-info.component';
 
 @NgModule({
-  declarations: [
-    AddToNotebookButton,
-    ComponentAnnotationsComponent,
-    ComponentHeader,
-    ComponentSaveSubmitButtons
-  ],
-  imports: [
-    ComponentStateInfoComponent,
-    PossibleScoreComponent,
-    PromptComponent,
-    StudentTeacherCommonModule
-  ],
+  declarations: [AddToNotebookButton, ComponentAnnotationsComponent, ComponentSaveSubmitButtons],
+  imports: [ComponentHeaderComponent, ComponentStateInfoComponent, StudentTeacherCommonModule],
   exports: [
     AddToNotebookButton,
     ComponentAnnotationsComponent,
-    ComponentHeader,
+    ComponentHeaderComponent,
     ComponentSaveSubmitButtons
   ]
 })

--- a/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.spec.ts
+++ b/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.spec.ts
@@ -22,6 +22,7 @@ import { OpenResponseInfo } from '../../../components/openResponse/OpenResponseI
 import { ComponentInfo } from '../../../components/ComponentInfo';
 import { MatCardModule } from '@angular/material/card';
 import { ComponentTypeServiceModule } from '../../../services/componentTypeService.module';
+import { ComponentHeaderComponent } from '../../../directives/component-header/component-header.component';
 
 let component: ComponentInfoDialogComponent;
 let fixture: ComponentFixture<ComponentInfoDialogComponent>;
@@ -40,6 +41,7 @@ describe('ComponentInfoDialogComponent', () => {
       ],
       imports: [
         BrowserAnimationsModule,
+        ComponentHeaderComponent,
         ComponentTypeServiceModule,
         HttpClientTestingModule,
         MatButtonModule,

--- a/src/assets/wise5/components/aiChat/ai-chat-student/ai-chat-student.component.spec.ts
+++ b/src/assets/wise5/components/aiChat/ai-chat-student/ai-chat-student.component.spec.ts
@@ -5,10 +5,9 @@ import { StudentTeacherCommonServicesModule } from '../../../../../app/student-t
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatCardModule } from '@angular/material/card';
-import { ComponentHeader } from '../../../directives/component-header/component-header.component';
+import { ComponentHeaderComponent } from '../../../directives/component-header/component-header.component';
 import { AiChatModule } from '../ai-chat.module';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { PromptComponent } from '../../../directives/prompt/prompt.component';
 import { AiChatComponent } from '../AiChatComponent';
 import { FormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
@@ -16,7 +15,6 @@ import { ProjectService } from '../../../services/projectService';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { ChatInputComponent } from '../../../common/chat-input/chat-input.component';
-import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
 
 describe('AiChatStudentComponent', () => {
   let component: AiChatStudentComponent;
@@ -24,11 +22,12 @@ describe('AiChatStudentComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [AiChatStudentComponent, ComponentHeader],
+      declarations: [AiChatStudentComponent],
       imports: [
         AiChatModule,
         BrowserAnimationsModule,
         ChatInputComponent,
+        ComponentHeaderComponent,
         FormsModule,
         HttpClientTestingModule,
         MatCardModule,
@@ -36,8 +35,6 @@ describe('AiChatStudentComponent', () => {
         MatFormFieldModule,
         MatInputModule,
         MatSnackBarModule,
-        PossibleScoreComponent,
-        PromptComponent,
         StudentTeacherCommonServicesModule
       ],
       providers: [AiChatService]

--- a/src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.spec.ts
+++ b/src/assets/wise5/components/audioOscillator/audio-oscillator-student/audio-oscillator-student.component.spec.ts
@@ -9,8 +9,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
-import { ComponentHeader } from '../../../directives/component-header/component-header.component';
+import { ComponentHeaderComponent } from '../../../directives/component-header/component-header.component';
 import { ProjectService } from '../../../services/projectService';
 import { AudioOscillatorStudent } from './audio-oscillator-student.component';
 import { AudioOscillatorStudentData } from '../AudioOscillatorStudentData';
@@ -33,6 +32,7 @@ describe('AudioOscillatorStudent', () => {
       imports: [
         BrowserAnimationsModule,
         BrowserModule,
+        ComponentHeaderComponent,
         FormsModule,
         HttpClientTestingModule,
         MatDialogModule,
@@ -41,11 +41,10 @@ describe('AudioOscillatorStudent', () => {
         MatInputModule,
         MatSelectModule,
         MatTooltipModule,
-        PossibleScoreComponent,
         ReactiveFormsModule,
         StudentTeacherCommonServicesModule
       ],
-      declarations: [AudioOscillatorStudent, ComponentHeader],
+      declarations: [AudioOscillatorStudent],
       schemas: [NO_ERRORS_SCHEMA]
     });
     fixture = TestBed.createComponent(AudioOscillatorStudent);

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.spec.ts
@@ -9,7 +9,7 @@ import { MatInputModule } from '@angular/material/input';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { ComputerAvatar } from '../../../common/computer-avatar/ComputerAvatar';
-import { ComponentHeader } from '../../../directives/component-header/component-header.component';
+import { ComponentHeaderComponent } from '../../../directives/component-header/component-header.component';
 import { ComputerAvatarService } from '../../../services/computerAvatarService';
 import { DialogGuidanceFeedbackService } from '../../../services/dialogGuidanceFeedbackService';
 import { ProjectService } from '../../../services/projectService';
@@ -26,7 +26,6 @@ import { DialogGuidanceComponent } from '../DialogGuidanceComponent';
 import { RawCRaterResponse } from '../../common/cRater/RawCRaterResponse';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ChatInputComponent } from '../../../common/chat-input/chat-input.component';
-import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
 
 let component: DialogGuidanceStudentComponent;
 let fixture: ComponentFixture<DialogGuidanceStudentComponent>;
@@ -50,10 +49,11 @@ function createDialogGuidanceComponent(isComputerAvatarEnabled: boolean): Dialog
 describe('DialogGuidanceStudentComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ComponentHeader, DialogGuidanceStudentComponent, DialogResponsesComponent],
+      declarations: [DialogGuidanceStudentComponent, DialogResponsesComponent],
       imports: [
         BrowserAnimationsModule,
         ChatInputComponent,
+        ComponentHeaderComponent,
         FormsModule,
         HttpClientTestingModule,
         MatCardModule,
@@ -61,7 +61,6 @@ describe('DialogGuidanceStudentComponent', () => {
         MatFormFieldModule,
         MatIconModule,
         MatInputModule,
-        PossibleScoreComponent,
         StudentTeacherCommonServicesModule
       ],
       providers: [DialogGuidanceFeedbackService],

--- a/src/assets/wise5/components/dialogGuidance/dialog-responses/dialog-responses.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-responses/dialog-responses.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ComponentHeader } from '../../../directives/component-header/component-header.component';
+import { ComponentHeaderComponent } from '../../../directives/component-header/component-header.component';
 import { DialogResponsesComponent } from './dialog-responses.component';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 
@@ -9,7 +9,8 @@ describe('DialogResponsesComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ComponentHeader, DialogResponsesComponent],
+      declarations: [DialogResponsesComponent],
+      imports: [ComponentHeaderComponent],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
   });

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.spec.ts
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.spec.ts
@@ -6,10 +6,9 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatRadioModule } from '@angular/material/radio';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { copy } from '../../../common/object/object';
-import { ComponentHeader } from '../../../directives/component-header/component-header.component';
+import { ComponentHeaderComponent } from '../../../directives/component-header/component-header.component';
 import { ProjectService } from '../../../services/projectService';
 import { MultipleChoiceComponent } from '../MultipleChoiceComponent';
 import { MultipleChoiceStudent } from './multiple-choice-student.component';
@@ -112,15 +111,15 @@ describe('MultipleChoiceStudentComponent', () => {
       imports: [
         BrowserAnimationsModule,
         BrowserModule,
+        ComponentHeaderComponent,
         HttpClientTestingModule,
         MatCheckboxModule,
         MatDialogModule,
         MatRadioModule,
-        PossibleScoreComponent,
         ReactiveFormsModule,
         StudentTeacherCommonServicesModule
       ],
-      declarations: [ComponentHeader, MultipleChoiceStudent],
+      declarations: [MultipleChoiceStudent],
       schemas: [NO_ERRORS_SCHEMA]
     });
     fixture = TestBed.createComponent(MultipleChoiceStudent);

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.spec.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.spec.ts
@@ -7,10 +7,9 @@ import { MatIconModule } from '@angular/material/icon';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
-import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { Component } from '../../../common/Component';
-import { ComponentHeader } from '../../../directives/component-header/component-header.component';
+import { ComponentHeaderComponent } from '../../../directives/component-header/component-header.component';
 import { ComponentSaveSubmitButtons } from '../../../directives/component-save-submit-buttons/component-save-submit-buttons.component';
 import { AudioRecorderService } from '../../../services/audioRecorderService';
 import { CRaterService } from '../../../services/cRaterService';
@@ -36,20 +35,15 @@ describe('OpenResponseStudent', () => {
         BrowserAnimationsModule,
         BrowserModule,
         CommonModule,
+        ComponentHeaderComponent,
         FormsModule,
         HttpClientTestingModule,
         MatDialogModule,
         MatIconModule,
-        PossibleScoreComponent,
         ReactiveFormsModule,
         StudentTeacherCommonServicesModule
       ],
-      declarations: [
-        ComponentHeader,
-        ComponentSaveSubmitButtons,
-        DialogWithoutCloseComponent,
-        OpenResponseStudent
-      ],
+      declarations: [ComponentSaveSubmitButtons, DialogWithoutCloseComponent, OpenResponseStudent],
       providers: [AudioRecorderService],
       schemas: [NO_ERRORS_SCHEMA]
     });

--- a/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.spec.ts
+++ b/src/assets/wise5/components/peerChat/peer-chat-student/peer-chat-student.component.spec.ts
@@ -18,8 +18,7 @@ import { PeerGroup } from '../PeerGroup';
 import { PeerChatStudentComponent } from './peer-chat-student.component';
 import { PeerGroupMember } from '../PeerGroupMember';
 import { of } from 'rxjs';
-import { ComponentHeader } from '../../../directives/component-header/component-header.component';
-import { PossibleScoreComponent } from '../../../../../app/possible-score/possible-score.component';
+import { ComponentHeaderComponent } from '../../../directives/component-header/component-header.component';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -31,7 +30,6 @@ import { PeerGrouping } from '../../../../../app/domain/peerGrouping';
 import { PauseScreenService } from '../../../services/pauseScreenService';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { FeedbackRule } from '../../common/feedbackRule/FeedbackRule';
-import { PromptComponent } from '../../../directives/prompt/prompt.component';
 import { PeerChatComponent } from '../PeerChatComponent';
 
 let component: PeerChatStudentComponent;
@@ -120,6 +118,7 @@ describe('PeerChatStudentComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,
+        ComponentHeaderComponent,
         FormsModule,
         HttpClientTestingModule,
         MatCardModule,
@@ -128,11 +127,9 @@ describe('PeerChatStudentComponent', () => {
         MatIconModule,
         MatInputModule,
         PeerChatModule,
-        PromptComponent,
-        PossibleScoreComponent,
         StudentTeacherCommonServicesModule
       ],
-      declarations: [ComponentHeader, PeerChatStudentComponent],
+      declarations: [PeerChatStudentComponent],
       providers: [
         AnnotationService,
         ComponentService,

--- a/src/assets/wise5/directives/component-header/component-header.component.spec.ts
+++ b/src/assets/wise5/directives/component-header/component-header.component.spec.ts
@@ -1,19 +1,24 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ComponentHeader } from './component-header.component';
+import { ComponentHeaderComponent } from './component-header.component';
 import { DomSanitizer } from '@angular/platform-browser';
-import { PromptComponent } from '../prompt/prompt.component';
 import { ComponentContent } from '../../common/ComponentContent';
 import { Component } from '../../common/Component';
+import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ProjectService } from '../../services/projectService';
 
-let component: ComponentHeader;
-let fixture: ComponentFixture<ComponentHeader>;
+let component: ComponentHeaderComponent;
+let fixture: ComponentFixture<ComponentHeaderComponent>;
 
 describe('ComponentHeaderComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ComponentHeader],
-      imports: [PromptComponent],
+      imports: [
+        ComponentHeaderComponent,
+        HttpClientTestingModule,
+        StudentTeacherCommonServicesModule
+      ],
       providers: [
         {
           provide: DomSanitizer,
@@ -24,10 +29,11 @@ describe('ComponentHeaderComponent', () => {
       ],
       schemas: [NO_ERRORS_SCHEMA]
     });
+    spyOn(TestBed.inject(ProjectService), 'getThemeSettings').and.returnValue({});
   });
 
   it('should show prompt', () => {
-    fixture = TestBed.createComponent(ComponentHeader);
+    fixture = TestBed.createComponent(ComponentHeaderComponent);
     component = fixture.componentInstance;
     component.component = new Component(
       {

--- a/src/assets/wise5/directives/component-header/component-header.component.ts
+++ b/src/assets/wise5/directives/component-header/component-header.component.ts
@@ -3,26 +3,31 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { Component as WISEComponent } from '../../common/Component';
 import { FeedbackRule } from '../../components/common/feedbackRule/FeedbackRule';
 import { DynamicPrompt } from '../dynamic-prompt/DynamicPrompt';
+import { PossibleScoreComponent } from '../../../../app/possible-score/possible-score.component';
+import { PromptComponent } from '../prompt/prompt.component';
+import { FlexLayoutModule } from '@angular/flex-layout';
 
 @Component({
+  imports: [FlexLayoutModule, PossibleScoreComponent, PromptComponent],
   selector: 'component-header',
-  styleUrls: ['component-header.component.scss'],
+  standalone: true,
+  styleUrl: 'component-header.component.scss',
   templateUrl: 'component-header.component.html'
 })
-export class ComponentHeader {
+export class ComponentHeaderComponent {
   @Input() component: WISEComponent;
-  dynamicPrompt: DynamicPrompt;
+  protected dynamicPrompt: DynamicPrompt;
   @Output() dynamicPromptChanged: EventEmitter<FeedbackRule> = new EventEmitter<FeedbackRule>();
-  prompt: SafeHtml;
+  protected prompt: SafeHtml;
 
   constructor(protected sanitizer: DomSanitizer) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.prompt = this.sanitizer.bypassSecurityTrustHtml(this.component.content.prompt);
     this.dynamicPrompt = new DynamicPrompt(this.component.content.dynamicPrompt);
   }
 
-  onDynamicPromptChanged(feedbackRule: FeedbackRule): void {
+  protected onDynamicPromptChanged(feedbackRule: FeedbackRule): void {
     this.dynamicPromptChanged.emit(feedbackRule);
   }
 }


### PR DESCRIPTION
## Changes
- Rename ComponentHeader to ComponentHeaderComponent
- Convert ComponentHeaderComponent to standalone component and update references
   - ComponentHeaderComponent now imports PromptComponent and PossibleScoreComponent 
- Clean up ComponentHeaderComponent: add protected modifier

## Test
- In the Student VLE, the prompt, dynamic prompt, and possible scores work as before