### PR TITLE
refactor(FaqComponents): Convert to standalone

### DIFF
--- a/src/app/help/faq/getting-started/getting-started.component.spec.ts
+++ b/src/app/help/faq/getting-started/getting-started.component.spec.ts
@@ -1,10 +1,9 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
 import { GettingStartedComponent } from './getting-started.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ConfigService } from '../../../services/config.service';
 import { Config } from '../../../domain/config';
 import { Observable } from 'rxjs';
+import { provideRouter } from '@angular/router';
 
 export class MockConfigService {
   getConfig(): Observable<Config> {
@@ -13,7 +12,7 @@ export class MockConfigService {
       logOutURL: '/logout',
       currentTime: new Date('2018-10-24T15:05:40.214').getTime()
     };
-    return Observable.create((observer) => {
+    return new Observable((observer) => {
       observer.next(config);
       observer.complete();
     });
@@ -27,9 +26,8 @@ describe('GettingStartedComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [GettingStartedComponent],
-        providers: [{ provide: ConfigService, useClass: MockConfigService }],
-        schemas: [NO_ERRORS_SCHEMA]
+        imports: [GettingStartedComponent],
+        providers: [{ provide: ConfigService, useClass: MockConfigService }, provideRouter([])]
       }).compileComponents();
     })
   );

--- a/src/app/help/faq/getting-started/getting-started.component.ts
+++ b/src/app/help/faq/getting-started/getting-started.component.ts
@@ -1,9 +1,13 @@
-import { Component, OnInit } from '@angular/core';
-import { ConfigService } from '../../../services/config.service';
+import { Component } from '@angular/core';
 import { FaqComponent } from '../faq.component';
+import { MatDividerModule } from '@angular/material/divider';
+import { CallToActionComponent } from '../../../modules/shared/call-to-action/call-to-action.component';
+import { MatIconModule } from '@angular/material/icon';
+import { FlexLayoutModule } from '@angular/flex-layout';
 
 @Component({
-  selector: 'app-getting-started',
+  imports: [CallToActionComponent, FlexLayoutModule, MatDividerModule, MatIconModule],
+  standalone: true,
   templateUrl: './getting-started.component.html'
 })
 export class GettingStartedComponent extends FaqComponent {}

--- a/src/app/help/faq/student-faq/student-faq.component.spec.ts
+++ b/src/app/help/faq/student-faq/student-faq.component.spec.ts
@@ -1,10 +1,9 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
 import { StudentFaqComponent } from './student-faq.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ConfigService } from '../../../services/config.service';
 import { Observable } from 'rxjs';
 import { Config } from '../../../domain/config';
+import { provideRouter } from '@angular/router';
 
 export class MockConfigService {
   getConfig(): Observable<Config> {
@@ -13,7 +12,7 @@ export class MockConfigService {
       logOutURL: '/logout',
       currentTime: new Date('2018-10-24T15:05:40.214').getTime()
     };
-    return Observable.create((observer) => {
+    return new Observable((observer) => {
       observer.next(config);
       observer.complete();
     });
@@ -27,9 +26,8 @@ describe('StudentFaqComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [StudentFaqComponent],
-        providers: [{ provide: ConfigService, useClass: MockConfigService }],
-        schemas: [NO_ERRORS_SCHEMA]
+        imports: [StudentFaqComponent],
+        providers: [{ provide: ConfigService, useClass: MockConfigService }, provideRouter([])]
       }).compileComponents();
     })
   );

--- a/src/app/help/faq/student-faq/student-faq.component.ts
+++ b/src/app/help/faq/student-faq/student-faq.component.ts
@@ -1,8 +1,14 @@
 import { Component } from '@angular/core';
 import { FaqComponent } from '../faq.component';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatIconModule } from '@angular/material/icon';
+import { CallToActionComponent } from '../../../modules/shared/call-to-action/call-to-action.component';
+import { RouterModule } from '@angular/router';
 
 @Component({
-  selector: 'app-student-faq',
+  imports: [CallToActionComponent, FlexLayoutModule, MatDividerModule, MatIconModule, RouterModule],
+  standalone: true,
   templateUrl: './student-faq.component.html'
 })
 export class StudentFaqComponent extends FaqComponent {}

--- a/src/app/help/faq/teacher-faq/teacher-faq.component.spec.ts
+++ b/src/app/help/faq/teacher-faq/teacher-faq.component.spec.ts
@@ -1,10 +1,9 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
 import { TeacherFaqComponent } from './teacher-faq.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ConfigService } from '../../../services/config.service';
 import { Observable } from 'rxjs';
 import { Config } from '../../../domain/config';
+import { provideRouter } from '@angular/router';
 
 export class MockConfigService {
   getConfig(): Observable<Config> {
@@ -13,7 +12,7 @@ export class MockConfigService {
       logOutURL: '/logout',
       currentTime: new Date('2018-10-24T15:05:40.214').getTime()
     };
-    return Observable.create((observer) => {
+    return new Observable((observer) => {
       observer.next(config);
       observer.complete();
     });
@@ -27,9 +26,8 @@ describe('TeacherFaqComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [TeacherFaqComponent],
-        providers: [{ provide: ConfigService, useClass: MockConfigService }],
-        schemas: [NO_ERRORS_SCHEMA]
+        imports: [TeacherFaqComponent],
+        providers: [{ provide: ConfigService, useClass: MockConfigService }, provideRouter([])]
       }).compileComponents();
     })
   );

--- a/src/app/help/faq/teacher-faq/teacher-faq.component.ts
+++ b/src/app/help/faq/teacher-faq/teacher-faq.component.ts
@@ -1,8 +1,14 @@
 import { Component } from '@angular/core';
 import { FaqComponent } from '../faq.component';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatIconModule } from '@angular/material/icon';
+import { CallToActionComponent } from '../../../modules/shared/call-to-action/call-to-action.component';
+import { RouterModule } from '@angular/router';
 
 @Component({
-  selector: 'app-teacher-faq',
+  imports: [CallToActionComponent, FlexLayoutModule, MatDividerModule, MatIconModule, RouterModule],
+  standalone: true,
   templateUrl: './teacher-faq.component.html'
 })
 export class TeacherFaqComponent extends FaqComponent {}

--- a/src/app/help/help.module.ts
+++ b/src/app/help/help.module.ts
@@ -11,13 +11,14 @@ import { MatDividerModule } from '@angular/material/divider';
 import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-action.component';
 
 @NgModule({
-  imports: [CallToActionComponent, CommonModule, HelpRoutingModule, MatDividerModule, SharedModule],
-  declarations: [
-    HelpComponent,
+  imports: [
+    CallToActionComponent,
+    CommonModule,
     GettingStartedComponent,
-    TeacherFaqComponent,
-    StudentFaqComponent,
-    HelpHomeComponent
-  ]
+    HelpRoutingModule,
+    MatDividerModule,
+    SharedModule
+  ],
+  declarations: [HelpComponent, TeacherFaqComponent, StudentFaqComponent, HelpHomeComponent]
 })
 export class HelpModule {}

--- a/src/app/help/help.module.ts
+++ b/src/app/help/help.module.ts
@@ -17,8 +17,9 @@ import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-
     GettingStartedComponent,
     HelpRoutingModule,
     MatDividerModule,
-    SharedModule
+    SharedModule,
+    StudentFaqComponent
   ],
-  declarations: [HelpComponent, TeacherFaqComponent, StudentFaqComponent, HelpHomeComponent]
+  declarations: [HelpComponent, TeacherFaqComponent, HelpHomeComponent]
 })
 export class HelpModule {}

--- a/src/app/help/help.module.ts
+++ b/src/app/help/help.module.ts
@@ -18,8 +18,9 @@ import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-
     HelpRoutingModule,
     MatDividerModule,
     SharedModule,
-    StudentFaqComponent
+    StudentFaqComponent,
+    TeacherFaqComponent
   ],
-  declarations: [HelpComponent, TeacherFaqComponent, HelpHomeComponent]
+  declarations: [HelpComponent, HelpHomeComponent]
 })
 export class HelpModule {}


### PR DESCRIPTION
## Changes
- Convert GettingStartedComponent, StudentFaqComponent, and TeacherFaqComponent to standalone component
   - update references
   - remove unused imports and selectors

## Test
- Getting Started, Student FAQ, and Teacher FAQ pages display and work as before, in particular:
   - links to sections in page and to another page
   - hero sections at the bottom of the pages 