### PR TITLE
refactor(AddToNotebookButtonComponent): Convert to standalone

### DIFF
--- a/src/app/student/student.component.module.ts
+++ b/src/app/student/student.component.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { AddToNotebookButton } from '../../assets/wise5/directives/add-to-notebook-button/add-to-notebook-button.component';
+import { AddToNotebookButtonComponent } from '../../assets/wise5/directives/add-to-notebook-button/add-to-notebook-button.component';
 import { ComponentHeaderComponent } from '../../assets/wise5/directives/component-header/component-header.component';
 import { ComponentSaveSubmitButtons } from '../../assets/wise5/directives/component-save-submit-buttons/component-save-submit-buttons.component';
 import { ComponentAnnotationsComponent } from '../../assets/wise5/directives/componentAnnotations/component-annotations.component';
@@ -7,10 +7,15 @@ import { StudentTeacherCommonModule } from '../student-teacher-common.module';
 import { ComponentStateInfoComponent } from '../../assets/wise5/common/component-state-info/component-state-info.component';
 
 @NgModule({
-  declarations: [AddToNotebookButton, ComponentAnnotationsComponent, ComponentSaveSubmitButtons],
-  imports: [ComponentHeaderComponent, ComponentStateInfoComponent, StudentTeacherCommonModule],
+  declarations: [ComponentAnnotationsComponent, ComponentSaveSubmitButtons],
+  imports: [
+    AddToNotebookButtonComponent,
+    ComponentHeaderComponent,
+    ComponentStateInfoComponent,
+    StudentTeacherCommonModule
+  ],
   exports: [
-    AddToNotebookButton,
+    AddToNotebookButtonComponent,
     ComponentAnnotationsComponent,
     ComponentHeaderComponent,
     ComponentSaveSubmitButtons

--- a/src/assets/wise5/directives/add-to-notebook-button/add-to-notebook-button.component.html
+++ b/src/assets/wise5/directives/add-to-notebook-button/add-to-notebook-button.component.html
@@ -1,9 +1,3 @@
-<button
-  mat-button
-  class="mat-accent mat-button"
-  [disabled]="isDisabled"
-  (click)="addToNotebook()"
-  i18n-matTooltip
->
+<button mat-button class="mat-accent mat-button" [disabled]="isDisabled" (click)="snipImage.next()">
   <mat-icon>note_add</mat-icon>&nbsp;<ng-container i18n>Add to Notebook</ng-container>
 </button>

--- a/src/assets/wise5/directives/add-to-notebook-button/add-to-notebook-button.component.ts
+++ b/src/assets/wise5/directives/add-to-notebook-button/add-to-notebook-button.component.ts
@@ -1,17 +1,14 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
+  imports: [MatButtonModule, MatIconModule],
   selector: 'add-to-notebook-button',
+  standalone: true,
   templateUrl: 'add-to-notebook-button.component.html'
 })
-export class AddToNotebookButton {
-  @Input()
-  isDisabled: boolean;
-
-  @Output()
-  snipImage = new EventEmitter<void>();
-
-  addToNotebook() {
-    this.snipImage.next();
-  }
+export class AddToNotebookButtonComponent {
+  @Input() isDisabled: boolean;
+  @Output() snipImage = new EventEmitter<void>();
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -18527,7 +18527,7 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/add-to-notebook-button/add-to-notebook-button.component.html</context>
-          <context context-type="linenumber">8</context>
+          <context context-type="linenumber">2</context>
         </context-group>
       </trans-unit>
       <trans-unit id="379f07df38b42d031cebe9c616411f3d69ea12f7" datatype="html">


### PR DESCRIPTION
## Changes
- Rename AddToNotebookButton to AddToNotebookButtonComponent
- Convert AddToNotebookButtonComponent to standalone component and update references
- Clean up AddToNotebookButtonComponent

## Test
- In the student VLE, AddToNotebookButtonComponent displays and works as before in ConceptMap, Draw, Embedded, and Label components, when add to notebook option is enabled for the unit. 