### PR TITLE
refactor(ComponentSaveSubmitButtonComponent): Convert to standalone

### DIFF
--- a/src/app/student/student.component.module.ts
+++ b/src/app/student/student.component.module.ts
@@ -1,25 +1,23 @@
 import { NgModule } from '@angular/core';
 import { AddToNotebookButtonComponent } from '../../assets/wise5/directives/add-to-notebook-button/add-to-notebook-button.component';
 import { ComponentHeaderComponent } from '../../assets/wise5/directives/component-header/component-header.component';
-import { ComponentSaveSubmitButtons } from '../../assets/wise5/directives/component-save-submit-buttons/component-save-submit-buttons.component';
+import { ComponentSaveSubmitButtonsComponent } from '../../assets/wise5/directives/component-save-submit-buttons/component-save-submit-buttons.component';
 import { ComponentAnnotationsComponent } from '../../assets/wise5/directives/componentAnnotations/component-annotations.component';
-import { StudentTeacherCommonModule } from '../student-teacher-common.module';
 import { ComponentStateInfoComponent } from '../../assets/wise5/common/component-state-info/component-state-info.component';
 
 @NgModule({
-  declarations: [ComponentSaveSubmitButtons],
   imports: [
     AddToNotebookButtonComponent,
     ComponentAnnotationsComponent,
     ComponentHeaderComponent,
-    ComponentStateInfoComponent,
-    StudentTeacherCommonModule
+    ComponentSaveSubmitButtonsComponent,
+    ComponentStateInfoComponent
   ],
   exports: [
     AddToNotebookButtonComponent,
     ComponentAnnotationsComponent,
     ComponentHeaderComponent,
-    ComponentSaveSubmitButtons
+    ComponentSaveSubmitButtonsComponent
   ]
 })
 export class StudentComponentModule {}

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.spec.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.spec.ts
@@ -10,7 +10,7 @@ import { of } from 'rxjs';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { Component } from '../../../common/Component';
 import { ComponentHeaderComponent } from '../../../directives/component-header/component-header.component';
-import { ComponentSaveSubmitButtons } from '../../../directives/component-save-submit-buttons/component-save-submit-buttons.component';
+import { ComponentSaveSubmitButtonsComponent } from '../../../directives/component-save-submit-buttons/component-save-submit-buttons.component';
 import { AudioRecorderService } from '../../../services/audioRecorderService';
 import { CRaterService } from '../../../services/cRaterService';
 import { NotebookService } from '../../../services/notebookService';
@@ -19,7 +19,6 @@ import { StudentDataService } from '../../../services/studentDataService';
 import { OpenResponseContent } from '../OpenResponseContent';
 import { OpenResponseService } from '../openResponseService';
 import { OpenResponseStudent } from './open-response-student.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { DialogWithoutCloseComponent } from '../../../directives/dialog-without-close/dialog-without-close.component';
 
 let component: OpenResponseStudent;
@@ -36,6 +35,7 @@ describe('OpenResponseStudent', () => {
         BrowserModule,
         CommonModule,
         ComponentHeaderComponent,
+        ComponentSaveSubmitButtonsComponent,
         FormsModule,
         HttpClientTestingModule,
         MatDialogModule,
@@ -43,9 +43,8 @@ describe('OpenResponseStudent', () => {
         ReactiveFormsModule,
         StudentTeacherCommonServicesModule
       ],
-      declarations: [ComponentSaveSubmitButtons, DialogWithoutCloseComponent, OpenResponseStudent],
-      providers: [AudioRecorderService],
-      schemas: [NO_ERRORS_SCHEMA]
+      declarations: [DialogWithoutCloseComponent, OpenResponseStudent],
+      providers: [AudioRecorderService]
     });
   });
 

--- a/src/assets/wise5/directives/component-save-submit-buttons/component-save-submit-buttons.component.html
+++ b/src/assets/wise5/directives/component-save-submit-buttons/component-save-submit-buttons.component.html
@@ -3,7 +3,7 @@
     *ngIf="isSaveButtonVisible"
     mat-raised-button
     color="primary"
-    (click)="save()"
+    (click)="saveButtonClicked.next()"
     [disabled]="isDisabled || !isDirty"
     i18n
   >
@@ -13,7 +13,7 @@
     *ngIf="isSubmitButtonVisible"
     mat-raised-button
     color="primary"
-    (click)="submit()"
+    (click)="submitButtonClicked.next()"
     [disabled]="isSubmitButtonDisabled || isDisabled || !isSubmitDirty"
     i18n
   >

--- a/src/assets/wise5/directives/component-save-submit-buttons/component-save-submit-buttons.component.ts
+++ b/src/assets/wise5/directives/component-save-submit-buttons/component-save-submit-buttons.component.ts
@@ -1,44 +1,25 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ComponentState } from '../../../../app/domain/componentState';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { ComponentStateInfoComponent } from '../../common/component-state-info/component-state-info.component';
+import { FlexLayoutModule } from '@angular/flex-layout';
 
 @Component({
+  imports: [CommonModule, FlexLayoutModule, ComponentStateInfoComponent, MatButtonModule],
   selector: 'component-save-submit-buttons',
-  styleUrls: ['component-save-submit-buttons.component.scss'],
+  standalone: true,
+  styleUrl: 'component-save-submit-buttons.component.scss',
   templateUrl: 'component-save-submit-buttons.component.html'
 })
-export class ComponentSaveSubmitButtons {
-  @Input()
-  isDirty: boolean;
-
-  @Input()
-  isDisabled: boolean;
-
-  @Input()
-  isSaveButtonVisible: boolean;
-
-  @Input()
-  isSubmitButtonDisabled: boolean;
-
-  @Input()
-  isSubmitButtonVisible: boolean;
-
-  @Input()
-  isSubmitDirty: boolean;
-
-  @Input()
-  componentState: ComponentState;
-
-  @Output()
-  saveButtonClicked = new EventEmitter<void>();
-
-  @Output()
-  submitButtonClicked = new EventEmitter<void>();
-
-  save() {
-    this.saveButtonClicked.next();
-  }
-
-  submit() {
-    this.submitButtonClicked.next();
-  }
+export class ComponentSaveSubmitButtonsComponent {
+  @Input() componentState: ComponentState;
+  @Input() isDirty: boolean;
+  @Input() isDisabled: boolean;
+  @Input() isSaveButtonVisible: boolean;
+  @Input() isSubmitButtonDisabled: boolean;
+  @Input() isSubmitButtonVisible: boolean;
+  @Input() isSubmitDirty: boolean;
+  @Output() saveButtonClicked = new EventEmitter<void>();
+  @Output() submitButtonClicked = new EventEmitter<void>();
 }


### PR DESCRIPTION
## Changes
- Rename ComponentSaveSubmitButton to ComponentSaveSubmitButtonComponent
- Convert ComponentSaveSubmitButtonComponent to standalone component
   - import ComponentStateInfoComponent that it uses
   - update references
- Clean up ComponentSaveSubmitButtonComponent
- Remove StudentTeacherCommonModule import from StudentComponentModule. All the necessary imports are now done though the standalone components in StudentComponentModule.

## Test
- In the student VLE, ComponentSaveSubmitButton displays and works as before. The save/submit button should display if authored, and the saved/submitted message should appear next to it
- Other standalone components in StudentComponentModule (AddToNotebookButtonComponent, ComponentAnnotationsComponent, ...) work as before.