### PR TITLE
refactor(HelpComponents): Convert to standalone

### DIFF
--- a/src/app/help/help-home/help-home.component.spec.ts
+++ b/src/app/help/help-home/help-home.component.spec.ts
@@ -1,18 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
 import { HelpHomeComponent } from './help-home.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { provideRouter } from '@angular/router';
 
 describe('HelpHomeComponent', () => {
   let component: HelpHomeComponent;
   let fixture: ComponentFixture<HelpHomeComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [HelpHomeComponent],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [HelpHomeComponent],
+        providers: [provideRouter([])]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HelpHomeComponent);

--- a/src/app/help/help-home/help-home.component.ts
+++ b/src/app/help/help-home/help-home.component.ts
@@ -1,12 +1,12 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+import { CallToActionComponent } from '../../modules/shared/call-to-action/call-to-action.component';
+import { FlexLayoutModule } from '@angular/flex-layout';
 
 @Component({
+  imports: [CallToActionComponent, FlexLayoutModule],
   selector: 'app-help-home',
-  templateUrl: './help-home.component.html',
-  styleUrls: ['./help-home.component.scss']
+  standalone: true,
+  styleUrl: './help-home.component.scss',
+  templateUrl: './help-home.component.html'
 })
-export class HelpHomeComponent implements OnInit {
-  constructor() {}
-
-  ngOnInit() {}
-}
+export class HelpHomeComponent {}

--- a/src/app/help/help.component.spec.ts
+++ b/src/app/help/help.component.spec.ts
@@ -1,18 +1,17 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
 import { HelpComponent } from './help.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 describe('HelpComponent', () => {
   let component: HelpComponent;
   let fixture: ComponentFixture<HelpComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [HelpComponent],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [HelpComponent]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HelpComponent);

--- a/src/app/help/help.component.ts
+++ b/src/app/help/help.component.ts
@@ -1,12 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 @Component({
+  imports: [RouterModule],
   selector: 'app-help',
-  templateUrl: './help.component.html',
-  styleUrls: ['./help.component.scss']
+  standalone: true,
+  styleUrl: './help.component.scss',
+  templateUrl: './help.component.html'
 })
-export class HelpComponent implements OnInit {
-  constructor() {}
-
-  ngOnInit() {}
-}
+export class HelpComponent {}

--- a/src/app/help/help.module.ts
+++ b/src/app/help/help.module.ts
@@ -15,12 +15,13 @@ import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-
     CallToActionComponent,
     CommonModule,
     GettingStartedComponent,
+    HelpHomeComponent,
     HelpRoutingModule,
     MatDividerModule,
     SharedModule,
     StudentFaqComponent,
     TeacherFaqComponent
   ],
-  declarations: [HelpComponent, HelpHomeComponent]
+  declarations: [HelpComponent]
 })
 export class HelpModule {}

--- a/src/app/help/help.module.ts
+++ b/src/app/help/help.module.ts
@@ -15,13 +15,13 @@ import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-
     CallToActionComponent,
     CommonModule,
     GettingStartedComponent,
+    HelpComponent,
     HelpHomeComponent,
     HelpRoutingModule,
     MatDividerModule,
     SharedModule,
     StudentFaqComponent,
     TeacherFaqComponent
-  ],
-  declarations: [HelpComponent]
+  ]
 })
 export class HelpModule {}

--- a/src/app/help/help.module.ts
+++ b/src/app/help/help.module.ts
@@ -1,25 +1,17 @@
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { HelpComponent } from './help.component';
 import { HelpRoutingModule } from './help-routing.module';
-import { SharedModule } from '../modules/shared/shared.module';
 import { GettingStartedComponent } from './faq/getting-started/getting-started.component';
 import { TeacherFaqComponent } from './faq/teacher-faq/teacher-faq.component';
 import { StudentFaqComponent } from './faq/student-faq/student-faq.component';
 import { HelpHomeComponent } from './help-home/help-home.component';
-import { MatDividerModule } from '@angular/material/divider';
-import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-action.component';
 
 @NgModule({
   imports: [
-    CallToActionComponent,
-    CommonModule,
     GettingStartedComponent,
     HelpComponent,
     HelpHomeComponent,
     HelpRoutingModule,
-    MatDividerModule,
-    SharedModule,
     StudentFaqComponent,
     TeacherFaqComponent
   ]


### PR DESCRIPTION
## Changes
- Convert HelpComponent and HelpHomeComponent to standalone component
   - update references and clean files
- Remove imports (SharedModule, MatDividerModule, etc) from HelpModule. All the necessary imports are now done though the standalone components.

## Test
- Getting Started, Student FAQ, and Teacher FAQ pages display and work as before, in particular:
   - links to sections in page and to another page
   - hero sections at the bottom of the pages 