### PR TITLE
refactor(ForgotComponents): Convert to standalone

### DIFF
--- a/src/app/forgot/forgot-home/forgot-home.component.spec.ts
+++ b/src/app/forgot/forgot-home/forgot-home.component.spec.ts
@@ -1,6 +1,6 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ForgotHomeComponent } from './forgot-home.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { provideRouter } from '@angular/router';
 
 describe('ForgotHomeComponent', () => {
   let component: ForgotHomeComponent;
@@ -8,12 +8,9 @@ describe('ForgotHomeComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ForgotHomeComponent],
-      schemas: [NO_ERRORS_SCHEMA]
+      imports: [ForgotHomeComponent],
+      providers: [provideRouter([])]
     });
-  });
-
-  beforeEach(() => {
     fixture = TestBed.createComponent(ForgotHomeComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/forgot/forgot-home/forgot-home.component.ts
+++ b/src/app/forgot/forgot-home/forgot-home.component.ts
@@ -1,12 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { CallToActionComponent } from '../../modules/shared/call-to-action/call-to-action.component';
 
 @Component({
-  selector: 'app-forgot-home',
-  templateUrl: './forgot-home.component.html',
-  styleUrls: ['./forgot-home.component.scss']
+  imports: [CallToActionComponent, FlexLayoutModule],
+  standalone: true,
+  styleUrl: './forgot-home.component.scss',
+  templateUrl: './forgot-home.component.html'
 })
-export class ForgotHomeComponent implements OnInit {
-  constructor() {}
-
-  ngOnInit() {}
-}
+export class ForgotHomeComponent {}

--- a/src/app/forgot/forgot.component.spec.ts
+++ b/src/app/forgot/forgot.component.spec.ts
@@ -1,20 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
 import { ForgotComponent } from './forgot.component';
-import { RouterTestingModule } from '@angular/router/testing';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { provideRouter } from '@angular/router';
 
 describe('ForgotComponent', () => {
   let component: ForgotComponent;
   let fixture: ComponentFixture<ForgotComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      declarations: [ForgotComponent],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [ForgotComponent],
+        providers: [provideRouter([])]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ForgotComponent);

--- a/src/app/forgot/forgot.component.ts
+++ b/src/app/forgot/forgot.component.ts
@@ -1,12 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 @Component({
-  selector: 'app-forgot',
-  templateUrl: './forgot.component.html',
-  styleUrls: ['./forgot.component.scss']
+  imports: [RouterModule],
+  standalone: true,
+  templateUrl: './forgot.component.html'
 })
-export class ForgotComponent implements OnInit {
-  constructor() {}
-
-  ngOnInit() {}
-}
+export class ForgotComponent {}

--- a/src/app/forgot/forgot.module.ts
+++ b/src/app/forgot/forgot.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-
 import { ForgotRoutingModule } from './forgot-routing.module';
 import { ForgotHomeComponent } from './forgot-home/forgot-home.component';
 import { ForgotComponent } from './forgot.component';
@@ -29,6 +28,7 @@ import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-
     CommonModule,
     ForgotComponent,
     ForgotHomeComponent,
+    ForgotStudentComponent,
     ForgotRoutingModule,
     FormsModule,
     MatDividerModule,
@@ -38,7 +38,6 @@ import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-
     SharedModule
   ],
   declarations: [
-    ForgotStudentComponent,
     ForgotTeacherComponent,
     ForgotStudentPasswordComponent,
     ForgotStudentUsernameComponent,

--- a/src/app/forgot/forgot.module.ts
+++ b/src/app/forgot/forgot.module.ts
@@ -27,6 +27,7 @@ import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-
   imports: [
     CallToActionComponent,
     CommonModule,
+    ForgotComponent,
     ForgotRoutingModule,
     FormsModule,
     MatDividerModule,
@@ -36,7 +37,6 @@ import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-
     SharedModule
   ],
   declarations: [
-    ForgotComponent,
     ForgotHomeComponent,
     ForgotStudentComponent,
     ForgotTeacherComponent,

--- a/src/app/forgot/forgot.module.ts
+++ b/src/app/forgot/forgot.module.ts
@@ -28,6 +28,7 @@ import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-
     CallToActionComponent,
     CommonModule,
     ForgotComponent,
+    ForgotHomeComponent,
     ForgotRoutingModule,
     FormsModule,
     MatDividerModule,
@@ -37,7 +38,6 @@ import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-
     SharedModule
   ],
   declarations: [
-    ForgotHomeComponent,
     ForgotStudentComponent,
     ForgotTeacherComponent,
     ForgotStudentPasswordComponent,

--- a/src/app/forgot/forgot.module.ts
+++ b/src/app/forgot/forgot.module.ts
@@ -29,6 +29,7 @@ import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-
     ForgotComponent,
     ForgotHomeComponent,
     ForgotStudentComponent,
+    ForgotTeacherComponent,
     ForgotRoutingModule,
     FormsModule,
     MatDividerModule,
@@ -38,7 +39,6 @@ import { CallToActionComponent } from '../modules/shared/call-to-action/call-to-
     SharedModule
   ],
   declarations: [
-    ForgotTeacherComponent,
     ForgotStudentPasswordComponent,
     ForgotStudentUsernameComponent,
     ForgotTeacherUsernameComponent,

--- a/src/app/forgot/student/forgot-student/forgot-student.component.spec.ts
+++ b/src/app/forgot/student/forgot-student/forgot-student.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ForgotStudentComponent } from './forgot-student.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { provideRouter } from '@angular/router';
 
 describe('ForgotStudentComponent', () => {
   let component: ForgotStudentComponent;
@@ -8,12 +8,9 @@ describe('ForgotStudentComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ForgotStudentComponent],
-      schemas: [NO_ERRORS_SCHEMA]
+      imports: [ForgotStudentComponent],
+      providers: [provideRouter([])]
     });
-  });
-
-  beforeEach(() => {
     fixture = TestBed.createComponent(ForgotStudentComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/forgot/student/forgot-student/forgot-student.component.ts
+++ b/src/app/forgot/student/forgot-student/forgot-student.component.ts
@@ -1,12 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { CallToActionComponent } from '../../../modules/shared/call-to-action/call-to-action.component';
 
 @Component({
-  selector: 'app-forgot-student',
-  templateUrl: './forgot-student.component.html',
-  styleUrls: ['./forgot-student.component.scss']
+  imports: [CallToActionComponent, FlexLayoutModule],
+  standalone: true,
+  styleUrl: './forgot-student.component.scss',
+  templateUrl: './forgot-student.component.html'
 })
-export class ForgotStudentComponent implements OnInit {
-  constructor() {}
-
-  ngOnInit() {}
-}
+export class ForgotStudentComponent {}

--- a/src/app/forgot/teacher/forgot-teacher/forgot-teacher.component.spec.ts
+++ b/src/app/forgot/teacher/forgot-teacher/forgot-teacher.component.spec.ts
@@ -1,6 +1,6 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ForgotTeacherComponent } from './forgot-teacher.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { provideRouter } from '@angular/router';
 
 describe('ForgotTeacherComponent', () => {
   let component: ForgotTeacherComponent;
@@ -8,8 +8,8 @@ describe('ForgotTeacherComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ForgotTeacherComponent],
-      schemas: [NO_ERRORS_SCHEMA]
+      imports: [ForgotTeacherComponent],
+      providers: [provideRouter([])]
     });
     fixture = TestBed.createComponent(ForgotTeacherComponent);
     component = fixture.componentInstance;

--- a/src/app/forgot/teacher/forgot-teacher/forgot-teacher.component.ts
+++ b/src/app/forgot/teacher/forgot-teacher/forgot-teacher.component.ts
@@ -1,12 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { CallToActionComponent } from '../../../modules/shared/call-to-action/call-to-action.component';
 
 @Component({
-  selector: 'app-forgot-teacher',
-  templateUrl: './forgot-teacher.component.html',
-  styleUrls: ['./forgot-teacher.component.scss']
+  imports: [FlexLayoutModule, CallToActionComponent],
+  standalone: true,
+  styleUrl: './forgot-teacher.component.scss',
+  templateUrl: './forgot-teacher.component.html'
 })
-export class ForgotTeacherComponent implements OnInit {
-  constructor() {}
-
-  ngOnInit() {}
-}
+export class ForgotTeacherComponent {}


### PR DESCRIPTION
## Changes
- Convert ForgotComponent, ForgotHomeComponent, ForgotStudentComponent, and ForgotTeacherComponent to standalone components
   - update references
   - remove unused imports and selectors

## Test
- Forgot and ForgotHome (/forgot), ForgotStudent (/forgot/student), and ForgotTeacher (/forgot/teacher) pages display and work as before. Note that pages further on in the forgot process have not been converted to standalone components yet, but they should continue to work as before.
