### PR TITLE
refactor(PreviewComponentComponent): Convert to standalone

### DIFF
--- a/src/app/classroom-monitor/show-node-info-dialog/show-node-info-dialog.component.spec.ts
+++ b/src/app/classroom-monitor/show-node-info-dialog/show-node-info-dialog.component.spec.ts
@@ -39,15 +39,10 @@ const node: any = {
   title: stepTitle
 };
 
-describe('ShowNodeInfoDialogComponent', () => {
+describe('ShowNodeInfoDialogComponents', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [
-        NodeInfoComponent,
-        OpenResponseStudent,
-        PreviewComponentComponent,
-        ShowNodeInfoDialogComponent
-      ],
+      declarations: [NodeInfoComponent, OpenResponseStudent, ShowNodeInfoDialogComponent],
       imports: [
         ClassroomMonitorTestingModule,
         ComponentHeaderComponent,
@@ -55,7 +50,8 @@ describe('ShowNodeInfoDialogComponent', () => {
         MatCardModule,
         MatDialogModule,
         MatIconModule,
-        MatToolbarModule
+        MatToolbarModule,
+        PreviewComponentComponent
       ],
       providers: [
         { provide: MAT_DIALOG_DATA, useValue: nodeId1 },

--- a/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html
+++ b/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html
@@ -15,13 +15,13 @@
     <preview-component
       *ngIf="previewComponents.length === 1"
       [component]="previewComponents[0]"
-    ></preview-component>
+    />
     <mat-tab-group *ngIf="previewComponents.length > 1" mat-stretch-tabs="false">
       <mat-tab
         *ngFor="let component of previewComponents; index as i"
         [label]="previewExamples[i].label"
       >
-        <preview-component [component]="component"></preview-component>
+        <preview-component [component]="component" />
       </mat-tab>
     </mat-tab-group>
   </mat-card>

--- a/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.spec.ts
+++ b/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.spec.ts
@@ -34,11 +34,7 @@ let outsideUrlInfo = new OutsideUrlInfo();
 describe('ComponentInfoDialogComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [
-        ComponentInfoDialogComponent,
-        ComponentTypeSelectorComponent,
-        PreviewComponentComponent
-      ],
+      declarations: [ComponentInfoDialogComponent, ComponentTypeSelectorComponent],
       imports: [
         BrowserAnimationsModule,
         ComponentHeaderComponent,
@@ -52,6 +48,7 @@ describe('ComponentInfoDialogComponent', () => {
         MatIconModule,
         MatSelectModule,
         MatTabsModule,
+        PreviewComponentComponent,
         PreviewComponentModule
       ],
       providers: [ComponentInfoService, { provide: MAT_DIALOG_DATA, useValue: 'OpenResponse' }]

--- a/src/assets/wise5/authoringTool/components/preview-component-dialog/preview-component-dialog.component.html
+++ b/src/assets/wise5/authoringTool/components/preview-component-dialog/preview-component-dialog.component.html
@@ -12,8 +12,7 @@
   <preview-component
     [component]="component"
     (starterStateChangedEvent)="updateStarterState($event)"
-  >
-  </preview-component>
+  />
 </mat-dialog-content>
 <mat-divider></mat-divider>
 <mat-dialog-actions align="end">

--- a/src/assets/wise5/authoringTool/components/preview-component/preview-component.component.ts
+++ b/src/assets/wise5/authoringTool/components/preview-component/preview-component.component.ts
@@ -15,6 +15,7 @@ import { components } from '../../../components/Components';
 
 @Component({
   selector: 'preview-component',
+  standalone: true,
   template: '<div class="component__wrapper"><div #component></div></div>'
 })
 export class PreviewComponentComponent {
@@ -36,7 +37,11 @@ export class PreviewComponentComponent {
     }
   }
 
-  renderComponent(): void {
+  ngOnDestroy(): void {
+    this.componentRef.destroy();
+  }
+
+  private renderComponent(): void {
     this.componentRef = createComponent(components[this.component.content.type].student, {
       hostElement: this.componentElementRef.nativeElement,
       environmentInjector: this.injector
@@ -48,9 +53,5 @@ export class PreviewComponentComponent {
       starterStateChangedEvent: this.starterStateChangedEvent
     });
     this.applicationRef.attachView(this.componentRef.hostView);
-  }
-
-  ngOnDestroy(): void {
-    this.componentRef.destroy();
   }
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/node-info/node-info.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/node-info/node-info.component.html
@@ -19,8 +19,7 @@
       >
         {{ component.assessmentItemIndex + '. ' + component.typeLabel }}&nbsp;
       </h3>
-      <preview-component [component]="component.component" [periodId]="periodId">
-      </preview-component>
+      <preview-component [component]="component.component" [periodId]="periodId" />
       <mat-card
         appearance="outlined"
         *ngIf="component.rubric"

--- a/src/assets/wise5/components/component/component-student.module.ts
+++ b/src/assets/wise5/components/component/component-student.module.ts
@@ -28,7 +28,7 @@ import { ComponentComponent } from './component.component';
 import { AiChatStudentModule } from '../aiChat/ai-chat-student/ai-chat-student.module';
 
 @NgModule({
-  declarations: [ComponentComponent, PreviewComponentComponent],
+  declarations: [ComponentComponent],
   imports: [
     AiChatStudentModule,
     AnimationStudentModule,
@@ -49,6 +49,7 @@ import { AiChatStudentModule } from '../aiChat/ai-chat-student/ai-chat-student.m
     OpenResponseStudentModule,
     OutsideUrlStudentModule,
     PeerChatStudentModule,
+    PreviewComponentComponent,
     ShowGroupWorkStudentModule,
     ShowMyWorkStudentModule,
     StudentAssetsDialogModule,

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -299,7 +299,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/preview-component-dialog/preview-component-dialog.component.html</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">19</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-dialog/select-peer-grouping-dialog.component.html</context>
@@ -13922,7 +13922,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Item Info</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/node-info/node-info.component.html</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9fe218829514884cdd0ca2300573a4e0428c324f" datatype="html">


### PR DESCRIPTION
## Changes
- Convert PreviewComponentComponent to standalone components
- Clean up code
   - use self-closing tags
   - add private modifier

## Test
- Preview Component displays and works as before in:
   - AT 
      - create component -> component info dialog
      - preview component dialog 
   - CM
      - node info  