### PR TITLE
refactor(SaveStarterStateComponent): Convert to standalone

### DIFF
--- a/src/assets/wise5/authoringTool/components/preview-component-dialog/preview-component-dialog.component.html
+++ b/src/assets/wise5/authoringTool/components/preview-component-dialog/preview-component-dialog.component.html
@@ -5,7 +5,7 @@
     class="notice-bg-bg"
     [component]="component"
     [starterState]="starterState"
-  ></save-starter-state>
+  />
 </ng-container>
 <mat-divider></mat-divider>
 <mat-dialog-content>

--- a/src/assets/wise5/authoringTool/components/preview-component/preview-component.module.ts
+++ b/src/assets/wise5/authoringTool/components/preview-component/preview-component.module.ts
@@ -6,12 +6,8 @@ import { ComponentStudentModule } from '../../../../../assets/wise5/components/c
 import { StudentTeacherCommonModule } from '../../../../../app/student-teacher-common.module';
 
 @NgModule({
-  declarations: [
-    PreviewComponentButtonComponent,
-    PreviewComponentDialogComponent,
-    SaveStarterStateComponent
-  ],
+  declarations: [PreviewComponentButtonComponent, PreviewComponentDialogComponent],
   exports: [PreviewComponentButtonComponent],
-  imports: [StudentTeacherCommonModule, ComponentStudentModule]
+  imports: [SaveStarterStateComponent, StudentTeacherCommonModule, ComponentStudentModule]
 })
 export class PreviewComponentModule {}

--- a/src/assets/wise5/authoringTool/components/save-starter-state/save-starter-state.component.html
+++ b/src/assets/wise5/authoringTool/components/save-starter-state/save-starter-state.component.html
@@ -4,19 +4,19 @@
     <button
       mat-icon-button
       color="primary"
-      matTooltip="Save Starter State"
+      matTooltip="Save starter state"
       matTooltipPosition="above"
-      (click)="confirmSave()"
-      [disabled]="!isDirty"
+      (click)="save()"
+      [disabled]="!dirty"
       i18n-matToolTip
     >
       <mat-icon>save</mat-icon>
     </button>
     <button
       mat-icon-button
-      matTooltip="Delete Starter State"
+      matTooltip="Delete starter state"
       matTooltipPosition="above"
-      (click)="confirmDelete()"
+      (click)="delete()"
       i18n-matToolTip
     >
       <mat-icon>close</mat-icon>

--- a/src/assets/wise5/authoringTool/components/save-starter-state/save-starter-state.component.ts
+++ b/src/assets/wise5/authoringTool/components/save-starter-state/save-starter-state.component.ts
@@ -1,37 +1,41 @@
-import { Component, Input, OnInit, SimpleChanges } from '@angular/core';
+import { Component, Input, SimpleChanges } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { TeacherNodeService } from '../../../services/teacherNodeService';
 import { Component as WISEComponent } from '../../../common/Component';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
+  imports: [FlexLayoutModule, MatButtonModule, MatIconModule, MatTooltipModule],
   selector: 'save-starter-state',
+  standalone: true,
   templateUrl: 'save-starter-state.component.html'
 })
-export class SaveStarterStateComponent implements OnInit {
+export class SaveStarterStateComponent {
   @Input() private component: WISEComponent;
-  protected isDirty: boolean;
+  protected dirty: boolean;
   @Input() private starterState: any;
 
   constructor(private matDialog: MatDialog, private nodeService: TeacherNodeService) {}
 
-  ngOnInit(): void {}
-
-  ngOnChanges(changes: SimpleChanges) {
-    this.isDirty = !changes.starterState.isFirstChange();
+  ngOnChanges(changes: SimpleChanges): void {
+    this.dirty = !changes.starterState.isFirstChange();
   }
 
-  protected confirmSave(): void {
+  protected save(): void {
     if (confirm($localize`Are you sure you want to save the starter state?`)) {
       this.nodeService.respondStarterState({
         nodeId: this.component.nodeId,
         componentId: this.component.id,
         starterState: this.starterState
       });
-      this.isDirty = false;
+      this.dirty = false;
     }
   }
 
-  protected confirmDelete(): void {
+  protected delete(): void {
     if (
       confirm(
         $localize`Are you sure you want to delete the starter state? This will also close this preview window.`

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9913,14 +9913,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to save the starter state?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/save-starter-state/save-starter-state.component.ts</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2719035378398088475" datatype="html">
         <source>Are you sure you want to delete the starter state? This will also close this preview window.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/save-starter-state/save-starter-state.component.ts</context>
-          <context context-type="linenumber">37</context>
+          <context context-type="linenumber">41</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d9921e33c659c824a3c39062f76cb572394ff373" datatype="html">
@@ -21234,28 +21234,28 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>File</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts</context>
-          <context context-type="linenumber">149</context>
+          <context context-type="linenumber">141</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3075681036535086015" datatype="html">
         <source>Insert from Notebook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts</context>
-          <context context-type="linenumber">163</context>
+          <context context-type="linenumber">155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="535405804327281099" datatype="html">
         <source>Insert note +</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts</context>
-          <context context-type="linenumber">164</context>
+          <context context-type="linenumber">156</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7138428925866529608" datatype="html">
         <source>Image from notebook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">182</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3570422532828875517" datatype="html">


### PR DESCRIPTION
## Changes
- Convert SaveStarterStateComponent to standalone component
- Clean up code
   - use self-closing tags
   - change texts "isDirty" -> "dirty", "Save Starter State" -> "Save starter state", etc

## Test
- Saving starter state in AT -> Preview Component dialog works as before