### PR TITLE
refactor(NavItemScoreComponent): Convert to standalone

### DIFF
--- a/src/app/teacher/classroom-monitor.module.ts
+++ b/src/app/teacher/classroom-monitor.module.ts
@@ -62,8 +62,7 @@ import { SaveIndicatorComponent } from '../../assets/wise5/common/save-indicator
     TeacherSummaryDisplay,
     ToolBarComponent,
     TopBarComponent,
-    ViewComponentRevisionsComponent,
-    NavItemScoreComponent
+    ViewComponentRevisionsComponent
   ],
   imports: [
     StudentTeacherCommonModule,
@@ -74,6 +73,7 @@ import { SaveIndicatorComponent } from '../../assets/wise5/common/save-indicator
     HighchartsChartModule,
     ManageStudentsModule,
     MilestoneModule,
+    NavItemScoreComponent,
     PeerGroupGradingModule,
     PreviewComponentModule,
     RouterModule,

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.html
@@ -101,7 +101,7 @@
         class="nav-item--list__info-item"
         [maxScore]="maxScore"
         [averageScore]="getNodeAverageScore()"
-      ></nav-item-score>
+      />
       <nav-item-progress
         [nodeCompletion]="getNodeCompletion()"
         [period]="currentPeriod"

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/navItemScore/nav-item-score.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/navItemScore/nav-item-score.component.html
@@ -1,4 +1,6 @@
-<span *ngIf="showScore" fxLayout="row" fxLayoutAlign="start center">
+@if (showScore) {
+<span fxLayout="row" fxLayoutAlign="start center">
   <mat-icon class="score"> grade </mat-icon>
   <span class="md-body-2 text-secondary">{{ averageScoreDisplay }}</span>
 </span>
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/navItemScore/nav-item-score.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/navItemScore/nav-item-score.component.ts
@@ -1,26 +1,23 @@
-'use strict';
-
 import { Component, Inject, Input, LOCALE_ID } from '@angular/core';
-import { formatNumber } from '@angular/common';
+import { CommonModule, formatNumber } from '@angular/common';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
+  imports: [CommonModule, FlexLayoutModule, MatIconModule],
   selector: 'nav-item-score',
+  standalone: true,
   templateUrl: 'nav-item-score.component.html'
 })
 export class NavItemScoreComponent {
-  @Input()
-  averageScore: any;
-
-  averageScoreDisplay: string = '';
-
-  @Input()
-  maxScore: any;
-
-  showScore: boolean = false;
+  @Input() averageScore: number | string;
+  protected averageScoreDisplay: string = '';
+  @Input() maxScore: number;
+  protected showScore: boolean;
 
   constructor(@Inject(LOCALE_ID) private locale: string) {}
 
-  ngOnChanges(changes) {
+  ngOnChanges(): void {
     if (typeof this.maxScore === 'number' || typeof this.averageScore === 'number') {
       this.showScore = true;
       this.averageScoreDisplay = this.getAverageScoreDisplay();
@@ -29,16 +26,14 @@ export class NavItemScoreComponent {
     }
   }
 
-  getAverageScoreDisplay(): string {
+  private getAverageScoreDisplay(): string {
     const averageScore = this.formatAverageScore(this.averageScore);
-    if (typeof this.maxScore === 'number') {
-      return `${averageScore}/${this.maxScore}`;
-    } else {
-      return `${averageScore}/0`;
-    }
+    return typeof this.maxScore === 'number'
+      ? `${averageScore}/${this.maxScore}`
+      : `${averageScore}/0`;
   }
 
-  formatAverageScore(averageScore: any): string {
+  private formatAverageScore(averageScore: number | string): number | string {
     if (typeof averageScore === 'number') {
       if (averageScore % 1 !== 0) {
         averageScore = formatNumber(averageScore, this.locale, '1.1-1').toString();


### PR DESCRIPTION
## Changes
- Convert NavItemScoreComponent to standalone component
- Clean up code
   - use self-closing tags
   - use new control flow syntax
   - add private modifiers and return types

## Test
- In CM > Grade by Step unit view, score appears as before
<img width="400" alt="Screenshot 2024-05-23 at 4 32 15 PM" src="https://github.com/WISE-Community/WISE-Client/assets/119416/9bc66c71-77dc-45ba-87d1-9cb5031b3d81">
