### PR TITLE
refactor(EditComponentAdvancedButtonComponent): Convert to standalone

### DIFF
--- a/src/app/teacher/component-authoring.module.ts
+++ b/src/app/teacher/component-authoring.module.ts
@@ -104,7 +104,6 @@ import { EditAiChatAdvancedComponent } from '../../assets/wise5/components/aiCha
     EditAnimationAdvancedComponent,
     EditAudioOscillatorAdvancedComponent,
     EditCommonAdvancedComponent,
-    EditComponentAdvancedButtonComponent,
     EditComponentAdvancedComponent,
     EditComponentAddToNotebookButtonComponent,
     EditComponentConstraintsComponent,
@@ -174,6 +173,7 @@ import { EditAiChatAdvancedComponent } from '../../assets/wise5/components/aiCha
   ],
   imports: [
     ConstraintAuthoringModule,
+    EditComponentAdvancedButtonComponent,
     SelectStepAndComponentComponent,
     StudentTeacherCommonModule,
     PeerGroupingAuthoringModule,

--- a/src/assets/wise5/authoringTool/components/edit-component-advanced-button/edit-component-advanced-button.component.html
+++ b/src/assets/wise5/authoringTool/components/edit-component-advanced-button/edit-component-advanced-button.component.html
@@ -1,7 +1,7 @@
 <button
   mat-icon-button
   color="primary"
-  (click)="showComponentAdvancedAuthoring($event)"
+  (click)="$event.stopPropagation(); showComponentAdvancedAuthoring()"
   matTooltip="Advanced"
   matTooltipPosition="above"
   i18n-matTooltip

--- a/src/assets/wise5/authoringTool/components/edit-component-advanced-button/edit-component-advanced-button.component.ts
+++ b/src/assets/wise5/authoringTool/components/edit-component-advanced-button/edit-component-advanced-button.component.ts
@@ -3,9 +3,14 @@ import { MatDialog } from '@angular/material/dialog';
 import { ComponentContent } from '../../../common/ComponentContent';
 import { EditComponentAdvancedComponent } from '../../../../../app/authoring-tool/edit-component-advanced/edit-component-advanced.component';
 import { Component as WiseComponent } from '../../../common/Component';
+import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
+  imports: [MatButtonModule, MatIconModule, MatTooltipModule],
   selector: 'edit-component-advanced-button',
+  standalone: true,
   templateUrl: 'edit-component-advanced-button.component.html'
 })
 export class EditComponentAdvancedButtonComponent {
@@ -14,8 +19,7 @@ export class EditComponentAdvancedButtonComponent {
 
   constructor(private dialog: MatDialog) {}
 
-  protected showComponentAdvancedAuthoring(event: Event): void {
-    event.stopPropagation();
+  protected showComponentAdvancedAuthoring(): void {
     this.dialog.open(EditComponentAdvancedComponent, {
       data: new WiseComponent(this.componentContent, this.nodeId),
       width: '80%'

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
@@ -151,7 +151,7 @@
               *ngIf="componentsToExpanded[component.id]"
               [componentContent]="component"
               [nodeId]="nodeId"
-            ></edit-component-advanced-button>
+            />
             <preview-component-button
               class="dynamic-component-button"
               [ngClass]="{


### PR DESCRIPTION
## Changes
- Convert EditComponentAdvancedButtonComponent to standalone component
- Clean up code
   - use self-closing tag
   - move event.stopPropagation() to template

## Test
- In AT, clicking on the component advanced button displays a dialog that lets you edit advanced settings for the component.