### PR TITLE
refactor(AddComponentButtonComponent): Convert to standalone

### DIFF
--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -63,7 +63,6 @@ import { PreviewComponentButtonComponent } from '../../assets/wise5/authoringToo
 
 @NgModule({
   declarations: [
-    AddComponentButtonComponent,
     AddLessonChooseTemplateComponent,
     AddLessonConfigureComponent,
     AddProjectComponent,
@@ -110,6 +109,7 @@ import { PreviewComponentButtonComponent } from '../../assets/wise5/authoringToo
     ProjectListComponent
   ],
   imports: [
+    AddComponentButtonComponent,
     AddLessonButtonComponent,
     AddStepButtonComponent,
     StudentTeacherCommonModule,

--- a/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.spec.ts
@@ -1,15 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AddComponentButtonComponent } from './add-component-button.component';
-import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatDialog } from '@angular/material/dialog';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
-import { RouterTestingModule } from '@angular/router/testing';
-import { MatIconModule } from '@angular/material/icon';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { ChooseNewComponent } from '../../../../../app/authoring-tool/add-component/choose-new-component/choose-new-component.component';
 import { of } from 'rxjs';
 import { Node } from '../../../common/Node';
+import { provideRouter } from '@angular/router';
 
 class MockTeacherProjectService {
   createComponent() {}
@@ -22,9 +21,11 @@ describe('AddComponentButtonComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [AddComponentButtonComponent],
-      imports: [MatDialogModule, MatIconModule, RouterTestingModule],
-      providers: [{ provide: TeacherProjectService, useClass: MockTeacherProjectService }]
+      imports: [AddComponentButtonComponent],
+      providers: [
+        { provide: TeacherProjectService, useClass: MockTeacherProjectService },
+        provideRouter([])
+      ]
     });
     fixture = TestBed.createComponent(AddComponentButtonComponent);
     component = fixture.componentInstance;

--- a/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.ts
+++ b/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.ts
@@ -5,9 +5,14 @@ import { ChooseNewComponent } from '../../../../../app/authoring-tool/add-compon
 import { filter } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Node } from '../../../common/Node';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
+  imports: [MatButtonModule, MatIconModule, MatTooltipModule],
   selector: 'add-component-button',
+  standalone: true,
   templateUrl: './add-component-button.component.html'
 })
 export class AddComponentButtonComponent {

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
@@ -36,7 +36,7 @@
     <add-component-button
       [node]="node"
       (newComponentsEvent)="highlightAndExpandComponents($event)"
-    ></add-component-button>
+    />
     <div *ngIf="isAnyComponentSelected()">
       <button
         mat-icon-button
@@ -204,7 +204,7 @@
           [insertAfterComponentId]="component.id"
           [node]="node"
           (newComponentsEvent)="highlightAndExpandComponents($event)"
-        ></add-component-button>
+        />
       </div>
     </div>
   </div>

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
@@ -42,13 +42,13 @@ describe('NodeAuthoringComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [
-        AddComponentButtonComponent,
         CopyComponentButtonComponent,
         EditNodeTitleComponent,
         NodeAuthoringComponent,
         TeacherNodeIconComponent
       ],
       imports: [
+        AddComponentButtonComponent,
         BrowserAnimationsModule,
         ComponentAuthoringModule,
         ComponentTypeServiceModule,


### PR DESCRIPTION
## Changes
- Convert AddComponentButtonComponent to standalone component
- Clean up code
   - use self-closing tag

## Test
- In AT, add component button at the beginning of the step and after components work as before.