### PR TITLE
fix(Authoring): Move lesson located before empty lesson breaks project

### DIFF
--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -2700,7 +2700,7 @@ export class TeacherProjectService extends ProjectService {
                       if (groupIdWeAreMoving === toNodeIdParentGroupId) {
                         // the transition is to a child in the group we are moving
 
-                        if (groupNode.startId == null) {
+                        if (groupNode.startId == null || groupNode.startId === '') {
                           // change the transition to point to the after group
                           transitionFromChild.to = firstNodeToRemoveTransitionToNodeId;
                         } else {


### PR DESCRIPTION
## Changes
- Fix bug when moving a lesson that is located before an empty lesson and placing it somewhere else causes the project to break

## Test
1. Create a project with

```
1: First Lesson
  1.1: First Step
2: Second Lesson
  2.1: Second Step
3: Third Lesson
```

2. Move "2: Second Lesson" (which is the lesson before the empty lesson) and place it before "1: First Lesson" or after "3: Third Lesson" (which is the empty lesson). This will break the project because "1.1: First Step" will end up with a transition to empty string

```
        {
            "id": "node1",
            "type": "node",
            "title": "First Step",
            "components": [],
            "constraints": [],
            "showSaveButton": false,
            "showSubmitButton": false,
            "transitionLogic": {
                "transitions": [
                    {
                        "to": ""
                    }
                ]
            }
        }
```


Closes #1821
