### PR TITLE
refactor(ComponentInfoDialog): Convert to standalone

### DIFF
--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -50,7 +50,6 @@ import { NodeAuthoringParentComponent } from '../../assets/wise5/authoringTool/n
 import { AddLessonChooseTemplateComponent } from '../../assets/wise5/authoringTool/addLesson/add-lesson-choose-template/add-lesson-choose-template.component';
 import { ComponentTypeButtonComponent } from '../../assets/wise5/authoringTool/components/component-type-button/component-type-button.component';
 import { ComponentInfoDialogComponent } from '../../assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component';
-import { ComponentTypeSelectorComponent } from '../../assets/wise5/authoringTool/components/component-type-selector/component-type-selector.component';
 import { EditNodeTitleComponent } from '../../assets/wise5/authoringTool/node/edit-node-title/edit-node-title.component';
 import { AddComponentButtonComponent } from '../../assets/wise5/authoringTool/node/add-component-button/add-component-button.component';
 import { CopyComponentButtonComponent } from '../../assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component';
@@ -80,7 +79,6 @@ import { PreviewComponentButtonComponent } from '../../assets/wise5/authoringToo
     ChooseNewNodeTemplate,
     ChooseMoveNodeLocationComponent,
     ChooseSimulationComponent,
-    ComponentInfoDialogComponent,
     ComponentTypeButtonComponent,
     ConcurrentAuthorsMessageComponent,
     ConfigureAutomatedAssessmentComponent,
@@ -113,8 +111,8 @@ import { PreviewComponentButtonComponent } from '../../assets/wise5/authoringToo
     AddStepButtonComponent,
     StudentTeacherCommonModule,
     ComponentAuthoringModule,
+    ComponentInfoDialogComponent,
     ComponentStudentModule,
-    ComponentTypeSelectorComponent,
     MatBadgeModule,
     MatChipsModule,
     ImportComponentModule,

--- a/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html
+++ b/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html
@@ -9,21 +9,20 @@
 <mat-dialog-content class="dialog-content-scroll">
   <h3 i18n>Description:</h3>
   <p class="description">{{ description }}</p>
-  <mat-divider></mat-divider>
+  <mat-divider/>
   <h3 i18n>Example:</h3>
   <mat-card appearance="outlined">
-    <preview-component
-      *ngIf="previewComponents.length === 1"
-      [component]="previewComponents[0]"
-    />
-    <mat-tab-group *ngIf="previewComponents.length > 1" mat-stretch-tabs="false">
-      <mat-tab
-        *ngFor="let component of previewComponents; index as i"
-        [label]="previewExamples[i].label"
-      >
-        <preview-component [component]="component" />
-      </mat-tab>
-    </mat-tab-group>
+    @if (previewComponents.length === 1) {
+    <preview-component [component]="previewComponents[0]" />
+    } @else if (previewComponents.length > 1) {
+      <mat-tab-group mat-stretch-tabs="false">
+        @for (component of previewComponents; track component; let i = $index) {
+          <mat-tab [label]="previewExamples[i].label">
+            <preview-component [component]="component" />
+          </mat-tab>
+        }
+      </mat-tab-group>
+    }
   </mat-card>
 </mat-dialog-content>
 <mat-dialog-actions fxLayoutAlign="end">

--- a/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.spec.ts
+++ b/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.spec.ts
@@ -1,27 +1,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ComponentInfoDialogComponent } from './component-info-dialog.component';
-import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
-import { MatDividerModule } from '@angular/material/divider';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { PreviewComponentComponent } from '../preview-component/preview-component.component';
 import { ProjectService } from '../../../services/projectService';
 import { ComponentInfoService } from '../../../services/componentInfoService';
-import { MatIconModule } from '@angular/material/icon';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectModule } from '@angular/material/select';
-import { MatButtonModule } from '@angular/material/button';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { ComponentTypeSelectorComponent } from '../component-type-selector/component-type-selector.component';
 import { ComponentInfoDialogHarness } from './component-info-dialog.harness';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { MatTabsModule } from '@angular/material/tabs';
 import { MultipleChoiceInfo } from '../../../components/multipleChoice/MultipleChoiceInfo';
 import { OutsideUrlInfo } from '../../../components/outsideURL/OutsideUrlInfo';
 import { OpenResponseInfo } from '../../../components/openResponse/OpenResponseInfo';
 import { ComponentInfo } from '../../../components/ComponentInfo';
-import { MatCardModule } from '@angular/material/card';
 import { ComponentTypeServiceModule } from '../../../services/componentTypeService.module';
-import { ComponentHeaderComponent } from '../../../directives/component-header/component-header.component';
 import { ComponentStudentModule } from '../../../../../assets/wise5/components/component/component-student.module';
 
 let component: ComponentInfoDialogComponent;
@@ -34,23 +24,12 @@ let outsideUrlInfo = new OutsideUrlInfo();
 describe('ComponentInfoDialogComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ComponentInfoDialogComponent],
       imports: [
         BrowserAnimationsModule,
-        ComponentHeaderComponent,
+        ComponentInfoDialogComponent,
         ComponentStudentModule,
-        ComponentTypeSelectorComponent,
         ComponentTypeServiceModule,
-        HttpClientTestingModule,
-        MatButtonModule,
-        MatCardModule,
-        MatDialogModule,
-        MatDividerModule,
-        MatFormFieldModule,
-        MatIconModule,
-        MatSelectModule,
-        MatTabsModule,
-        PreviewComponentComponent
+        HttpClientTestingModule
       ],
       providers: [ComponentInfoService, { provide: MAT_DIALOG_DATA, useValue: 'OpenResponse' }]
     }).compileComponents();

--- a/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.ts
+++ b/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.ts
@@ -1,17 +1,34 @@
 import { Component, Inject } from '@angular/core';
-import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { ComponentInfoService } from '../../../services/componentInfoService';
-import { ComponentInfo } from '../../../components/ComponentInfo';
 import { ComponentFactory } from '../../../common/ComponentFactory';
 import { Component as WISEComponent } from '../../../common/Component';
+import { CommonModule } from '@angular/common';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { ComponentTypeSelectorComponent } from '../component-type-selector/component-type-selector.component';
+import { PreviewComponentComponent } from '../preview-component/preview-component.component';
+import { MatCardModule } from '@angular/material/card';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDividerModule } from '@angular/material/divider';
 
 @Component({
-  selector: 'component-info-dialog',
-  templateUrl: './component-info-dialog.component.html',
-  styleUrls: ['./component-info-dialog.component.scss']
+  imports: [
+    CommonModule,
+    ComponentTypeSelectorComponent,
+    FlexLayoutModule,
+    MatButtonModule,
+    MatCardModule,
+    MatDialogModule,
+    MatDividerModule,
+    MatTabsModule,
+    PreviewComponentComponent
+  ],
+  standalone: true,
+  styleUrl: './component-info-dialog.component.scss',
+  templateUrl: './component-info-dialog.component.html'
 })
 export class ComponentInfoDialogComponent {
-  private componentInfo: ComponentInfo;
   protected description: string;
   protected previewComponents: WISEComponent[] = [];
   protected previewExamples: any[] = [];
@@ -25,10 +42,10 @@ export class ComponentInfoDialogComponent {
     this.displayComponent(this.componentType);
   }
 
-  protected displayComponent(componentType: any): void {
-    this.componentInfo = this.componentInfoService.getInfo(componentType);
-    this.description = this.componentInfo.getDescription();
-    this.previewExamples = this.componentInfo.getPreviewExamples();
+  protected displayComponent(componentType: string): void {
+    const componentInfo = this.componentInfoService.getInfo(componentType);
+    this.description = componentInfo.getDescription();
+    this.previewExamples = componentInfo.getPreviewExamples();
     this.previewComponents = this.previewExamples.map((example: any) => {
       return new ComponentFactory().getComponent(example.content, 'node1');
     });

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -295,7 +295,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">29</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/preview-component-dialog/preview-component-dialog.component.html</context>


### PR DESCRIPTION
## Changes
- Convert ComponentInfoDialog to standalone component
- Clean up code
   - use self-closing tag
   - use new template control flow blocks
   - update imports
      - ComponentTypeSelectorComponent is now directly imported by ComponentInfoDialog, not AuthoringToolModule 
   
## Test
In AT > Add new component, launch the component info dialog (click on info button in add new component dialog). Verify that the component info in the dialog is displayed as before.