### PR TITLE
refactor(ComponentTypeButtonComponent): Convert to standalone

### DIFF
--- a/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html
+++ b/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html
@@ -11,7 +11,7 @@
       <component-type-button
         [componentType]="componentType.type"
         (componentSelectedEvent)="selectComponent(componentType.type)"
-      ></component-type-button>
+      />
     </ng-container>
   </div>
 </mat-dialog-content>

--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -49,7 +49,6 @@ import { ChooseImportUnitComponent } from '../authoring-tool/import-step/choose-
 import { NodeAuthoringParentComponent } from '../../assets/wise5/authoringTool/node/node-authoring-parent/node-authoring-parent.component';
 import { AddLessonChooseTemplateComponent } from '../../assets/wise5/authoringTool/addLesson/add-lesson-choose-template/add-lesson-choose-template.component';
 import { ComponentTypeButtonComponent } from '../../assets/wise5/authoringTool/components/component-type-button/component-type-button.component';
-import { ComponentInfoDialogComponent } from '../../assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component';
 import { EditNodeTitleComponent } from '../../assets/wise5/authoringTool/node/edit-node-title/edit-node-title.component';
 import { AddComponentButtonComponent } from '../../assets/wise5/authoringTool/node/add-component-button/add-component-button.component';
 import { CopyComponentButtonComponent } from '../../assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component';
@@ -79,7 +78,6 @@ import { PreviewComponentButtonComponent } from '../../assets/wise5/authoringToo
     ChooseNewNodeTemplate,
     ChooseMoveNodeLocationComponent,
     ChooseSimulationComponent,
-    ComponentTypeButtonComponent,
     ConcurrentAuthorsMessageComponent,
     ConfigureAutomatedAssessmentComponent,
     CopyComponentButtonComponent,
@@ -110,8 +108,8 @@ import { PreviewComponentButtonComponent } from '../../assets/wise5/authoringToo
     AddStepButtonComponent,
     StudentTeacherCommonModule,
     ComponentAuthoringModule,
-    ComponentInfoDialogComponent,
     ComponentStudentModule,
+    ComponentTypeButtonComponent,
     MatBadgeModule,
     MatChipsModule,
     ImportComponentModule,

--- a/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html
+++ b/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html
@@ -44,7 +44,7 @@
           <component-type-button
             [componentType]="componentType.type"
             (componentSelectedEvent)="addComponent(componentType)"
-          ></component-type-button>
+          />
         </div>
       </div>
       <p class="info mat-small" i18n>

--- a/src/assets/wise5/authoringTool/components/component-type-button/component-type-button.component.html
+++ b/src/assets/wise5/authoringTool/components/component-type-button/component-type-button.component.html
@@ -1,6 +1,6 @@
 <mat-card appearance="outlined">
   <div fxLayout="row" fxLayoutAlign="start center">
-    <button mat-button (click)="select()" class="select-button" i18n>
+    <button mat-button (click)="componentSelectedEvent.emit()" class="select-button" i18n>
       {{ label }}
     </button>
     <button

--- a/src/assets/wise5/authoringTool/components/component-type-button/component-type-button.component.spec.ts
+++ b/src/assets/wise5/authoringTool/components/component-type-button/component-type-button.component.spec.ts
@@ -4,9 +4,6 @@ import { ComponentInfoService } from '../../../services/componentInfoService';
 import { ComponentServiceLookupService } from '../../../services/componentServiceLookupService';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatIconModule } from '@angular/material/icon';
-import { MatCardModule } from '@angular/material/card';
 
 describe('ComponentTypeButtonComponent', () => {
   let component: ComponentTypeButtonComponent;
@@ -14,12 +11,9 @@ describe('ComponentTypeButtonComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ComponentTypeButtonComponent],
       imports: [
+        ComponentTypeButtonComponent,
         HttpClientTestingModule,
-        MatCardModule,
-        MatDialogModule,
-        MatIconModule,
         StudentTeacherCommonServicesModule
       ],
       providers: [ComponentInfoService, ComponentServiceLookupService]

--- a/src/assets/wise5/authoringTool/components/component-type-button/component-type-button.component.ts
+++ b/src/assets/wise5/authoringTool/components/component-type-button/component-type-button.component.ts
@@ -2,14 +2,27 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ComponentInfoService } from '../../../services/componentInfoService';
 import { ComponentInfoDialogComponent } from '../component-info-dialog/component-info-dialog.component';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
+  imports: [
+    ComponentInfoDialogComponent,
+    FlexLayoutModule,
+    MatButtonModule,
+    MatCardModule,
+    MatIconModule,
+    MatTooltipModule
+  ],
   selector: 'component-type-button',
-  templateUrl: './component-type-button.component.html',
-  styleUrls: ['./component-type-button.component.scss']
+  standalone: true,
+  styleUrl: './component-type-button.component.scss',
+  templateUrl: './component-type-button.component.html'
 })
 export class ComponentTypeButtonComponent {
-  private componentInfo: any;
   @Output() componentSelectedEvent: EventEmitter<void> = new EventEmitter<void>();
   @Input() componentType: string;
   protected label: string;
@@ -17,8 +30,8 @@ export class ComponentTypeButtonComponent {
   constructor(private componentInfoService: ComponentInfoService, private dialog: MatDialog) {}
 
   ngOnInit(): void {
-    this.componentInfo = this.componentInfoService.getInfo(this.componentType);
-    this.label = this.componentInfo.getLabel();
+    const componentInfo = this.componentInfoService.getInfo(this.componentType);
+    this.label = componentInfo.getLabel();
   }
 
   protected preview(): void {
@@ -29,9 +42,5 @@ export class ComponentTypeButtonComponent {
         top: '100px'
       }
     });
-  }
-
-  protected select(): void {
-    this.componentSelectedEvent.emit();
   }
 }


### PR DESCRIPTION
## Changes
- Convert ComponentTypeButtonComponent to standalone component
- Clean up code
   - use self-closing tag
   - update imports
      - ComponentInfoDialog is now directly imported by ComponentTypeButtonComponent, not AuthoringToolModule 
   
## Test
- In AT > Add new component dialog, the component info button appears as before
- Launch the component info dialog. Verify that the component info in the dialog is displayed as before.