### PR TITLE
fix(Authoring): Add step double click adds multiple steps

### DIFF
--- a/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html
@@ -61,13 +61,11 @@
       mat-raised-button
       color="primary"
       (click)="import(getSelectedNodesToImport())"
-      [disabled]="getSelectedNodesToImport().length == 0"
-      matTooltip="Submit"
-      i18n-matTooltip
-      matTooltipPosition="above"
-      i18n
+      [disabled]="getSelectedNodesToImport().length == 0 || submitting"
+      class="button--progress"
     >
-      Submit
+      <mat-progress-bar *ngIf="submitting" mode="indeterminate"/>
+      <ng-container i18n>Submit</ng-container>
     </button>
   </div>
 </div>

--- a/src/assets/wise5/authoringTool/addNode/abstract-import-step/abstract-import-step.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/abstract-import-step/abstract-import-step.component.ts
@@ -8,6 +8,7 @@ import { TeacherProjectService } from '../../../services/teacherProjectService';
 @Directive()
 export abstract class AbstractImportStepComponent implements OnInit {
   protected importProjectId: number;
+  protected submitting: boolean;
   protected targetId: string;
 
   constructor(
@@ -25,6 +26,7 @@ export abstract class AbstractImportStepComponent implements OnInit {
   }
 
   protected import(nodesToImport: any[]): void {
+    this.submitting = true;
     this.copyNodesService
       .copyNodes(nodesToImport, this.importProjectId, this.configService.getProjectId())
       .subscribe((copiedNodes: any[]) => {

--- a/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html
+++ b/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html
@@ -69,12 +69,12 @@
       <button
         mat-raised-button
         color="primary"
-        [disabled]="!addNodeFormGroup.valid"
+        [disabled]="!addNodeFormGroup.valid || submitting"
         (click)="submit()"
-        aria-label="Submit"
-        i18n
+        class="button--progress"
       >
-        Submit
+        <mat-progress-bar *ngIf="submitting" mode="indeterminate"/>
+        <ng-container i18n>Submit</ng-container>
       </button>
     </div>
   </div>

--- a/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.ts
@@ -16,6 +16,7 @@ export class AddYourOwnNode {
   });
   protected componentTypes: any[];
   protected initialComponents: string[] = [];
+  protected submitting: boolean;
   protected targetId: string;
 
   constructor(
@@ -44,6 +45,7 @@ export class AddYourOwnNode {
   }
 
   protected submit(): void {
+    this.submitting = true;
     const newNode = this.projectService.createNode(this.addNodeFormGroup.controls['title'].value);
     if (this.isGroupNode(this.targetId)) {
       this.projectService.createNodeInside(newNode, this.targetId);

--- a/src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.html
+++ b/src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.html
@@ -51,11 +51,12 @@
     <button
       mat-raised-button
       color="primary"
-      [disabled]="selectedNode == null"
+      [disabled]="selectedNode == null || submitting"
       (click)="import([selectedNode])"
-      i18n
+      class="button--progress"
     >
-      Submit
+      <mat-progress-bar *ngIf="submitting" mode="indeterminate"/>
+      <ng-container i18n>Submit</ng-container>
     </button>
   </div>
 </div>

--- a/src/assets/wise5/authoringTool/addNode/configure-automated-assessment/configure-automated-assessment.component.html
+++ b/src/assets/wise5/authoringTool/addNode/configure-automated-assessment/configure-automated-assessment.component.html
@@ -39,6 +39,15 @@
     </button>
     <span fxFlex></span>
     <button mat-button color="primary" routerLink="../../.." i18n>Cancel</button>
-    <button mat-raised-button color="primary" (click)="import([node])" i18n>Submit</button>
+    <button
+        mat-raised-button
+        color="primary"
+        [disabled]="submitting"
+        (click)="import([node])"
+        class="button--progress"
+    >
+      <mat-progress-bar *ngIf="submitting" mode="indeterminate"/>
+      <ng-container i18n>Submit</ng-container>
+    </button>
   </div>
 </div>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1504,7 +1504,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Submit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">65</context>
+          <context context-type="linenumber">68</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
@@ -1543,8 +1543,16 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">20</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
+          <context context-type="linenumber">77</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.html</context>
+          <context context-type="linenumber">59</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/configure-automated-assessment/configure-automated-assessment.component.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">50</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.html</context>
@@ -1577,17 +1585,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/node/node.component.html</context>
           <context context-type="linenumber">56</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="134d4dcbdf14d91b4d88bd9e920f3f0c91eebb43" datatype="html">
-        <source> Submit </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">69,71</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.html</context>
-          <context context-type="linenumber">57,59</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dc834df3c90c7b9021cfa37b2be737c2134249a5" datatype="html">
@@ -9279,10 +9276,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
           <context context-type="linenumber">38,40</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">76,78</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/node/node.component.html</context>


### PR DESCRIPTION
## Changes
- Prevent the ability to click the add step submit button multiple times

## Test
1. Go to the add step view for the ways you can add a step. Make sure this fix works for all these methods.
- Choose your own
- Import from another unit
- Automated Assessment
- Interactive Simulation
2. Get to the page where you can click the "Submit" button
3. Double click the "Submit" button really fast
4. Only one new step should be added. This used to create a step twice and the node id of the new step would show up twice in the group ids. Now it should only show up once.

Closes #1830