### PR TITLE
fix(Authoring): Add lesson double click submit adds multiple lessons

### DIFF
--- a/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html
+++ b/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html
@@ -33,10 +33,11 @@
         mat-button
         class="mat-raised-button mat-primary"
         (click)="submit()"
-        [disabled]="!addLessonFormGroup.valid"
-        i18n
+        [disabled]="!addLessonFormGroup.valid || submitting"
+        class="button--progress"
       >
-        Submit
+        <mat-progress-bar *ngIf="submitting" mode="indeterminate"/>
+        <ng-container i18n>Submit</ng-container>
       </button>
     </div>
   </div>

--- a/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.ts
+++ b/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.ts
@@ -13,6 +13,7 @@ export class AddLessonConfigureComponent {
   protected addLessonFormGroup: FormGroup = this.fb.group({
     title: new FormControl('', [Validators.required])
   });
+  protected submitting: boolean;
   protected target: string;
   @ViewChild('titleField') titleField: ElementRef;
 
@@ -32,6 +33,7 @@ export class AddLessonConfigureComponent {
   }
 
   protected submit(): void {
+    this.submitting = true;
     const newLesson = this.projectService.createGroup(
       this.addLessonFormGroup.controls['title'].value
     );

--- a/src/assets/wise5/authoringTool/structure/configure-structure.component.ts
+++ b/src/assets/wise5/authoringTool/structure/configure-structure.component.ts
@@ -12,6 +12,7 @@ export abstract class ConfigureStructureComponent {
   protected target: string;
   private structure: any = {};
   private structureDir: string = 'assets/wise5/authoringTool/structure';
+  protected submitting: boolean;
 
   constructor(
     private http: HttpClient,
@@ -58,6 +59,7 @@ export abstract class ConfigureStructureComponent {
   }
 
   protected submit(): void {
+    this.submitting = true;
     this.structure = this.injectUniqueIds(this.structure);
     this.addNodesToProject(this.structure.nodes);
     const target = history.state.target;

--- a/src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.html
+++ b/src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.html
@@ -23,6 +23,15 @@
     </button>
     <span fxFlex></span>
     <button mat-button color="primary" routerLink="../../.." i18n>Cancel</button>
-    <button mat-raised-button color="primary" (click)="submit()" i18n>Submit</button>
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="submit()"
+      [disabled]="submitting"
+      class="button--progress"
+    >
+      <mat-progress-bar *ngIf="submitting" mode="indeterminate" />
+      <ng-container i18n>Submit</ng-container>
+    </button>
   </div>
 </div>

--- a/src/assets/wise5/authoringTool/structure/ki-cycle-using-oer/ki-cycle-using-oer.component.html
+++ b/src/assets/wise5/authoringTool/structure/ki-cycle-using-oer/ki-cycle-using-oer.component.html
@@ -14,6 +14,15 @@
     </button>
     <span fxFlex></span>
     <button mat-button color="primary" routerLink="../../.." i18n>Cancel</button>
-    <button mat-raised-button color="primary" (click)="submit()" i18n>Submit</button>
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="submit()"
+      [disabled]="submitting"
+      class="button--progress"
+    >
+      <mat-progress-bar *ngIf="submitting" mode="indeterminate" />
+      <ng-container i18n>Submit</ng-container>
+    </button>
   </div>
 </div>

--- a/src/assets/wise5/authoringTool/structure/peer-review-and-revision/peer-review-and-revision.component.html
+++ b/src/assets/wise5/authoringTool/structure/peer-review-and-revision/peer-review-and-revision.component.html
@@ -12,6 +12,15 @@
     </button>
     <span fxFlex></span>
     <button mat-button color="primary" routerLink="../../.." i18n>Cancel</button>
-    <button mat-raised-button color="primary" (click)="submit()" i18n>Submit</button>
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="submit()"
+      [disabled]="submitting"
+      class="button--progress"
+    >
+      <mat-progress-bar *ngIf="submitting" mode="indeterminate" />
+      <ng-container i18n>Submit</ng-container>
+    </button>
   </div>
 </div>

--- a/src/assets/wise5/authoringTool/structure/self-directed-investigation/self-directed-investigation.component.html
+++ b/src/assets/wise5/authoringTool/structure/self-directed-investigation/self-directed-investigation.component.html
@@ -13,6 +13,15 @@
     </button>
     <span fxFlex></span>
     <button mat-button color="primary" routerLink="../../.." i18n>Cancel</button>
-    <button mat-raised-button color="primary" (click)="submit()" i18n>Submit</button>
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="submit()"
+      [disabled]="submitting"
+      class="button--progress"
+    >
+      <mat-progress-bar *ngIf="submitting" mode="indeterminate"/>
+      <ng-container i18n>Submit</ng-container>
+    </button>
   </div>
 </div>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1543,24 +1543,28 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">20</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/configure-automated-assessment/configure-automated-assessment.component.html</context>
           <context context-type="linenumber">42</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.html</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">34</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/ki-cycle-using-oer/ki-cycle-using-oer.component.html</context>
-          <context context-type="linenumber">17</context>
+          <context context-type="linenumber">25</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/peer-review-and-revision/peer-review-and-revision.component.html</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="linenumber">23</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/self-directed-investigation/self-directed-investigation.component.html</context>
-          <context context-type="linenumber">16</context>
+          <context context-type="linenumber">24</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/draw/edit-draw-connected-components/edit-draw-connected-components.component.html</context>
@@ -9274,21 +9278,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">64,66</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="b570c9b6f5d96fb6f6969cb9397019829c34e82c" datatype="html">
-        <source> Submit </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.html</context>
-          <context context-type="linenumber">38,40</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">76,78</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/vle/node/node.component.html</context>
-          <context context-type="linenumber">59,61</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="891f639ffcf9d31aea80ea7e8e428a6597b059b3" datatype="html">
         <source>Step Title</source>
         <context-group purpose="location">
@@ -9329,6 +9318,17 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
           <context context-type="linenumber">50,52</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="b570c9b6f5d96fb6f6969cb9397019829c34e82c" datatype="html">
+        <source> Submit </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
+          <context context-type="linenumber">76,78</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/vle/node/node.component.html</context>
+          <context context-type="linenumber">59,61</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6009535360963985115" datatype="html">


### PR DESCRIPTION
## Changes
- Prevent the ability to click the add lesson submit button multiple times

## Test
1. Go to the add lesson view for any of these ways you can add a lesson
- Choose Your Own
- Jigsaw
- Self-Directed Investigation
- Peer Review & Revision
- KI Lesson with OER
2. Get to the page where you can click the "Submit" button
3. Double click the "Submit" button really fast
4. Only one new lesson should be added. This used to create a lesson twice and the node id of the new lesson would show up twice in the group0 ids. Now it should only show up once.

Closes #1832