### PR TITLE
build(npm): Update prettier version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
         "karma-json-fixtures-preprocessor": "0.0.6",
         "karma-spec-reporter": "0.0.36",
         "karma-webpack": "^5.0.0",
-        "prettier": "2.2.1",
+        "prettier": "^3.3.2",
         "protractor": "~7.0.0",
         "sass": "^1.50.1",
         "ts-loader": "^6.2.2",
@@ -26194,15 +26194,18 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
+      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-hrtime": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "karma-json-fixtures-preprocessor": "0.0.6",
     "karma-spec-reporter": "0.0.36",
     "karma-webpack": "^5.0.0",
-    "prettier": "2.2.1",
+    "prettier": "^3.3.2",
     "protractor": "~7.0.0",
     "sass": "^1.50.1",
     "ts-loader": "^6.2.2",


### PR DESCRIPTION
## Changes
- Updated prettier version from 2.2.1 to 3.3.2

## Test
- Run ```npm install```
- Restart VS Code if you already have it open
- Open ```add-your-own-node.component.html```
- Paste this code into the file
- Save the file
- Prettier should clean the code so that the button parameters are each on their own line. Previously Prettier would display an error at the bottom right of VS Code and would not clean up the file.
```
      <button mat-raised-button color="primary" [disabled]="!addNodeFormGroup.valid || submitting" (click)="submit()" class="button--progress">
        <mat-progress-bar *ngIf="submitting" mode="indeterminate"/>
        <ng-container i18n>Submit</ng-container>
      </button>
```

Closes #1834
