### PR TITLE
feat(Translation): Support hints for translatable inputs and textareas

### DIFF
--- a/src/assets/wise5/authoringTool/components/abstract-translatable-field/abstract-translatable-field.component.scss
+++ b/src/assets/wise5/authoringTool/components/abstract-translatable-field/abstract-translatable-field.component.scss
@@ -3,7 +3,9 @@
 
   .mat-mdc-form-field-hint-wrapper {
     position: relative;
-    margin: -16px 0 4px;
+    margin: -20px 0 4px;
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .mat-mdc-form-field-hint-spacer {
@@ -12,5 +14,6 @@
 
   .source-language {
     padding: 4px 8px;
+    margin-top: 4px;
   }
 }

--- a/src/assets/wise5/authoringTool/components/abstract-translatable-field/abstract-translatable-field.component.ts
+++ b/src/assets/wise5/authoringTool/components/abstract-translatable-field/abstract-translatable-field.component.ts
@@ -14,6 +14,7 @@ export abstract class AbstractTranslatableFieldComponent {
   private currentTranslations$ = toObservable(this.projectTranslationService.currentTranslations);
   protected defaultLanguage: Language = this.projectService.getLocale().getDefaultLanguage();
   @Output() defaultLanguageTextChanged: Subject<string> = new Subject<string>();
+  @Input() hint: string;
   protected i18nId: string;
   @Input() key: string;
   @Input() label: string;

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
@@ -1,22 +1,31 @@
-<mat-form-field *ngIf="!showTranslationInput()">
-  <mat-label>{{ label }}</mat-label>
-  <input
-    matInput
-    [(ngModel)]="content[key]"
-    (ngModelChange)="defaultLanguageTextChanged.next($event)"
-    placeholder="{{ placeholder }}"
-  />
-</mat-form-field>
-<mat-form-field *ngIf="showTranslationInput()" class="translatable">
-  <mat-label>{{ label }} ({{ currentLanguage().language }})</mat-label>
-  <input
-    matInput
-    [ngModel]="translationText"
-    (ngModelChange)="translationTextChanged.next($event)"
-    placeholder="{{ placeholder }}"
-  />
-  <mat-hint class="source-language selected-bg-bg">
-    <strong><mat-icon>translate</mat-icon> {{ defaultLanguage.language }}:</strong>
-    {{ content[key] }}
-  </mat-hint>
-</mat-form-field>
+@if (!showTranslationInput()) {
+  <mat-form-field>
+    <mat-label>{{ label }}</mat-label>
+    <input
+      matInput
+      [(ngModel)]="content[key]"
+      (ngModelChange)="defaultLanguageTextChanged.next($event)"
+      placeholder="{{ placeholder }}"
+    />
+    @if (hint) {
+      <mat-hint>{{ hint }}</mat-hint>
+    }
+  </mat-form-field>
+} @if (showTranslationInput()) {
+  <mat-form-field *ngIf="showTranslationInput()" class="translatable">
+    <mat-label>{{ label }} ({{ currentLanguage().language }})</mat-label>
+    <input
+      matInput
+      [ngModel]="translationText"
+      (ngModelChange)="translationTextChanged.next($event)"
+      placeholder="{{ placeholder }}"
+    />
+    @if (hint) {
+      <mat-hint>{{ hint }}</mat-hint>
+    }
+    <mat-hint class="source-language selected-bg-bg">
+      <strong><mat-icon>translate</mat-icon> {{ defaultLanguage.language }}:</strong>
+      {{ content[key] }}
+    </mat-hint>
+  </mat-form-field>
+}

--- a/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-input/translatable-input.component.html
@@ -11,8 +11,8 @@
       <mat-hint>{{ hint }}</mat-hint>
     }
   </mat-form-field>
-} @if (showTranslationInput()) {
-  <mat-form-field *ngIf="showTranslationInput()" class="translatable">
+} @else {
+  <mat-form-field class="translatable">
     <mat-label>{{ label }} ({{ currentLanguage().language }})</mat-label>
     <input
       matInput

--- a/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.html
+++ b/src/assets/wise5/authoringTool/components/translatable-textarea/translatable-textarea.component.html
@@ -1,25 +1,34 @@
-<mat-form-field *ngIf="!showTranslationInput()">
-  <mat-label>{{ label }}</mat-label>
-  <textarea
-    matInput
-    [(ngModel)]="content[key]"
-    (ngModelChange)="defaultLanguageTextChanged.next($event)"
-    placeholder="{{ placeholder }}"
-    cdkTextareaAutosize
-  >
-  </textarea>
-</mat-form-field>
-<mat-form-field *ngIf="showTranslationInput()" class="translatable">
-  <mat-label>{{ label }} ({{ currentLanguage().language }})</mat-label>
-  <textarea
-    matInput
-    [ngModel]="translationText"
-    (ngModelChange)="translationTextChanged.next($event)"
-    placeholder="{{ placeholder }}"
-    cdkTextareaAutosize
-  ></textarea>
-  <mat-hint class="source-language selected-bg-bg">
-    <strong><mat-icon>translate</mat-icon> {{ defaultLanguage.language }}:</strong>
-    {{ content[key] }}
-  </mat-hint>
-</mat-form-field>
+@if (!showTranslationInput()) {
+  <mat-form-field>
+    <mat-label>{{ label }}</mat-label>
+    <textarea
+      matInput
+      [(ngModel)]="content[key]"
+      (ngModelChange)="defaultLanguageTextChanged.next($event)"
+      placeholder="{{ placeholder }}"
+      cdkTextareaAutosize
+    >
+    </textarea>
+    @if (hint) {
+      <mat-hint>{{ hint }}</mat-hint>
+    }
+  </mat-form-field>
+} @if (showTranslationInput()) {
+  <mat-form-field class="translatable">
+    <mat-label>{{ label }} ({{ currentLanguage().language }})</mat-label>
+    <textarea
+      matInput
+      [ngModel]="translationText"
+      (ngModelChange)="translationTextChanged.next($event)"
+      placeholder="{{ placeholder }}"
+      cdkTextareaAutosize
+    ></textarea>
+    @if (hint) {
+      <mat-hint>{{ hint }}</mat-hint>
+    }
+    <mat-hint class="source-language selected-bg-bg">
+      <strong><mat-icon>translate</mat-icon> {{ defaultLanguage.language }}:</strong>
+      {{ content[key] }}
+    </mat-hint>
+  </mat-form-field>
+}

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html
@@ -1,4 +1,4 @@
-<div fxLayout="column" fxLayoutGap="16px">
+<div class="edit-dialog-guidance" fxLayout="column" fxLayoutGap="16px">
   <mat-checkbox
     color="primary"
     [(ngModel)]="computerAvatarSettings.useGlobalComputerAvatar"
@@ -6,41 +6,39 @@
     i18n
     >Use Global Computer Avatar</mat-checkbox
   >
-  <mat-form-field class="avatar-label" appearance="fill">
-    <mat-label i18n>Computer Avatar Label</mat-label>
-    <input
-      matInput
-      [(ngModel)]="computerAvatarSettings.label"
-      (ngModelChange)="componentChanged()"
-      placeholder="Thought Buddy"
-      i18n-placeholder
-    />
-    <mat-hint i18n>This is what the computer avatar will be referred as</mat-hint>
-  </mat-form-field>
-  <mat-form-field appearance="fill">
-    <mat-label i18n>Computer Avatar Prompt</mat-label>
-    <textarea
-      matInput
-      [(ngModel)]="computerAvatarSettings.prompt"
-      (ngModelChange)="componentChanged()"
-      placeholder="Discuss your answer with a thought buddy!"
-      i18n-placeholder
-      cdkTextareaAutosize
-    >
-    </textarea>
-    <mat-hint i18n>This text will introduce the avatar selection task</mat-hint>
-  </mat-form-field>
-  <mat-form-field appearance="fill">
-    <mat-label i18n>Computer Avatar Initial Response</mat-label>
-    <input
-      matInput
-      [(ngModel)]="computerAvatarSettings.initialResponse"
-      (ngModelChange)="componentChanged()"
-      placeholder="Hi there! It's nice to meet you. What do you think about..."
-      i18n-placeholder
-    />
-    <mat-hint i18n>Computer avatar will initiate dialog with this text</mat-hint>
-  </mat-form-field>
+  <translatable-input
+    [content]="computerAvatarSettings"
+    key="label"
+    label="Computer Avatar Label"
+    i18n-label
+    placeholder="Thought Buddy"
+    i18n-placeholder
+    (defaultLanguageTextChanged)="componentChanged()"
+    class="name"
+    hint="This is what the computer avatar will be referred to as"
+  />
+  <translatable-input
+    [content]="computerAvatarSettings"
+    key="prompt"
+    label="Computer Avatar Prompt"
+    i18n-label
+    placeholder="Discuss your answer with a thought buddy!"
+    i18n-placeholder
+    (defaultLanguageTextChanged)="componentChanged()"
+    class="name"
+    hint="This text will introduce the avatar selection task"
+  />
+  <translatable-input
+    [content]="computerAvatarSettings"
+    key="initialResponse"
+    label="Computer Avatar Initial Response"
+    i18n-label
+    placeholder="Hi there! It's nice to meet you. What do you think about..."
+    i18n-placeholder
+    (defaultLanguageTextChanged)="componentChanged()"
+    class="name"
+    hint="Computer avatar will initiate dialog with this text"
+  />
   <div class="avatars">
     <div class="mat-subtitle-1">Computer avatars students can choose:</div>
     <div fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="16px">

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html
@@ -16,6 +16,7 @@
     (defaultLanguageTextChanged)="componentChanged()"
     class="name"
     hint="This is what the computer avatar will be referred to as"
+    i18n-hint
   />
   <translatable-input
     [content]="computerAvatarSettings"
@@ -27,6 +28,7 @@
     (defaultLanguageTextChanged)="componentChanged()"
     class="name"
     hint="This text will introduce the avatar selection task"
+    i18n-hint
   />
   <translatable-input
     [content]="computerAvatarSettings"
@@ -38,6 +40,7 @@
     (defaultLanguageTextChanged)="componentChanged()"
     class="name"
     hint="Computer avatar will initiate dialog with this text"
+    i18n-hint
   />
   <div class="avatars">
     <div class="mat-subtitle-1">Computer avatars students can choose:</div>

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.scss
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.scss
@@ -1,39 +1,47 @@
-.avatar-label {
-  max-width: 400px;
-}
-
-.avatars {
-  margin: 16px 0;
-}
-
-/* TODO(mdc-migration): The following rule targets internal classes of button that may no longer apply for the MDC version. */
-.mat-button-toggle-group {
-  margin-top: 16px;
-}
-
-/* TODO(mdc-migration): The following rule targets internal classes of button that may no longer apply for the MDC version. */
-/* TODO(mdc-migration): The following rule targets internal classes of button that may no longer apply for the MDC version. */
-.mat-button-toggle-group-appearance-standard {
-  /* TODO(mdc-migration): The following rule targets internal classes of button that may no longer apply for the MDC version. */
-  .mat-button-toggle, .mat-button-toggle + .mat-button-toggle {
-    border-left: 0 none;
+.edit-dialog-guidance {
+  .avatar-label {
+    max-width: 400px;
   }
-}
 
-/* TODO(mdc-migration): The following rule targets internal classes of button that may no longer apply for the MDC version. */
-.mat-button-toggle-checked {
-  background-color: transparent;
-}
+  .avatars {
+    margin: 16px 0;
+  }
 
-.avatar-image {
-  width: 88px;
-  margin: 0 auto;
-  height: auto;
-  border-radius: 50%;
-  padding: 8px 0;
-}
+  /* TODO(mdc-migration): The following rule targets internal classes of button that may no longer apply for the MDC version. */
+  .mat-button-toggle-group {
+    margin-top: 16px;
+  }
 
-.name {
-  line-height: 1;
-  padding-bottom: 8px;
+  /* TODO(mdc-migration): The following rule targets internal classes of button that may no longer apply for the MDC version. */
+  /* TODO(mdc-migration): The following rule targets internal classes of button that may no longer apply for the MDC version. */
+  .mat-button-toggle-group-appearance-standard {
+    /* TODO(mdc-migration): The following rule targets internal classes of button that may no longer apply for the MDC version. */
+    .mat-button-toggle, .mat-button-toggle + .mat-button-toggle {
+      border-left: 0 none;
+    }
+  }
+
+  /* TODO(mdc-migration): The following rule targets internal classes of button that may no longer apply for the MDC version. */
+  .mat-button-toggle-checked {
+    background-color: transparent;
+  }
+
+  .avatar-image {
+    width: 88px;
+    margin: 0 auto;
+    height: auto;
+    border-radius: 50%;
+    padding: 8px 0;
+  }
+
+  .name {
+    line-height: 1;
+    padding-bottom: 8px;
+  }
+
+  translatable-input {
+    .mat-mdc-form-field {
+      width: 100%;
+    }
+  }
 }

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.ts
@@ -1,10 +1,11 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { ComputerAvatar } from '../../../common/computer-avatar/ComputerAvatar';
 import { ComputerAvatarService } from '../../../services/computerAvatarService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { ComputerAvatarSettings } from '../../../common/computer-avatar/ComputerAvatarSettings';
 
 @Component({
+  encapsulation: ViewEncapsulation.None,
   selector: 'edit-dialog-guidance-computer-avatar',
   styleUrls: ['edit-dialog-guidance-computer-avatar.component.scss'],
   templateUrl: './edit-dialog-guidance-computer-avatar.component.html'

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9908,7 +9908,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">92</context>
+          <context context-type="linenumber">90</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component.html</context>
@@ -17195,42 +17195,28 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Computer Avatar Label</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">10</context>
+          <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5259202f409ce68afebe226dbdfd1164080c8354" datatype="html">
         <source>Thought Buddy</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">15</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="51e0301771667a3262784b0ae17ce504f94254e8" datatype="html">
-        <source>This is what the computer avatar will be referred as</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">18</context>
+          <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b1e071dd153cd41f10c927d7152b58c10d143091" datatype="html">
         <source>Computer Avatar Prompt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">21</context>
+          <context context-type="linenumber">23</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e613415e9c6e4c83d994717820278a6fce5452eb" datatype="html">
         <source>Discuss your answer with a thought buddy!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">26</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="41a133b581aac4fb993dcbb529388571cb714470" datatype="html">
-        <source>This text will introduce the avatar selection task</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e6d52ee834360f0d9cf115f9b181bf390f0ca0e4" datatype="html">
@@ -17244,63 +17230,56 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Hi there! It&apos;s nice to meet you. What do you think about...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">39</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="42171c1193c9971ed94b551d15abe6c23afe5602" datatype="html">
-        <source>Computer avatar will initiate dialog with this text</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">36</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6d35db3e303ce2b0a7ca704d01e40db06c2261ac" datatype="html">
         <source>Select all avatars</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dbcb5c68926fbb89335f710a022a7fce90f41f69" datatype="html">
         <source> Select All </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">54,56</context>
+          <context context-type="linenumber">52,54</context>
         </context-group>
       </trans-unit>
       <trans-unit id="661e889c7bc2e4c7817524d979f92bde5e12d8c5" datatype="html">
         <source>Select no avatars</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">61</context>
+          <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit>
       <trans-unit id="02a2e57913fbe388e0308b6bb44de16ad70f740b" datatype="html">
         <source> Select None </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">64,66</context>
+          <context context-type="linenumber">62,64</context>
         </context-group>
       </trans-unit>
       <trans-unit id="51c96f0051a84a0981042239f47b3f38ee2257cf" datatype="html">
         <source>Avatars available to students</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">71</context>
+          <context context-type="linenumber">69</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c0a308497c02864bc2c7cefcf0274368d3e5edc7" datatype="html">
         <source>Toggle <x id="INTERPOLATION" equiv-text="{{ computerAvatar.name }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">79</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5f9ab61f40e9053c2e217864b1d0b00b1df5f35f" datatype="html">
         <source>Not selected</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">99</context>
+          <context context-type="linenumber">97</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1942410144330587547" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9908,7 +9908,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">90</context>
+          <context context-type="linenumber">93</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component.html</context>
@@ -17205,81 +17205,102 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="8a659007ab6a46eb40594607444d41602909dccd" datatype="html">
+        <source>This is what the computer avatar will be referred to as</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="b1e071dd153cd41f10c927d7152b58c10d143091" datatype="html">
         <source>Computer Avatar Prompt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">23</context>
+          <context context-type="linenumber">24</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e613415e9c6e4c83d994717820278a6fce5452eb" datatype="html">
         <source>Discuss your answer with a thought buddy!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="41a133b581aac4fb993dcbb529388571cb714470" datatype="html">
+        <source>This text will introduce the avatar selection task</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e6d52ee834360f0d9cf115f9b181bf390f0ca0e4" datatype="html">
         <source>Computer Avatar Initial Response</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">34</context>
+          <context context-type="linenumber">36</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fd892b03fa033d52a2d7df8739e111f7c2103bee" datatype="html">
         <source>Hi there! It&apos;s nice to meet you. What do you think about...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">36</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="42171c1193c9971ed94b551d15abe6c23afe5602" datatype="html">
+        <source>Computer avatar will initiate dialog with this text</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
+          <context context-type="linenumber">42</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6d35db3e303ce2b0a7ca704d01e40db06c2261ac" datatype="html">
         <source>Select all avatars</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">52</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dbcb5c68926fbb89335f710a022a7fce90f41f69" datatype="html">
         <source> Select All </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">52,54</context>
+          <context context-type="linenumber">55,57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="661e889c7bc2e4c7817524d979f92bde5e12d8c5" datatype="html">
         <source>Select no avatars</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">59</context>
+          <context context-type="linenumber">62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="02a2e57913fbe388e0308b6bb44de16ad70f740b" datatype="html">
         <source> Select None </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">62,64</context>
+          <context context-type="linenumber">65,67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="51c96f0051a84a0981042239f47b3f38ee2257cf" datatype="html">
         <source>Avatars available to students</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">69</context>
+          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c0a308497c02864bc2c7cefcf0274368d3e5edc7" datatype="html">
         <source>Toggle <x id="INTERPOLATION" equiv-text="{{ computerAvatar.name }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">77</context>
+          <context context-type="linenumber">80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5f9ab61f40e9053c2e217864b1d0b00b1df5f35f" datatype="html">
         <source>Not selected</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component.html</context>
-          <context context-type="linenumber">97</context>
+          <context context-type="linenumber">100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1942410144330587547" datatype="html">


### PR DESCRIPTION
## Changes
- Add a `hint` input field to translatable inputs and textareas.
- Display hint text above the default language text for a translatable field.

## Test
Make sure the following fields in Dialog Guidance authoring are translatable and that the hint instruction text displays for both the default language and when in translation mode for other supported languages:
- Computer Avatar Label
- Computer Avatar Prompt
- Computer Avatar Initial Response
