### PR TITLE
feat(Multilingual Unit): Copy single component generates new translations

### DIFF
--- a/src/app/services/copyTranslationsService.spec.ts
+++ b/src/app/services/copyTranslationsService.spec.ts
@@ -1,0 +1,50 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { TeacherProjectService } from '../../assets/wise5/services/teacherProjectService';
+import { StudentTeacherCommonServicesModule } from '../student-teacher-common-services.module';
+import { ProjectLocale } from '../domain/projectLocale';
+import { ComponentContent } from '../../assets/wise5/common/ComponentContent';
+import { ConfigService } from '../../assets/wise5/services/configService';
+import { CopyTranslationsService } from '../../assets/wise5/services/copyTranslationsService';
+import { Node } from '../../assets/wise5/common/Node';
+
+let configService: ConfigService;
+let http: HttpTestingController;
+let projectService: TeacherProjectService;
+let service: CopyTranslationsService;
+describe('CopyTranslationsService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, StudentTeacherCommonServicesModule],
+      providers: [CopyTranslationsService, TeacherProjectService],
+      teardown: { destroyAfterEach: false }
+    });
+    configService = TestBed.inject(ConfigService);
+    http = TestBed.inject(HttpTestingController);
+    projectService = TestBed.inject(TeacherProjectService);
+    service = TestBed.inject(CopyTranslationsService);
+  });
+  tryCopyComponents();
+});
+
+function tryCopyComponents() {
+  describe('tryCopyComponents()', () => {
+    it('fetches all supported translations', () => {
+      spyOn(projectService, 'getLocale').and.returnValue(
+        new ProjectLocale({ default: 'en_us', supported: ['es', 'ja'] })
+      );
+      spyOn(configService, 'getProjectId').and.returnValue('123');
+      spyOn(configService, 'getConfigParam').and.returnValue('/123/project.json');
+      service.tryCopyTranslations({} as Node, [
+        {
+          id: 'abc',
+          type: 'OpenResponse',
+          prompt: 'hello',
+          'prompt.i18n': { id: 'xyz' }
+        } as ComponentContent
+      ]);
+      http.expectOne(`/123/translations.es.json`).flush({ xyz: {} });
+      http.expectOne(`/123/translations.ja.json`).flush({ xyz: {} });
+    });
+  });
+}

--- a/src/app/teacher/teacher-authoring.module.ts
+++ b/src/app/teacher/teacher-authoring.module.ts
@@ -34,6 +34,7 @@ import { RouterModule } from '@angular/router';
 import { ComponentInfoService } from '../../assets/wise5/services/componentInfoService';
 import { TeacherProjectTranslationService } from '../../assets/wise5/services/teacherProjectTranslationService';
 import { DeleteTranslationsService } from '../../assets/wise5/services/deleteTranslationsService';
+import { CopyTranslationsService } from '../../assets/wise5/services/copyTranslationsService';
 
 @NgModule({
   imports: [StudentTeacherCommonModule, AuthoringToolModule, RouterModule, AuthoringRoutingModule],
@@ -42,6 +43,7 @@ import { DeleteTranslationsService } from '../../assets/wise5/services/deleteTra
     ComponentInfoService,
     CopyNodesService,
     CopyProjectService,
+    CopyTranslationsService,
     DataExportService,
     { provide: DataService, useExisting: TeacherDataService },
     TeacherProjectTranslationService,

--- a/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.html
+++ b/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.html
@@ -2,7 +2,7 @@
   mat-icon-button
   color="primary"
   (click)="copy($event)"
-  matTooltip="Copy Component"
+  matTooltip="Copy component"
   matTooltipPosition="above"
   i18n-matTooltip
 >

--- a/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.spec.ts
@@ -2,6 +2,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CopyComponentButtonComponent } from './copy-component-button.component';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { MatIconModule } from '@angular/material/icon';
+import { CopyTranslationsService } from '../../../services/copyTranslationsService';
+import { ConfigService } from '../../../services/configService';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 class MockTeacherProjectService {}
 describe('CopyComponentButtonComponent', () => {
@@ -11,8 +14,12 @@ describe('CopyComponentButtonComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [CopyComponentButtonComponent],
-      imports: [MatIconModule],
-      providers: [{ provide: TeacherProjectService, useClass: MockTeacherProjectService }]
+      imports: [HttpClientTestingModule, MatIconModule],
+      providers: [
+        ConfigService,
+        CopyTranslationsService,
+        { provide: TeacherProjectService, useClass: MockTeacherProjectService }
+      ]
     });
     fixture = TestBed.createComponent(CopyComponentButtonComponent);
     component = fixture.componentInstance;

--- a/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.ts
+++ b/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { CopyTranslationsService } from '../../../services/copyTranslationsService';
 import { Node } from '../../../common/Node';
 
 @Component({
@@ -11,12 +12,16 @@ export class CopyComponentButtonComponent {
   @Output() newComponentEvent = new EventEmitter<any[]>();
   @Input() node: Node;
 
-  constructor(private projectService: TeacherProjectService) {}
+  constructor(
+    private copyTranslationsService: CopyTranslationsService,
+    private projectService: TeacherProjectService
+  ) {}
 
   protected copy(event: Event): void {
     event.stopPropagation();
     const newComponents = this.node.copyComponents([this.componentId], this.componentId);
     this.projectService.saveProject();
+    this.copyTranslationsService.tryCopyTranslations(this.node, newComponents);
     this.newComponentEvent.emit(newComponents);
   }
 }

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
@@ -17,7 +17,6 @@ import { ComponentAuthoringModule } from '../../../../../app/teacher/component-a
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
 import { DebugElement } from '@angular/core';
 import { DragDropModule } from '@angular/cdk/drag-drop';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
 import { TeacherNodeService } from '../../../services/teacherNodeService';
@@ -29,6 +28,7 @@ import { TeacherProjectTranslationService } from '../../../services/teacherProje
 import { ComponentTypeServiceModule } from '../../../services/componentTypeService.module';
 import { DeleteTranslationsService } from '../../../services/deleteTranslationsService';
 import { PreviewComponentButtonComponent } from '../../components/preview-component-button/preview-component-button.component';
+import { CopyTranslationsService } from '../../../services/copyTranslationsService';
 
 let component: NodeAuthoringComponent;
 let component1: any;
@@ -58,12 +58,12 @@ describe('NodeAuthoringComponent', () => {
         MatIconModule,
         MatInputModule,
         PreviewComponentButtonComponent,
-        RouterTestingModule,
         StudentTeacherCommonServicesModule,
         TeacherNodeIconComponent
       ],
       providers: [
         ClassroomStatusService,
+        CopyTranslationsService,
         DeleteTranslationsService,
         TeacherProjectTranslationService,
         ProjectAssetService,

--- a/src/assets/wise5/services/copyTranslationsService.ts
+++ b/src/assets/wise5/services/copyTranslationsService.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@angular/core';
+import { EditTranslationsService } from './editProjectTranslationsService';
+import { Node } from '../common/Node';
+import { Observable, forkJoin } from 'rxjs';
+import { generateRandomKey } from '../common/string/string';
+import { ComponentContent } from '../common/ComponentContent';
+
+interface I18NReplaceKey {
+  new: string;
+  original: string;
+}
+
+@Injectable()
+export class CopyTranslationsService extends EditTranslationsService {
+  tryCopyTranslations(node: Node, components: ComponentContent[]): void {
+    if (this.projectService.getLocale().hasTranslations()) {
+      this.copyTranslations(
+        node,
+        components.map((c) => c.id)
+      );
+    }
+  }
+
+  private async copyTranslations(node: Node, componentIds: string[]): Promise<void> {
+    const allTranslations = await this.fetchAllTranslations();
+    const i18nKeys = node.components
+      .filter((component) => componentIds.includes(component.id))
+      .flatMap((component) => this.replaceI18NKeys(component));
+    const saveTranslationRequests: Observable<Object>[] = [];
+    allTranslations.forEach((translations, language) => {
+      i18nKeys.forEach((i18nKey) => (translations[i18nKey.new] = translations[i18nKey.original]));
+      saveTranslationRequests.push(
+        this.http.post(
+          `/api/author/project/translate/${this.configService.getProjectId()}/${language.locale}`,
+          translations
+        )
+      );
+    });
+    forkJoin(saveTranslationRequests).subscribe();
+    this.projectService.saveProject();
+  }
+
+  protected replaceI18NKeys(componentElement: object): I18NReplaceKey[] {
+    let i18nKeys = Object.keys(componentElement)
+      .filter((key) => key.endsWith('.i18n'))
+      .map((key) => {
+        const originalI18NKey = componentElement[key].id;
+        const newI18NKey = generateRandomKey(30);
+        componentElement[key].id = newI18NKey;
+        return { original: originalI18NKey, new: newI18NKey };
+      });
+    Object.values(componentElement).forEach((value) => {
+      if (Array.isArray(value)) {
+        i18nKeys = i18nKeys.concat(...value.map((val) => this.replaceI18NKeys(val)));
+      } else if (typeof value === 'object' && value != null) {
+        i18nKeys = i18nKeys.concat(this.replaceI18NKeys(value));
+      }
+    });
+    return i18nKeys;
+  }
+}

--- a/src/assets/wise5/services/deleteTranslationsService.ts
+++ b/src/assets/wise5/services/deleteTranslationsService.ts
@@ -1,23 +1,10 @@
-import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, forkJoin, lastValueFrom } from 'rxjs';
-import { Translations } from '../../../app/domain/translations';
+import { Observable, forkJoin } from 'rxjs';
 import { ComponentContent } from '../common/ComponentContent';
-import { ConfigService } from './configService';
-import { Language } from '../../../app/domain/language';
-import { ProjectTranslationService } from './projectTranslationService';
-import { TeacherProjectService } from './teacherProjectService';
+import { EditTranslationsService } from './editProjectTranslationsService';
 
 @Injectable()
-export class DeleteTranslationsService extends ProjectTranslationService {
-  constructor(
-    protected configService: ConfigService,
-    protected http: HttpClient,
-    protected projectService: TeacherProjectService
-  ) {
-    super(configService, http, projectService);
-  }
-
+export class DeleteTranslationsService extends EditTranslationsService {
   tryDeleteComponents(components: ComponentContent[]): void {
     if (this.projectService.getLocale().hasTranslations()) {
       this.deleteComponents(components);
@@ -38,22 +25,6 @@ export class DeleteTranslationsService extends ProjectTranslationService {
       );
     });
     forkJoin(saveTranslationRequests).subscribe();
-  }
-
-  private async fetchAllTranslations(): Promise<Map<Language, Translations>> {
-    const allTranslations = new Map<Language, Translations>();
-    await Promise.all(
-      this.projectService
-        .getLocale()
-        .getSupportedLanguages()
-        .map(async (language) => {
-          allTranslations.set(
-            language,
-            await lastValueFrom(this.fetchTranslations(language.locale))
-          );
-        })
-    );
-    return allTranslations;
   }
 
   private getI18NKeys(componentElement: object): string[] {

--- a/src/assets/wise5/services/editProjectTranslationsService.ts
+++ b/src/assets/wise5/services/editProjectTranslationsService.ts
@@ -1,0 +1,35 @@
+import { HttpClient } from '@angular/common/http';
+import { ConfigService } from './configService';
+import { ProjectTranslationService } from './projectTranslationService';
+import { TeacherProjectService } from './teacherProjectService';
+import { lastValueFrom } from 'rxjs';
+import { Translations } from '../../../app/domain/translations';
+import { Language } from '../../../app/domain/language';
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class EditTranslationsService extends ProjectTranslationService {
+  constructor(
+    protected configService: ConfigService,
+    protected http: HttpClient,
+    protected projectService: TeacherProjectService
+  ) {
+    super(configService, http, projectService);
+  }
+
+  protected async fetchAllTranslations(): Promise<Map<Language, Translations>> {
+    const allTranslations = new Map<Language, Translations>();
+    await Promise.all(
+      this.projectService
+        .getLocale()
+        .getSupportedLanguages()
+        .map(async (language) => {
+          allTranslations.set(
+            language,
+            await lastValueFrom(this.fetchTranslations(language.locale))
+          );
+        })
+    );
+    return allTranslations;
+  }
+}

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -11886,8 +11886,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">38</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6e04c490706ecafe8e0c842513b700e165d97bc2" datatype="html">
-        <source>Copy Component</source>
+      <trans-unit id="37388c2e35d4617387f50fa50d46a8d04e4d7e43" datatype="html">
+        <source>Copy component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.html</context>
           <context context-type="linenumber">5</context>


### PR DESCRIPTION
## Changes
- Copying a single component generates new translations ids and copies over translations for the new component
- Note: to keep the scope small, I did not implement copying components via other methods.

## Test
- In the node authoring view, click on the "Copy component" button for a component (not the checkbox -> copy method). This should:
   - copy the component
   - generate new translation ids for the new component (look at project.json)
   - copy the translations that were in the original component, but with new the new translation ids (look at translations.[language].json)
- Deleting components deletes translations from the translations.[language].json files as before. I extracted common code to a new EditTranslationsService class.