### PR TITLE
fix(Home Page): Library units not loading

### DIFF
--- a/src/app/modules/library/library.module.ts
+++ b/src/app/modules/library/library.module.ts
@@ -56,6 +56,7 @@ import { SelectTagsComponent } from '../../teacher/select-tags/select-tags.compo
 import { MatChipsModule } from '@angular/material/chips';
 import { SelectMenuComponent } from '../shared/select-menu/select-menu.component';
 import { UnitTagsComponent } from '../../teacher/unit-tags/unit-tags.component';
+import { ProjectTagService } from '../../../assets/wise5/services/projectTagService';
 
 const materialModules = [
   MatAutocompleteModule,
@@ -123,6 +124,10 @@ const materialModules = [
     UnitTagsComponent,
     materialModules
   ],
-  providers: [LibraryService, { provide: MatPaginatorIntl, useClass: LibraryPaginatorIntl }]
+  providers: [
+    LibraryService,
+    { provide: MatPaginatorIntl, useClass: LibraryPaginatorIntl },
+    ProjectTagService
+  ]
 })
 export class LibraryModule {}


### PR DESCRIPTION
## Changes
- Add ProjectTagService to the LibraryModule so that library units show up on the home page

## Test
- Go to the home page and make sure the library units show up
- The error below used to show up but now it shouldn't
```
core.mjs:6531 ERROR NullInjectorError: NullInjectorError: No provider for projectTagService!
    at Kr.get (core.mjs:1654:27)
    at fo.get (core.mjs:3093:33)
    at fo.get (core.mjs:3093:33)
    at fo.get (core.mjs:3093:33)
    at Hc.get (core.mjs:15723:36)
    at uf (core.mjs:5730:39)
    at hf (core.mjs:5778:12)
    at Object.gs (core.mjs:11050:19)
    at B.#e.ɵfac [as factory] (library-project.component.ts:19:37)
```

Closes #1854
