### PR TITLE
feat(Multilingual Unit): Copy multiple components generates new translations

### DIFF
--- a/src/assets/wise5/authoringTool/node/chooseComponentLocation/choose-component-location.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/chooseComponentLocation/choose-component-location.component.spec.ts
@@ -5,6 +5,7 @@ import { ComponentTypeService } from '../../../services/componentTypeService';
 import { ConfigService } from '../../../services/configService';
 import { TeacherDataService } from '../../../services/teacherDataService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
+import { CopyTranslationsService } from '../../../services/copyTranslationsService';
 
 const nodeId = 'node1';
 const components = [
@@ -35,9 +36,8 @@ class MockTeacherDataService {
 class MockComponentTypeService {}
 
 let component: ChooseComponentLocationComponent;
-let teacherProjectService: TeacherProjectService;
 
-describe('InsertComponent', () => {
+describe('ChooseComponentLocationComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -45,12 +45,12 @@ describe('InsertComponent', () => {
         ChooseComponentLocationComponent,
         { provide: ComponentTypeService, useClass: MockComponentTypeService },
         ConfigService,
+        CopyTranslationsService,
         { provide: TeacherProjectService, useClass: MockProjectService },
         { provide: TeacherDataService, useClass: MockTeacherDataService }
       ]
     });
     component = TestBed.inject(ChooseComponentLocationComponent);
-    teacherProjectService = TestBed.inject(TeacherProjectService);
   });
 
   it('should create', () => {

--- a/src/assets/wise5/authoringTool/node/chooseComponentLocation/choose-component-location.component.ts
+++ b/src/assets/wise5/authoringTool/node/chooseComponentLocation/choose-component-location.component.ts
@@ -5,6 +5,7 @@ import { TeacherDataService } from '../../../services/teacherDataService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { Node } from '../../../common/Node';
 import { Router } from '@angular/router';
+import { CopyTranslationsService } from '../../../services/copyTranslationsService';
 
 @Component({
   selector: 'choose-component-location',
@@ -18,6 +19,7 @@ export class ChooseComponentLocationComponent {
 
   constructor(
     private componentTypeService: ComponentTypeService,
+    private copyTranslationsService: CopyTranslationsService,
     private configService: ConfigService,
     private dataService: TeacherDataService,
     private projectService: TeacherProjectService,
@@ -47,10 +49,12 @@ export class ChooseComponentLocationComponent {
   }
 
   private copyComponents(insertAfterComponentId: string = null): any[] {
-    return this.node.copyComponents(
+    const newComponents = this.node.copyComponents(
       this.selectedComponents.map((c) => c.id),
       insertAfterComponentId
     );
+    this.copyTranslationsService.tryCopyTranslations(this.node, newComponents);
+    return newComponents;
   }
 
   private moveComponents(insertAfterComponentId: string = null): any[] {


### PR DESCRIPTION
## Changes
- Copying multiple components generates new translations ids and copies over translations for the new components

## Test
- In the node authoring view, select multiple components (using the checkbox) and then click on the "Copy Components". Select a location for the copied components. This should:
   - copy the components
   - generate new translation ids for the new components (look at project.json)
   - copy the translations that were in the original components, but with new the new translation ids (look at translations.[language].json)