### PR TITLE
refactor(Announcement): Convert to standalone

### DIFF
--- a/src/app/announcement/announcement-dialog.component.html
+++ b/src/app/announcement/announcement-dialog.component.html
@@ -3,13 +3,10 @@
   <div class="info-block" [innerHTML]="data.content"></div>
 </mat-dialog-content>
 <mat-dialog-actions align="end">
-  <a
-    mat-button
-    *ngFor="let button of data.buttons"
-    color="{{ button.color }}"
-    href="{{ button.link }}"
-  >
-    {{ button.text }}
-  </a>
+  @for (button of data.buttons; track button) {
+    <a mat-button color="{{ button.color }}" href="{{ button.link }}">
+      {{ button.text }}
+    </a>
+  }
   <button mat-button mat-dialog-close cdkFocusRegionstart i18n>Close</button>
 </mat-dialog-actions>

--- a/src/app/announcement/announcement.component.html
+++ b/src/app/announcement/announcement.component.html
@@ -12,7 +12,7 @@
     mat-icon-button
     i18n-aria-label
     aria-label="Dismiss"
-    (click)="dismiss()"
+    (click)="dismiss.emit()"
   >
     <mat-icon>close</mat-icon>
   </button>

--- a/src/app/announcement/announcement.component.html
+++ b/src/app/announcement/announcement.component.html
@@ -1,14 +1,11 @@
 <div class="announcement mat-caption dark-theme center primary-bg" fxLayoutAlign="center center">
   <span class="announcement__content" fxLayoutGap="4px" fxLayoutAlign="center center">
     <span>{{ announcement.bannerText }}</span>
-    <button
-      *ngIf="announcement.bannerButton"
-      mat-button
-      color="primary"
-      (click)="showAnnouncementDetails()"
-    >
-      {{ announcement.bannerButton }}
-    </button>
+    @if (announcement.bannerButton) {
+      <button mat-button color="primary" (click)="showAnnouncementDetails()">
+        {{ announcement.bannerButton }}
+      </button>
+    }
   </span>
   <button
     class="announcement__dismiss"

--- a/src/app/announcement/announcement.component.spec.ts
+++ b/src/app/announcement/announcement.component.spec.ts
@@ -2,7 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AnnouncementComponent } from './announcement.component';
 import { Announcement } from '../domain/announcement';
 import { MatDialog } from '@angular/material/dialog';
-import { By } from '@angular/platform-browser';
 
 describe('AnnouncementComponent', () => {
   let component: AnnouncementComponent;
@@ -41,15 +40,5 @@ describe('AnnouncementComponent', () => {
     const compiled = fixture.debugElement.nativeElement;
     expect(compiled.textContent).toContain('This is an announcement.');
     expect(compiled.textContent).toContain('Do something');
-  });
-
-  it('should emit dismiss event on dismiss button click', async () => {
-    spyOn(component.doDismiss, 'emit');
-    const dismissButton = fixture.debugElement.query(
-      By.css('.announcement__dismiss')
-    ).nativeElement;
-    dismissButton.click();
-    fixture.detectChanges();
-    expect(component.doDismiss.emit).toHaveBeenCalled();
   });
 });

--- a/src/app/announcement/announcement.component.spec.ts
+++ b/src/app/announcement/announcement.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { AnnouncementComponent } from './announcement.component';
 import { Announcement } from '../domain/announcement';
 import { MatDialog } from '@angular/material/dialog';
@@ -11,7 +10,7 @@ describe('AnnouncementComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [AnnouncementComponent],
+      imports: [AnnouncementComponent],
       providers: [
         {
           provide: MatDialog,
@@ -19,8 +18,7 @@ describe('AnnouncementComponent', () => {
             closeAll: () => {}
           }
         }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
+      ]
     });
   });
 
@@ -47,8 +45,9 @@ describe('AnnouncementComponent', () => {
 
   it('should emit dismiss event on dismiss button click', async () => {
     spyOn(component.doDismiss, 'emit');
-    const dismissButton = fixture.debugElement.query(By.css('.announcement__dismiss'))
-      .nativeElement;
+    const dismissButton = fixture.debugElement.query(
+      By.css('.announcement__dismiss')
+    ).nativeElement;
     dismissButton.click();
     fixture.detectChanges();
     expect(component.doDismiss.emit).toHaveBeenCalled();

--- a/src/app/announcement/announcement.component.ts
+++ b/src/app/announcement/announcement.component.ts
@@ -21,14 +21,9 @@ import { CommonModule } from '@angular/common';
 })
 export class AnnouncementComponent {
   @Input() announcement: Announcement = new Announcement();
-  @Output('callback') doCallback: EventEmitter<any> = new EventEmitter<any>();
-  @Output('dismiss') doDismiss: EventEmitter<any> = new EventEmitter<any>();
+  @Output() dismiss: EventEmitter<void> = new EventEmitter<void>();
 
   constructor(public dialog: MatDialog) {}
-
-  protected dismiss(): void {
-    this.doDismiss.emit();
-  }
 
   protected showAnnouncementDetails(): void {
     this.dialog.open(AnnouncementDialogComponent, {

--- a/src/app/announcement/announcement.component.ts
+++ b/src/app/announcement/announcement.component.ts
@@ -1,30 +1,36 @@
 import { Component, EventEmitter, Input, Output, ViewEncapsulation, Inject } from '@angular/core';
 import { Announcement } from '../domain/announcement';
-import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import {
+  MatDialogRef,
+  MAT_DIALOG_DATA,
+  MatDialog,
+  MatDialogModule
+} from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { CommonModule } from '@angular/common';
 
 @Component({
+  encapsulation: ViewEncapsulation.None,
+  imports: [CommonModule, FlexLayoutModule, MatButtonModule, MatDialogModule, MatIconModule],
   selector: 'app-announcement',
-  templateUrl: './announcement.component.html',
-  styleUrls: ['./announcement.component.scss'],
-  encapsulation: ViewEncapsulation.None
+  standalone: true,
+  styleUrl: './announcement.component.scss',
+  templateUrl: './announcement.component.html'
 })
 export class AnnouncementComponent {
-  @Input()
-  announcement: Announcement = new Announcement();
-
-  @Output('callback')
-  doCallback: EventEmitter<any> = new EventEmitter<any>();
-
-  @Output('dismiss')
-  doDismiss: EventEmitter<any> = new EventEmitter<any>();
+  @Input() announcement: Announcement = new Announcement();
+  @Output('callback') doCallback: EventEmitter<any> = new EventEmitter<any>();
+  @Output('dismiss') doDismiss: EventEmitter<any> = new EventEmitter<any>();
 
   constructor(public dialog: MatDialog) {}
 
-  dismiss() {
+  protected dismiss(): void {
     this.doDismiss.emit();
   }
 
-  showAnnouncementDetails() {
+  protected showAnnouncementDetails(): void {
     this.dialog.open(AnnouncementDialogComponent, {
       data: this.announcement,
       panelClass: 'dialog-md'

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,7 +8,7 @@
       class="top-content"
       [announcement]="announcement"
       (dismiss)="dismissAnnouncement()"
-    ></app-announcement>
+    />
     <app-header *ngIf="showHeaderAndFooter" class="dark-theme top-content" />
     <div fxFlex>
       <router-outlet></router-outlet>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -43,13 +43,9 @@ export function initialize(
 }
 
 @NgModule({
-  declarations: [
-    AppComponent,
-    AnnouncementComponent,
-    AnnouncementDialogComponent,
-    TrackScrollDirective
-  ],
+  declarations: [AppComponent, AnnouncementDialogComponent, TrackScrollDirective],
   imports: [
+    AnnouncementComponent,
     BrowserModule,
     BrowserAnimationsModule,
     FormsModule,

--- a/src/app/domain/announcement.ts
+++ b/src/app/domain/announcement.ts
@@ -1,8 +1,10 @@
+import { AnnouncementButton } from './announcementButton';
+
 export class Announcement {
   visible: boolean = true;
   bannerText: string = '';
   bannerButton: string = '';
   title: string = '';
   content: string = '';
-  buttons: string[] = [];
+  buttons: AnnouncementButton[] = [];
 }

--- a/src/app/domain/announcementButton.ts
+++ b/src/app/domain/announcementButton.ts
@@ -1,0 +1,5 @@
+export class AnnouncementButton {
+  color: string;
+  link: string;
+  text: string;
+}

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -263,7 +263,7 @@
         <source>Close</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/announcement/announcement-dialog.component.html</context>
-          <context context-type="linenumber">14</context>
+          <context context-type="linenumber">11</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-component-advanced/edit-component-advanced.component.html</context>
@@ -354,7 +354,7 @@
         <source>Dismiss</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/announcement/announcement.component.html</context>
-          <context context-type="linenumber">17</context>
+          <context context-type="linenumber">14</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.html</context>


### PR DESCRIPTION
## Changes
- Convert Announcement component to standalone

## Test
- Make sure the home page shows the announcement when one has been set in the portal

You can use this database query to set an announcement
```
update portal set announcement='{"visible":true,"bannerText":"Welcome Distance Learners and Teachers!","bannerButton":"Learn More","title":"WISE Support for Distance Learning","content":"<p>The Web-Based Inquiry Science Environment (WISE) provides standards-aligned online inquiry science units. Our team is now working directly with teachers to implement, customize, and create web-based distance learning curricula for their students. We are hosting weekly office hours, facilitating teachers to collaborate on strategies for customizing WISE to create their own instruction, and supporting students and families. WISE is free to use and available worldwide.</p><p>In this challenging time, teachers are doing innovative work to ensure their students have engaging science learning opportunities and are connecting with their peers and teachers. They are connecting with colleagues to share ideas and resources and are adapting WISE units to meet the needs of their students.</p><p>Are you interested in using WISE with your students? Or are you a family member looking to supplement your students\' learning while at home? We want to help! Join us for weekly Zoom office hours every Monday from 1-3pm PDT. We will answer any questions you might have and can help you facilitate and/or customize WISE units. You can also join our WISE Community at <a href=\\"https://wise-discuss.berkeley.edu\\">https://wise-discuss.berkeley.edu</a>. <a href=\\"https://wise.berkeley.edu/contact\\">Contact us</a> at any time and let us know if you\'re interested in joining office hours or have any questions or comments. We\'d love to hear about your experiences, challenges, and successes in adapting your teaching to a distance learning model!</p><p>We wish everyone good health and hope you\'re all staying safe! Best wishes,<p>The WISE Team</p>","buttons":[{"text":"Contact Us","link":"https://wise.berkeley.edu/contact","color":"accent"}]}' where id=1;
```

- Make sure the home page does not show an announcement when one has not been set in the portal

You can use this database query to remove an announcement
```
update portal set announcement='{"visible":false,"bannerText":"","bannerButton":"","title":"","content":"","buttons":[]}' where id=1;
```