### PR TITLE
refactor(Dialog With Close): Convert to standalone

### DIFF
--- a/src/app/domain/dialogData.ts
+++ b/src/app/domain/dialogData.ts
@@ -1,5 +1,5 @@
 export interface DialogData {
   content: string;
-  title: string;
   scroll: boolean;
+  title: string;
 }

--- a/src/assets/wise5/directives/dialog-with-close/dialog-with-close.component.html
+++ b/src/assets/wise5/directives/dialog-with-close/dialog-with-close.component.html
@@ -1,13 +1,12 @@
 <h2 mat-dialog-title [innerHTML]="dialogData.title"></h2>
-<div
-  *ngIf="dialogData.scroll"
-  mat-dialog-content
-  class="dialog-content-scroll"
-  [innerHTML]="dialogData.content"
-></div>
-<div *ngIf="!dialogData.scroll" mat-dialog-content>
-  <div class="info-block" [innerHTML]="dialogData.content"></div>
-</div>
+@if (dialogData.scroll) {
+  <div mat-dialog-content class="dialog-content-scroll" [innerHTML]="dialogData.content"></div>
+}
+@if (!dialogData.scroll) {
+  <div mat-dialog-content>
+    <div class="info-block" [innerHTML]="dialogData.content"></div>
+  </div>
+}
 <mat-dialog-actions align="end">
   <button mat-button mat-dialog-close i18n>Close</button>
 </mat-dialog-actions>

--- a/src/assets/wise5/directives/dialog-with-close/dialog-with-close.component.spec.ts
+++ b/src/assets/wise5/directives/dialog-with-close/dialog-with-close.component.spec.ts
@@ -8,8 +8,7 @@ describe('DialogWithCloseComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MatDialogModule],
-      declarations: [DialogWithCloseComponent],
+      imports: [DialogWithCloseComponent, MatDialogModule],
       providers: [
         { provide: MAT_DIALOG_DATA, useValue: {} },
         { provide: MatDialogRef, useValue: {} }

--- a/src/assets/wise5/directives/dialog-with-close/dialog-with-close.component.ts
+++ b/src/assets/wise5/directives/dialog-with-close/dialog-with-close.component.ts
@@ -1,8 +1,12 @@
 import { Component } from '@angular/core';
 import { DialogComponent } from '../dialog/dialog.component';
+import { MatDialogModule } from '@angular/material/dialog';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
 
 @Component({
-  selector: 'dialog-with-close',
+  imports: [CommonModule, MatButtonModule, MatDialogModule],
+  standalone: true,
   templateUrl: './dialog-with-close.component.html'
 })
 export class DialogWithCloseComponent extends DialogComponent {}

--- a/src/assets/wise5/directives/simple-dialog.module.ts
+++ b/src/assets/wise5/directives/simple-dialog.module.ts
@@ -10,15 +10,13 @@ import { DialogWithoutCloseComponent } from './dialog-without-close/dialog-witho
 
 @NgModule({
   declarations: [
-    DialogWithCloseComponent,
     DialogWithConfirmComponent,
     DialogWithOpenInNewWindowComponent,
     DialogWithoutCloseComponent,
     DialogWithSpinnerComponent
   ],
-  imports: [StudentTeacherCommonModule, MatButtonModule, MatDialogModule],
+  imports: [DialogWithCloseComponent, StudentTeacherCommonModule, MatButtonModule, MatDialogModule],
   exports: [
-    DialogWithCloseComponent,
     DialogWithConfirmComponent,
     DialogWithOpenInNewWindowComponent,
     DialogWithoutCloseComponent,

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -331,7 +331,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/dialog-with-close/dialog-with-close.component.html</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">11</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/dialog-with-open-in-new-window/dialog-with-open-in-new-window.component.html</context>


### PR DESCRIPTION
## Changes
- Convert DialogWithClose component to standalone

## Test
1. Open a unit in the Authoring Tool
2. Go into a step
3. Add rubric text to the step
4. Preview the step
5. Click on the rubric icon
6. Make sure the rubric shows up in the dialog popup