### PR TITLE
feat(Multilingual Unit): Copy multiple steps generates new translations

### DIFF
--- a/src/app/services/copyTranslationsService.spec.ts
+++ b/src/app/services/copyTranslationsService.spec.ts
@@ -35,7 +35,7 @@ function tryCopyComponents() {
       );
       spyOn(configService, 'getProjectId').and.returnValue('123');
       spyOn(configService, 'getConfigParam').and.returnValue('/123/project.json');
-      service.tryCopyTranslations({} as Node, [
+      service.tryCopyComponents({} as Node, [
         {
           id: 'abc',
           type: 'OpenResponse',

--- a/src/assets/wise5/authoringTool/choose-node-location/choose-copy-node-location/choose-copy-node-location.component.ts
+++ b/src/assets/wise5/authoringTool/choose-node-location/choose-copy-node-location/choose-copy-node-location.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { CopyNodesService } from '../../../services/copyNodesService';
 import { ChooseNodeLocationComponent } from '../choose-node-location.component';
+import { CopyTranslationsService } from '../../../services/copyTranslationsService';
 
 @Component({
   templateUrl: 'choose-copy-node-location.component.html',
@@ -11,6 +12,7 @@ import { ChooseNodeLocationComponent } from '../choose-node-location.component';
 export class ChooseCopyNodeLocationComponent extends ChooseNodeLocationComponent {
   constructor(
     private copyNodesService: CopyNodesService,
+    private copyTranslationsService: CopyTranslationsService,
     protected projectService: TeacherProjectService,
     protected route: ActivatedRoute,
     protected router: Router
@@ -19,10 +21,14 @@ export class ChooseCopyNodeLocationComponent extends ChooseNodeLocationComponent
   }
 
   protected insertAfter(nodeId: string): any[] {
-    return this.copyNodesService.copyNodesAfter(this.selectedNodeIds, nodeId);
+    const newNodes = this.copyNodesService.copyNodesAfter(this.selectedNodeIds, nodeId);
+    this.copyTranslationsService.tryCopyNodes(newNodes);
+    return newNodes;
   }
 
   protected insertInside(groupNodeId: string): any[] {
-    return this.copyNodesService.copyNodesInsideGroup(this.selectedNodeIds, groupNodeId);
+    const newNodes = this.copyNodesService.copyNodesInsideGroup(this.selectedNodeIds, groupNodeId);
+    this.copyTranslationsService.tryCopyNodes(newNodes);
+    return newNodes;
   }
 }

--- a/src/assets/wise5/authoringTool/node/chooseComponentLocation/choose-component-location.component.ts
+++ b/src/assets/wise5/authoringTool/node/chooseComponentLocation/choose-component-location.component.ts
@@ -53,7 +53,7 @@ export class ChooseComponentLocationComponent {
       this.selectedComponents.map((c) => c.id),
       insertAfterComponentId
     );
-    this.copyTranslationsService.tryCopyTranslations(this.node, newComponents);
+    this.copyTranslationsService.tryCopyComponents(this.node, newComponents);
     return newComponents;
   }
 

--- a/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.ts
+++ b/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.ts
@@ -21,7 +21,7 @@ export class CopyComponentButtonComponent {
     event.stopPropagation();
     const newComponents = this.node.copyComponents([this.componentId], this.componentId);
     this.projectService.saveProject();
-    this.copyTranslationsService.tryCopyTranslations(this.node, newComponents);
+    this.copyTranslationsService.tryCopyComponents(this.node, newComponents);
     this.newComponentEvent.emit(newComponents);
   }
 }

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
@@ -20,6 +20,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { AddStepButtonComponent } from '../add-step-button/add-step-button.component';
 import { DeleteTranslationsService } from '../../services/deleteTranslationsService';
 import { provideRouter } from '@angular/router';
+import { CopyTranslationsService } from '../../services/copyTranslationsService';
 
 let component: ProjectAuthoringLessonComponent;
 let fixture: ComponentFixture<ProjectAuthoringLessonComponent>;
@@ -50,6 +51,7 @@ describe('ProjectAuthoringLessonComponent', () => {
       providers: [
         ClassroomStatusService,
         CopyNodesService,
+        CopyTranslationsService,
         DeleteNodeService,
         DeleteTranslationsService,
         provideRouter([]),

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.spec.ts
@@ -15,6 +15,7 @@ import { DeleteNodeService } from '../../services/deleteNodeService';
 import { CopyNodesService } from '../../services/copyNodesService';
 import { DeleteTranslationsService } from '../../services/deleteTranslationsService';
 import { provideRouter } from '@angular/router';
+import { CopyTranslationsService } from '../../services/copyTranslationsService';
 
 const nodeId1 = 'nodeId1';
 const node = { id: nodeId1 };
@@ -38,6 +39,7 @@ describe('ProjectAuthoringStepComponent', () => {
       providers: [
         ClassroomStatusService,
         CopyNodesService,
+        CopyTranslationsService,
         DeleteNodeService,
         DeleteTranslationsService,
         provideRouter([]),

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
@@ -7,6 +7,7 @@ import { NodeTypeSelected } from '../domain/node-type-selected';
 import { DeleteNodeService } from '../../services/deleteNodeService';
 import { CopyNodesService } from '../../services/copyNodesService';
 import { DeleteTranslationsService } from '../../services/deleteTranslationsService';
+import { CopyTranslationsService } from '../../services/copyTranslationsService';
 
 @Component({
   selector: 'project-authoring-step',
@@ -22,6 +23,7 @@ export class ProjectAuthoringStepComponent {
 
   constructor(
     private copyNodesService: CopyNodesService,
+    private copyTranslationsService: CopyTranslationsService,
     private dataService: TeacherDataService,
     private deleteNodeService: DeleteNodeService,
     private deleteTranslationsService: DeleteTranslationsService,
@@ -106,7 +108,8 @@ export class ProjectAuthoringStepComponent {
   }
 
   protected copy(): void {
-    this.copyNodesService.copyNodesAfter([this.step.id], this.step.id);
+    const newNodes = this.copyNodesService.copyNodesAfter([this.step.id], this.step.id);
+    this.copyTranslationsService.tryCopyNodes(newNodes);
     this.saveAndRefreshProject();
   }
 

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
@@ -12,7 +12,6 @@ import { ClassroomStatusService } from '../../services/classroomStatusService';
 import { MatDialogModule } from '@angular/material/dialog';
 import { ConcurrentAuthorsMessageComponent } from '../concurrent-authors-message/concurrent-authors-message.component';
 import { NodeAuthoringComponent } from '../node/node-authoring/node-authoring.component';
-import { TeacherNodeIconComponent } from '../teacher-node-icon/teacher-node-icon.component';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { FormsModule } from '@angular/forms';
@@ -37,6 +36,7 @@ import { HttpClient } from '@angular/common/http';
 import { AddLessonButtonComponent } from '../add-lesson-button/add-lesson-button.component';
 import { AddStepButtonComponent } from '../add-step-button/add-step-button.component';
 import { DeleteTranslationsService } from '../../services/deleteTranslationsService';
+import { CopyTranslationsService } from '../../services/copyTranslationsService';
 
 let configService: ConfigService;
 let component: ProjectAuthoringComponent;
@@ -78,6 +78,7 @@ describe('ProjectAuthoringComponent', () => {
       providers: [
         ClassroomStatusService,
         CopyNodesService,
+        CopyTranslationsService,
         DeleteNodeService,
         DeleteTranslationsService,
         MoveNodesService,

--- a/src/assets/wise5/services/copyTranslationsService.ts
+++ b/src/assets/wise5/services/copyTranslationsService.ts
@@ -37,7 +37,7 @@ export class CopyTranslationsService extends EditTranslationsService {
     this.projectService.saveProject();
   }
 
-  tryCopyTranslations(node: Node, components: ComponentContent[]): void {
+  tryCopyComponents(node: Node, components: ComponentContent[]): void {
     if (this.projectService.getLocale().hasTranslations()) {
       this.copyTranslations(
         node,

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12626,7 +12626,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete this step?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts</context>
-          <context context-type="linenumber">114</context>
+          <context context-type="linenumber">117</context>
         </context-group>
       </trans-unit>
       <trans-unit id="57cf305f9bfd681c70dc26e914108d06384ade9f" datatype="html">


### PR DESCRIPTION
## Changes
- Copying a single step and multiple steps generates new translations ids and copies over translations for the new steps

## Test (in the project authoring view)
- Click on the "Copy step" button for a single step. This should:
   - copy the step
   - generate new translation ids for the new step (look at project.json)
   - copy the translations that were in the original step, but with new the new translation ids (look at translations.[language].json)
- Select multiple components (using the checkbox) and then click on the "Copy" button. Select a location for the copied steps. This should:
   - copy the steps
   - generate new translation ids for the new steps (look at project.json)
   - copy the translations that were in the original steps, but with new the new translation ids (look at translations.[language].json)