### PR TITLE
refactor(StepInfoComponent): Convert to standalone

### DIFF
--- a/src/app/classroom-monitor/step-info/step-info.component.html
+++ b/src/app/classroom-monitor/step-info/step-info.component.html
@@ -2,17 +2,21 @@
   <node-icon [nodeId]="nodeId" size="18" fxHide.xs />
   <span fxHide.xs>&nbsp;&nbsp;</span>
   <span>{{ stepTitle }}</span>
-  <status-icon
-    *ngIf="hasAlert"
-    [class]="alertIconClass"
-    [name]="alertIconName"
-    [tooltip]="alertIconLabel"
-  />
-  <status-icon
-    *ngIf="hasRubrics"
-    class="info"
-    name="info"
-    [tooltip]="rubricIconLabel"
-  />
-  <span *ngIf="hasNewWork" class="badge badge--info animate-fade" i18n>New</span>
+  @if (hasAlert) {
+    <status-icon
+      [class]="alertIconClass"
+      [name]="alertIconName"
+      [tooltip]="alertIconLabel"
+    />
+  }
+  @if (hasRubrics) {
+    <status-icon
+      class="info"
+      name="info"
+      [tooltip]="rubricIconLabel"
+    />
+  }
+  @if (hasNewWork) {
+    <span class="badge badge--info animate-fade" i18n>New</span>
+  }
 </div>

--- a/src/app/classroom-monitor/step-info/step-info.component.ts
+++ b/src/app/classroom-monitor/step-info/step-info.component.ts
@@ -1,25 +1,31 @@
 import { Component, Input } from '@angular/core';
 import { TeacherProjectService } from '../../../assets/wise5/services/teacherProjectService';
+import { CommonModule } from '@angular/common';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { StatusIconComponent } from '../status-icon/status-icon.component';
+import { NodeIconComponent } from '../../../assets/wise5/vle/node-icon/node-icon.component';
 
 @Component({
+  imports: [CommonModule, FlexLayoutModule, NodeIconComponent, StatusIconComponent],
   selector: 'step-info',
+  standalone: true,
   templateUrl: 'step-info.component.html'
 })
 export class StepInfoComponent {
-  alertIconClass: string;
-  alertIconLabel: string;
-  alertIconName: string;
+  protected alertIconClass: string;
+  protected alertIconLabel: string;
+  protected alertIconName: string;
   @Input() hasAlert: boolean;
   @Input() hasNewAlert: boolean;
   @Input() hasNewWork: boolean;
-  hasRubrics: boolean;
+  protected hasRubrics: boolean;
   @Input() nodeId: string;
-  rubricIconLabel: string;
-  stepTitle: string;
+  protected rubricIconLabel: string;
+  protected stepTitle: string;
 
   constructor(private projectService: TeacherProjectService) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.stepTitle = this.projectService.getNodePositionAndTitle(this.nodeId);
     if (this.hasAlert) {
       this.alertIconClass = this.hasNewAlert ? 'warn' : 'text-disabled';

--- a/src/app/teacher/classroom-monitor.module.ts
+++ b/src/app/teacher/classroom-monitor.module.ts
@@ -53,7 +53,6 @@ import { StepToolsComponent } from '../../assets/wise5/common/stepTools/step-too
     NotificationsMenuComponent,
     PauseScreensMenuComponent,
     ShowNodeInfoDialogComponent,
-    StepInfoComponent,
     StepItemComponent,
     StudentGradingComponent,
     StudentGradingToolsComponent,
@@ -79,6 +78,7 @@ import { StepToolsComponent } from '../../assets/wise5/common/stepTools/step-too
     RouterModule,
     SaveIndicatorComponent,
     SelectPeriodModule,
+    StepInfoComponent,
     StepToolsComponent
   ]
 })

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.html
@@ -21,8 +21,7 @@
           [hasNewAlert]="hasNewAlert"
           [hasNewWork]="hasNewWork"
           [nodeId]="nodeId"
-        >
-        </step-info>
+        />
       </div>
       <div fxFlex="{{ showScore ? 30 : 20 }}" fxLayout="row" fxLayoutAlign="center center">
         <workgroup-node-status [statusText]="statusText" [statusClass]="statusClass">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1728,7 +1728,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/classroom-monitor/step-info/step-info.component.html</context>
-          <context context-type="linenumber">17</context>
+          <context context-type="linenumber">20</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroupInfo/workgroup-info.component.html</context>
@@ -1804,7 +1804,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Has new alert(s)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/classroom-monitor/step-info/step-info.component.ts</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">34</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroupInfo/workgroup-info.component.ts</context>
@@ -1819,7 +1819,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Has dismissed alert(s)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/classroom-monitor/step-info/step-info.component.ts</context>
-          <context context-type="linenumber">29</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroupInfo/workgroup-info.component.ts</context>
@@ -1830,7 +1830,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Step has rubrics/teaching tips</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/classroom-monitor/step-info/step-info.component.ts</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">38</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts</context>


### PR DESCRIPTION
## Changes
- Convert StepInfoComponent to standalone component
- Clean up code
   
## Test
- In CM > grade-by-student > pick a student to view
   - the node icon, node title appear as before for each node in the unit
   - any node status icons appear, if applicable (alerts, rubrics)
