### PR TITLE
feat(Multilingual Unit): Log selected language and load previous-selected language on VLE start

### DIFF
--- a/src/app/common/project-language-chooser/project-language-chooser.component.spec.ts
+++ b/src/app/common/project-language-chooser/project-language-chooser.component.spec.ts
@@ -6,6 +6,13 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatMenuHarness, MatMenuItemHarness } from '@angular/material/menu/testing';
+import { ProjectService } from '../../../assets/wise5/services/projectService';
+
+class MockProjectService {
+  currentLanguage() {
+    return null;
+  }
+}
 
 let loader: HarnessLoader;
 let component: ProjectLanguageChooserComponent;
@@ -13,7 +20,8 @@ let fixture: ComponentFixture<ProjectLanguageChooserComponent>;
 describe('ProjectLanguageChooserComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [BrowserAnimationsModule, HttpClientTestingModule, ProjectLanguageChooserComponent]
+      imports: [BrowserAnimationsModule, HttpClientTestingModule, ProjectLanguageChooserComponent],
+      providers: [{ provide: ProjectService, useClass: MockProjectService }]
     }).compileComponents();
   });
 
@@ -37,6 +45,10 @@ describe('ProjectLanguageChooserComponent', () => {
   it('keeps selected language option when language option changes', async () => {
     const menuHarness = await loader.getHarness(MatMenuHarness);
     await menuHarness.clickItem({ text: 'Japanese' });
+    spyOn(TestBed.inject(ProjectService), 'currentLanguage').and.returnValue({
+      locale: 'ja',
+      language: 'Japanese'
+    });
     setProjectLocale(new ProjectLocale({ default: 'it', supported: ['de', 'fr', 'ja', 'es'] }));
     const options = await getOptions();
     const selected = await options[3].host();

--- a/src/app/common/project-language-chooser/project-language-chooser.component.ts
+++ b/src/app/common/project-language-chooser/project-language-chooser.component.ts
@@ -6,6 +6,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { ProjectService } from '../../../assets/wise5/services/projectService';
 
 @Component({
   standalone: true,
@@ -21,8 +22,11 @@ export class ProjectLanguageChooserComponent implements OnChanges {
   protected selectedLanguage: Language;
   @Input() tooltip: string = $localize`Select language`;
 
+  constructor(private projectService: ProjectService) {}
+
   ngOnChanges(): void {
     this.availableLanguages = this.projectLocale.getAvailableLanguages();
+    this.selectedLanguage = this.projectService.currentLanguage();
     if (
       this.selectedLanguage == null ||
       !this.availableLanguages.some((lang) => lang.locale === this.selectedLanguage.locale)

--- a/src/app/services/studentProjectTranslationService.spec.ts
+++ b/src/app/services/studentProjectTranslationService.spec.ts
@@ -3,6 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { StudentTeacherCommonServicesModule } from '../student-teacher-common-services.module';
 import { StudentProjectTranslationService } from '../../assets/wise5/services/studentProjectTranslationService';
 import { ProjectService } from '../../assets/wise5/services/projectService';
+import { StudentDataService } from '../../assets/wise5/services/studentDataService';
 import { ProjectLocale } from '../domain/projectLocale';
 import demoProjectJSON_import from './sampleData/curriculum/Demo.project.json';
 import { copy } from '../../assets/wise5/common/object/object';
@@ -11,29 +12,39 @@ import { ConfigService } from '../../assets/wise5/services/configService';
 let http: HttpTestingController;
 let demoProjectJSON: any;
 let configService: ConfigService;
+let dataService: StudentDataService;
 let projectService: ProjectService;
 let service: StudentProjectTranslationService;
 describe('StudentProjectTranslationService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, StudentTeacherCommonServicesModule]
+      imports: [HttpClientTestingModule, StudentTeacherCommonServicesModule],
+      providers: [
+        {
+          provide: StudentDataService,
+          useValue: jasmine.createSpyObj('StudentDataService', ['saveVLEEvent', 'getCurrentNodeId'])
+        }
+      ]
     });
     http = TestBed.inject(HttpTestingController);
     demoProjectJSON = copy(demoProjectJSON_import);
     configService = TestBed.inject(ConfigService);
+    dataService = TestBed.inject(StudentDataService);
     projectService = TestBed.inject(ProjectService);
     service = TestBed.inject(StudentProjectTranslationService);
     spyOn(projectService, 'getOriginalProject').and.returnValue(demoProjectJSON);
   });
-  describe('translate()', () => {
+  describe('switchLanguage()', () => {
     describe('has no translations to apply', () => {
       beforeEach(() => {
         spyOn(projectService, 'getLocale').and.returnValue(
           new ProjectLocale({ default: 'en_US', supported: [] })
         );
+        spyOn(projectService, 'setCurrentLanguage').and.stub();
+        spyOn(configService, 'isRunActive').and.returnValue(true);
       });
       it('should keep original project in tact', () => {
-        service.translate().then(() => {
+        service.switchLanguage({ language: 'Japanese', locale: 'ja' }, 'student').then(() => {
           expect(projectService.getProjectTitle()).toEqual('Demo Project');
         });
       });
@@ -46,11 +57,11 @@ describe('StudentProjectTranslationService', () => {
         spyOn(configService, 'getConfigParam').and.returnValue('/123/project.json');
       });
       it('should retrieve translation mapping file and translate project', () => {
-        service.translate('es').then(() => {
+        service.switchLanguage({ language: 'Spanish', locale: 'es' }, 'student').then(() => {
           expect(projectService.getProjectTitle()).toEqual('Proyecto de demostración');
-        });
-        http.expectOne('/123/translations.es.json').flush({
-          d66d3be571e16cf8d0166286a0a632ec: { value: 'Proyecto de demostración', modified: 456 }
+          http.expectOne('/123/translations.es.json').flush({
+            d66d3be571e16cf8d0166286a0a632ec: { value: 'Proyecto de demostración', modified: 456 }
+          });
         });
       });
     });

--- a/src/app/services/studentStatusService.spec.ts
+++ b/src/app/services/studentStatusService.spec.ts
@@ -9,6 +9,8 @@ import { of } from 'rxjs';
 import { MatDialogModule } from '@angular/material/dialog';
 import { StudentTeacherCommonServicesModule } from '../student-teacher-common-services.module';
 import { NodeProgressService } from '../../assets/wise5/services/nodeProgressService';
+import { ProjectService } from '../../assets/wise5/services/projectService';
+import { ProjectLocale } from '../domain/projectLocale';
 
 let configService: ConfigService;
 let http: HttpClient;
@@ -92,6 +94,9 @@ function saveStudentStatus_nodeStatusChanged_PostStudentStatus() {
     spyOn(configService, 'getStudentStatusURL').and.returnValue(studentStatusUrl);
     spyOn(studentDataService, 'getCurrentNodeId').and.returnValue(nodeId);
     spyOn(nodeProgressService, 'getNodeProgress').and.returnValue(projectCompletion);
+    spyOn(TestBed.inject(ProjectService), 'getLocale').and.returnValue(
+      new ProjectLocale({ default: 'en_US', supported: [] })
+    );
     const httpPostSpy = spyOn(http, 'post').and.callFake((url: string, body: any) => {
       return of({} as any);
     });

--- a/src/app/student/top-bar/top-bar.component.ts
+++ b/src/app/student/top-bar/top-bar.component.ts
@@ -178,6 +178,7 @@ export class TopBarComponent {
   }
 
   protected changeLanguage(language: Language): void {
-    this.projectTranslationService.translate(language.locale);
+    this.projectTranslationService.switchLanguage(language, 'student');
+    this.studentDataService.updateNodeStatuses();
   }
 }

--- a/src/assets/wise5/common/StudentStatus.ts
+++ b/src/assets/wise5/common/StudentStatus.ts
@@ -1,8 +1,10 @@
+import { Language } from '../../../app/domain/language';
 import { NodeProgress } from './NodeProgress';
 
 export class StudentStatus {
   computerAvatarId?: string;
   currentNodeId: string;
+  language?: Language;
   nodeStatuses: any;
   periodId: number;
   projectCompletion: NodeProgress;

--- a/src/assets/wise5/services/studentProjectTranslationService.ts
+++ b/src/assets/wise5/services/studentProjectTranslationService.ts
@@ -4,9 +4,23 @@ import { copy } from '../common/object/object';
 import { Translations } from '../../../app/domain/translations';
 import { ProjectTranslationService } from './projectTranslationService';
 import { toSignal, toObservable } from '@angular/core/rxjs-interop';
+import { Language } from '../../../app/domain/language';
+import { HttpClient } from '@angular/common/http';
+import { ConfigService } from './configService';
+import { ProjectService } from './projectService';
+import { StudentDataService } from './studentDataService';
 
 @Injectable()
 export class StudentProjectTranslationService extends ProjectTranslationService {
+  constructor(
+    protected configService: ConfigService,
+    private dataService: StudentDataService,
+    protected http: HttpClient,
+    protected projectService: ProjectService
+  ) {
+    super(configService, http, projectService);
+  }
+
   currentTranslations = toSignal(
     toObservable(this.projectService.currentLanguage).pipe(
       switchMap((language) =>
@@ -18,7 +32,20 @@ export class StudentProjectTranslationService extends ProjectTranslationService 
     { initialValue: {} }
   );
 
-  translate(locale = 'en_US'): Promise<any> {
+  async switchLanguage(language: Language, requester: 'student' | 'system'): Promise<void> {
+    this.projectService.setCurrentLanguage(language);
+    await this.translate(language.locale);
+    this.dataService.saveVLEEvent(
+      this.dataService.getCurrentNodeId(),
+      null,
+      null,
+      'Language',
+      'languageSelected',
+      { language: language.locale, requester: requester }
+    );
+  }
+
+  private translate(locale = 'en_US'): Promise<any> {
     const project = this.revertToOriginalProject();
     return lastValueFrom(
       this.projectService.getLocale().hasTranslationsToApply(locale)

--- a/src/assets/wise5/services/studentStatusService.ts
+++ b/src/assets/wise5/services/studentStatusService.ts
@@ -6,6 +6,8 @@ import { ConfigService } from './configService';
 import { NodeProgressService } from './nodeProgressService';
 import { NodeStatusService } from './nodeStatusService';
 import { StudentDataService } from './studentDataService';
+import { ProjectService } from './projectService';
+import { StudentProjectTranslationService } from './studentProjectTranslationService';
 
 @Injectable()
 export class StudentStatusService {
@@ -16,6 +18,8 @@ export class StudentStatusService {
     private configService: ConfigService,
     private nodeProgressService: NodeProgressService,
     private nodeStatusService: NodeStatusService,
+    private projectService: ProjectService,
+    private projectTranslationService: StudentProjectTranslationService,
     private studentDataService: StudentDataService
   ) {
     studentDataService.nodeStatusesChanged$.subscribe(() => {
@@ -33,6 +37,10 @@ export class StudentStatusService {
           studentStatus == null
             ? new StudentStatus()
             : new StudentStatus(JSON.parse(studentStatus.status));
+        const language = this.studentStatus.language;
+        if (language != null) {
+          this.projectTranslationService.switchLanguage(language, 'system');
+        }
       });
   }
 
@@ -67,6 +75,9 @@ export class StudentStatusService {
     const computerAvatarId = this.getComputerAvatarId();
     if (computerAvatarId != null) {
       studentStatusJSON.computerAvatarId = computerAvatarId;
+    }
+    if (this.projectService.getLocale().hasTranslations()) {
+      studentStatusJSON.language = this.projectService.currentLanguage();
     }
     this.studentStatus = studentStatusJSON;
     const studentStatusParams = {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1867,7 +1867,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Select language</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/common/project-language-chooser/project-language-chooser.component.ts</context>
-          <context context-type="linenumber">22</context>
+          <context context-type="linenumber">23</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4c00c8f929591b166c1e22e74a414a4dd42ff00b" datatype="html">


### PR DESCRIPTION
## Changes
- When in student run mode
   - Log language selection events in the event table. Every time the student switches a language, we save an event.
   - Display unit in previously-selected language, if applicable

## Test
- In a student run for a unit with multiple languages
   - switch between different languages on different steps. In the database, check that the events are saved in the events table.
      - The event name is "languageSelected"
      - The event data is ```{"requester":"user","language":"[LOCALE]"}```
      - You should also see a row for ```{"requester":"system","language":"[LOCALE]"}```. This is saved when the VLE loads, it looks up the last-saved language in StudentStatus and switches to it
   - Refresh the browser, or exit -> reload the unit. The unit should be rendered in your last-saved language. 
- In a student run for a unit without multiple languages, everything works as before