### PR TITLE
refactor(NotebookLauncherComponent): Convert to standalone

### DIFF
--- a/src/app/notebook/notebook-launcher/notebook-launcher.component.html
+++ b/src/app/notebook/notebook-launcher/notebook-launcher.component.html
@@ -1,5 +1,4 @@
 <button
-  *ngIf="notebookConfig.itemTypes.note.enabled"
   mat-fab
   color="accent"
   [attr.aria-label]="label"

--- a/src/app/notebook/notebook-launcher/notebook-launcher.component.ts
+++ b/src/app/notebook/notebook-launcher/notebook-launcher.component.ts
@@ -1,23 +1,26 @@
 import { Component, Input } from '@angular/core';
 import { NotebookService } from '../../../assets/wise5/services/notebookService';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
+  imports: [MatButtonModule, MatIconModule, MatTooltipModule],
   selector: 'notebook-launcher',
+  standalone: true,
   templateUrl: 'notebook-launcher.component.html'
 })
 export class NotebookLauncherComponent {
-  @Input()
-  notebookConfig: any;
+  protected label: string = '';
+  @Input() notebookConfig: any;
 
-  label: string = '';
-
-  constructor(private NotebookService: NotebookService) {}
+  constructor(private notebookService: NotebookService) {}
 
   ngOnInit(): void {
     this.label = this.notebookConfig.itemTypes.note.label.link;
   }
 
-  showNotes(): void {
-    this.NotebookService.setNotesVisible(true);
+  protected showNotes(): void {
+    this.notebookService.setNotesVisible(true);
   }
 }

--- a/src/app/notebook/notebook.module.ts
+++ b/src/app/notebook/notebook.module.ts
@@ -26,7 +26,6 @@ import { WiseTinymceEditorComponent } from '../../assets/wise5/directives/wise-t
   declarations: [
     NotebookParentComponent,
     NotebookItemComponent,
-    NotebookLauncherComponent,
     NotebookNotesComponent,
     NotebookReportComponent,
     NotebookReportAnnotationsComponent
@@ -47,6 +46,7 @@ import { WiseTinymceEditorComponent } from '../../assets/wise5/directives/wise-t
     MatTabsModule,
     MatToolbarModule,
     MatTooltipModule,
+    NotebookLauncherComponent,
     WiseTinymceEditorComponent
   ],
   exports: [

--- a/src/assets/wise5/vle/vle.component.html
+++ b/src/assets/wise5/vle/vle.component.html
@@ -14,8 +14,7 @@
       [config]="notebookConfig"
     >
     </notebook-report>
-    <notebook-launcher *ngIf="notesEnabled && !notesVisible" [notebookConfig]="notebookConfig">
-    </notebook-launcher>
+    <notebook-launcher *ngIf="notesEnabled && !notesVisible" [notebookConfig]="notebookConfig" />
   </mat-drawer-content>
 </mat-drawer-container>
 


### PR DESCRIPTION
## Changes
- Convert NotebookLauncherComponent to standalone component
- Clean up code
   
## Test
- In the VLE, the notebook launcher button (fab icon at the bottom-right corner)
   - appears and works as before when it is enabled
   - is hidden when it is disabled