### PR TITLE
refactor(EditComponentWidthComponent): Convert to standalone

### DIFF
--- a/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.html
+++ b/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.html
@@ -13,7 +13,7 @@
   <edit-component-max-score [componentContent]="component.content"> </edit-component-max-score>
   <edit-component-exclude-from-total-score [componentContent]="component.content">
   </edit-component-exclude-from-total-score>
-  <edit-component-width [componentContent]="component.content"> </edit-component-width>
+  <edit-component-width [componentContent]="component.content" />
   <edit-component-rubric [componentContent]="component.content"> </edit-component-rubric>
   <edit-component-tags [componentContent]="component.content"> </edit-component-tags>
 </div>

--- a/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.spec.ts
+++ b/src/app/authoring-tool/edit-common-advanced/edit-common-advanced.component.spec.ts
@@ -17,7 +17,6 @@ import { EditComponentRubricComponent } from '../edit-component-rubric/edit-comp
 import { EditComponentSaveButtonComponent } from '../edit-component-save-button/edit-component-save-button.component';
 import { EditComponentSubmitButtonComponent } from '../edit-component-submit-button/edit-component-submit-button.component';
 import { EditComponentTagsComponent } from '../edit-component-tags/edit-component-tags.component';
-import { EditComponentWidthComponent } from '../edit-component-width/edit-component-width.component';
 import { EditConnectedComponentsAddButtonComponent } from '../edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { EditConnectedComponentsComponent } from '../edit-connected-components/edit-connected-components.component';
 import { EditCommonAdvancedComponent } from './edit-common-advanced.component';
@@ -49,7 +48,6 @@ describe('EditCommonAdvancedComponent', () => {
         EditComponentTagsComponent,
         EditComponentSaveButtonComponent,
         EditComponentSubmitButtonComponent,
-        EditComponentWidthComponent,
         EditConnectedComponentsAddButtonComponent,
         EditConnectedComponentsComponent
       ],

--- a/src/app/authoring-tool/edit-component-width/edit-component-width.component.ts
+++ b/src/app/authoring-tool/edit-component-width/edit-component-width.component.ts
@@ -1,8 +1,13 @@
 import { Component } from '@angular/core';
 import { EditComponentFieldComponent } from '../edit-component-field.component';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { FormsModule } from '@angular/forms';
 
 @Component({
+  imports: [FormsModule, MatFormFieldModule, MatInputModule],
   selector: 'edit-component-width',
+  standalone: true,
   templateUrl: 'edit-component-width.component.html'
 })
 export class EditComponentWidthComponent extends EditComponentFieldComponent {}

--- a/src/app/teacher/component-authoring.module.ts
+++ b/src/app/teacher/component-authoring.module.ts
@@ -117,7 +117,6 @@ import { RequiredErrorLabelComponent } from '../../assets/wise5/authoringTool/no
     EditComponentSaveButtonComponent,
     EditComponentSubmitButtonComponent,
     EditComponentTagsComponent,
-    EditComponentWidthComponent,
     EditConceptMapAdvancedComponent,
     EditConceptMapConnectedComponentsComponent,
     EditConnectedComponentDefaultSelectsComponent,
@@ -173,6 +172,7 @@ import { RequiredErrorLabelComponent } from '../../assets/wise5/authoringTool/no
   imports: [
     ComponentConstraintAuthoringComponent,
     EditComponentAdvancedButtonComponent,
+    EditComponentWidthComponent,
     PeerGroupingAuthoringModule,
     RequiredErrorLabelComponent,
     SelectStepAndComponentComponent,

--- a/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.spec.ts
+++ b/src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.spec.ts
@@ -16,7 +16,6 @@ import { EditComponentRubricComponent } from '../../../../../app/authoring-tool/
 import { EditComponentSaveButtonComponent } from '../../../../../app/authoring-tool/edit-component-save-button/edit-component-save-button.component';
 import { EditComponentSubmitButtonComponent } from '../../../../../app/authoring-tool/edit-component-submit-button/edit-component-submit-button.component';
 import { EditComponentTagsComponent } from '../../../../../app/authoring-tool/edit-component-tags/edit-component-tags.component';
-import { EditComponentWidthComponent } from '../../../../../app/authoring-tool/edit-component-width/edit-component-width.component';
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { EditConnectedComponentsComponent } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
@@ -53,7 +52,6 @@ describe('EditConceptMapAdvancedComponent', () => {
         EditComponentSaveButtonComponent,
         EditComponentSubmitButtonComponent,
         EditComponentTagsComponent,
-        EditComponentWidthComponent,
         EditConceptMapAdvancedComponent,
         EditConnectedComponentsAddButtonComponent,
         EditConnectedComponentsComponent

--- a/src/assets/wise5/components/discussion/edit-discussion-advanced/edit-discussion-advanced.component.html
+++ b/src/assets/wise5/components/discussion/edit-discussion-advanced/edit-discussion-advanced.component.html
@@ -3,7 +3,7 @@
   <edit-component-exclude-from-total-score
     [componentContent]="componentContent"
   ></edit-component-exclude-from-total-score>
-  <edit-component-width [componentContent]="componentContent"></edit-component-width>
+  <edit-component-width [componentContent]="componentContent" />
   <edit-component-rubric [componentContent]="componentContent"></edit-component-rubric>
   <edit-component-tags [componentContent]="componentContent"></edit-component-tags>
 </div>

--- a/src/assets/wise5/components/draw/edit-draw-advanced/edit-draw-advanced.component.html
+++ b/src/assets/wise5/components/draw/edit-draw-advanced/edit-draw-advanced.component.html
@@ -16,7 +16,7 @@
   <edit-component-max-score [componentContent]="componentContent"> </edit-component-max-score>
   <edit-component-exclude-from-total-score [componentContent]="componentContent">
   </edit-component-exclude-from-total-score>
-  <edit-component-width [componentContent]="componentContent"> </edit-component-width>
+  <edit-component-width [componentContent]="componentContent" />
   <edit-component-rubric [componentContent]="componentContent"> </edit-component-rubric>
   <edit-component-tags [componentContent]="componentContent"> </edit-component-tags>
 </div>

--- a/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.html
+++ b/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.html
@@ -181,7 +181,7 @@
   <edit-component-max-score [componentContent]="componentContent"> </edit-component-max-score>
   <edit-component-exclude-from-total-score [componentContent]="componentContent">
   </edit-component-exclude-from-total-score>
-  <edit-component-width [componentContent]="componentContent"> </edit-component-width>
+  <edit-component-width [componentContent]="componentContent" />
   <edit-component-rubric [componentContent]="componentContent"> </edit-component-rubric>
   <edit-component-tags [componentContent]="componentContent"> </edit-component-tags>
 </div>

--- a/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.spec.ts
+++ b/src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.spec.ts
@@ -17,7 +17,6 @@ import { EditComponentRubricComponent } from '../../../../../app/authoring-tool/
 import { EditComponentSaveButtonComponent } from '../../../../../app/authoring-tool/edit-component-save-button/edit-component-save-button.component';
 import { EditComponentSubmitButtonComponent } from '../../../../../app/authoring-tool/edit-component-submit-button/edit-component-submit-button.component';
 import { EditComponentTagsComponent } from '../../../../../app/authoring-tool/edit-component-tags/edit-component-tags.component';
-import { EditComponentWidthComponent } from '../../../../../app/authoring-tool/edit-component-width/edit-component-width.component';
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { EditConnectedComponentsComponent } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
@@ -54,7 +53,6 @@ describe('EditGraphAdvancedComponent', () => {
         EditComponentSaveButtonComponent,
         EditComponentSubmitButtonComponent,
         EditComponentTagsComponent,
-        EditComponentWidthComponent,
         EditConnectedComponentsAddButtonComponent,
         EditConnectedComponentsComponent,
         EditGraphAdvancedComponent

--- a/src/assets/wise5/components/html/edit-html-advanced/edit-html-advanced.component.html
+++ b/src/assets/wise5/components/html/edit-html-advanced/edit-html-advanced.component.html
@@ -1,4 +1,4 @@
-<edit-component-width [componentContent]="componentContent"></edit-component-width>
+<edit-component-width [componentContent]="componentContent" />
 <edit-component-rubric [componentContent]="componentContent"></edit-component-rubric>
 <edit-component-constraints [componentContent]="component.content"></edit-component-constraints>
 <edit-component-json [component]="component"></edit-component-json>

--- a/src/assets/wise5/components/label/edit-label-advanced/edit-label-advanced.component.html
+++ b/src/assets/wise5/components/label/edit-label-advanced/edit-label-advanced.component.html
@@ -16,7 +16,7 @@
   <edit-component-max-score [componentContent]="componentContent"> </edit-component-max-score>
   <edit-component-exclude-from-total-score [componentContent]="componentContent">
   </edit-component-exclude-from-total-score>
-  <edit-component-width [componentContent]="componentContent"> </edit-component-width>
+  <edit-component-width [componentContent]="componentContent" />
   <edit-component-rubric [componentContent]="componentContent"> </edit-component-rubric>
   <edit-component-tags [componentContent]="componentContent"> </edit-component-tags>
 </div>

--- a/src/assets/wise5/components/match/edit-match-advanced/edit-match-advanced.component.html
+++ b/src/assets/wise5/components/match/edit-match-advanced/edit-match-advanced.component.html
@@ -34,7 +34,7 @@
   <edit-component-max-score [componentContent]="componentContent"> </edit-component-max-score>
   <edit-component-exclude-from-total-score [componentContent]="componentContent">
   </edit-component-exclude-from-total-score>
-  <edit-component-width [componentContent]="componentContent"> </edit-component-width>
+  <edit-component-width [componentContent]="componentContent" />
   <edit-component-rubric [componentContent]="componentContent"> </edit-component-rubric>
   <edit-component-tags [componentContent]="componentContent"> </edit-component-tags>
 </div>

--- a/src/assets/wise5/components/multipleChoice/edit-multiple-choice-advanced/edit-multiple-choice-advanced.component.html
+++ b/src/assets/wise5/components/multipleChoice/edit-multiple-choice-advanced/edit-multiple-choice-advanced.component.html
@@ -22,7 +22,7 @@
   <edit-component-max-score [componentContent]="componentContent"> </edit-component-max-score>
   <edit-component-exclude-from-total-score [componentContent]="componentContent">
   </edit-component-exclude-from-total-score>
-  <edit-component-width [componentContent]="componentContent"> </edit-component-width>
+  <edit-component-width [componentContent]="componentContent" />
   <edit-component-rubric [componentContent]="componentContent"> </edit-component-rubric>
   <edit-component-tags [componentContent]="componentContent"> </edit-component-tags>
 </div>

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.spec.ts
@@ -17,7 +17,6 @@ import { EditComponentRubricComponent } from '../../../../../app/authoring-tool/
 import { EditComponentSaveButtonComponent } from '../../../../../app/authoring-tool/edit-component-save-button/edit-component-save-button.component';
 import { EditComponentSubmitButtonComponent } from '../../../../../app/authoring-tool/edit-component-submit-button/edit-component-submit-button.component';
 import { EditComponentTagsComponent } from '../../../../../app/authoring-tool/edit-component-tags/edit-component-tags.component';
-import { EditComponentWidthComponent } from '../../../../../app/authoring-tool/edit-component-width/edit-component-width.component';
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { EditConnectedComponentsComponent } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
@@ -58,7 +57,6 @@ describe('EditOpenResponseAdvancedComponent', () => {
         EditComponentSaveButtonComponent,
         EditComponentSubmitButtonComponent,
         EditComponentTagsComponent,
-        EditComponentWidthComponent,
         EditConnectedComponentsAddButtonComponent,
         EditConnectedComponentsComponent,
         EditOpenResponseAdvancedComponent

--- a/src/assets/wise5/components/outsideURL/edit-outside-url-advanced/edit-outside-url-advanced.component.html
+++ b/src/assets/wise5/components/outsideURL/edit-outside-url-advanced/edit-outside-url-advanced.component.html
@@ -1,4 +1,4 @@
-<edit-component-width [componentContent]="componentContent"></edit-component-width>
+<edit-component-width [componentContent]="componentContent" />
 <edit-component-rubric [componentContent]="componentContent"></edit-component-rubric>
 <edit-component-constraints [componentContent]="component.content"></edit-component-constraints>
 <edit-component-json [component]="component"></edit-component-json>

--- a/src/assets/wise5/components/summary/edit-summary-advanced/edit-summary-advanced.component.html
+++ b/src/assets/wise5/components/summary/edit-summary-advanced/edit-summary-advanced.component.html
@@ -1,5 +1,5 @@
 <div fxLayout="column">
-  <edit-component-width [componentContent]="componentContent"></edit-component-width>
+  <edit-component-width [componentContent]="componentContent" />
   <edit-component-rubric [componentContent]="componentContent"></edit-component-rubric>
   <edit-component-tags [componentContent]="componentContent"></edit-component-tags>
   <edit-component-constraints [componentContent]="component.content"></edit-component-constraints>

--- a/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html
+++ b/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html
@@ -264,7 +264,7 @@
   <edit-component-max-score [componentContent]="componentContent"> </edit-component-max-score>
   <edit-component-exclude-from-total-score [componentContent]="componentContent">
   </edit-component-exclude-from-total-score>
-  <edit-component-width [componentContent]="componentContent"> </edit-component-width>
+  <edit-component-width [componentContent]="componentContent" />
   <edit-component-rubric [componentContent]="componentContent"> </edit-component-rubric>
   <edit-component-tags [componentContent]="componentContent"> </edit-component-tags>
 </div>

--- a/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.spec.ts
+++ b/src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.spec.ts
@@ -17,7 +17,6 @@ import { EditComponentRubricComponent } from '../../../../../app/authoring-tool/
 import { EditComponentSaveButtonComponent } from '../../../../../app/authoring-tool/edit-component-save-button/edit-component-save-button.component';
 import { EditComponentSubmitButtonComponent } from '../../../../../app/authoring-tool/edit-component-submit-button/edit-component-submit-button.component';
 import { EditComponentTagsComponent } from '../../../../../app/authoring-tool/edit-component-tags/edit-component-tags.component';
-import { EditComponentWidthComponent } from '../../../../../app/authoring-tool/edit-component-width/edit-component-width.component';
 import { EditConnectedComponentsAddButtonComponent } from '../../../../../app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component';
 import { EditConnectedComponentsComponent } from '../../../../../app/authoring-tool/edit-connected-components/edit-connected-components.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
@@ -57,7 +56,6 @@ describe('EditTableAdvancedComponent', () => {
         EditComponentSaveButtonComponent,
         EditComponentSubmitButtonComponent,
         EditComponentTagsComponent,
-        EditComponentWidthComponent,
         EditConnectedComponentsAddButtonComponent,
         EditConnectedComponentsComponent,
         EditTableAdvancedComponent,


### PR DESCRIPTION
## Changes
- Convert EditComponentWidthComponent to standalone component
- Clean up code
   
## Test
- In AT, for a component's advanced editing view, set the component's (of HTML, label, graph, draw, etc) width to 50 and verify in preview mode that it takes up half of the screen's width.