### PR TITLE
refactor(ChooseNewNodeTemplateComponent): Convert to standalone

### DIFF
--- a/src/app/teacher/authoring-routing.module.ts
+++ b/src/app/teacher/authoring-routing.module.ts
@@ -11,7 +11,7 @@ import { NodeAdvancedAuthoringComponent } from '../../assets/wise5/authoringTool
 import { NodeAdvancedConstraintAuthoringComponent } from '../../assets/wise5/authoringTool/node/advanced/constraint/node-advanced-constraint-authoring.component';
 import { ChooseComponentLocationComponent } from '../../assets/wise5/authoringTool/node/chooseComponentLocation/choose-component-location.component';
 import { AddLessonConfigureComponent } from '../../assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component';
-import { ChooseNewNodeTemplate } from '../../assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component';
+import { ChooseNewNodeTemplateComponent } from '../../assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component';
 import { AddYourOwnNode } from '../../assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component';
 import { ChooseAutomatedAssessmentComponent } from '../../assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component';
 import { ConfigureAutomatedAssessmentComponent } from '../../assets/wise5/authoringTool/addNode/configure-automated-assessment/configure-automated-assessment.component';
@@ -95,7 +95,7 @@ const routes: Routes = [
               },
               {
                 path: 'choose-template',
-                component: ChooseNewNodeTemplate
+                component: ChooseNewNodeTemplateComponent
               },
               {
                 path: 'import-step',

--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { AddYourOwnNode } from '../../assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component';
-import { ChooseNewNodeTemplate } from '../../assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component';
+import { ChooseNewNodeTemplateComponent } from '../../assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component';
 import { AdvancedProjectAuthoringComponent } from '../../assets/wise5/authoringTool/advanced/advanced-project-authoring.component';
 import { CardSelectorComponent } from '../../assets/wise5/authoringTool/components/card-selector/card-selector.component';
 import { RubricAuthoringComponent } from '../../assets/wise5/authoringTool/rubric/rubric-authoring.component';
@@ -74,7 +74,6 @@ import { StepToolsComponent } from '../../assets/wise5/common/stepTools/step-too
     ChooseImportStepComponent,
     ChooseImportUnitComponent,
     ChooseNewComponent,
-    ChooseNewNodeTemplate,
     ChooseMoveNodeLocationComponent,
     ChooseSimulationComponent,
     ConcurrentAuthorsMessageComponent,
@@ -103,6 +102,7 @@ import { StepToolsComponent } from '../../assets/wise5/common/stepTools/step-too
     AddComponentButtonComponent,
     AddLessonButtonComponent,
     AddStepButtonComponent,
+    ChooseNewNodeTemplateComponent,
     StudentTeacherCommonModule,
     ComponentAuthoringModule,
     ComponentStudentModule,

--- a/src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.html
+++ b/src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.html
@@ -1,21 +1,23 @@
 <h5 i18n>Start from scratch, import from another unit, or choose a step template:</h5>
 <div fxLayout="row wrap" fxLayoutAlign="center" fxLayoutAlign.gt-sm="start">
-  <mat-card *ngFor="let template of templates" appearance="outlined">
-    <mat-card-title>
-      <h6 class="center">{{ template.label }}</h6>
-    </mat-card-title>
-    <mat-card-content fxLayoutAlign="center center">
-      <mat-icon class="mat-48 text">{{ template.icon }}</mat-icon>
-    </mat-card-content>
-    <mat-card-actions fxLayout="row" fxLayoutAlign="start center">
-      <button mat-flat-button color="primary" (click)="chooseTemplate(template)" fxFlex i18n>
-        Select
-      </button>
-    </mat-card-actions>
-  </mat-card>
+  @for (template of templates; track template.route) {
+    <mat-card appearance="outlined">
+      <mat-card-title>
+        <h6 class="center">{{ template.label }}</h6>
+      </mat-card-title>
+      <mat-card-content fxLayoutAlign="center center">
+        <mat-icon class="mat-48 text">{{ template.icon }}</mat-icon>
+      </mat-card-content>
+      <mat-card-actions fxLayout="row" fxLayoutAlign="start center">
+        <button mat-flat-button color="primary" (click)="chooseTemplate(template)" fxFlex i18n>
+          Select
+        </button>
+      </mat-card-actions>
+    </mat-card>
+  }
 </div>
 <div class="nav-controls">
-  <mat-divider></mat-divider>
+  <mat-divider />
   <div>
     <button mat-button class="mat-primary" routerLink="../.." i18n>Cancel</button>
   </div>

--- a/src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts
@@ -1,13 +1,28 @@
 import { Component } from '@angular/core';
 import { NewNodeTemplate } from '../NewNodeTemplate';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { MatCardModule } from '@angular/material/card';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
-  selector: 'choose-new-node-template',
-  templateUrl: 'choose-new-node-template.component.html',
-  styleUrls: ['choose-new-node-template.component.scss', '../../add-content.scss']
+  imports: [
+    CommonModule,
+    FlexLayoutModule,
+    MatButtonModule,
+    MatCardModule,
+    MatDividerModule,
+    MatIconModule,
+    RouterModule
+  ],
+  standalone: true,
+  styleUrls: ['choose-new-node-template.component.scss', '../../add-content.scss'],
+  templateUrl: 'choose-new-node-template.component.html'
 })
-export class ChooseNewNodeTemplate {
+export class ChooseNewNodeTemplateComponent {
   protected templates: NewNodeTemplate[] = [
     {
       label: $localize`Create Your Own`,

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -457,7 +457,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.html</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">22</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.html</context>
@@ -9403,10 +9403,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addLesson/add-lesson-choose-template/add-lesson-choose-template.component.html</context>
           <context context-type="linenumber">13,15</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.html</context>
-          <context context-type="linenumber">11,13</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="a9862dafec3ad203ef4a2dea04416d7675f21dd4" datatype="html">
         <source> *Based on our work with classroom teachers, we have developed several lesson structures that follow the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://wise.berkeley.edu/about#ki&quot; target=&quot;_blank&quot;&gt;"/>Knowledge Integration<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> framework and help teachers productively integrate open educational resources (OERs) into their curricula. These structures have also proven useful for developing students&apos; capacity for self-directed learning. We have made the structures very general, so that teachers can customize and incorporate them into any WISE unit to strengthen support for knowledge integration and self-directed learning.
@@ -9424,7 +9420,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts</context>
-          <context context-type="linenumber">13</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9161763152537068038" datatype="html">
@@ -9565,25 +9561,36 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="e11a19f1ab295da63dbb5e942c351fde8d6a6360" datatype="html">
+        <source> Select </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.html</context>
+          <context context-type="linenumber">12,14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/components/card-selector/card-selector.component.html</context>
+          <context context-type="linenumber">35,37</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="7152189031040166896" datatype="html">
         <source>Import From Another Unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts</context>
-          <context context-type="linenumber">18</context>
+          <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8293078288618811295" datatype="html">
         <source>Automated Assessment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts</context>
-          <context context-type="linenumber">23</context>
+          <context context-type="linenumber">38</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6013229483538709548" datatype="html">
         <source>Interactive Simulation</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.ts</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9430426ed5a9b22d6dcf57e82af9318742f4b2bc" datatype="html">
@@ -10005,13 +10012,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component.html</context>
           <context context-type="linenumber">73</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="e11a19f1ab295da63dbb5e942c351fde8d6a6360" datatype="html">
-        <source> Select </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/components/card-selector/card-selector.component.html</context>
-          <context context-type="linenumber">35,37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f871b41bfbdb193507cce2cd848c2d02bde77a03" datatype="html">


### PR DESCRIPTION
## Changes
- Convert ChooseNewNodeTemplateComponent to standalone component
- Clean up code
   
## Test
- In AT's Add Step view (where you choose between "create your own", "import from another unit...", etc), the page displays the options and works as before.
   - The 4 different options take you to the right pages 
   - "Cancel" takes you back to unit view 