### PR TITLE
fix(Events): Node exited event now saves when changing steps

### DIFF
--- a/src/assets/wise5/vle/node/node.component.ts
+++ b/src/assets/wise5/vle/node/node.component.ts
@@ -134,6 +134,10 @@ export class NodeComponent implements OnInit {
     );
 
     this.studentDataService.currentNodeChanged$.subscribe(() => {
+      this.nodeUnloaded(this.node.id);
+      if (this.node.isEvaluateTransitionLogicOn('exitNode')) {
+        this.nodeService.evaluateTransitionLogic();
+      }
       this.initializeNode();
     });
     this.studentDataService.nodeStatusesChanged$.subscribe(() => {
@@ -155,9 +159,8 @@ export class NodeComponent implements OnInit {
       this.nodeService.evaluateTransitionLogic();
     }
 
-    const latestComponentState = this.studentDataService.getLatestComponentStateByNodeIdAndComponentId(
-      this.node.id
-    );
+    const latestComponentState =
+      this.studentDataService.getLatestComponentStateByNodeIdAndComponentId(this.node.id);
     if (latestComponentState) {
       this.latestComponentState = latestComponentState;
     }
@@ -200,10 +203,6 @@ export class NodeComponent implements OnInit {
 
   ngOnDestroy() {
     this.stopAutoSaveInterval();
-    this.nodeUnloaded(this.node.id);
-    if (this.node.isEvaluateTransitionLogicOn('exitNode')) {
-      this.nodeService.evaluateTransitionLogic();
-    }
     this.subscriptions.unsubscribe();
   }
 


### PR DESCRIPTION
## Changes
- Properly save nodeExited event when the student changes step. This likely stopped working when we converted to Angular. Previously we were saving the nodeExited event when the node component was destroyed but the node component no longer gets destroyed in Angular. Now we save the nodeExited event on this.studentDataService.currentNodeChanged$.

## Test
1. Sign in as a student
2. Launch a unit
3. Navigate to different steps by using the previous or next step buttons or the select step drop down
4. Check the events database table. You should see nodeExited events. Previously nodeExited events would not be saved when you changed steps.

Closes #1871