### PR TITLE
fix(Events): Duplicate node entered and node exited events

### DIFF
--- a/src/assets/wise5/services/studentDataService.ts
+++ b/src/assets/wise5/services/studentDataService.ts
@@ -26,17 +26,20 @@ export class StudentDataService extends DataService {
   private componentDirtySource: Subject<boolean> = new Subject<boolean>();
   public componentDirty$: Observable<any> = this.componentDirtySource.asObservable();
   private componentSaveTriggeredSource: Subject<boolean> = new Subject<boolean>();
-  public componentSaveTriggered$: Observable<any> = this.componentSaveTriggeredSource.asObservable();
+  public componentSaveTriggered$: Observable<any> =
+    this.componentSaveTriggeredSource.asObservable();
   private componentSubmitDirtySource: Subject<boolean> = new Subject<boolean>();
   public componentSubmitDirty$: Observable<any> = this.componentSubmitDirtySource.asObservable();
   private componentSubmitTriggeredSource: Subject<boolean> = new Subject<boolean>();
-  public componentSubmitTriggered$: Observable<any> = this.componentSubmitTriggeredSource.asObservable();
+  public componentSubmitTriggered$: Observable<any> =
+    this.componentSubmitTriggeredSource.asObservable();
   private componentStudentDataSource: Subject<any> = new Subject<any>();
   public componentStudentData$: Observable<any> = this.componentStudentDataSource.asObservable();
   private dataRetrievedSource: Subject<any> = new Subject<any>();
   public dataRetrieved$: Observable<any> = this.dataRetrievedSource.asObservable();
   private studentWorkSavedToServerSource: Subject<any> = new Subject<any>();
-  public studentWorkSavedToServer$: Observable<any> = this.studentWorkSavedToServerSource.asObservable();
+  public studentWorkSavedToServer$: Observable<any> =
+    this.studentWorkSavedToServerSource.asObservable();
   private navItemIsExpandedSource: Subject<any> = new Subject<any>();
   public navItemIsExpanded$: Observable<any> = this.navItemIsExpandedSource.asObservable();
   private nodeStatusesChangedSource: Subject<void> = new Subject<void>();
@@ -276,6 +279,12 @@ export class StudentDataService extends DataService {
       data
     );
     events.push(newEvent);
+    const componentStates = undefined;
+    const annotations = undefined;
+    return this.saveToServer(componentStates, events, annotations);
+  }
+
+  saveEvents(events: any): Promise<any> {
     const componentStates = undefined;
     const annotations = undefined;
     return this.saveToServer(componentStates, events, annotations);

--- a/src/assets/wise5/vle/node/node.component.ts
+++ b/src/assets/wise5/vle/node/node.component.ts
@@ -133,16 +133,20 @@ export class NodeComponent implements OnInit {
       })
     );
 
-    this.studentDataService.currentNodeChanged$.subscribe(() => {
-      this.nodeUnloaded(this.node.id);
-      if (this.node.isEvaluateTransitionLogicOn('exitNode')) {
-        this.nodeService.evaluateTransitionLogic();
-      }
-      this.initializeNode();
-    });
-    this.studentDataService.nodeStatusesChanged$.subscribe(() => {
-      this.updateComponentVisibility();
-    });
+    this.subscriptions.add(
+      this.studentDataService.currentNodeChanged$.subscribe(() => {
+        if (this.node.isEvaluateTransitionLogicOn('exitNode')) {
+          this.nodeService.evaluateTransitionLogic();
+        }
+        this.initializeNode();
+      })
+    );
+
+    this.subscriptions.add(
+      this.studentDataService.nodeStatusesChanged$.subscribe(() => {
+        this.updateComponentVisibility();
+      })
+    );
   }
 
   initializeNode(): void {
@@ -164,22 +168,6 @@ export class NodeComponent implements OnInit {
     if (latestComponentState) {
       this.latestComponentState = latestComponentState;
     }
-
-    const componentId = null;
-    const componentType = null;
-    const category = 'Navigation';
-    const event = 'nodeEntered';
-    const eventData = {
-      nodeId: this.node.id
-    };
-    this.studentDataService.saveVLEEvent(
-      this.node.id,
-      componentId,
-      componentType,
-      category,
-      event,
-      eventData
-    );
 
     if (this.configService.isPreview()) {
       this.rubric = this.node.rubric;
@@ -444,29 +432,10 @@ export class NodeComponent implements OnInit {
     );
   }
 
-  private nodeUnloaded(nodeId: string): void {
-    const componentId = null;
-    const componentType = null;
-    const category = 'Navigation';
-    const event = 'nodeExited';
-    const eventData = {
-      nodeId: nodeId
-    };
-    this.studentDataService.saveVLEEvent(
-      nodeId,
-      componentId,
-      componentType,
-      category,
-      event,
-      eventData
-    );
-  }
-
   private registerExitListener(): void {
     this.subscriptions.add(
       this.sessionService.exit$.subscribe(() => {
         this.stopAutoSaveInterval();
-        this.nodeUnloaded(this.node.id);
       })
     );
   }

--- a/src/assets/wise5/vle/vle.component.ts
+++ b/src/assets/wise5/vle/vle.component.ts
@@ -14,7 +14,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { WiseLinkService } from '../../../app/services/wiseLinkService';
 import { convertToPNGFile } from '../common/canvas/canvas';
 import { NodeStatusService } from '../services/nodeStatusService';
-import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { SafeResourceUrl } from '@angular/platform-browser';
 
 @Component({
   selector: 'vle',
@@ -54,6 +54,11 @@ export class VLEComponent implements AfterViewInit {
     private studentDataService: StudentDataService,
     private wiseLinkService: WiseLinkService
   ) {}
+
+  @HostListener('window:beforeunload')
+  beforeUnload(): void {
+    this.saveNodeExitedEvent();
+  }
 
   ngAfterViewInit(): void {
     this.initializeVLEService.initialized$.subscribe((initialized: boolean) => {
@@ -103,6 +108,7 @@ export class VLEComponent implements AfterViewInit {
     this.currentNode = this.studentDataService.getCurrentNode();
     this.setLayoutState();
     this.initializeSubscriptions();
+    this.saveNodeEnteredEvent();
   }
 
   ngOnDestroy() {
@@ -165,49 +171,17 @@ export class VLEComponent implements AfterViewInit {
     this.subscriptions.add(
       this.studentDataService.currentNodeChanged$.subscribe(({ previousNode }) => {
         this.currentNode = this.studentDataService.getCurrentNode();
-        let currentNodeId = this.currentNode.id;
-
+        const currentNodeId = this.currentNode.id;
         this.studentDataService.updateStackHistory(currentNodeId);
         this.nodeStatusService.setNodeIsVisited(currentNodeId);
-
-        let componentId, componentType, category, eventName, eventData, eventNodeId;
-        if (previousNode != null && this.projectService.isGroupNode(previousNode.id)) {
-          // going from group to node or group to group
-          componentId = null;
-          componentType = null;
-          category = 'Navigation';
-          eventName = 'nodeExited';
-          eventData = {
-            nodeId: previousNode.id
-          };
-          eventNodeId = previousNode.id;
-          this.studentDataService.saveVLEEvent(
-            eventNodeId,
-            componentId,
-            componentType,
-            category,
-            eventName,
-            eventData
-          );
+        const events = [];
+        if (previousNode != null) {
+          events.push(this.createNodeExitedEvent(previousNode.id));
         }
+        events.push(this.createNodeEnteredEvent());
+        this.studentDataService.saveEvents(events);
 
         if (this.projectService.isGroupNode(currentNodeId)) {
-          componentId = null;
-          componentType = null;
-          category = 'Navigation';
-          eventName = 'nodeEntered';
-          eventData = {
-            nodeId: currentNodeId
-          };
-          eventNodeId = currentNodeId;
-          this.studentDataService.saveVLEEvent(
-            eventNodeId,
-            componentId,
-            componentType,
-            category,
-            eventName,
-            eventData
-          );
         } else {
           this.scrollToTop();
         }
@@ -386,5 +360,35 @@ export class VLEComponent implements AfterViewInit {
         return this.projectService.getMaxScoreForComponent(nodeId, componentId);
       }
     };
+  }
+
+  private saveNodeEnteredEvent(): void {
+    this.studentDataService.saveEvents([this.createNodeEnteredEvent()]);
+  }
+
+  private saveNodeExitedEvent(): void {
+    this.studentDataService.saveEvents([this.createNodeExitedEvent()]);
+  }
+
+  private createNodeEnteredEvent(): any {
+    return this.createNodeEvent('nodeEntered');
+  }
+
+  private createNodeExitedEvent(nodeId: string = this.currentNode.id): any {
+    return this.createNodeEvent('nodeExited', nodeId);
+  }
+
+  private createNodeEvent(eventName: string, nodeId: string = this.currentNode.id) {
+    return this.studentDataService.createNewEvent(
+      nodeId,
+      null,
+      'VLE',
+      null,
+      'Navigation',
+      eventName,
+      {
+        nodeId: nodeId
+      }
+    );
   }
 }

--- a/src/assets/wise5/vle/vle.component.ts
+++ b/src/assets/wise5/vle/vle.component.ts
@@ -378,7 +378,7 @@ export class VLEComponent implements AfterViewInit {
     return this.createNodeEvent('nodeExited', nodeId);
   }
 
-  private createNodeEvent(eventName: string, nodeId: string = this.currentNode.id) {
+  private createNodeEvent(eventName: string, nodeId: string = this.currentNode.id): any {
     return this.studentDataService.createNewEvent(
       nodeId,
       null,


### PR DESCRIPTION
## Changes
- Duplicate events are no longer saved
- Removed nodeEntered and nodeExited event saving in NodeComponent. nodeEntered and nodeExited events are only saved in the VLEComponent now.
- When the student changes step, we now send the nodeExited and nodeEntered events in a single request to prevent the events being saved out of order
- We now save a nodeExited event on window:beforeunload so that the nodeExited event is saved when the student refreshes the page or closes the tab

## Test
- Make sure duplicate nodeEntered and nodeExited events are not saved when viewing the student project view
- Make sure the nodeExited and nodeEntered events are saved in the correct order in the database when the student changes step
- Make sure the nodeExited event is saved when refreshing the page or closing the tab
- Make sure the nodeEntered event is saved when the student launches the unit

Closes #1873