### PR TITLE
refactor(WorkgroupNodeStatusComponent): Convert to standalone

### DIFF
--- a/src/app/classroom-monitor/workgroup-node-status/workgroup-node-status.component.ts
+++ b/src/app/classroom-monitor/workgroup-node-status/workgroup-node-status.component.ts
@@ -2,12 +2,10 @@ import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'workgroup-node-status',
+  standalone: true,
   template: `<span class="md-body-2 block center {{ statusClass }}">{{ statusText }}</span>`
 })
 export class WorkgroupNodeStatusComponent {
-  @Input()
-  statusClass: string = 'text-secondary';
-
-  @Input()
-  statusText: string;
+  @Input() statusClass: string = 'text-secondary';
+  @Input() statusText: string;
 }

--- a/src/app/teacher/grading-common.module.ts
+++ b/src/app/teacher/grading-common.module.ts
@@ -20,7 +20,8 @@ import { NavItemProgressComponent } from '../classroom-monitor/nav-item-progress
     ComponentGradingModule,
     IntersectionObserverModule,
     StatusIconComponent,
-    StudentTeacherCommonModule
+    StudentTeacherCommonModule,
+    WorkgroupNodeStatusComponent
   ],
   declarations: [
     EditComponentAnnotationsComponent,
@@ -32,7 +33,6 @@ import { NavItemProgressComponent } from '../classroom-monitor/nav-item-progress
     WorkgroupInfoComponent,
     WorkgroupItemComponent,
     WorkgroupNodeScoreComponent,
-    WorkgroupNodeStatusComponent,
     WorkgroupSelectAutocompleteComponent
   ],
   exports: [

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-workgroup-item/milestone-workgroup-item.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-workgroup-item/milestone-workgroup-item.component.html
@@ -25,8 +25,7 @@
         ></workgroup-info>
       </div>
       <div *ngIf="locations.length == 1" fxFlex="30" fxLayout="row" fxLayoutAlign="center center">
-        <workgroup-node-status [statusText]="statusText" [statusClass]="statusClass">
-        </workgroup-node-status>
+        <workgroup-node-status [statusText]="statusText" [statusClass]="statusClass" />
       </div>
       <div
         *ngIf="showScore && locations.length > 1"

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.html
@@ -25,8 +25,7 @@
         ></workgroup-info>
       </div>
       <div fxFlex="{{ showScore ? 30 : 20 }}" fxLayout="row" fxLayoutAlign="center center">
-        <workgroup-node-status [statusText]="statusText" [statusClass]="statusClass">
-        </workgroup-node-status>
+        <workgroup-node-status [statusText]="statusText" [statusClass]="statusClass" />
       </div>
       <div *ngIf="showScore" fxFlex="20" fxLayout="row" fxLayoutAlign="center center">
         <workgroup-node-score [score]="score" [maxScore]="maxScore"></workgroup-node-score>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.html
@@ -24,8 +24,7 @@
         />
       </div>
       <div fxFlex="{{ showScore ? 30 : 20 }}" fxLayout="row" fxLayoutAlign="center center">
-        <workgroup-node-status [statusText]="statusText" [statusClass]="statusClass">
-        </workgroup-node-status>
+        <workgroup-node-status [statusText]="statusText" [statusClass]="statusClass" />
       </div>
       <div *ngIf="showScore" fxFlex="20" fxLayout="row" fxLayoutAlign="center center">
         <workgroup-node-score [score]="score" [maxScore]="maxScore"></workgroup-node-score>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13675,14 +13675,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Step <x id="INTERPOLATION" equiv-text="{{ getNodePosition(firstNodeId) }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-workgroup-item/milestone-workgroup-item.component.html</context>
-          <context context-type="linenumber">73</context>
+          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ac74039732320d9727aad59519cd7961c2decd08" datatype="html">
         <source>Step <x id="INTERPOLATION" equiv-text="{{ getNodePosition(lastNodeId) }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-workgroup-item/milestone-workgroup-item.component.html</context>
-          <context context-type="linenumber">95</context>
+          <context context-type="linenumber">94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="314850458480650903" datatype="html">


### PR DESCRIPTION
## Changes
- Convert WorkgroupNodeStatusComponent to standalone

## Test
Make sure the WorkgroupNodeStatusComponent works in these locations in the Teacher Tools

Grade By Step
1. Click Grade By Step
2. Click a step
3. Make sure the Status column displays a value

Grade By Team
1. Click Grade By Team
2. Click a team
3. Make sure the Status column displays a value

Milestone
1. Click Milestones
2. Click on a milestone card
3. Click on the Student Work tab
4. Make sure the Status column displays a value
