### PR TITLE
fix(Timestamp): Save annotations, events, student work with milliseconds

### DIFF
--- a/src/assets/wise5/services/annotationService.ts
+++ b/src/assets/wise5/services/annotationService.ts
@@ -13,7 +13,8 @@ export class AnnotationService {
   annotations: Annotation[] = [];
   dummyAnnotationId: number = 1; // used in preview mode when we simulate saving of annotation
   private annotationSavedToServerSource: Subject<Annotation> = new Subject<Annotation>();
-  public annotationSavedToServer$: Observable<Annotation> = this.annotationSavedToServerSource.asObservable();
+  public annotationSavedToServer$: Observable<Annotation> =
+    this.annotationSavedToServerSource.asObservable();
   private annotationReceivedSource: Subject<Annotation> = new Subject<Annotation>();
   public annotationReceived$: Observable<Annotation> = this.annotationReceivedSource.asObservable();
 
@@ -318,7 +319,7 @@ export class AnnotationService {
     const localNotebookItemId = null;
     const notebookItemId = null;
     const annotationType = 'autoScore';
-    const clientSaveTime = Date.parse(new Date().toString());
+    const clientSaveTime = new Date().getTime();
     const annotation = this.createAnnotation(
       annotationId,
       runId,
@@ -354,7 +355,7 @@ export class AnnotationService {
     const localNotebookItemId = null;
     const notebookItemId = null;
     const annotationType = 'autoComment';
-    const clientSaveTime = Date.parse(new Date().toString());
+    const clientSaveTime = new Date().getTime();
     const annotation = this.createAnnotation(
       annotationId,
       runId,
@@ -399,7 +400,7 @@ export class AnnotationService {
     const localNotebookItemId = null;
     const notebookItemId = null;
     const annotationType = 'inappropriateFlag';
-    const clientSaveTime = Date.parse(new Date().toString());
+    const clientSaveTime = new Date().getTime();
     const annotation = this.createAnnotation(
       annotationId,
       runId,

--- a/src/assets/wise5/services/studentDataService.ts
+++ b/src/assets/wise5/services/studentDataService.ts
@@ -294,7 +294,7 @@ export class StudentDataService extends DataService {
       runId: this.ConfigService.getRunId(),
       periodId: this.ConfigService.getPeriodId(),
       workgroupId: this.ConfigService.getWorkgroupId(),
-      clientSaveTime: Date.parse(new Date().toString())
+      clientSaveTime: new Date().getTime()
     };
   }
 

--- a/src/assets/wise5/services/teacherDataService.ts
+++ b/src/assets/wise5/services/teacherDataService.ts
@@ -30,7 +30,8 @@ export class TeacherDataService extends DataService {
   private currentPeriodChangedSource: Subject<any> = new Subject<any>();
   public currentPeriodChanged$: Observable<any> = this.currentPeriodChangedSource.asObservable();
   private currentWorkgroupChangedSource: Subject<any> = new Subject<any>();
-  public currentWorkgroupChanged$: Observable<any> = this.currentWorkgroupChangedSource.asObservable();
+  public currentWorkgroupChanged$: Observable<any> =
+    this.currentWorkgroupChangedSource.asObservable();
 
   constructor(
     private http: HttpClient,
@@ -158,7 +159,7 @@ export class TeacherDataService extends DataService {
       projectId: this.ConfigService.getProjectId(),
       runId: this.ConfigService.getRunId(),
       workgroupId: this.ConfigService.getWorkgroupId(),
-      clientSaveTime: Date.parse(new Date().toString()),
+      clientSaveTime: new Date().getTime(),
       context: context,
       nodeId: nodeId,
       componentId: componentId,

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13899,7 +13899,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/teacherDataService.ts</context>
-          <context context-type="linenumber">575</context>
+          <context context-type="linenumber">576</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6933068701447776492" datatype="html">


### PR DESCRIPTION
## Changes
- Save annotations, events, and student work with milliseconds

## Test
- Test with https://github.com/WISE-Community/WISE-API/pull/278
- Generate annotations, events, and student work and make sure the database saves the milliseconds

Closes #1877
