### PR TITLE
refactor(TeacherProjectService): Move deleteTransition() to Node

### DIFF
--- a/src/app/services/teacherProjectService.spec.ts
+++ b/src/app/services/teacherProjectService.spec.ts
@@ -52,7 +52,6 @@ describe('TeacherProjectService', () => {
   registerNewProject();
   isNodeIdUsed();
   isNodeIdToInsertTargetNotSpecified();
-  testDeleteTransition();
   testGetNodeIdAfter();
   testCreateNodeAfter();
   shouldGetTheBranchLetter();
@@ -164,18 +163,6 @@ function isNodeIdToInsertTargetNotSpecified() {
     it('should return false for active nodes and groups', () => {
       expect(service.isNodeIdToInsertTargetNotSpecified('activeNodes')).toBeFalsy();
       expect(service.isNodeIdToInsertTargetNotSpecified('activeGroups')).toBeFalsy();
-    });
-  });
-}
-
-function testDeleteTransition() {
-  describe('deleteTransition', () => {
-    it('should delete existing transition from the node', () => {
-      service.setProject(demoProjectJSON);
-      const node1 = service.getNodeById('node1');
-      expect(service.nodeHasTransitionToNodeId(node1, 'node2')).toBeTruthy();
-      service.deleteTransition(node1, node1.transitionLogic.transitions[0]);
-      expect(service.nodeHasTransitionToNodeId(node1, 'node2')).toBeFalsy();
     });
   });
 }

--- a/src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts
@@ -57,7 +57,10 @@ export class NodeAdvancedPathAuthoringComponent implements OnInit {
     { value: 'studentDataChanged', text: $localize`Student Data Changed` }
   ];
 
-  constructor(private projectService: TeacherProjectService, private route: ActivatedRoute) {}
+  constructor(
+    private projectService: TeacherProjectService,
+    private route: ActivatedRoute
+  ) {}
 
   ngOnInit() {
     this.route.parent.parent.params.subscribe((params) => {
@@ -198,11 +201,11 @@ export class NodeAdvancedPathAuthoringComponent implements OnInit {
     this.saveProject();
   }
 
-  deleteTransition(transition): void {
+  deleteTransition(transition: any): void {
     const stepTitle = this.projectService.getNodePositionAndTitle(transition.to);
     const answer = confirm($localize`Are you sure you want to delete this path to "${stepTitle}"?`);
     if (answer) {
-      this.projectService.deleteTransition(this.node, transition);
+      this.projectService.getNode(this.node.id).deleteTransition(transition);
       this.saveProject();
     }
   }

--- a/src/assets/wise5/common/Node.spec.ts
+++ b/src/assets/wise5/common/Node.spec.ts
@@ -6,6 +6,9 @@ const componentId2 = 'c2';
 let node: Node;
 const nodeId1 = 'node1';
 const nodeId2 = 'node2';
+const node1TransitionLogic = {
+  transitions: [{ to: 'node2' }, { to: 'node3' }]
+};
 
 describe('Node', () => {
   beforeEach(() => {
@@ -15,6 +18,7 @@ describe('Node', () => {
       { id: componentId1, prompt: 'a' },
       { id: componentId2, prompt: 'b' }
     ];
+    node.transitionLogic = node1TransitionLogic;
   });
   copyComponents();
   deleteComponent();
@@ -23,6 +27,7 @@ describe('Node', () => {
   moveComponents();
   replaceComponent();
   getAllRelatedComponents();
+  deleteTransition();
 });
 
 function copyComponents() {
@@ -195,6 +200,17 @@ function getAllRelatedComponents_stepHasDiscussionWithConnectedComponent_getsRel
         { nodeId: nodeId1, componentId: componentId1 },
         { nodeId: nodeId2, componentId: componentId2, type: 'importWork' }
       ]);
+    });
+  });
+}
+
+function deleteTransition() {
+  describe('deleteTransition', () => {
+    it('should delete existing transition from the node', () => {
+      expect(node.getTransitionLogic().transitions.length).toEqual(2);
+      node.deleteTransition(node1TransitionLogic.transitions[0]);
+      expect(node.getTransitionLogic().transitions.length).toEqual(1);
+      expect(node.getTransitionLogic().transitions[0].to).toEqual('node3');
     });
   });
 }

--- a/src/assets/wise5/common/Node.ts
+++ b/src/assets/wise5/common/Node.ts
@@ -200,4 +200,19 @@ export class Node {
   getConstraints(): any[] {
     return this.constraints;
   }
+
+  deleteTransition(transition: any): void {
+    const transitions = this.transitionLogic.transitions;
+    const index = transitions.indexOf(transition);
+    if (index > -1) {
+      transitions.splice(index, 1);
+    }
+    if (transitions.length <= 1) {
+      // these settings only apply when there are multiple transitions
+      this.transitionLogic.howToChooseAmongAvailablePaths = null;
+      this.transitionLogic.whenToChoosePath = null;
+      this.transitionLogic.canChangePath = null;
+      this.transitionLogic.maxPathsVisitable = null;
+    }
+  }
 }

--- a/src/assets/wise5/common/TransitionLogic.ts
+++ b/src/assets/wise5/common/TransitionLogic.ts
@@ -5,4 +5,5 @@ export interface TransitionLogic {
   howToChooseAmongAvailablePaths?: string;
   transitions: Transition[];
   whenToChoosePath?: string;
+  maxPathsVisitable?: number;
 }

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -412,21 +412,6 @@ export class TeacherProjectService extends ProjectService {
     return numRubrics;
   }
 
-  deleteTransition(node, transition) {
-    const nodeTransitions = node.transitionLogic.transitions;
-    const index = nodeTransitions.indexOf(transition);
-    if (index > -1) {
-      nodeTransitions.splice(index, 1);
-    }
-    if (nodeTransitions.length <= 1) {
-      // these settings only apply when there are multiple transitions
-      node.transitionLogic.howToChooseAmongAvailablePaths = null;
-      node.transitionLogic.whenToChoosePath = null;
-      node.transitionLogic.canChangePath = null;
-      node.transitionLogic.maxPathsVisitable = null;
-    }
-  }
-
   getBackgroundColor(nodeId: string): string {
     const branchPathLetter = this.nodeIdToBranchPathLetter[nodeId];
     if (branchPathLetter != null) {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12045,14 +12045,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete this requirement?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">135</context>
+          <context context-type="linenumber">138</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9161423248419359552" datatype="html">
         <source>Are you sure you want to delete this path to &quot;<x id="PH" equiv-text="stepTitle"/>&quot;?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
-          <context context-type="linenumber">203</context>
+          <context context-type="linenumber">206</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cf11597f80309219c947fba6c22b94290f6371d2" datatype="html">


### PR DESCRIPTION
## Changes
- Move ```deleteTransition()``` from TeacherProjectService to Node and update references

## Test
- In node advanced authoring > edit transitions, try deleting path(s) and verify that the changes are properly reflected in the node's JSON. (```transitionLogic.transitions``` array)