### PR TITLE
refactor(TeacherProjectService): Move setMaxScoreForComponent to GradingEditComponentMaxScore

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/grading-edit-component-max-score/grading-edit-component-max-score.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/grading-edit-component-max-score/grading-edit-component-max-score.component.spec.ts
@@ -6,29 +6,32 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { CopyNodesService } from '../../../services/copyNodesService';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { ComponentContent } from '../../../common/ComponentContent';
 
 let component: GradingEditComponentMaxScoreComponent;
 let fixture: ComponentFixture<GradingEditComponentMaxScoreComponent>;
 let saveProjectSpy;
-let setMaxScoreForComponentSpy;
+let getComponentSpy;
 let projectService: TeacherProjectService;
 
 describe('GradingEditComponentMaxScoreComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-    declarations: [GradingEditComponentMaxScoreComponent],
-    schemas: [NO_ERRORS_SCHEMA],
-    imports: [StudentTeacherCommonServicesModule],
-    providers: [CopyNodesService, TeacherProjectService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-});
+      declarations: [GradingEditComponentMaxScoreComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: [StudentTeacherCommonServicesModule],
+      providers: [
+        CopyNodesService,
+        TeacherProjectService,
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting()
+      ]
+    });
     projectService = TestBed.inject(TeacherProjectService);
     fixture = TestBed.createComponent(GradingEditComponentMaxScoreComponent);
     component = fixture.componentInstance;
     saveProjectSpy = spyOn(projectService, 'saveProject').and.callFake(() => new Promise(() => {}));
-    setMaxScoreForComponentSpy = spyOn(
-      projectService,
-      'setMaxScoreForComponent'
-    ).and.callFake(() => {});
+    getComponentSpy = spyOn(projectService, 'getComponent').and.returnValue({} as ComponentContent);
   });
   saveMaxScore();
 });
@@ -48,13 +51,13 @@ function saveMaxScore() {
 
 function shouldSave(maxScore: number) {
   setMaxScoreAndSave(maxScore);
-  expect(setMaxScoreForComponentSpy).toHaveBeenCalled();
+  expect(getComponentSpy).toHaveBeenCalled();
   expect(saveProjectSpy).toHaveBeenCalled();
 }
 
 function shouldNotSave(maxScore: number) {
   setMaxScoreAndSave(maxScore);
-  expect(setMaxScoreForComponentSpy).not.toHaveBeenCalled();
+  expect(getComponentSpy).not.toHaveBeenCalled();
   expect(saveProjectSpy).not.toHaveBeenCalled();
 }
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/grading-edit-component-max-score/grading-edit-component-max-score.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/grading-edit-component-max-score/grading-edit-component-max-score.component.ts
@@ -5,9 +5,14 @@ import { TeacherProjectService } from '../../../services/teacherProjectService';
 
 @Component({
   selector: 'grading-edit-component-max-score',
-  styles: [`
-/* TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-.mat-form-field-infix { width: inherit; }`],
+  styles: [
+    `
+      /* TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
+      .mat-form-field-infix {
+        width: inherit;
+      }
+    `
+  ],
   templateUrl: 'grading-edit-component-max-score.component.html',
   encapsulation: ViewEncapsulation.None
 })
@@ -37,7 +42,7 @@ export class GradingEditComponentMaxScoreComponent {
   saveMaxScore(): void {
     const maxScore = Number(this.maxScore);
     if (maxScore >= 0) {
-      this.projectService.setMaxScoreForComponent(this.nodeId, this.componentId, maxScore);
+      this.projectService.getComponent(this.nodeId, this.componentId).maxScore = maxScore;
       this.projectService.saveProject();
       this.maxScore = this.maxScore || 0;
     }

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -1821,13 +1821,6 @@ export class TeacherProjectService extends ProjectService {
     return maxScore;
   }
 
-  setMaxScoreForComponent(nodeId: string, componentId: string, maxScore: number): void {
-    const component = this.getComponent(nodeId, componentId);
-    if (component != null) {
-      component.maxScore = maxScore;
-    }
-  }
-
   hasGroupStartId(nodeId) {
     const startId = this.getGroupStartId(nodeId);
     return startId != null && startId != '';


### PR DESCRIPTION
## Changes
- Remove TeacherProjectService.setMaxScoreForComponent() and implement it in GradingEditComponentMaxScoreComponent. No need to null-check the component, because we are editing the max score for a specific component at this stage.

## Test
- In CM > grade by team or step, set the max score for a component. It should save.