### PR TITLE
refactor(PathService): Clean up arePathsEmpty()

### DIFF
--- a/src/app/services/pathService.spec.ts
+++ b/src/app/services/pathService.spec.ts
@@ -11,6 +11,7 @@ describe('PathService', () => {
     service = TestBed.inject(PathService);
   });
   consolidatePaths();
+  arePathsEmpty();
 });
 
 function consolidatePaths() {
@@ -32,6 +33,15 @@ function consolidatePaths() {
         'node7',
         'node8'
       ]);
+    });
+  });
+}
+
+function arePathsEmpty() {
+  describe('arePathsEmpty()', () => {
+    it('should return true iff all paths are empty', () => {
+      expect(service.arePathsEmpty([[], []])).toBeTrue();
+      expect(service.arePathsEmpty([['node1'], []])).toBeFalse();
     });
   });
 }

--- a/src/assets/wise5/services/pathService.ts
+++ b/src/assets/wise5/services/pathService.ts
@@ -8,7 +8,7 @@ export class PathService {
    * @return true iff all the paths are empty
    */
   arePathsEmpty(paths: string[][]): boolean {
-    return !paths.some((path) => path.length > 0);
+    return paths.every((path) => path.length === 0);
   }
 
   /**

--- a/src/assets/wise5/services/pathService.ts
+++ b/src/assets/wise5/services/pathService.ts
@@ -5,19 +5,10 @@ export class PathService {
   /**
    * Check if all the paths are empty
    * @param paths an array of paths. each path is an array of node ids
-   * @return whether all the paths are empty
+   * @return true iff all the paths are empty
    */
   arePathsEmpty(paths: string[][]): boolean {
-    if (paths != null) {
-      for (let path of paths) {
-        if (path != null) {
-          if (path.length !== 0) {
-            return false;
-          }
-        }
-      }
-    }
-    return true;
+    return !paths.some((path) => path.length > 0);
   }
 
   /**


### PR DESCRIPTION
## Changes
- Remove unnecessary null-checks
- Use ```array.every()``` to simplify logic
- Add test

## Test
- Verify that null-checks weren't really necessary
- Verify that the function works as intended