### PR TITLE
refactor(ProjectService): Remove getTransitionLogicByFromId() 

### DIFF
--- a/src/app/services/studentNodeService.spec.ts
+++ b/src/app/services/studentNodeService.spec.ts
@@ -1,12 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 import { StudentNodeService } from '../../assets/wise5/services/studentNodeService';
 import { StudentTeacherCommonServicesModule } from '../student-teacher-common-services.module';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { NodeStatusService } from '../../assets/wise5/services/nodeStatusService';
 import { DataService } from './data.service';
 import { ProjectService } from '../../assets/wise5/services/projectService';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { Node } from '../../assets/wise5/common/Node';
 
 let dataService: DataService;
 let dialog: MatDialog;
@@ -18,9 +18,9 @@ let service: StudentNodeService;
 describe('StudentNodeService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-    imports: [MatDialogModule, StudentTeacherCommonServicesModule],
-    providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-});
+      imports: [MatDialogModule, StudentTeacherCommonServicesModule],
+      providers: [provideHttpClient(withInterceptorsFromDi())]
+    });
     dataService = TestBed.inject(DataService);
     dialog = TestBed.inject(MatDialog);
     service = TestBed.inject(StudentNodeService);
@@ -87,9 +87,11 @@ function getNextNodeId_previouslyBranched_getsNodeFromPreviousBranchPathTaken() 
 function getNextNodeId_currentNodeHasTransition_getsNodeFromTransition() {
   describe('current node has a transition', () => {
     it('gets the node id from the transition', async () => {
-      spyOn(projectService, 'getTransitionLogicByFromNodeId').and.returnValue({
+      const node = new Node();
+      node.transitionLogic = {
         transitions: [{ to: nodeId2 }]
-      });
+      };
+      spyOn(projectService, 'getNode').and.returnValue(node);
       expect(await service.getNextNodeId()).toEqual(nodeId2);
     });
   });

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -720,22 +720,12 @@ export class ProjectService {
   }
 
   /**
-   * Get the transition logic for a node
-   * @param fromNodeId the from node id
-   * @returns the transition logic object
-   */
-  getTransitionLogicByFromNodeId(fromNodeId: string): TransitionLogic {
-    return this.getNode(fromNodeId).getTransitionLogic();
-  }
-
-  /**
    * Get the transitions for a node
    * @param fromNodeId the node to get transitions from
    * @returns {Array} an array of transitions
    */
   getTransitionsByFromNodeId(fromNodeId: string): Transition[] {
-    const transitionLogic = this.getTransitionLogicByFromNodeId(fromNodeId);
-    return transitionLogic.transitions ?? [];
+    return this.getNode(fromNodeId).getTransitionLogic().transitions ?? [];
   }
 
   /**

--- a/src/assets/wise5/services/studentNodeService.ts
+++ b/src/assets/wise5/services/studentNodeService.ts
@@ -81,7 +81,7 @@ export class StudentNodeService extends NodeService {
   getNextNodeId(currentId?: string): Promise<any> {
     return new Promise((resolve, reject) => {
       const currentNodeId = currentId ?? this.DataService.getCurrentNodeId();
-      const transitionLogic = this.ProjectService.getTransitionLogicByFromNodeId(currentNodeId);
+      const transitionLogic = this.ProjectService.getNode(currentNodeId).getTransitionLogic();
       const branchPathTakenEvents =
         this.DataService.getBranchPathTakenEventsByNodeId(currentNodeId);
       if (this.hasPreviouslyBranchedAndCannotChange(branchPathTakenEvents, transitionLogic)) {
@@ -100,7 +100,7 @@ export class StudentNodeService extends NodeService {
   }
 
   private resolveNextNodeIdFromTransition(resolve: any, currentNodeId: string): void {
-    const transitionLogic = this.ProjectService.getTransitionLogicByFromNodeId(currentNodeId);
+    const transitionLogic = this.ProjectService.getNode(currentNodeId).getTransitionLogic();
     if (transitionLogic.transitions.length == 0) {
       this.getNextNodeIdFromParent(resolve, currentNodeId);
     } else {
@@ -113,8 +113,7 @@ export class StudentNodeService extends NodeService {
   private getNextNodeIdFromParent(resolve: any, currentNodeId: string): void {
     const parentGroupId = this.ProjectService.getParentGroupId(currentNodeId);
     if (parentGroupId != null) {
-      const parentTransitionLogic =
-        this.ProjectService.getTransitionLogicByFromNodeId(parentGroupId);
+      const parentTransitionLogic = this.ProjectService.getNode(parentGroupId).getTransitionLogic();
       this.chooseTransition(parentGroupId, parentTransitionLogic).then((transition: any) => {
         const transitionToNodeId = transition.to;
         const startId = this.ProjectService.isGroupNode(transitionToNodeId)

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -345,7 +345,7 @@ export class TeacherProjectService extends ProjectService {
    * are assigned branch paths on this branch point.
    */
   getBranchCriteriaDescription(nodeId) {
-    const transitionLogic = this.getTransitionLogicByFromNodeId(nodeId);
+    const transitionLogic = this.getNode(nodeId).getTransitionLogic();
     for (const transition of transitionLogic.transitions) {
       if (transition.criteria != null && transition.criteria.length > 0) {
         for (const singleCriteria of transition.criteria) {


### PR DESCRIPTION
## Changes
- Replace calls to ```ProjectService.getTransitionLogicByFromId(nodeId)``` with ```ProjectService.getNode(nodeId).getTransitionLogic()```. This encapsulates the data (transitionLogic) better. Also, the "fromId" part of the name was not really useful.

## Test
- VLE works as before