### PR TITLE
refactor(TeacherProjectService): Move getNumberOfRubricsByNodeId() to Node

### DIFF
--- a/src/app/classroom-monitor/step-info/step-info.component.ts
+++ b/src/app/classroom-monitor/step-info/step-info.component.ts
@@ -34,7 +34,7 @@ export class StepInfoComponent {
         ? $localize`Has new alert(s)`
         : $localize`Has dismissed alert(s)`;
     }
-    this.hasRubrics = this.projectService.getNumberOfRubricsByNodeId(this.nodeId) > 0;
+    this.hasRubrics = this.projectService.getNode(this.nodeId).getNumRubrics() > 0;
     this.rubricIconLabel = $localize`Step has rubrics/teaching tips`;
   }
 }

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
@@ -76,7 +76,7 @@ export class ProjectAuthoringStepComponent {
   }
 
   protected nodeHasRubric(nodeId: string): boolean {
-    return this.projectService.nodeHasRubric(nodeId);
+    return this.projectService.getNode(nodeId).getNumRubrics() > 0;
   }
 
   protected getConstraintDescriptions(nodeId: string): string {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading-view/node-grading-view.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading-view/node-grading-view.component.ts
@@ -139,7 +139,7 @@ export class NodeGradingViewComponent implements OnInit {
       this.canViewStudentNames = this.configService.getPermissions().canViewStudentNames;
       this.setWorkgroupsById();
       this.sortWorkgroups();
-      this.numRubrics = this.projectService.getNumberOfRubricsByNodeId(node.id);
+      this.numRubrics = node.getNumRubrics();
       document.body.scrollTop = document.documentElement.scrollTop = 0;
     });
   }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.spec.ts
@@ -7,6 +7,7 @@ import { TeacherProjectService } from '../../../../services/teacherProjectServic
 import { ClassroomMonitorTestingModule } from '../../../classroom-monitor-testing.module';
 import { NavItemComponent } from './nav-item.component';
 import { NodeService } from '../../../../services/nodeService';
+import { Node } from '../../../../common/Node';
 
 class MockNotificationService {
   getAlertNotifications() {
@@ -39,10 +40,9 @@ class MockTeacherProjectService {
   nodeHasWork() {}
   getMaxScoreForNode() {}
   getNode() {
-    return { getIcon: () => {} };
+    return new Node();
   }
   getParentGroup() {}
-  getNumberOfRubricsByNodeId() {}
 }
 
 let component: NavItemComponent;

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts
@@ -76,7 +76,7 @@ export class NavItemComponent implements OnInit {
       this.parentGroupId = parentGroup.id;
     }
     this.getAlertNotifications();
-    this.hasRubrics = this.projectService.getNumberOfRubricsByNodeId(this.nodeId) > 0;
+    this.hasRubrics = this.projectService.getNode(this.nodeId).getNumRubrics() > 0;
     this.alertIconLabel = $localize`Has new alert(s)`;
     this.alertIconClass = 'warn';
     this.alertIconName = 'notifications';

--- a/src/assets/wise5/common/Node.spec.ts
+++ b/src/assets/wise5/common/Node.spec.ts
@@ -28,6 +28,7 @@ describe('Node', () => {
   replaceComponent();
   getAllRelatedComponents();
   deleteTransition();
+  getNumRubrics();
 });
 
 function copyComponents() {
@@ -211,6 +212,20 @@ function deleteTransition() {
       node.deleteTransition(node1TransitionLogic.transitions[0]);
       expect(node.getTransitionLogic().transitions.length).toEqual(1);
       expect(node.getTransitionLogic().transitions[0].to).toEqual('node3');
+    });
+  });
+}
+
+function getNumRubrics() {
+  describe('getNumRubrics()', () => {
+    it("should return 0 when node and components don't have any rubric", () => {
+      expect(node.getNumRubrics()).toEqual(0);
+    });
+    it('should return total number of rubrics for the node and its components', () => {
+      node.rubric = 'node rubric';
+      node.components[0].rubric = 'component 1 rubric';
+      node.components[1].rubric = 'component 2 rubric';
+      expect(node.getNumRubrics()).toEqual(3);
     });
   });
 }

--- a/src/assets/wise5/common/Node.ts
+++ b/src/assets/wise5/common/Node.ts
@@ -215,4 +215,15 @@ export class Node {
       this.transitionLogic.maxPathsVisitable = null;
     }
   }
+
+  getNumRubrics(): number {
+    let numRubrics = 0;
+    if (this.rubric != null && this.rubric != '') {
+      numRubrics++;
+    }
+    numRubrics += this.components.filter(
+      (component) => component.rubric != null && component.rubric != ''
+    ).length;
+    return numRubrics;
+  }
 }

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -380,38 +380,6 @@ export class TeacherProjectService extends ProjectService {
     return null;
   }
 
-  nodeHasRubric(nodeId: string): boolean {
-    return this.getNumberOfRubricsByNodeId(nodeId) > 0;
-  }
-
-  /**
-   * Get the total number of rubrics (step + components) for the given nodeId
-   * @param nodeId the node id
-   * @return Number of rubrics for the node
-   */
-  getNumberOfRubricsByNodeId(nodeId: string): number {
-    let numRubrics = 0;
-    const node = this.getNodeById(nodeId);
-    if (node) {
-      const nodeRubric = node.rubric;
-      if (nodeRubric != null && nodeRubric != '') {
-        numRubrics++;
-      }
-      const components = node.components;
-      if (components && components.length) {
-        for (let component of components) {
-          if (component) {
-            const componentRubric = component.rubric;
-            if (componentRubric != null && componentRubric != '') {
-              numRubrics++;
-            }
-          }
-        }
-      }
-    }
-    return numRubrics;
-  }
-
   getBackgroundColor(nodeId: string): string {
     const branchPathLetter = this.nodeIdToBranchPathLetter[nodeId];
     if (branchPathLetter != null) {


### PR DESCRIPTION
## Changes
- Move ```TeacherProjectService.getNumberOfRubricsByNodeId()``` to ```Node.getNumRubrics()``` and update references.
- Clean up logic in ```Node.getNumRubrics()```
   - Remove unnecessary checks
   - Use ```filter()``` and ```.length```
- Add test for ```Node.getNumRubrics()```

## Test
- In AT > unit view, if a step (or its components) has any rubric, the rubric icon appears next to the step title
- In CM > grade by step, if a step (or its components) has any rubric, the "Info + Tips(X)" button appears on the page. X should equal the total number of rubrics for the step and its components