### PR TITLE
refactor(NodeNavigation): Convert to standalone

### DIFF
--- a/src/app/student/vle/student-vle.module.ts
+++ b/src/app/student/vle/student-vle.module.ts
@@ -40,7 +40,6 @@ import { NodeComponent } from '../../../assets/wise5/vle/node/node.component';
     ChooseBranchPathDialogComponent,
     GenerateImageDialogComponent,
     GroupTabsComponent,
-    NodeNavigationComponent,
     SafeUrl,
     VLEComponent,
     VLEParentComponent
@@ -51,6 +50,7 @@ import { NodeComponent } from '../../../assets/wise5/vle/node/node.component';
     MatDialogModule,
     NavigationComponent,
     NodeComponent,
+    NodeNavigationComponent,
     NodeStatusIconComponent,
     RunEndedAndLockedMessageComponent,
     SimpleDialogModule,

--- a/src/assets/wise5/directives/node-navigation/node-navigation.component.html
+++ b/src/assets/wise5/directives/node-navigation/node-navigation.component.html
@@ -1,21 +1,13 @@
 <div fxLayoutAlign="start center" fxLayoutGap="4px">
-  <button
-    *ngIf="hasPrevNode"
-    mat-button
-    class="mat-raised-button mat-primary"
-    (click)="goToPrevNode()"
-    i18n
-  >
-    Previous step
-  </button>
+  @if (hasPrevNode) {
+    <button mat-button class="mat-raised-button mat-primary" (click)="goToPrevNode()" i18n>
+      Previous step
+    </button>
+  }
   <span fxFlex></span>
-  <button
-    *ngIf="hasNextNode"
-    mat-button
-    class="mat-raised-button mat-primary"
-    (click)="goToNextNode()"
-    i18n
-  >
-    Next step
-  </button>
+  @if (hasNextNode) {
+    <button mat-button class="mat-raised-button mat-primary" (click)="goToNextNode()" i18n>
+      Next step
+    </button>
+  }
 </div>

--- a/src/assets/wise5/directives/node-navigation/node-navigation.component.ts
+++ b/src/assets/wise5/directives/node-navigation/node-navigation.component.ts
@@ -2,27 +2,35 @@ import { Component, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { NodeService } from '../../services/nodeService';
 import { StudentDataService } from '../../services/studentDataService';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { MatButtonModule } from '@angular/material/button';
+import { CommonModule } from '@angular/common';
 
 @Component({
+  imports: [CommonModule, FlexLayoutModule, MatButtonModule],
   selector: 'node-navigation',
+  standalone: true,
   templateUrl: './node-navigation.component.html'
 })
 export class NodeNavigationComponent implements OnInit {
-  hasNextNode: boolean;
-  hasPrevNode: boolean;
+  protected hasNextNode: boolean;
+  protected hasPrevNode: boolean;
   private subscriptions: Subscription = new Subscription();
 
-  constructor(private nodeService: NodeService, private studentDataService: StudentDataService) {}
+  constructor(
+    private dataService: StudentDataService,
+    private nodeService: NodeService
+  ) {}
 
   ngOnInit(): void {
     this.checkPreviousAndNextNodes();
     this.subscriptions.add(
-      this.studentDataService.currentNodeChanged$.subscribe(() => {
+      this.dataService.currentNodeChanged$.subscribe(() => {
         this.checkPreviousAndNextNodes();
       })
     );
     this.subscriptions.add(
-      this.studentDataService.nodeStatusesChanged$.subscribe(() => {
+      this.dataService.nodeStatusesChanged$.subscribe(() => {
         this.checkPreviousAndNextNodes();
       })
     );
@@ -36,11 +44,11 @@ export class NodeNavigationComponent implements OnInit {
     });
   }
 
-  goToPrevNode(): void {
+  protected goToPrevNode(): void {
     this.nodeService.goToPrevNode();
   }
 
-  goToNextNode(): void {
+  protected goToNextNode(): void {
     this.nodeService.goToNextNode();
   }
 }

--- a/src/assets/wise5/vle/vle.component.html
+++ b/src/assets/wise5/vle/vle.component.html
@@ -45,10 +45,10 @@
     <div class="tab-content">
       <run-ended-and-locked-message *ngIf="runEndedAndLocked" />
       @if (layoutState === 'node') {
-        <node class="node-tabbed top" />
+        <node class="node-tabbed top" [node]="currentNode" />
       }
       <div class="node-nav">
-        <node-navigation class="l-constrained"></node-navigation>
+        <node-navigation class="l-constrained" />
       </div>
     </div>
   </div>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -21499,18 +21499,18 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="e0a9d4bf9fa677b18e0c334249274957d3ee7fab" datatype="html">
+      <trans-unit id="95d52dbba6e41e91cac9ad8ab8a49a15fc502c6a" datatype="html">
         <source> Previous step </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/node-navigation/node-navigation.component.html</context>
-          <context context-type="linenumber">8,10</context>
+          <context context-type="linenumber">3,5</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="96247ff61a36a0a5c6d3d28c5e0df0391df45a0e" datatype="html">
+      <trans-unit id="ecd0eb64543f4002e3e0f212a9e3be7e8be48546" datatype="html">
         <source> Next step </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/node-navigation/node-navigation.component.html</context>
-          <context context-type="linenumber">18,20</context>
+          <context context-type="linenumber">9,11</context>
         </context-group>
       </trans-unit>
       <trans-unit id="866753876041645935" datatype="html">


### PR DESCRIPTION
## Changes
- Convert NodeNavigationComponent to standalone component. This component is used to show/hide the prev/next buttons at the bottom of the page for a tabbed navigation themed unit.
- Clean up code
   
## Test Prep
Make a unit use the tabbed navigation theme. In AT > Project JSON view, add this as the top JSON attribute:
```
    "theme": "tab",
```

## Test
- In VLE for a unit tab theme (see "Test Prep" above)
   - the prev button is hidden when there is no previous step (e.g., you're on the first step in the unit)
   - the next button is hidden when there is no next step (e.g., you're on the last step in the unit)
   - the prev and next buttons should be visible in other cases