### PR TITLE
refactor(TeacherProjectService): Move doesAnyComponentHaveWork() to NodeAuthoringComponent

### DIFF
--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
@@ -212,7 +212,7 @@ export class NodeAuthoringComponent implements OnInit {
 
   private checkIfNeedToShowNodeSaveOrNodeSubmitButtons(): void {
     if (!this.projectService.doesAnyComponentInNodeShowSubmitButton(this.nodeId)) {
-      if (this.projectService.doesAnyComponentHaveWork(this.nodeId)) {
+      if (this.hasComponentsWithWork()) {
         this.nodeJson.showSaveButton = true;
         this.nodeJson.showSubmitButton = false;
         this.hideAllComponentSaveButtons();
@@ -221,6 +221,12 @@ export class NodeAuthoringComponent implements OnInit {
         this.nodeJson.showSubmitButton = false;
       }
     }
+  }
+
+  private hasComponentsWithWork(): boolean {
+    return this.node.components.some((component) =>
+      this.componentServiceLookupService.getService(component.type).componentHasWork(component)
+    );
   }
 
   /**

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -1624,22 +1624,6 @@ export class TeacherProjectService extends ProjectService {
   }
 
   /**
-   * Returns true iff any component in the step generates work
-   * @param nodeId the node id
-   * @return whether any components in the step generates work
-   */
-  doesAnyComponentHaveWork(nodeId) {
-    const node = this.getNodeById(nodeId);
-    for (const component of node.components) {
-      const service = this.componentServiceLookupService.getService(component.type);
-      if (service != null && service.componentHasWork(component)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
    * Check if any of the components in the node are showing their submit button.
    * @param nodeId {string} The node id to check.
    * @return {boolean} Whether any of the components in the node show their submit button.


### PR DESCRIPTION
## Changes
- Move ```TeacherProjectService.doesAnyComponentHaveWork()``` to ```NodeAuthoringComponent.hasComponentsWithWork()```
- Clean up ```NodeAuthoringComponent.hasComponentsWithWork()```
   - use ```array.some()```
   - remove unnecessary checks 

## Test
- In the AT > step editing view, the node's "show save/submit button" settings are properly set when you delete component(s) as before, e.g.,
   - if no component has submit button but there is at least one component that saves work, the node's save button should be set to show 