### PR TITLE
refactor(TeacherProjectService): Move branch description functions to ProjectAuthoringStepComponent

### DIFF
--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
@@ -48,11 +48,39 @@ export class ProjectAuthoringStepComponent {
   }
 
   protected getNumberOfBranchPaths(nodeId: string): number {
-    return this.projectService.getNumberOfBranchPaths(nodeId);
+    return this.projectService.getTransitionsByFromNodeId(nodeId).length;
   }
 
+  /**
+   * If this step is a branch point, we will return the criteria that is used
+   * to determine which path the student gets assigned to.
+   * @param nodeId The node id of the branch point.
+   * @returns A human readable string containing the criteria of how students
+   * are assigned branch paths on this branch point.
+   */
   protected getBranchCriteriaDescription(nodeId: string): string {
-    return this.projectService.getBranchCriteriaDescription(nodeId);
+    const transitionLogic = this.projectService.getNode(nodeId).getTransitionLogic();
+    for (const transition of transitionLogic.transitions) {
+      if (transition.criteria != null && transition.criteria.length > 0) {
+        for (const singleCriteria of transition.criteria) {
+          if (singleCriteria.name === 'choiceChosen') {
+            return 'multiple choice';
+          } else if (singleCriteria.name === 'score') {
+            return 'score';
+          }
+        }
+      }
+    }
+
+    /*
+     * None of the transitions had a specific criteria so the branching is just
+     * based on the howToChooseAmongAvailablePaths field.
+     */
+    if (transitionLogic.howToChooseAmongAvailablePaths === 'workgroupId') {
+      return 'workgroup ID';
+    } else if (transitionLogic.howToChooseAmongAvailablePaths === 'random') {
+      return 'random assignment';
+    }
   }
 
   protected getStepBackgroundColor(nodeId: string): string {

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -310,51 +310,6 @@ export class TeacherProjectService extends ProjectService {
     this.project.rubric = html;
   }
 
-  /**
-   * Get the number of branch paths. This is assuming the node is a branch point.
-   * @param nodeId The node id of the branch point node.
-   * @return The number of branch paths for this branch point.
-   */
-  getNumberOfBranchPaths(nodeId) {
-    const transitions = this.getTransitionsByFromNodeId(nodeId);
-    if (transitions != null) {
-      return transitions.length;
-    }
-    return 0;
-  }
-
-  /**
-   * If this step is a branch point, we will return the criteria that is used
-   * to determine which path the student gets assigned to.
-   * @param nodeId The node id of the branch point.
-   * @returns A human readable string containing the criteria of how students
-   * are assigned branch paths on this branch point.
-   */
-  getBranchCriteriaDescription(nodeId) {
-    const transitionLogic = this.getNode(nodeId).getTransitionLogic();
-    for (const transition of transitionLogic.transitions) {
-      if (transition.criteria != null && transition.criteria.length > 0) {
-        for (const singleCriteria of transition.criteria) {
-          if (singleCriteria.name === 'choiceChosen') {
-            return 'multiple choice';
-          } else if (singleCriteria.name === 'score') {
-            return 'score';
-          }
-        }
-      }
-    }
-
-    /*
-     * None of the transitions had a specific criteria so the branching is just
-     * based on the howToChooseAmongAvailablePaths field.
-     */
-    if (transitionLogic.howToChooseAmongAvailablePaths === 'workgroupId') {
-      return 'workgroup ID';
-    } else if (transitionLogic.howToChooseAmongAvailablePaths === 'random') {
-      return 'random assignment';
-    }
-  }
-
   setProjectScriptFilename(scriptFilename) {
     this.project.script = scriptFilename;
   }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12809,7 +12809,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Are you sure you want to delete this step?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts</context>
-          <context context-type="linenumber">112</context>
+          <context context-type="linenumber">140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="57cf305f9bfd681c70dc26e914108d06384ade9f" datatype="html">


### PR DESCRIPTION
## Changes
- Move functions related to generating branch description text from TeacherProjectService to ProjectAuthoringStepComponent, where it's actually being used
   - getNumberOfBranchPaths()
   - getBranchCriteriaDescription()
- Clean up code 

## Test
- In AT > unit view for a unit with branches, the tooltip text on the branch icon should display text with how many paths the branch has and what the branch criteria is, like this:
<img width="510" alt="Screenshot 2024-08-20 at 1 59 21 PM" src="https://github.com/user-attachments/assets/88170bec-4486-4516-a9e0-370293dc4866">

<img width="488" alt="Screenshot 2024-08-20 at 2 01 34 PM" src="https://github.com/user-attachments/assets/77682754-2b45-43fd-b2aa-870007ab884d">
