### PR TITLE
fix(Graph Authoring): Connected component does not repopulate values

### DIFF
--- a/src/app/authoring-tool/select-component/select-component.component.ts
+++ b/src/app/authoring-tool/select-component/select-component.component.ts
@@ -56,7 +56,7 @@ export class SelectComponentComponent {
     if (numAllowedComponents === 1) {
       this.componentId = allowedComponent.id;
       this.componentChanged();
-    } else {
+    } else if (!this.components.map((component) => component.id).includes(this.componentId)) {
       this.componentId = null;
     }
   }

--- a/src/assets/wise5/components/graph/edit-graph-connected-components/edit-graph-connected-components.component.ts
+++ b/src/assets/wise5/components/graph/edit-graph-connected-components/edit-graph-connected-components.component.ts
@@ -54,7 +54,6 @@ export class EditGraphConnectedComponentsComponent extends EditConnectedComponen
       connectedComponent.xColumn = 0;
       connectedComponent.yColumn = 1;
     }
-    connectedComponent.type = 'importWork';
   }
 
   connectedComponentShowClassmateWorkChanged(connectedComponent: any) {


### PR DESCRIPTION
## Changes
- Fix Graph connected component authoring not repopulating values

## Test
Connected component Component value
1. Open a unit in the Authoring Tool
2. Create a step titled "Graph and Draw" with a Graph item and a Draw item
3. Create another step titled "Graph" with a Graph item
4. Go into the "Graph" step
5. Open the Graph item advanced view
6. Add a connected component
7. Set the connected component Step to the "Graph and Draw" step
8. Set the connected component Component to the Draw item
9. Set the connected component type to "Import Work"
10. Refresh the page and open the Graph item advanced view
11. The connected component Component value should be set to the Draw item (previously it would be set to blank)

Connected component Type value
1. Open a unit in the Authoring Tool
2. Create a step titled "Graph 1" with a Graph item
3. Create another step titled "Graph 2" with a Graph item
4. Go into the "Graph 2" step
5. Open the Graph item advanced view
6. Add a connected component
7. Set the connected component Step to the "Graph 1" step
8. Set the connected component Component to the Graph item
9. Set the connected component type to "Show Work"
10. Refresh the page and open the Graph item advanced view
11. The connected component Type value should be set to "Show Work" (previously it would be set to "Import Work")

Closes #1908