### PR TITLE
chore(DrawingTool): Upgrade to 2.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@stomp/stompjs": "^5.4.4",
         "@tinymce/tinymce-angular": "^7.0.0",
         "@wise-community/angular-password-strength-meter": "^12.0.4",
-        "@wise-community/drawing-tool": "^2.3.0-pre.1",
+        "@wise-community/drawing-tool": "^2.3.2",
         "@zxcvbn-ts/core": "^3.0.4",
         "@zxcvbn-ts/language-en": "^3.0.2",
         "buffer": "^6.0.3",
@@ -9248,9 +9248,9 @@
       }
     },
     "node_modules/@wise-community/drawing-tool": {
-      "version": "2.3.0-pre.1",
-      "resolved": "https://registry.npmjs.org/@wise-community/drawing-tool/-/drawing-tool-2.3.0-pre.1.tgz",
-      "integrity": "sha512-hnGQX06NoKVvoNZlSAxDzfwbdkWApttvr4Yn4KGagSJCbBi0czQR2DHJ5GZbYXiOtJBYzIs5iaSpirNOg2xe7g==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@wise-community/drawing-tool/-/drawing-tool-2.3.2.tgz",
+      "integrity": "sha512-SoxnVleEqBx94HVqagAPB0DNoDtGgMHT1GK5uNRgWnz8R1DfiVLp6pJUCaKFkTdIlDiYhuL4N0iEAZOEepctEA==",
       "license": "MIT",
       "dependencies": {
         "eventemitter2": "~0.4.14",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@stomp/rx-stomp": "^1.1.4",
     "@stomp/stompjs": "^5.4.4",
     "@tinymce/tinymce-angular": "^7.0.0",
-    "@wise-community/drawing-tool": "^2.3.0-pre.1",
+    "@wise-community/drawing-tool": "^2.3.2",
     "@zxcvbn-ts/core": "^3.0.4",
     "@zxcvbn-ts/language-en": "^3.0.2",
     "@wise-community/angular-password-strength-meter": "^12.0.4",


### PR DESCRIPTION
## Changes
- Upgrade DrawingTool from 2.3-pre to 2.3.2

## Test Prep
- Run ```npm install``` to update dependencies

## Test
- Drawing tool works as before, in particular:
   - stamps 
   - saving/loading work