### PR TITLE
refactor(GroupTabsComponent): Convert to standalone

### DIFF
--- a/src/app/student/vle/student-vle.module.ts
+++ b/src/app/student/vle/student-vle.module.ts
@@ -39,7 +39,6 @@ import { NodeComponent } from '../../../assets/wise5/vle/node/node.component';
   declarations: [
     ChooseBranchPathDialogComponent,
     GenerateImageDialogComponent,
-    GroupTabsComponent,
     SafeUrl,
     VLEComponent,
     VLEParentComponent
@@ -47,6 +46,7 @@ import { NodeComponent } from '../../../assets/wise5/vle/node/node.component';
   imports: [
     CommonModule,
     ComponentStudentModule,
+    GroupTabsComponent,
     MatDialogModule,
     NavigationComponent,
     NodeComponent,

--- a/src/assets/wise5/directives/group-tabs/group-tabs.component.html
+++ b/src/assets/wise5/directives/group-tabs/group-tabs.component.html
@@ -4,6 +4,7 @@
   animationDuration="0ms"
   class="app-bg-bg"
 >
-  <mat-tab *ngFor="let node of groupNodes" [label]="node.title" [disabled]="node.disabled">
-  </mat-tab>
+  @for (node of groupNodes; track node.id) {
+    <mat-tab [label]="node.title" [disabled]="node.disabled" />
+  }
 </mat-tab-group>

--- a/src/assets/wise5/directives/group-tabs/group-tabs.component.spec.ts
+++ b/src/assets/wise5/directives/group-tabs/group-tabs.component.spec.ts
@@ -1,13 +1,17 @@
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { NodeStatusService } from '../../services/nodeStatusService';
 import { StudentDataService } from '../../services/studentDataService';
 import { VLEProjectService } from '../../vle/vleProjectService';
 import { GroupTabsComponent } from './group-tabs.component';
 import { NodeService } from '../../services/nodeService';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatTabGroupHarness } from '@angular/material/tabs/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-const group1 = { id: 'group1' };
-const group2 = { id: 'group2' };
+const group1 = { id: 'group1', title: 'Lesson 1', startId: 'node1' };
+const group2 = { id: 'group2', title: 'Lesson 2', startId: 'node2' };
 const node1 = { id: 'node1' };
 
 class MockNodeStatusService {
@@ -47,10 +51,14 @@ class MockStudentDataService {
 }
 
 let component: GroupTabsComponent;
+let fixture: ComponentFixture<GroupTabsComponent>;
+let loader: HarnessLoader;
 let projectService: VLEProjectService;
+let tabGroup: MatTabGroupHarness;
 describe('GroupTabsComponent', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     TestBed.configureTestingModule({
+      imports: [BrowserAnimationsModule],
       providers: [
         GroupTabsComponent,
         { provide: NodeService, useClass: MockNodeService },
@@ -59,8 +67,12 @@ describe('GroupTabsComponent', () => {
         { provide: StudentDataService, useClass: MockStudentDataService }
       ]
     });
-    component = TestBed.inject(GroupTabsComponent);
+    fixture = TestBed.createComponent(GroupTabsComponent);
+    component = fixture.componentInstance;
     projectService = TestBed.inject(VLEProjectService);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    tabGroup = await loader.getHarness(MatTabGroupHarness);
   });
   ngOnInit();
   goToGroupTab();
@@ -68,23 +80,19 @@ describe('GroupTabsComponent', () => {
 
 function ngOnInit() {
   describe('ngOnInit()', () => {
-    it('should initialize class variables', () => {
-      component.ngOnInit();
-      expect(component.groupNodes.length).toEqual(2);
-      expect(component.selectedTabIndex).toEqual(0);
+    it('should initialize class variables', async () => {
+      expect((await tabGroup.getTabs()).length).toEqual(2);
+      expect(await (await tabGroup.getSelectedTab()).getLabel()).toEqual('Lesson 1');
     });
   });
 }
 
 function goToGroupTab() {
   describe('goToGroupTab()', () => {
-    it("should call function to set new group's startNodeId", () => {
-      component.groupNodes = [
-        { id: 'group1', disabled: false, startId: 'node1', title: 'Lesson 1' }
-      ];
+    it("should call function to set new group's startNodeId", async () => {
       const spy = spyOn(TestBed.inject(NodeService), 'setCurrentNode');
-      component.goToGroupTab(0);
-      expect(spy).toHaveBeenCalledWith('node1');
+      await (await tabGroup.getTabs())[1].select();
+      expect(spy).toHaveBeenCalledWith('node2');
     });
   });
 }

--- a/src/assets/wise5/directives/group-tabs/group-tabs.component.ts
+++ b/src/assets/wise5/directives/group-tabs/group-tabs.component.ts
@@ -4,6 +4,8 @@ import { NodeStatusService } from '../../services/nodeStatusService';
 import { StudentDataService } from '../../services/studentDataService';
 import { VLEProjectService } from '../../vle/vleProjectService';
 import { NodeService } from '../../services/nodeService';
+import { CommonModule } from '@angular/common';
+import { MatTabsModule } from '@angular/material/tabs';
 
 class GroupNode {
   id: string;
@@ -13,12 +15,14 @@ class GroupNode {
 }
 
 @Component({
+  imports: [CommonModule, MatTabsModule],
   selector: 'group-tabs',
+  standalone: true,
   templateUrl: './group-tabs.component.html'
 })
 export class GroupTabsComponent implements OnInit {
-  groupNodes: GroupNode[] = [];
-  selectedTabIndex: number;
+  protected groupNodes: GroupNode[] = [];
+  protected selectedTabIndex: number;
   private subscriptions: Subscription = new Subscription();
 
   constructor(
@@ -62,7 +66,7 @@ export class GroupTabsComponent implements OnInit {
     );
   }
 
-  goToGroupTab(groupTabIndex: number): void {
+  protected goToGroupTab(groupTabIndex: number): void {
     const groupStartNodeId = this.groupNodes[groupTabIndex].startId;
     this.nodeService.setCurrentNode(groupStartNodeId);
   }

--- a/src/assets/wise5/vle/vle.component.html
+++ b/src/assets/wise5/vle/vle.component.html
@@ -41,7 +41,7 @@
     class="vle-content tabbed"
     [ngClass]="{ 'nav-view': layoutState === 'nav', 'node-view': layoutState === 'node' }"
   >
-    <group-tabs></group-tabs>
+    <group-tabs />
     <div class="tab-content">
       <run-ended-and-locked-message *ngIf="runEndedAndLocked" />
       @if (layoutState === 'node') {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -18957,46 +18957,46 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Are you sure you want to overwrite the current line data?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">231</context>
+          <context context-type="linenumber">237</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6882380861047606832" datatype="html">
         <source>The series you are trying to add a point to is currently hidden. Please show the series by clicking the series name in the legend and try adding the point again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">846</context>
+          <context context-type="linenumber">852</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2852989551014711458" datatype="html">
         <source>You can not edit this series. Please choose a series that can be edited.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">860</context>
+          <context context-type="linenumber">866</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7053114367342967943" datatype="html">
         <source>Are you sure you want to reset the series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1093</context>
+          <context context-type="linenumber">1099</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7889560203726829643" datatype="html">
         <source>Are you sure you want to reset the &quot;<x id="PH" equiv-text="seriesName"/>&quot; series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1095</context>
+          <context context-type="linenumber">1101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6999515396807067782" datatype="html">
         <source>Trial</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1593</context>
+          <context context-type="linenumber">1518</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">2417</context>
+          <context context-type="linenumber">2350</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7500488806315952979" datatype="html">


### PR DESCRIPTION
## Changes
- Convert GroupTabsComponent to standalone
- Clean up code
- Update tests to use harness instead of making the component's functions public (just for the sake of testing)

## Test Prep
Make a unit use the tabbed navigation theme. In AT > Project JSON view, add this as the top JSON attribute:
```
    "theme": "tab",
```

## Test (in VLE)
- For a unit with tab theme (see "Test Prep" above), the lessons appears as tabs, and you can click on the tab to go to the lesson
- For a unit with regular (non-tab) theme, the VLE loads and works as before