### PR TITLE
refactor(TeacherProjectService): move createGroup() and createNode()

### DIFF
--- a/src/app/services/projectService.spec.ts
+++ b/src/app/services/projectService.spec.ts
@@ -79,8 +79,6 @@ describe('ProjectService', () => {
   // TODO: add test for service.removeDuplicatePaths()
   // TODO: add test for service.pathsEqual()
   // TODO: add test for service.getNodeContentByNodeId()
-  // TODO: add test for service.createGroup()
-  // TODO: add test for service.createNode()
   // TODO: add test for service.createNodeInside()
   // TODO: add test for service.createNodeAfter()
   // TODO: add test for service.insertNodeAfterInGroups()

--- a/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.ts
+++ b/src/assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component.ts
@@ -34,9 +34,17 @@ export class AddLessonConfigureComponent {
 
   protected submit(): void {
     this.submitting = true;
-    const newLesson = this.projectService.createGroup(
-      this.addLessonFormGroup.controls['title'].value
-    );
+    const newLesson = {
+      id: this.projectService.getNextAvailableGroupId(),
+      type: 'group',
+      title: this.addLessonFormGroup.controls['title'].value,
+      startId: '',
+      constraints: [],
+      transitionLogic: {
+        transitions: []
+      },
+      ids: []
+    };
     if (this.target === 'group0' || this.target === 'inactiveGroups') {
       this.projectService.createNodeInside(newLesson, this.target);
     } else {

--- a/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.ts
@@ -80,7 +80,18 @@ export class AddYourOwnNodeComponent {
 
   protected submit(): void {
     this.submitting = true;
-    const newNode = this.projectService.createNode(this.addNodeFormGroup.controls['title'].value);
+    const newNode = {
+      id: this.projectService.getNextAvailableNodeId(),
+      title: this.addNodeFormGroup.controls['title'].value,
+      type: 'node',
+      constraints: [],
+      transitionLogic: {
+        transitions: []
+      },
+      showSaveButton: false,
+      showSubmitButton: false,
+      components: []
+    };
     if (this.isGroupNode(this.targetId)) {
       this.projectService.createNodeInside(newNode, this.targetId);
     } else {

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -82,45 +82,6 @@ export class TeacherProjectService extends ProjectService {
       });
   }
 
-  /**
-   * Create a new group
-   * @param title the title of the group
-   * @returns the group object
-   */
-  createGroup(title: string): any {
-    return {
-      id: this.getNextAvailableGroupId(),
-      type: 'group',
-      title: title,
-      startId: '',
-      constraints: [],
-      transitionLogic: {
-        transitions: []
-      },
-      ids: []
-    };
-  }
-
-  /**
-   * Create a new node
-   * @param title the title of the node
-   * @returns the node object
-   */
-  createNode(title) {
-    return {
-      id: this.getNextAvailableNodeId(),
-      title: title,
-      type: 'node',
-      constraints: [],
-      transitionLogic: {
-        transitions: []
-      },
-      showSaveButton: false,
-      showSubmitButton: false,
-      components: []
-    };
-  }
-
   getNodesWithNewIds(nodes: any[]): any[] {
     const oldToNewIds = this.getOldToNewIds(nodes);
     return nodes.map((node: any) => {


### PR DESCRIPTION
## Changes
- Move ```TeacherProjectService.createGroup()``` to AddLessonConfigureComponent
- Move ```TeacherProjectService.createNode()``` to AddYourOwnNodeComponent

## Test
- These features work as before. Make sure that the new node/lesson is created.
   - Add your own node
   - Add your own lesson