### PR TITLE
refactor(TeacherProjectService): Move removeNodeFromInactiveNodes() to MoveNodesService

### DIFF
--- a/src/assets/wise5/services/moveNodesService.ts
+++ b/src/assets/wise5/services/moveNodesService.ts
@@ -206,12 +206,11 @@ export class MoveNodesService {
 
   private removeNodeFromInactiveNodes(nodeId: string): void {
     let node = null;
-    let parentGroup = this.projectService.getParentGroup(nodeId);
-    if (parentGroup != null) {
+    if (this.projectService.getParentGroup(nodeId) != null) {
       this.projectService.removeChildFromParent(nodeId);
     }
 
-    let inactiveNodes = this.projectService.project.inactiveNodes;
+    const inactiveNodes = this.projectService.project.inactiveNodes;
     for (let i = 0; i < inactiveNodes.length; i++) {
       let inactiveNode = inactiveNodes[i];
       if (inactiveNode.id === nodeId) {

--- a/src/assets/wise5/services/moveNodesService.ts
+++ b/src/assets/wise5/services/moveNodesService.ts
@@ -117,11 +117,11 @@ export class MoveNodesService {
    * also move all of its children to active.
    */
   private moveToActive(node: any): void {
-    this.projectService.removeNodeFromInactiveNodes(node.id);
+    this.removeNodeFromInactiveNodes(node.id);
     this.projectService.addNode(node);
     if (this.projectService.isGroupNode(node.id)) {
       for (const childId of node.ids) {
-        this.projectService.addNode(this.projectService.removeNodeFromInactiveNodes(childId));
+        this.projectService.addNode(this.removeNodeFromInactiveNodes(childId));
       }
     }
   }
@@ -132,7 +132,7 @@ export class MoveNodesService {
    * @param nodeIdToInsertInside place the node inside this
    */
   private moveFromInactiveToInactiveInsertInside(node: any, nodeIdToInsertInside: string): void {
-    this.projectService.removeNodeFromInactiveNodes(node.id);
+    this.removeNodeFromInactiveNodes(node.id);
     if (this.projectService.isGroupNode(node.id)) {
       /*
        * remove the group's child nodes from our data structures so that we can
@@ -200,7 +200,46 @@ export class MoveNodesService {
   }
 
   private moveInactiveNodeToInactiveSection(node: any, nodeIdToInsertAfter: string): void {
-    this.projectService.removeNodeFromInactiveNodes(node.id);
+    this.removeNodeFromInactiveNodes(node.id);
     this.projectService.addInactiveNodeInsertAfter(node, nodeIdToInsertAfter);
+  }
+
+  private removeNodeFromInactiveNodes(nodeId: string): void {
+    let node = null;
+    let parentGroup = this.projectService.getParentGroup(nodeId);
+    if (parentGroup != null) {
+      this.projectService.removeChildFromParent(nodeId);
+    }
+
+    let inactiveNodes = this.projectService.project.inactiveNodes;
+    for (let i = 0; i < inactiveNodes.length; i++) {
+      let inactiveNode = inactiveNodes[i];
+      if (inactiveNode.id === nodeId) {
+        node = inactiveNode;
+        inactiveNodes.splice(i, 1);
+        break;
+      }
+    }
+    this.removeNodeFromInactiveStepNodes(nodeId);
+    this.removeNodeFromInactiveGroupNodes(nodeId);
+    return node;
+  }
+
+  private removeNodeFromInactiveStepNodes(nodeId: string): void {
+    for (let i = 0; i < this.projectService.inactiveStepNodes.length; i++) {
+      if (nodeId == this.projectService.inactiveStepNodes[i].id) {
+        this.projectService.inactiveStepNodes.splice(i, 1);
+        break;
+      }
+    }
+  }
+
+  private removeNodeFromInactiveGroupNodes(nodeId: string): void {
+    for (let i = 0; i < this.projectService.inactiveGroupNodes.length; i++) {
+      if (nodeId == this.projectService.inactiveGroupNodes[i].id) {
+        this.projectService.inactiveGroupNodes.splice(i, 1);
+        break;
+      }
+    }
   }
 }

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -1550,38 +1550,6 @@ export class TeacherProjectService extends ProjectService {
   }
 
   /**
-   * Remove the node from the inactive nodes array
-   * @param nodeId the node to remove
-   * @returns the node that was removed
-   */
-  removeNodeFromInactiveNodes(nodeId) {
-    let node = null;
-    if (nodeId != null) {
-      let parentGroup = this.getParentGroup(nodeId);
-      if (parentGroup != null) {
-        this.removeChildFromParent(nodeId);
-      }
-
-      let inactiveNodes = this.project.inactiveNodes;
-      if (inactiveNodes != null) {
-        for (let i = 0; i < inactiveNodes.length; i++) {
-          let inactiveNode = inactiveNodes[i];
-          if (inactiveNode != null) {
-            if (nodeId === inactiveNode.id) {
-              node = inactiveNode;
-              inactiveNodes.splice(i, 1);
-              break;
-            }
-          }
-        }
-      }
-      this.removeNodeFromInactiveStepNodes(nodeId);
-      this.removeNodeFromInactiveGroupNodes(nodeId);
-    }
-    return node;
-  }
-
-  /**
    * Remove the child node from the parent group.
    * @param nodeId The child node to remove from the parent.
    */
@@ -1619,34 +1587,6 @@ export class TeacherProjectService extends ProjectService {
         if (!startIdUpdated) {
           parentGroup.startId = '';
         }
-      }
-    }
-  }
-
-  /**
-   * Remove the node from the inactive step nodes array.
-   * @param nodeId The node id of the node we want to remove from the
-   * inactive step nodes array.
-   */
-  removeNodeFromInactiveStepNodes(nodeId) {
-    for (let i = 0; i < this.inactiveStepNodes.length; i++) {
-      if (nodeId == this.inactiveStepNodes[i].id) {
-        this.inactiveStepNodes.splice(i, 1);
-        break;
-      }
-    }
-  }
-
-  /**
-   * Remove the node from the inactive group nodes array.
-   * @param nodeId The node id of the group we want to remove from the
-   * inactive group nodes array.
-   */
-  removeNodeFromInactiveGroupNodes(nodeId) {
-    for (let i = 0; i < this.inactiveGroupNodes.length; i++) {
-      if (nodeId == this.inactiveGroupNodes[i].id) {
-        this.inactiveGroupNodes.splice(i, 1);
-        break;
       }
     }
   }


### PR DESCRIPTION
## Changes
- Move ```TeacherProjectService.removeNodeFromInactiveNodes()``` and related functions to MoveNodesService. This is used when inactive nodes/groups are moved to the active section in the authoring tool.
- Remove unnecessary null checks in ```removeNodeFromInactiveNodes()```

## Test
- Verify that the null checks in ```removeNodeFromInactiveNodes()``` were not really necessary
- In the AT, moving nodes and groups works as before, in these cases:
   - inactive to active
   - inactive to inactive 
