### PR TITLE
refactor(TeacherProjectService): Extract RegisterProjectService

### DIFF
--- a/src/app/services/registerProjectService.spec.ts
+++ b/src/app/services/registerProjectService.spec.ts
@@ -1,0 +1,33 @@
+import { TestBed } from '@angular/core/testing';
+import { RegisterProjectService } from '../../assets/wise5/services/registerProjectService';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+
+let http: HttpTestingController;
+let service: RegisterProjectService;
+describe('RegisterProjectService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        RegisterProjectService,
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting()
+      ]
+    });
+    http = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(RegisterProjectService);
+  });
+  register();
+});
+
+function register() {
+  describe('register()', () => {
+    it('should make a post request to register endpoint', () => {
+      const newProjectIdExpected = 1;
+      service.register('test', '{}').subscribe((actualProjectId) => {
+        expect(actualProjectId);
+      });
+      http.expectOne('/api/author/project/new').flush(newProjectIdExpected);
+    });
+  });
+}

--- a/src/app/services/teacherProjectService.spec.ts
+++ b/src/app/services/teacherProjectService.spec.ts
@@ -51,7 +51,6 @@ describe('TeacherProjectService', () => {
     };
     service.applicationNodes = [];
   });
-  registerNewProject();
   isNodeIdToInsertTargetNotSpecified();
   testGetNodeIdAfter();
   testCreateNodeAfter();
@@ -111,23 +110,6 @@ function createConfigServiceGetConfigParamSpy() {
     } else if (param === 'wiseBaseURL') {
       return wiseBaseURL;
     }
-  });
-}
-
-function registerNewProject() {
-  describe('registerNewProject', () => {
-    it('should register new project', () => {
-      createConfigServiceGetConfigParamSpy();
-      const newProjectIdExpected = projectIdDefault;
-      const newProjectIdActual = service.registerNewProject(
-        scootersProjectName,
-        scootersProjectJSONString
-      );
-      http.expectOne(registerNewProjectURL).flush(newProjectIdExpected);
-      newProjectIdActual.then((result) => {
-        expect(result).toEqual(newProjectIdExpected);
-      });
-    });
   });
 }
 

--- a/src/app/teacher/teacher-authoring.module.ts
+++ b/src/app/teacher/teacher-authoring.module.ts
@@ -38,6 +38,7 @@ import { CopyTranslationsService } from '../../assets/wise5/services/copyTransla
 import { CreateComponentService } from '../../assets/wise5/services/createComponentService';
 import { NotifyAuthorService } from '../../assets/wise5/services/notifyAuthorService';
 import { RemoveNodeIdFromTransitionsService } from '../../assets/wise5/services/removeNodeIdFromTransitionsService';
+import { RegisterProjectService } from '../../assets/wise5/services/registerProjectService';
 
 @NgModule({
   imports: [StudentTeacherCommonModule, AuthoringToolModule, RouterModule, AuthoringRoutingModule],
@@ -66,6 +67,7 @@ import { RemoveNodeIdFromTransitionsService } from '../../assets/wise5/services/
     DeleteTranslationsService,
     { provide: PeerGroupService, useExisting: TeacherPeerGroupService },
     { provide: ProjectService, useExisting: TeacherProjectService },
+    RegisterProjectService,
     RemoveNodeIdFromTransitionsService,
     TeacherDataService,
     TeacherDiscussionService,

--- a/src/assets/wise5/authoringTool/add-project/add-project.component.spec.ts
+++ b/src/assets/wise5/authoringTool/add-project/add-project.component.spec.ts
@@ -18,18 +18,24 @@ describe('AddProjectComponent', () => {
   let fixture: ComponentFixture<AddProjectComponent>;
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    declarations: [AddProjectComponent],
-    schemas: [NO_ERRORS_SCHEMA],
-    imports: [BrowserAnimationsModule,
+      declarations: [AddProjectComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: [
+        BrowserAnimationsModule,
         MatDialogModule,
         MatDividerModule,
         MatFormFieldModule,
         MatIconModule,
         MatInputModule,
         ReactiveFormsModule,
-        StudentTeacherCommonServicesModule],
-    providers: [TeacherProjectService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-}).compileComponents();
+        StudentTeacherCommonServicesModule
+      ],
+      providers: [
+        TeacherProjectService,
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting()
+      ]
+    }).compileComponents();
     fixture = TestBed.createComponent(AddProjectComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/assets/wise5/authoringTool/add-project/add-project.component.ts
+++ b/src/assets/wise5/authoringTool/add-project/add-project.component.ts
@@ -1,11 +1,12 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
-import { TeacherProjectService } from '../../services/teacherProjectService';
+import { RegisterProjectService } from '../../services/registerProjectService';
 import { MatDialog } from '@angular/material/dialog';
 import { DialogWithSpinnerComponent } from '../../directives/dialog-with-spinner/dialog-with-spinner.component';
 import { Router } from '@angular/router';
 import { copy } from '../../common/object/object';
 import { newProjectTemplate } from '../new-project-template';
+import { catchError, Observable, throwError } from 'rxjs';
 
 @Component({
   selector: 'add-project',
@@ -21,7 +22,7 @@ export class AddProjectComponent {
   constructor(
     private dialog: MatDialog,
     private fb: FormBuilder,
-    private projectService: TeacherProjectService,
+    private registerProjectService: RegisterProjectService,
     private router: Router
   ) {}
 
@@ -43,15 +44,19 @@ export class AddProjectComponent {
     const project = copy(newProjectTemplate);
     project.metadata.title = this.addProjectFormGroup.controls['title'].value;
     const projectJSONString = JSON.stringify(project, null, 4);
-    this.projectService
-      .registerNewProject(project.metadata.title, projectJSONString)
-      .then((projectId) => {
+    this.registerProjectService
+      .register(project.metadata.title, projectJSONString)
+      .pipe(catchError(this.handleRegisterError))
+      .subscribe((projectId) => {
         this.dialog.closeAll();
         this.router.navigate([`/teacher/edit/unit/${projectId}`]);
-      })
-      .catch(() => {
-        this.dialog.closeAll();
-        alert($localize`There was an error creating this unit. Please contact WISE staff.`);
       });
+  }
+
+  private handleRegisterError(): Observable<never> {
+    this.dialog.closeAll;
+    const errorMsg = $localize`There was an error creating this unit. Please contact WISE staff.`;
+    alert(errorMsg);
+    return throwError(() => new Error(errorMsg));
   }
 }

--- a/src/assets/wise5/services/registerProjectService.ts
+++ b/src/assets/wise5/services/registerProjectService.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable()
+export class RegisterProjectService {
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Registers a new project having the projectJSON content with the server.
+   * Returns a new project id if the project is successfully registered.
+   * @param name title of the new project
+   * @param projectJSONString a valid JSON string of the project
+   */
+  register(name: string, projectJSONString: string): Observable<number> {
+    return this.http.post<number>('/api/author/project/new', {
+      projectName: name,
+      projectJSONString: projectJSONString
+    });
+  }
+}

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -66,23 +66,6 @@ export class TeacherProjectService extends ProjectService {
   }
 
   /**
-   * Registers a new project having the projectJSON content with the server.
-   * Returns a new project id if the project is successfully registered.
-   * @param projectJSONString a valid JSON string
-   */
-  registerNewProject(projectName, projectJSONString) {
-    return this.http
-      .post(this.configService.getConfigParam('registerNewProjectURL'), {
-        projectName: projectName,
-        projectJSONString: projectJSONString
-      })
-      .toPromise()
-      .then((newProjectId) => {
-        return newProjectId;
-      });
-  }
-
-  /**
    * Create a new group
    * @param title the title of the group
    * @returns the group object

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9466,14 +9466,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Creating Unit...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-project/add-project.component.ts</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">40</context>
         </context-group>
       </trans-unit>
       <trans-unit id="153622098599923481" datatype="html">
         <source>There was an error creating this unit. Please contact WISE staff.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-project/add-project.component.ts</context>
-          <context context-type="linenumber">54</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3f3eed30db20799da458408b4d53206e5c8c8684" datatype="html">


### PR DESCRIPTION
## Changes
- Extract function to register a new project from TeacherProjectService to RegisterProjectService
- Update references
- Clean code

## Test
- In the AT > project listing page, try creating a new unit. It should work as before.  