### PR TITLE
refactor(TeacherProjectService): getNodesByToNodeId()

### DIFF
--- a/src/assets/wise5/services/nodeService.ts
+++ b/src/assets/wise5/services/nodeService.ts
@@ -8,6 +8,7 @@ import { ChooseBranchPathDialogComponent } from '../../../app/preview/modules/ch
 import { DataService } from '../../../app/services/data.service';
 import { Observable, Subject } from 'rxjs';
 import { ConstraintService } from './constraintService';
+import { TransitionLogic } from '../common/TransitionLogic';
 
 @Injectable()
 export class NodeService {
@@ -176,92 +177,87 @@ export class NodeService {
    * for how to choose a transition
    * @returns a promise that will return a transition
    */
-  chooseTransition(nodeId, transitionLogic): any {
+  protected chooseTransition(nodeId: string, transitionLogic: TransitionLogic): Promise<any> {
     const existingPromise = this.getChooseTransitionPromise(nodeId);
     if (existingPromise != null) {
       return existingPromise;
     }
     const promise = new Promise((resolve, reject) => {
       let transitionResult = this.getTransitionResultByNodeId(nodeId);
-      if (
-        transitionResult == null ||
-        (transitionLogic != null && transitionLogic.canChangePath == true)
-      ) {
+      if (transitionResult == null || transitionLogic.canChangePath == true) {
         /*
          * we have not previously calculated the transition or the
          * transition logic allows the student to change branch paths
          * so we will calculate the transition again
          */
         const transitions = transitionLogic.transitions;
-        if (transitions != null) {
-          const availableTransitions = this.getAvailableTransitions(transitions);
-          if (availableTransitions.length == 0) {
-            transitionResult = null;
-          } else if (availableTransitions.length == 1) {
-            transitionResult = availableTransitions[0];
-          } else if (availableTransitions.length > 1) {
-            if (this.ConfigService.isPreview()) {
+        const availableTransitions = this.getAvailableTransitions(transitions);
+        if (availableTransitions.length == 0) {
+          transitionResult = null;
+        } else if (availableTransitions.length == 1) {
+          transitionResult = availableTransitions[0];
+        } else if (availableTransitions.length > 1) {
+          if (this.ConfigService.isPreview()) {
+            /*
+             * we are in preview mode so we will let the user choose
+             * the branch path to go to
+             */
+            if (transitionResult != null) {
               /*
-               * we are in preview mode so we will let the user choose
-               * the branch path to go to
+               * the user has previously chosen the branch path
+               * so we will use the transition they chose and
+               * not ask them again
                */
-              if (transitionResult != null) {
-                /*
-                 * the user has previously chosen the branch path
-                 * so we will use the transition they chose and
-                 * not ask them again
-                 */
-              } else {
-                const paths = [];
-                for (const availableTransition of availableTransitions) {
-                  const toNodeId = availableTransition.to;
-                  const path = {
-                    nodeId: toNodeId,
-                    nodeTitle: this.ProjectService.getNodePositionAndTitle(toNodeId),
-                    transition: availableTransition
-                  };
-                  paths.push(path);
-                }
-                const dialogRef = this.dialog.open(ChooseBranchPathDialogComponent, {
-                  data: {
-                    paths: paths,
-                    nodeId: nodeId
-                  },
-                  disableClose: true
-                });
-                dialogRef.afterClosed().subscribe((result) => {
-                  resolve(result);
-                });
-              }
             } else {
-              /*
-               * we are in regular student run mode so we will choose
-               * the branch according to how the step was authored
-               */
-              const howToChooseAmongAvailablePaths = transitionLogic.howToChooseAmongAvailablePaths;
-              if (
-                howToChooseAmongAvailablePaths == null ||
-                howToChooseAmongAvailablePaths === '' ||
-                howToChooseAmongAvailablePaths === 'random'
-              ) {
-                // choose a random transition
-
-                const randomIndex = Math.floor(Math.random() * availableTransitions.length);
-                transitionResult = availableTransitions[randomIndex];
-              } else if (howToChooseAmongAvailablePaths === 'workgroupId') {
-                // use the workgroup id to choose the transition
-
-                const workgroupId = this.ConfigService.getWorkgroupId();
-                const index = workgroupId % availableTransitions.length;
-                transitionResult = availableTransitions[index];
-              } else if (howToChooseAmongAvailablePaths === 'firstAvailable') {
-                // choose the first available transition
-
-                transitionResult = availableTransitions[0];
-              } else if (howToChooseAmongAvailablePaths === 'lastAvailable') {
-                // choose the last available transition
-                transitionResult = availableTransitions[availableTransitions.length - 1];
+              const paths = [];
+              for (const availableTransition of availableTransitions) {
+                const toNodeId = availableTransition.to;
+                const path = {
+                  nodeId: toNodeId,
+                  nodeTitle: this.ProjectService.getNodePositionAndTitle(toNodeId),
+                  transition: availableTransition
+                };
+                paths.push(path);
               }
+              const dialogRef = this.dialog.open(ChooseBranchPathDialogComponent, {
+                data: {
+                  paths: paths,
+                  nodeId: nodeId
+                },
+                disableClose: true
+              });
+              dialogRef.afterClosed().subscribe((result) => {
+                resolve(result);
+              });
+            }
+          } else {
+            /*
+             * we are in regular student run mode so we will choose
+             * the branch according to how the step was authored
+             */
+            const howToChooseAmongAvailablePaths = transitionLogic.howToChooseAmongAvailablePaths;
+            if (
+              howToChooseAmongAvailablePaths == null ||
+              howToChooseAmongAvailablePaths === '' ||
+              howToChooseAmongAvailablePaths === 'random'
+            ) {
+              // choose a random transition
+
+              const randomIndex = Math.floor(Math.random() * availableTransitions.length);
+              transitionResult = availableTransitions[randomIndex];
+            } else if (howToChooseAmongAvailablePaths === 'workgroupId') {
+              // use the workgroup id to choose the transition
+
+              const workgroupId = this.ConfigService.getWorkgroupId();
+              const index = workgroupId % availableTransitions.length;
+              transitionResult = availableTransitions[index];
+            } else if (howToChooseAmongAvailablePaths === 'firstAvailable') {
+              // choose the first available transition
+
+              transitionResult = availableTransitions[0];
+            } else if (howToChooseAmongAvailablePaths === 'lastAvailable') {
+              // choose the last available transition
+              transitionResult = availableTransitions[availableTransitions.length - 1];
             }
           }
         }
@@ -283,18 +279,11 @@ export class NodeService {
     return promise;
   }
 
-  getAvailableTransitions(transitions: any) {
-    const availableTransitions = [];
-    for (const transition of transitions) {
-      const criteria = transition.criteria;
-      if (
-        criteria == null ||
-        (criteria != null && this.constraintService.evaluateCriterias(criteria))
-      ) {
-        availableTransitions.push(transition);
-      }
-    }
-    return availableTransitions;
+  private getAvailableTransitions(transitions: any): any[] {
+    return transitions.filter(
+      (transition) =>
+        transition.criteria == null || this.constraintService.evaluateCriterias(transition.criteria)
+    );
   }
 
   /**

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -731,26 +731,12 @@ export class ProjectService {
   /**
    * Get nodes that have a transition to the given node id
    * @param toNodeId the node id
-   * @returns an array of node objects that transition to the
-   * given node id
+   * @returns an array of node objects that transition to the given node id
    */
-  getNodesByToNodeId(toNodeId: string): any {
-    const nodesByToNodeId = [];
-    if (toNodeId != null) {
-      const nodes = this.project.nodes;
-      for (let node of nodes) {
-        if (this.nodeHasTransitionToNodeId(node, toNodeId)) {
-          nodesByToNodeId.push(node);
-        }
-      }
-      const inactiveNodes = this.getInactiveNodes();
-      for (let inactiveNode of inactiveNodes) {
-        if (this.nodeHasTransitionToNodeId(inactiveNode, toNodeId)) {
-          nodesByToNodeId.push(inactiveNode);
-        }
-      }
-    }
-    return nodesByToNodeId;
+  getNodesByToNodeId(toNodeId: string): any[] {
+    return this.project.nodes
+      .concat(this.getInactiveNodes())
+      .filter((node) => this.nodeHasTransitionToNodeId(node, toNodeId));
   }
 
   getInactiveNodes(): any {

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -878,18 +878,16 @@ export class TeacherProjectService extends ProjectService {
    * Update all the transitions that point to the group and change
    * them to point to the new start id
    */
-  updateStepTransitionsToGroup(nodeIdToInsertInside, nodeIdToInsert) {
-    const nodesThatTransitionToGroup = this.getNodesByToNodeId(nodeIdToInsertInside);
-    for (let nodeThatTransitionsToGroup of nodesThatTransitionToGroup) {
+  private updateStepTransitionsToGroup(groupId: string, nodeIdToInsert: string): void {
+    for (const nodeThatTransitionsToGroup of this.getNodesByToNodeId(groupId)) {
       if (!this.isGroupNode(nodeThatTransitionsToGroup.id)) {
-        this.updateToTransition(nodeThatTransitionsToGroup, nodeIdToInsertInside, nodeIdToInsert);
+        this.updateToTransition(nodeThatTransitionsToGroup, groupId, nodeIdToInsert);
       }
     }
   }
 
-  updateTransitionsToStartId(startId, nodeIdToInsert) {
-    const nodesThatTransitionToStartId = this.getNodesByToNodeId(startId);
-    for (let nodeThatTransitionToStartId of nodesThatTransitionToStartId) {
+  private updateTransitionsToStartId(startId: string, nodeIdToInsert: string): void {
+    for (const nodeThatTransitionToStartId of this.getNodesByToNodeId(startId)) {
       this.updateToTransition(nodeThatTransitionToStartId, startId, nodeIdToInsert);
     }
   }


### PR DESCRIPTION
## Changes
- Simplify ```TeacherProjectService.getNodesByToNodeId()``` using ```concat``` and ```filter()```
- Remove unnecessary null check in ```RemoveNodeIdFromTransitionsService.remove()```. The call to ```TeacherProjectService.getNodesByToNodeId()``` should never return an array with null element(s).
- Remove line that was never used in ```RemoveNodeIdFromTransitionsService```:
```
        // get all the nodes that have a transition to the node we are removing
        const nodesByToNodeId = this.projectService.getNodesByToNodeId(groupIdWeAreMoving);
```
- Clean up other related code

## Test
- Verify that the null check in ```RemoveNodeIdFromTransitionsService.remove()``` was really not necessary.
- These actions work as before in the AT > unit view:
   - Moving step(s)/group(s) in/between active and inactive sections
   - Deleting step(s)/group(s) in/between active and inactive sections