### PR TITLE
refactor(ProjectService): getNodesWithTransitionToNodeId()

### DIFF
--- a/src/app/services/deleteNodeService.spec.ts
+++ b/src/app/services/deleteNodeService.spec.ts
@@ -54,14 +54,14 @@ function shouldDeleteAStepFromTheProject() {
     expect(
       projectService.nodeHasTransitionToNodeId(projectService.getNodeById('node5'), 'node6')
     ).toBeTruthy();
-    expect(projectService.getNodesWithTransitionToNodeId('node6').length).toEqual(1);
+    expect(projectService.getNodesByToNodeId('node6').length).toEqual(1);
     service.deleteNode('node5');
     expect(projectService.getNodes().length).toEqual(53);
     expect(projectService.getNodeById('node5')).toBeNull();
     expect(
       projectService.nodeHasTransitionToNodeId(projectService.getNodeById('node4'), 'node6')
     ).toBeTruthy();
-    expect(projectService.getNodesWithTransitionToNodeId('node6').length).toEqual(1);
+    expect(projectService.getNodesByToNodeId('node6').length).toEqual(1);
   });
 }
 
@@ -80,10 +80,10 @@ function shouldDeleteAStepThatIsTheStartIdOfTheProject() {
   it('should delete a step that is the start id of the project', () => {
     projectService.setProject(demoProjectJSON);
     expect(projectService.getStartNodeId()).toEqual('node1');
-    expect(projectService.getNodesWithTransitionToNodeId('node2').length).toEqual(1);
+    expect(projectService.getNodesByToNodeId('node2').length).toEqual(1);
     service.deleteNode('node1');
     expect(projectService.getStartNodeId()).toEqual('node2');
-    expect(projectService.getNodesWithTransitionToNodeId('node2').length).toEqual(0);
+    expect(projectService.getNodesByToNodeId('node2').length).toEqual(0);
   });
 }
 
@@ -126,13 +126,13 @@ function shouldDeleteTheFirstActivityFromTheProject() {
     expect(projectService.getGroupStartId('group0')).toEqual('group1');
     expect(projectService.getStartNodeId()).toEqual('node1');
     expect(projectService.getNodes().length).toEqual(54);
-    expect(projectService.getNodesWithTransitionToNodeId('node20').length).toEqual(1);
+    expect(projectService.getNodesByToNodeId('node20').length).toEqual(1);
     service.deleteNode('group1');
     expect(projectService.getNodeById('group1')).toBeNull();
     expect(projectService.getGroupStartId('group0')).toEqual('group2');
     expect(projectService.getStartNodeId()).toEqual('node20');
     expect(projectService.getNodes().length).toEqual(34);
-    expect(projectService.getNodesWithTransitionToNodeId('node20').length).toEqual(0);
+    expect(projectService.getNodesByToNodeId('node20').length).toEqual(0);
   });
 }
 

--- a/src/assets/wise5/services/nodeService.ts
+++ b/src/assets/wise5/services/nodeService.ts
@@ -104,9 +104,10 @@ export class NodeService {
         }
       } else {
         // get all the nodes that transition to the current node
-        const nodeIdsByToNodeId = this.ProjectService.getNodesWithTransitionToNodeId(currentNodeId);
-        if (nodeIdsByToNodeId == null) {
-        } else if (nodeIdsByToNodeId.length === 1) {
+        const nodeIdsByToNodeId = this.ProjectService.getNodesByToNodeId(currentNodeId).map(
+          (node) => node.id
+        );
+        if (nodeIdsByToNodeId.length === 1) {
           // there is only one node that transitions to the current node
           prevNodeId = nodeIdsByToNodeId[0];
         } else if (nodeIdsByToNodeId.length > 1) {

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -770,20 +770,6 @@ export class ProjectService {
   }
 
   /**
-   * Get node ids of all the nodes that have a to transition to the given node id
-   * @param toNodeId
-   * @returns all the node ids that have a transition to the given node id
-   */
-  getNodesWithTransitionToNodeId(toNodeId: string): string[] {
-    const nodeIds = [];
-    const nodes = this.getNodesByToNodeId(toNodeId);
-    for (let node of nodes) {
-      nodeIds.push(node.id);
-    }
-    return nodeIds;
-  }
-
-  /**
    * Retrieves the project JSON from Config.projectURL and returns it.
    * If Config.projectURL is undefined, returns null.
    */


### PR DESCRIPTION
## Changes
- Remove ```ProjectService.getNodesWithTransitionToNodeId()``` and write the logic directly in ```NodeService.getPrevNodeId()```, the only place where it's used
- Remove unnecessary null check (```nodeIdsByToNodeId == null```) in ```NodeService.getPrevNodeId()```. This should always be an array.
- Update tests

## Test
- In the Student VLE, navigating to previous node works as before