### PR TITLE
refactor(TeacherProjectService): move getComponentPosition() to Node

### DIFF
--- a/src/app/services/insertComponentService.spec.ts
+++ b/src/app/services/insertComponentService.spec.ts
@@ -1,36 +1,35 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { copy } from '../../assets/wise5/common/object/object';
 import { InsertComponentService } from '../../assets/wise5/services/insertComponentService';
 import { TeacherProjectService } from '../../assets/wise5/services/teacherProjectService';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { Node } from '../../assets/wise5/common/Node';
 
 class MockProjectService {
+  getNode() {}
   getNodeById() {}
-  getComponentPosition() {}
 }
 let service: InsertComponentService;
 let projectService: TeacherProjectService;
-const NODE1 = {
-  id: 'n1',
-  components: [{ id: 'c1' }, { id: 'c2' }]
-};
 let node;
 describe('InsertComponentService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-    imports: [],
-    providers: [
+      imports: [],
+      providers: [
         InsertComponentService,
         { provide: TeacherProjectService, useClass: MockProjectService },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting()
-    ]
-});
+      ]
+    });
     service = TestBed.inject(InsertComponentService);
     projectService = TestBed.inject(TeacherProjectService);
-    node = copy(NODE1);
+    node = new Node();
+    node.id = 'n1';
+    node.components = [{ id: 'c1' }, { id: 'c2' }];
     spyOn(projectService, 'getNodeById').and.returnValue(node);
+    spyOn(projectService, 'getNode').and.returnValue(node);
   });
   insertComponents();
 });
@@ -42,7 +41,6 @@ function insertComponents() {
       expectComponentsMatchIds(node.components, ['c3', 'c4', 'c1', 'c2']);
     });
     it('should insert components after the specified component', () => {
-      spyOn(projectService, 'getComponentPosition').and.returnValue(0);
       service.insertComponents([{ id: 'c3' }, { id: 'c4' }], 'n1', 'c1');
       expectComponentsMatchIds(node.components, ['c1', 'c3', 'c4', 'c2']);
     });

--- a/src/app/services/teacherProjectService.spec.ts
+++ b/src/app/services/teacherProjectService.spec.ts
@@ -70,7 +70,6 @@ describe('TeacherProjectService', () => {
   shouldBeAbleToInsertAStepNodeInsideAGroupNode();
   shouldBeAbleToInsertAGroupNodeInsideAGroupNode();
   shouldNotBeAbleToInsertAStepNodeInsideAStepNode();
-  getComponentPosition();
   addCurrentUserToAuthors_CM_shouldAddUserInfo();
   getNodeIds();
   getInactiveNodeIds();
@@ -415,24 +414,6 @@ function insertNodeAfterInTransitions() {
   });
   it('should be able to insert an activity node after another activity node', () => {
     expectInsertNodeAfterInTransition('group1', 'group2');
-  });
-}
-
-function getComponentPosition() {
-  it('should get the component position by node id and comonent id', () => {
-    service.setProject(scootersProjectJSON);
-    const nullNodeIdResult = service.getComponentPosition(null, '57lxhwfp5r');
-    expect(nullNodeIdResult).toEqual(-1);
-    const nullComponentIdResult = service.getComponentPosition('node13', null);
-    expect(nullComponentIdResult).toEqual(-1);
-    const nodeIdDNEResult = service.getComponentPosition('badNodeId', '57lxhwfp5r');
-    expect(nodeIdDNEResult).toEqual(-1);
-    const componentIdDNEResult = service.getComponentPosition('node13', 'badComponentId');
-    expect(componentIdDNEResult).toEqual(-1);
-    const componentExists = service.getComponentPosition('node13', '57lxhwfp5r');
-    expect(componentExists).toEqual(0);
-    const componentExists2 = service.getComponentPosition('node9', 'mnzx68ix8h');
-    expect(componentExists2).toEqual(1);
   });
 }
 

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/AbstractComponentDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/AbstractComponentDataExportStrategy.ts
@@ -182,7 +182,7 @@ export abstract class AbstractComponentDataExportStrategy extends AbstractDataEx
       row,
       columnNameToNumber,
       'Component Part Number',
-      this.projectService.getComponentPosition(nodeId, component.id) + 1
+      this.projectService.getNode(nodeId).getComponentPosition(component.id) + 1
     );
     this.setColumnValue(
       row,

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/AbstractDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/AbstractDataExportStrategy.ts
@@ -183,7 +183,8 @@ export abstract class AbstractDataExportStrategy implements DataExportStrategy {
   ): string {
     const runId = this.configService.getRunId();
     const stepNumber = this.projectService.getNodePositionById(nodeId);
-    const componentNumber = this.projectService.getComponentPosition(nodeId, componentId) + 1;
+    const componentNumber =
+      this.projectService.getNode(nodeId).getComponentPosition(componentId) + 1;
     return (
       `${runId}_step_${stepNumber}_component_` +
       `${componentNumber}_${componentTypeWithUnderscore}_work.csv`

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/DiscussionComponentDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/DiscussionComponentDataExportStrategy.ts
@@ -151,7 +151,7 @@ export class DiscussionComponentDataExportStrategy extends AbstractComponentData
     row[columnNameToNumber['Node ID']] = nodeId;
     row[columnNameToNumber['Step Title']] = this.projectService.getNodePositionAndTitle(nodeId);
     row[columnNameToNumber['Component Part Number']] =
-      this.projectService.getComponentPosition(nodeId, componentId) + 1;
+      this.projectService.getNode(nodeId).getComponentPosition(componentId) + 1;
     row[columnNameToNumber['Component ID']] = component.id;
     row[columnNameToNumber['Component Type']] = component.type;
     row[columnNameToNumber['Component Prompt']] = removeHTMLTags(component.prompt);

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/EventDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/EventDataExportStrategy.ts
@@ -436,10 +436,9 @@ export class EventDataExportStrategy extends AbstractDataExportStrategy {
   }
 
   private setComponentPartNumber(row, columnNameToNumber, data) {
-    const componentPartNumber = this.projectService.getComponentPosition(
-      data.nodeId,
-      data.componentId
-    );
+    const componentPartNumber = this.projectService
+      .getNode(data.nodeId)
+      .getComponentPosition(data.componentId);
     if (componentPartNumber != -1) {
       row[columnNameToNumber['Component Part Number']] = componentPartNumber + 1;
     }

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/ExportStrategyTester.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/ExportStrategyTester.ts
@@ -12,6 +12,7 @@ import { ComponentState } from '../../../../../app/domain/componentState';
 import { Annotation } from '../../../common/Annotation';
 import { ComponentDataExportParams } from '../ComponentDataExportParams';
 import { ExportItemComponent } from '../export-item/export-item.component';
+import { Node } from '../../../common/Node';
 
 export class ExportStrategyTester {
   annotationService: AnnotationService = new AnnotationService(null, null, null);
@@ -109,9 +110,9 @@ export class ExportStrategyTester {
     spyOn(this.teacherProjectService, 'getNodePositionAndTitle').and.returnValue(
       this.nodePositionAndTitle
     );
-    spyOn(this.teacherProjectService, 'getComponentPosition').and.returnValue(
-      this.componentPosition
-    );
+    const node = new Node();
+    node.components = [{ id: this.componentId }];
+    spyOn(this.teacherProjectService, 'getNode').and.returnValue(node);
     spyOn(this.teacherProjectService, 'getProjectTitle').and.returnValue(this.projectTitle);
   }
 
@@ -151,10 +152,9 @@ export class ExportStrategyTester {
       null,
       null
     );
-    this.generateCSVFileSpy = spyOn(
-      this.componentExportStrategy,
-      'generateCSVFile'
-    ).and.callFake(() => {});
+    this.generateCSVFileSpy = spyOn(this.componentExportStrategy, 'generateCSVFile').and.callFake(
+      () => {}
+    );
     return controller;
   }
 

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/NotebookDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/NotebookDataExportStrategy.ts
@@ -84,10 +84,9 @@ export class NotebookDataExportStrategy extends AbstractDataExportStrategy {
     row[columnNameToNumber['Step Title']] = this.controller.getNodeTitleByNodeId(
       notebookItem.nodeId
     );
-    const position = this.projectService.getComponentPosition(
-      notebookItem.nodeId,
-      notebookItem.componentId
-    );
+    const position = this.projectService
+      .getNode(notebookItem.nodeId)
+      .getComponentPosition(notebookItem.componentId);
     if (position != -1) {
       row[columnNameToNumber['Component Part Number']] = position + 1;
     }

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/NotificationDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/NotificationDataExportStrategy.ts
@@ -70,10 +70,9 @@ export class NotificationDataExportStrategy extends AbstractDataExportStrategy {
     row[columnNameToNumber['Step Title']] = this.controller.getNodeTitleByNodeId(
       notification.nodeId
     );
-    const componentPosition = this.projectService.getComponentPosition(
-      notification.nodeId,
-      notification.componentId
-    );
+    const componentPosition = this.projectService
+      .getNode(notification.nodeId)
+      .getComponentPosition(notification.componentId);
     if (componentPosition != -1) {
       row[columnNameToNumber['Component Part Number']] = componentPosition + 1;
     }

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/PeerChatComponentDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/PeerChatComponentDataExportStrategy.ts
@@ -155,7 +155,7 @@ export class PeerChatComponentDataExportStrategy extends AbstractComponentDataEx
       row,
       columnNameToNumber,
       'Component Part Number',
-      this.projectService.getComponentPosition(nodeId, component.id) + 1
+      this.projectService.getNode(nodeId).getComponentPosition(component.id) + 1
     );
     this.setColumnValue(
       row,

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/StudentWorkDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/StudentWorkDataExportStrategy.ts
@@ -98,9 +98,8 @@ export class StudentWorkDataExportStrategy extends AbstractDataExportStrategy {
           this.teacherDataService.injectRevisionCounterIntoComponentStates(
             this.teacherDataService.getComponentStatesByWorkgroupId(workgroupId)
           );
-          componentStates = this.teacherDataService.getLatestComponentStatesByWorkgroupId(
-            workgroupId
-          );
+          componentStates =
+            this.teacherDataService.getLatestComponentStatesByWorkgroupId(workgroupId);
         }
         if (componentStates != null) {
           for (var c = 0; c < componentStates.length; c++) {
@@ -218,8 +217,9 @@ export class StudentWorkDataExportStrategy extends AbstractDataExportStrategy {
       componentState.nodeId
     );
     var componentPartNumber =
-      this.projectService.getComponentPosition(componentState.nodeId, componentState.componentId) +
-      1;
+      this.projectService
+        .getNode(componentState.nodeId)
+        .getComponentPosition(componentState.componentId) + 1;
     row[columnNameToNumber['Component Part Number']] = componentPartNumber;
     var component = this.projectService.getComponent(
       componentState.nodeId,
@@ -233,18 +233,15 @@ export class StudentWorkDataExportStrategy extends AbstractDataExportStrategy {
         row[columnNameToNumber['Component Prompt']] = prompt;
       }
     }
-    var teacherScoreAnnotation = this.annotationService.getLatestTeacherScoreAnnotationByStudentWorkId(
-      componentState.id
-    );
-    var teacherCommentAnnotation = this.annotationService.getLatestTeacherCommentAnnotationByStudentWorkId(
-      componentState.id
-    );
+    var teacherScoreAnnotation =
+      this.annotationService.getLatestTeacherScoreAnnotationByStudentWorkId(componentState.id);
+    var teacherCommentAnnotation =
+      this.annotationService.getLatestTeacherCommentAnnotationByStudentWorkId(componentState.id);
     var autoScoreAnnotation = this.annotationService.getLatestAutoScoreAnnotationByStudentWorkId(
       componentState.id
     );
-    var autoCommentAnnotation = this.annotationService.getLatestAutoCommentAnnotationByStudentWorkId(
-      componentState.id
-    );
+    var autoCommentAnnotation =
+      this.annotationService.getLatestAutoCommentAnnotationByStudentWorkId(componentState.id);
     if (teacherScoreAnnotation != null) {
       if (teacherScoreAnnotation.serverSaveTime != null) {
         var teacherScoreServerSaveTime = new Date(teacherScoreAnnotation.serverSaveTime);
@@ -253,9 +250,8 @@ export class StudentWorkDataExportStrategy extends AbstractDataExportStrategy {
             teacherScoreServerSaveTime.toDateString() +
             ' ' +
             teacherScoreServerSaveTime.toLocaleTimeString();
-          row[
-            columnNameToNumber['Teacher Score Server Timestamp']
-          ] = teacherScoreServerSaveTimeString;
+          row[columnNameToNumber['Teacher Score Server Timestamp']] =
+            teacherScoreServerSaveTimeString;
         }
       }
       if (teacherScoreAnnotation.clientSaveTime != null) {
@@ -265,9 +261,8 @@ export class StudentWorkDataExportStrategy extends AbstractDataExportStrategy {
             teacherScoreClientSaveTime.toDateString() +
             ' ' +
             teacherScoreClientSaveTime.toLocaleTimeString();
-          row[
-            columnNameToNumber['Teacher Score Client Timestamp']
-          ] = teacherScoreClientSaveTimeString;
+          row[columnNameToNumber['Teacher Score Client Timestamp']] =
+            teacherScoreClientSaveTimeString;
         }
       }
       var data = teacherScoreAnnotation.data;
@@ -293,9 +288,8 @@ export class StudentWorkDataExportStrategy extends AbstractDataExportStrategy {
             teacherCommentServerSaveTime.toDateString() +
             ' ' +
             teacherCommentServerSaveTime.toLocaleTimeString();
-          row[
-            columnNameToNumber['Teacher Comment Server Timestamp']
-          ] = teacherCommentServerSaveTimeString;
+          row[columnNameToNumber['Teacher Comment Server Timestamp']] =
+            teacherCommentServerSaveTimeString;
         }
       }
       if (teacherCommentAnnotation.clientSaveTime != null) {
@@ -305,9 +299,8 @@ export class StudentWorkDataExportStrategy extends AbstractDataExportStrategy {
             teacherCommentClientSaveTime.toDateString() +
             ' ' +
             teacherCommentClientSaveTime.toLocaleTimeString();
-          row[
-            columnNameToNumber['Teacher Comment Client Timestamp']
-          ] = teacherCommentClientSaveTimeString;
+          row[columnNameToNumber['Teacher Comment Client Timestamp']] =
+            teacherCommentClientSaveTimeString;
         }
       }
       var data = teacherCommentAnnotation.data;
@@ -360,9 +353,8 @@ export class StudentWorkDataExportStrategy extends AbstractDataExportStrategy {
             autoCommentServerSaveTime.toDateString() +
             ' ' +
             autoCommentServerSaveTime.toLocaleTimeString();
-          row[
-            columnNameToNumber['Auto Comment Server Timestamp']
-          ] = autoCommentServerSaveTimeString;
+          row[columnNameToNumber['Auto Comment Server Timestamp']] =
+            autoCommentServerSaveTimeString;
         }
       }
       if (autoCommentAnnotation.clientSaveTime != null) {
@@ -372,9 +364,8 @@ export class StudentWorkDataExportStrategy extends AbstractDataExportStrategy {
             autoCommentClientSaveTime.toDateString() +
             ' ' +
             autoCommentClientSaveTime.toLocaleTimeString();
-          row[
-            columnNameToNumber['Auto Comment Client Timestamp']
-          ] = autoCommentClientSaveTimeString;
+          row[columnNameToNumber['Auto Comment Client Timestamp']] =
+            autoCommentClientSaveTimeString;
         }
       }
       var data = autoCommentAnnotation.data;

--- a/src/assets/wise5/common/Node.spec.ts
+++ b/src/assets/wise5/common/Node.spec.ts
@@ -29,6 +29,7 @@ describe('Node', () => {
   getAllRelatedComponents();
   deleteTransition();
   getNumRubrics();
+  getComponentPosition();
 });
 
 function copyComponents() {
@@ -226,6 +227,16 @@ function getNumRubrics() {
       node.components[0].rubric = 'component 1 rubric';
       node.components[1].rubric = 'component 2 rubric';
       expect(node.getNumRubrics()).toEqual(3);
+    });
+  });
+}
+
+function getComponentPosition() {
+  describe('getComponentPosition()', () => {
+    it('should return index of the specified component id', () => {
+      expect(node.getComponentPosition(componentId1)).toEqual(0);
+      expect(node.getComponentPosition(componentId2)).toEqual(1);
+      expect(node.getComponentPosition('invalid_id')).toEqual(-1);
     });
   });
 }

--- a/src/assets/wise5/common/Node.ts
+++ b/src/assets/wise5/common/Node.ts
@@ -226,4 +226,8 @@ export class Node {
     ).length;
     return numRubrics;
   }
+
+  getComponentPosition(componentId: string): number {
+    return this.components.findIndex((component) => component.id === componentId);
+  }
 }

--- a/src/assets/wise5/services/insertComponentService.ts
+++ b/src/assets/wise5/services/insertComponentService.ts
@@ -17,6 +17,6 @@ export class InsertComponentService {
   private getInitialInsertPosition(nodeId: string, insertAfterComponentId: string): number {
     return insertAfterComponentId == null
       ? 0
-      : this.projectService.getComponentPosition(nodeId, insertAfterComponentId) + 1;
+      : this.projectService.getNode(nodeId).getComponentPosition(insertAfterComponentId) + 1;
   }
 }

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -1133,30 +1133,6 @@ export class TeacherProjectService extends ProjectService {
   }
 
   /**
-   * Returns the position of the component in the node by node id and
-   * component id, 0-indexed.
-   * @param nodeId the node id
-   * @param componentId the component id
-   * @returns the component's position or -1 if nodeId or componentId are null
-   * or doesn't exist in the project.
-   */
-  getComponentPosition(nodeId: string, componentId: string): number {
-    if (nodeId != null && componentId != null) {
-      const components = this.getComponents(nodeId);
-      for (let c = 0; c < components.length; c++) {
-        const tempComponent = components[c];
-        if (tempComponent != null) {
-          const tempComponentId = tempComponent.id;
-          if (componentId === tempComponentId) {
-            return c;
-          }
-        }
-      }
-    }
-    return -1;
-  }
-
-  /**
    * Update the transitions so that the fromGroup points to the newToGroup
    *
    * Before


### PR DESCRIPTION
## Changes
- Move ```TeacherProjectService.getComponentPosition()``` to ```Node.getComponentPosition()```. The new call is ```projectService.getNode().getComponentPosition()```. This better encapsulates the data.
- Clean up ```Node.getComponentPosition()``` using ```findIndex()```
- Update references and tests

## Test
- In AT > edit step view, try importing component(s) at the beginning and after existing components.
- In CM > Data export, try exporting few of these and verify that the "Component Part Number" column looks correct
   - Student Work
   - Events
   - Notifications
   - Item Data > Open Response
   - Item Data > Peer Chat