### PR TITLE
fix(Multilingual Unit): Component content doesn't update when changing language

### DIFF
--- a/src/assets/wise5/vle/node/node.component.html
+++ b/src/assets/wise5/vle/node/node.component.html
@@ -9,7 +9,7 @@
         <help-icon [content]="node.rubric" label="Step Info" i18n-label icon="info" />
       </div>
     }
-    @for (component of components; track component.id) {
+    @for (component of components; track component) {
       <div
         id="component_{{ component.id }}"
         class="component"


### PR DESCRIPTION
This broke when we converted Node to standalone. When we started tracking by "component.id" in the for loop, even though the content changed, angular didn't detect the change.

## Changes
- Fix for the above

## Test
- Component content translations should update immediately when switching to another language
- Single-language units should work as before

Closes #1936 
