### PR TITLE
fix(CM): Pausing/unpausing lessons does not persist to DB

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.spec.ts
@@ -40,6 +40,9 @@ class MockTeacherProjectService {
   isGroupNode() {}
   nodeHasWork() {}
   getMaxScoreForNode() {}
+  getNodeById() {
+    return { constraints: [] };
+  }
   getNode() {
     return new Node();
   }
@@ -121,7 +124,7 @@ function toggleLockNode() {
     });
     describe('when there is no teacherRemovalConstraint', () => {
       it('should add constraint', () => {
-        const getNodeSpy = spyOn(projectService, 'getNode').and.returnValue(node1);
+        const getNodeSpy = spyOn(projectService, 'getNodeById').and.returnValue(node1);
         expect(node1.constraints.length).toEqual(0);
         lockNodeButton.click();
         expect(getNodeSpy).toHaveBeenCalled();
@@ -141,7 +144,7 @@ function toggleLockNode() {
             Object({ name: 'teacherRemoval', params: Object({ periodId: periodId }) })
           ]
         });
-        const getNodeSpy = spyOn(projectService, 'getNode').and.returnValue(node1);
+        const getNodeSpy = spyOn(projectService, 'getNodeById').and.returnValue(node1);
         const dataService = TestBed.inject(TeacherDataService);
         const currentPeriodSpy = spyOn(dataService, 'getCurrentPeriod').and.returnValue({
           periodId: periodId

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts
@@ -187,7 +187,7 @@ export class NavItemComponent implements OnInit {
   }
 
   isLocked(): boolean {
-    const constraints = this.projectService.getNode(this.nodeId).constraints;
+    const constraints = this.projectService.getNodeById(this.nodeId).constraints ?? [];
     return (
       (this.isShowingAllPeriods() && this.isLockedForAll(constraints)) ||
       (!this.isShowingAllPeriods() &&
@@ -218,7 +218,7 @@ export class NavItemComponent implements OnInit {
   }
 
   protected toggleLockNode(): void {
-    const node = this.projectService.getNode(this.nodeId);
+    const node = this.projectService.getNodeById(this.nodeId);
     const isLocked = this.isLocked();
     if (isLocked) {
       this.unlockNode(node);
@@ -270,7 +270,10 @@ export class NavItemComponent implements OnInit {
         }
       ]
     };
-    node.addConstraint(lockConstraint);
+    if (node.constraints == null) {
+      node.constraints = [];
+    }
+    node.constraints.push(lockConstraint);
   }
 
   private unlockNodeForAllPeriods(node: Node): void {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -14218,7 +14218,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>All Periods</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts</context>
-          <context context-type="linenumber">371</context>
+          <context context-type="linenumber">374</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component.ts</context>
@@ -14233,7 +14233,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Period: <x id="PH" equiv-text="this.currentPeriod.periodName"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts</context>
-          <context context-type="linenumber">372</context>
+          <context context-type="linenumber">375</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component.ts</context>
@@ -14244,14 +14244,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Unlock for <x id="PH" equiv-text="this.getPeriodLabel()"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts</context>
-          <context context-type="linenumber">377</context>
+          <context context-type="linenumber">380</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2330813372531032088" datatype="html">
         <source>Lock for <x id="PH" equiv-text="this.getPeriodLabel()"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeProgress/nav-item/nav-item.component.ts</context>
-          <context context-type="linenumber">378</context>
+          <context context-type="linenumber">381</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5411ee1bc7179f254f2db73cf448e995fca45f43" datatype="html">


### PR DESCRIPTION
## Changes
- Changed to get node that is in the project JSON. The changes weren't persisting because we were working with the Node object, which did not sync back to the project JSON.

## Test
- Pause/unpausing lessons should persist after refreshing