### PR TITLE
Fix unit icon URL and Chinese filenames not auto-completing URLs.

### DIFF
--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.ts
@@ -129,7 +129,7 @@ export class ProjectInfoAuthoringComponent {
 
   protected setFeaturedProjectIcon(projectIcon: string): void {
     this.projectService.setFeaturedProjectIcon(projectIcon).then(() => {
-      this.projectIcon = `projectIcons/${projectIcon}`;
+      this.projectIcon = `/projectIcons/${projectIcon}`;
       this.showProjectIcon();
       this.closeEditProjectIconMode();
     });

--- a/src/assets/wise5/services/projectService.ts
+++ b/src/assets/wise5/services/projectService.ts
@@ -443,7 +443,7 @@ export class ProjectService {
       // note that this also works for \"abc.png and \'abc.png, where the quotes are escaped
       contentString = contentString.replace(
         new RegExp(
-          "('|\"|\\\\'|\\\\\")[^:][^/]?[^/]?[a-zA-Z0-9@%&;\\._\\/\\s\\-']*[.]" +
+          "('|\"|\\\\'|\\\\\")[^:][^/]?[^/]?[a-zA-Z0-9\u4e00-\u9fa5@%&;\\._\\/\\s\\-']*[.]" +
             '(png|jpe?g|pdf|gif|mov|mp4|mp3|wav|swf|css|txt|json|xlsx?|doc|html.*?|js).*?' +
             '(\'|"|\\\\\'|\\\\")',
           'gi'


### PR DESCRIPTION
## Changes
1. Updated the `setFeaturedProjectIcon` method in `project-info-authoring.component.ts` to correctly construct the unit icon URL.
2. Modified the regex in `projectService.ts` to support Chinese characters in filenames.

## Test
 - I haven’t had the chance to fully test these changes. Could you please help by verifying the following?
 Thank you!

## Pic
 - Attached is a screenshot illustrating the original issue with the incorrect unit icon URL and the URL auto-completion for Chinese filenames.

1. 
 ![image](https://github.com/user-attachments/assets/512ade55-de79-4c62-bfe5-ca6c96f79a33)

2. 
 ![image](https://github.com/user-attachments/assets/1e1acc11-ef63-4b48-9677-8c71505455ad)
