### PR TITLE
feat(a11y): Add keyboard accessibility to AT unit home

### DIFF
--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -65,6 +65,7 @@ import { PreviewComponentButtonComponent } from '../../assets/wise5/authoringToo
 import { StepToolsComponent } from '../../assets/wise5/common/stepTools/step-tools.component';
 import { EditBranchComponent } from '../../assets/wise5/authoringTool/edit-branch/edit-branch.component';
 import { ComponentTypeButtonComponent } from '../../assets/wise5/authoringTool/components/component-type-button/component-type-button.component';
+import { MatExpansionModule } from '@angular/material/expansion';
 
 @NgModule({
   declarations: [
@@ -119,6 +120,7 @@ import { ComponentTypeButtonComponent } from '../../assets/wise5/authoringTool/c
     EditNodeTitleComponent,
     MatBadgeModule,
     MatChipsModule,
+    MatExpansionModule,
     ImportComponentModule,
     NgSelectModule,
     NodeAdvancedAuthoringModule,

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -1,32 +1,29 @@
-<div id="{{ lesson.id }}" class="lesson" [ngClass]="{ 'lesson-collapsed': !expanded }">
-  <div
-    (click)="toggleExpanded()"
-    class="lesson-bar full-width pointer"
-    fxLayout="row wrap"
-    fxLayoutAlign="start center"
-  >
-    <mat-checkbox
-      color="primary"
-      (change)="selectNode($event.checked)"
-      (click)="$event.stopPropagation()"
-      [disabled]="nodeTypeSelected() === 'step'"
-      aria-label="Select lesson"
-      i18n-aria-label
-    >
-      <node-icon-and-title [nodeId]="lesson.id" [showPosition]="showPosition" />
-    </mat-checkbox>
-    <div
-      class="lesson-expand-collapse-div"
-      matTooltip="Click to expand/collapse lesson"
-      matTooltipPosition="above"
-      i18n-matTooltip
-    ></div>
-    <div class="lesson-buttons" [ngClass]="{ 'lesson-expanded': expanded }" fxLayoutGap="8px">
+<mat-expansion-panel
+  [expanded]="expanded"
+  class="lesson"
+  (opened)="toggleExpanded(true)"
+  (closed)="toggleExpanded(false)"
+>
+  <mat-expansion-panel-header aria-label="Expand/collapse lesson" i18n-aria-label>
+    <mat-panel-title>
+      <mat-checkbox
+        color="primary"
+        (change)="selectNode($event.checked)"
+        (click)="$event.stopPropagation()"
+        (keydown)="$event.stopPropagation()"
+        [disabled]="nodeTypeSelected() === 'step'"
+        aria-label="Select lesson"
+        i18n-aria-label
+      >
+        <node-icon-and-title [nodeId]="lesson.id" [showPosition]="showPosition" />
+      </mat-checkbox>
+    </mat-panel-title>
+    <mat-panel-description class="text" fxLayoutAlign="end center" fxLayoutGap="4px">
       <button
         class="enable-in-translation"
         mat-icon-button
-        (click)="setCurrentNode(lesson.id)"
-        color="primary"
+        (click)="$event.stopPropagation(); setCurrentNode(lesson.id)"
+        (keydown)="$event.stopPropagation()"
         matTooltip="Edit lesson"
         matTooltipPosition="above"
         i18n-matTooltip
@@ -36,7 +33,7 @@
       <button
         mat-icon-button
         (click)="$event.stopPropagation(); move()"
-        color="primary"
+        (keydown)="$event.stopPropagation()"
         matTooltip="Move lesson"
         matTooltipPosition="above"
         i18n-matTooltip
@@ -46,30 +43,17 @@
       <button
         mat-icon-button
         (click)="$event.stopPropagation(); delete()"
-        color="primary"
+        (keydown)="$event.stopPropagation()"
         matTooltip="Delete lesson"
         matTooltipPosition="above"
         i18n-matTooltip
       >
         <mat-icon>delete</mat-icon>
       </button>
-    </div>
-    <div class="expand-collapse-icon">
-      <div *ngIf="!expanded" fxLayoutAlign="center center">
-        <mat-icon>expand_more</mat-icon>
-      </div>
-      <div *ngIf="expanded" fxLayoutAlign="center center">
-        <mat-icon>expand_less</mat-icon>
-      </div>
-    </div>
-  </div>
-  <div *ngIf="expanded" fxLayout="column">
-    <div
-      *ngFor="let childId of lesson.ids"
-      class="step-div"
-      fxLayout="row wrap"
-      fxLayoutAlign="start center"
-    >
+    </mat-panel-description>
+  </mat-expansion-panel-header>
+  <div>
+    <div *ngFor="let childId of lesson.ids" fxLayout="row wrap" fxLayoutAlign="start center">
       <project-authoring-step
         [step]="idToNode[childId]"
         (selectNodeEvent)="selectNodeEvent.emit($event)"
@@ -93,4 +77,4 @@
       </button>
     </div>
   </div>
-</div>
+</mat-expansion-panel>

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.scss
@@ -1,53 +1,23 @@
 .lesson {
-  padding: 8px;
-  margin: 16px 0px;
-  border: 2px solid #dddddd;
-  border-radius: 6px;
-  position: relative;
-}
-
-.lesson:hover {
-  &.lesson-collapsed {
-    background-color: #add8e6;
+  .mat-expansion-panel-header {
+    padding-inline-start: 8px;
   }
-}
 
-.lesson:hover .lesson-buttons {
-  display: block;
-}
-
-.lesson-bar {
-  height: 40px;
-}
-
-.full-width {
-  width: 100%;
-}
-
-.pointer {
-  cursor: pointer;
-}
-
-.lesson-expand-collapse-div {
-  flex-grow: 1;
-  align-self: stretch;
-}
-
-.lesson-buttons {
-  margin-right: 8px;
-  display: none;
-
-  &.lesson-expanded {
-    display: block;
+  .mat-expansion-panel-body {
+    padding-left: 8px;
+    padding-right: 8px;
   }
-}
 
-.expand-collapse-icon {
-  width: 40px;
-  margin-right: 10px;
-}
+  .lesson-bar {
+    height: 40px;
+  }
 
-.no-steps-message {
-  height: 40px;
-  margin-left: 40px;
+  .full-width {
+    width: 100%;
+  }
+
+  .no-steps-message {
+    height: 40px;
+    margin-left: 40px;
+  }
 }

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
@@ -12,8 +12,6 @@ import { NodeIconAndTitleComponent } from '../choose-node-location/node-icon-and
 import { FormsModule } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
 import { ProjectAuthoringStepComponent } from '../project-authoring-step/project-authoring-step.component';
-import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ProjectAuthoringLessonHarness } from './project-authoring-lesson.harness';
 import { DeleteNodeService } from '../../services/deleteNodeService';
 import { CopyNodesService } from '../../services/copyNodesService';
 import { MatMenuModule } from '@angular/material/menu';
@@ -24,11 +22,12 @@ import { CopyTranslationsService } from '../../services/copyTranslationsService'
 import { TeacherProjectTranslationService } from '../../services/teacherProjectTranslationService';
 import { RemoveNodeIdFromTransitionsService } from '../../services/removeNodeIdFromTransitionsService';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 let component: ProjectAuthoringLessonComponent;
 let fixture: ComponentFixture<ProjectAuthoringLessonComponent>;
 const groupId1 = 'group1';
-let harness: ProjectAuthoringLessonHarness;
 const nodeId1 = 'node1';
 const nodeId2 = 'node2';
 let teacherProjectService: TeacherProjectService;
@@ -49,9 +48,11 @@ describe('ProjectAuthoringLessonComponent', () => {
       declarations: [ProjectAuthoringLessonComponent, ProjectAuthoringStepComponent],
       imports: [
         AddStepButtonComponent,
+        BrowserAnimationsModule,
         FormsModule,
         MatCheckboxModule,
         MatDialogModule,
+        MatExpansionModule,
         MatIconModule,
         MatMenuModule,
         NodeIconAndTitleComponent,
@@ -85,40 +86,9 @@ describe('ProjectAuthoringLessonComponent', () => {
     component = fixture.componentInstance;
     component.lesson = group1;
     fixture.detectChanges();
-    harness = await TestbedHarnessEnvironment.harnessForFixture(
-      fixture,
-      ProjectAuthoringLessonHarness
-    );
   });
 
-  lessonIsExpanded_clickCollapseButton_hideSteps();
-  lessonIsCollapsed_clickExpandButton_showSteps();
+  it('creates', () => {
+    expect(component).toBeTruthy();
+  });
 });
-
-function lessonIsExpanded_clickCollapseButton_hideSteps() {
-  describe('lesson is expanded', () => {
-    describe('lesson div is clicked', () => {
-      it('hides steps', async () => {
-        component.expanded = true;
-        (await harness.getExpandCollapseDiv()).click();
-        expect(component.expanded).toBeFalse();
-        const steps = await harness.getSteps();
-        expect(steps.length).toEqual(0);
-      });
-    });
-  });
-}
-
-function lessonIsCollapsed_clickExpandButton_showSteps() {
-  describe('lesson is collapsed', () => {
-    describe('lesson div is clicked', () => {
-      it('shows steps', async () => {
-        component.expanded = false;
-        (await harness.getExpandCollapseDiv()).click();
-        expect(component.expanded).toBeTrue();
-        const steps = await harness.getSteps();
-        expect(steps.length).toEqual(2);
-      });
-    });
-  });
-}

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, Signal } from '@angular/core';
+import { Component, EventEmitter, Input, Output, Signal, ViewEncapsulation } from '@angular/core';
 import { TeacherDataService } from '../../services/teacherDataService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { SelectNodeEvent } from '../domain/select-node-event';
@@ -12,7 +12,8 @@ import { AddStepTarget } from '../../../../app/domain/addStepTarget';
 @Component({
   selector: 'project-authoring-lesson',
   templateUrl: './project-authoring-lesson.component.html',
-  styleUrls: ['./project-authoring-lesson.component.scss']
+  styleUrls: ['./project-authoring-lesson.component.scss'],
+  encapsulation: ViewEncapsulation.None
 })
 export class ProjectAuthoringLessonComponent {
   @Input() expanded: boolean = true;
@@ -47,8 +48,8 @@ export class ProjectAuthoringLessonComponent {
     this.dataService.setCurrentNodeByNodeId(nodeId);
   }
 
-  protected toggleExpanded(): void {
-    this.expanded = !this.expanded;
+  protected toggleExpanded(opened: boolean = true): void {
+    this.expanded = opened;
     this.onExpandedChanged.emit({ id: this.lesson.id, expanded: this.expanded });
   }
 

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.harness.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.harness.ts
@@ -4,7 +4,6 @@ import {
   ProjectAuthoringNodeHarness,
   ProjectAuthoringNodeHarnessFilters
 } from '../project-authoring/project-authoring-node.harness';
-
 import { MatExpansionPanelHarness } from '@angular/material/expansion/testing';
 
 export class ProjectAuthoringLessonHarness extends ProjectAuthoringNodeHarness {

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.harness.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.harness.ts
@@ -5,10 +5,11 @@ import {
   ProjectAuthoringNodeHarnessFilters
 } from '../project-authoring/project-authoring-node.harness';
 
+import { MatExpansionPanelHarness } from '@angular/material/expansion/testing';
+
 export class ProjectAuthoringLessonHarness extends ProjectAuthoringNodeHarness {
   static hostSelector = 'project-authoring-lesson';
-  getExpandCollapseDiv = this.locatorFor('.lesson-expand-collapse-div');
-  getExpandCollapseIcon = this.locatorFor('.expand-collapse-icon .mat-icon');
+  getLesson = this.locatorFor(MatExpansionPanelHarness);
   getSteps = this.locatorForAll(ProjectAuthoringStepHarness);
 
   static with(
@@ -24,10 +25,10 @@ export class ProjectAuthoringLessonHarness extends ProjectAuthoringNodeHarness {
   }
 
   async isExpanded(): Promise<boolean> {
-    return (await (await this.getExpandCollapseIcon()).text()) === 'expand_less';
+    return (await (await this.getLesson()).isExpanded()) === true;
   }
 
   async isCollapsed(): Promise<boolean> {
-    return (await (await this.getExpandCollapseIcon()).text()) === 'expand_more';
+    return (await (await this.getLesson()).isExpanded()) === false;
   }
 }

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
@@ -1,12 +1,16 @@
 <div
   id="{{ step.id }}"
   fxLayoutAlign="start center"
-  fxLayoutGap="10px"
-  class="step pointer"
+  fxLayoutGap="8px"
+  class="step"
   [ngClass]="{ 'branch-path-step': isNodeInAnyBranchPath(step.id) }"
   [ngStyle]="{ 'background-color': getStepBackgroundColor(step.id) }"
   (click)="setCurrentNode(step.id)"
+  (keyup.enter)="setCurrentNode(step.id)"
   role="button"
+  tabindex="0"
+  aria-label="Edit step"
+  i18n-aria-label
 >
   <mat-checkbox
     color="primary"
@@ -32,63 +36,66 @@
         <mat-icon class="rotate-180">call_split</mat-icon>
       </button>
     }
-    <mat-icon
+    <button
       *ngIf="nodeHasConstraint(step.id)"
+      mat-icon-button
       (click)="constraintIconClicked(step.id); $event.stopPropagation()"
       matTooltip="{{ getNumberOfConstraintsOnNode(step.id) }} Constraint(s) {{
         getConstraintDescriptions(step.id)
       }}"
       matTooltipPosition="right"
       i18n-matTooltip
-      >block</mat-icon
     >
+      <mat-icon>block</mat-icon>
+    </button>
     <mat-icon
       *ngIf="nodeHasRubric(step.id)"
-      matTooltip="Has Rubric"
-      matTooltipPosition="right"
+      tabindex="0"
+      matTooltip="Has rubric/teaching tips"
+      matTooltipPosition="above"
       i18n-matTooltip
       >message</mat-icon
     >
   </div>
   <div
-    class="step-click-to-enter-div"
-    matTooltip="Click to enter step"
+    fxFlex
+    class="tooltip-helper"
+    matTooltip="Edit step"
     matTooltipPosition="above"
     i18n-matTooltip
-    fxFlex
   ></div>
-  <div class="dynamic-step-buttons">
-    <div fxLayoutAlign="start center">
-      <button
-        mat-icon-button
-        (click)="move(); $event.stopPropagation()"
-        color="primary"
-        matTooltip="Move step"
-        matTooltipPosition="above"
-        i18n-matTooltip
-      >
-        <mat-icon>redo</mat-icon>
-      </button>
-      <button
-        mat-icon-button
-        (click)="copy(); $event.stopPropagation()"
-        color="primary"
-        matTooltip="Copy step"
-        matTooltipPosition="above"
-        i18n-matTooltip
-      >
-        <mat-icon>content_copy</mat-icon>
-      </button>
-      <button
-        mat-icon-button
-        (click)="delete(); $event.stopPropagation()"
-        color="primary"
-        matTooltip="Delete step"
-        matTooltipPosition="above"
-        i18n-matTooltip
-      >
-        <mat-icon>delete</mat-icon>
-      </button>
-    </div>
+  <!-- <div class="dynamic-step-buttons"> -->
+  <div fxLayoutAlign="start center">
+    <button
+      class="step-action"
+      mat-icon-button
+      (click)="move(); $event.stopPropagation()"
+      matTooltip="Move step"
+      matTooltipPosition="above"
+      i18n-matTooltip
+    >
+      <mat-icon>redo</mat-icon>
+    </button>
+    <button
+      class="step-action"
+      mat-icon-button
+      (click)="copy(); $event.stopPropagation()"
+      matTooltip="Copy step"
+      matTooltipPosition="above"
+      i18n-matTooltip
+    >
+      <mat-icon>content_copy</mat-icon>
+    </button>
+    <button
+      class="step-action"
+      mat-icon-button
+      (click)="delete(); $event.stopPropagation()"
+      matTooltip="Delete step"
+      matTooltipPosition="above"
+      i18n-matTooltip
+    >
+      <mat-icon>delete</mat-icon>
+    </button>
   </div>
+  <!-- </div> -->
 </div>

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.scss
@@ -1,10 +1,11 @@
 .step {
   height: 50px;
   padding: 4px;
-  margin: 4px 10px 4px 30px;
+  margin: 4px 4px 4px 30px;
   border: 2px solid #dddddd;
   border-radius: 6px;
   position: relative;
+  cursor: pointer;
 }
 
 .step:hover {
@@ -15,25 +16,20 @@
   margin-left: 55px !important;
 }
 
-.pointer {
-  cursor: pointer;
-}
-
-.dynamic-step-buttons {
+.step-action {
   display: none;
 }
 
-.step:hover, .step:focus {
-  .dynamic-step-buttons {
+.step:hover, .step:focus-within {
+  .step-action {
     display: block;
   }
-}
-
-.step-click-to-enter-div {
-  flex-grow: 1;
-  align-self: stretch;
-}
+}                       
 
 .rotate-180 {
   transform: rotate(180deg);
+}
+
+.tooltip-helper {
+  height: 100%;
 }

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
@@ -112,10 +112,12 @@ export class ProjectAuthoringStepComponent {
   }
 
   protected constraintIconClicked(nodeId: string): void {
-    this.dataService.setCurrentNodeByNodeId(nodeId);
-    this.router.navigate([
-      `/teacher/edit/unit/${this.projectId}/node/${nodeId}/advanced/constraint`
-    ]);
+    if (!this.isNodeInAnyBranchPath(nodeId)) {
+      this.dataService.setCurrentNodeByNodeId(nodeId);
+      this.router.navigate([
+        `/teacher/edit/unit/${this.projectId}/node/${nodeId}/advanced/constraint`
+      ]);
+    }
   }
 
   protected goToEditBranch(nodeId: string): void {

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -1,4 +1,4 @@
-<div class="project-content" fxLayout="row wrap" fxLayoutGap="15px">
+<div class="project-content" fxLayout="row wrap" fxLayoutGap="16px">
   <button
     mat-raised-button
     color="primary"
@@ -54,12 +54,12 @@
     - Collapse All
   </button>
 </div>
-<div class="all-nodes-div">
+<div class="all-nodes-div" fxLayout="column" fxLayoutGap="8px">
   <div *ngIf="lessons.length === 0" fxLayout="row" fxLayoutAlign="start center">
     <div i18n>There are no lessons</div>
     <add-lesson-button [active]="true"></add-lesson-button>
   </div>
-  <div *ngFor="let lesson of lessons; let first = first" fxLayout="row">
+  <div *ngFor="let lesson of lessons; let first = first" fxLayout="row" fxLayoutGap="4px">
     <project-authoring-lesson
       [lesson]="lesson"
       (selectNodeEvent)="selectNode($event)"
@@ -69,12 +69,7 @@
       (onExpandedChanged)="onExpandedChanged($event)"
       fxFlex
     ></project-authoring-lesson>
-    <add-lesson-button
-      class="add-lesson-button-next-to-lesson"
-      [active]="true"
-      [first]="first"
-      [lessonId]="lesson.id"
-    ></add-lesson-button>
+    <add-lesson-button [active]="true" [first]="first" [lessonId]="lesson.id"></add-lesson-button>
   </div>
   <div>
     <h6 class="unused-header" i18n>Unused Lessons</h6>
@@ -82,21 +77,23 @@
       <div i18n>There are no unused lessons</div>
       <add-lesson-button></add-lesson-button>
     </div>
-    <div *ngFor="let inactiveGroupNode of inactiveGroupNodes; let first = first" fxLayout="row">
-      <project-authoring-lesson
-        [lesson]="inactiveGroupNode"
-        (selectNodeEvent)="selectNode($event)"
-        [showPosition]="false"
-        [projectId]="projectId"
-        [expanded]="lessonIdToExpanded()[inactiveGroupNode.id]"
-        (onExpandedChanged)="onExpandedChanged($event)"
-        fxFlex
-      ></project-authoring-lesson>
-      <add-lesson-button
-        class="add-lesson-button-next-to-lesson"
-        [first]="first"
-        [lessonId]="inactiveGroupNode.id"
-      ></add-lesson-button>
+    <div fxLayout="column" fxLayoutGap="8px">
+      <div
+        *ngFor="let inactiveGroupNode of inactiveGroupNodes; let first = first"
+        fxLayout="row"
+        fxLayoutGap="4px"
+      >
+        <project-authoring-lesson
+          [lesson]="inactiveGroupNode"
+          (selectNodeEvent)="selectNode($event)"
+          [showPosition]="false"
+          [projectId]="projectId"
+          [expanded]="lessonIdToExpanded()[inactiveGroupNode.id]"
+          (onExpandedChanged)="onExpandedChanged($event)"
+          fxFlex
+        ></project-authoring-lesson>
+        <add-lesson-button [first]="first" [lessonId]="inactiveGroupNode.id"></add-lesson-button>
+      </div>
     </div>
     <div>
       <h6 class="unused-header" i18n>Unused Steps</h6>

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.scss
@@ -36,7 +36,3 @@
 .mat-icon {
   margin: 0px;
 }
-
-.add-lesson-button-next-to-lesson {
-  margin-top: 20px;
-}

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.spec.ts
@@ -39,6 +39,7 @@ import { DeleteTranslationsService } from '../../services/deleteTranslationsServ
 import { CopyTranslationsService } from '../../services/copyTranslationsService';
 import { TeacherProjectTranslationService } from '../../services/teacherProjectTranslationService';
 import { RemoveNodeIdFromTransitionsService } from '../../services/removeNodeIdFromTransitionsService';
+import { MatExpansionModule } from '@angular/material/expansion';
 
 let configService: ConfigService;
 let component: ProjectAuthoringComponent;
@@ -68,6 +69,7 @@ describe('ProjectAuthoringComponent', () => {
         MatButtonModule,
         MatCheckboxModule,
         MatDialogModule,
+        MatExpansionModule,
         MatFormFieldModule,
         MatIconModule,
         MatInputModule,

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -1,4 +1,13 @@
-import { Component, Input, OnInit, Signal, WritableSignal, computed, signal } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnInit,
+  Signal,
+  ViewChild,
+  WritableSignal,
+  computed,
+  signal
+} from '@angular/core';
 import { DeleteNodeService } from '../../services/deleteNodeService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { TeacherDataService } from '../../services/teacherDataService';
@@ -12,6 +21,7 @@ import { ExpandEvent } from '../domain/expand-event';
 import { DeleteTranslationsService } from '../../services/deleteTranslationsService';
 import { ComponentContent } from '../../common/ComponentContent';
 import { copy } from '../../common/object/object';
+import { MatExpansionPanel } from '@angular/material/expansion';
 
 @Component({
   selector: 'project-authoring',
@@ -33,6 +43,7 @@ export class ProjectAuthoringComponent implements OnInit {
   protected lessonIdToExpanded: WritableSignal<{ [key: string]: boolean }> = signal({});
   protected nodeIdToChecked: any = {};
   protected nodeTypeSelected: Signal<NodeTypeSelected>;
+  @ViewChild('panel') panel: MatExpansionPanel;
   @Input('unitId') protected projectId?: number;
   private subscriptions: Subscription = new Subscription();
 

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -1,13 +1,4 @@
-import {
-  Component,
-  Input,
-  OnInit,
-  Signal,
-  ViewChild,
-  WritableSignal,
-  computed,
-  signal
-} from '@angular/core';
+import { Component, Input, OnInit, Signal, WritableSignal, computed, signal } from '@angular/core';
 import { DeleteNodeService } from '../../services/deleteNodeService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { TeacherDataService } from '../../services/teacherDataService';
@@ -21,7 +12,6 @@ import { ExpandEvent } from '../domain/expand-event';
 import { DeleteTranslationsService } from '../../services/deleteTranslationsService';
 import { ComponentContent } from '../../common/ComponentContent';
 import { copy } from '../../common/object/object';
-import { MatExpansionPanel } from '@angular/material/expansion';
 
 @Component({
   selector: 'project-authoring',
@@ -43,7 +33,6 @@ export class ProjectAuthoringComponent implements OnInit {
   protected lessonIdToExpanded: WritableSignal<{ [key: string]: boolean }> = signal({});
   protected nodeIdToChecked: any = {};
   protected nodeTypeSelected: Signal<NodeTypeSelected>;
-  @ViewChild('panel') panel: MatExpansionPanel;
   @Input('unitId') protected projectId?: number;
   private subscriptions: Subscription = new Subscription();
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13040,7 +13040,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>Are you sure you want to delete the <x id="PH" equiv-text="selectedNodeIds.length"/> selected item(s)?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">102</context>
+          <context context-type="linenumber">91</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e8fb2ceb6f8d4c3e90a6a688e9024461e67f44f0" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9572,7 +9572,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">88</context>
+          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="abeeca08450df34a78cb591b634d6d16ef5b7dad" datatype="html">
@@ -10155,7 +10155,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8fa7f8678048f0ed8a8c670b4348e2a2c709af33" datatype="html">
@@ -10181,7 +10181,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">102</context>
+          <context context-type="linenumber">99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0217500199a3e48a7b95762b14b79dad49e76beb" datatype="html">
@@ -12874,52 +12874,63 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">235</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="aa1e9403a7628338251b1d3e4e6e83d80d5f397a" datatype="html">
+        <source>Expand/collapse lesson</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="6ab64ec395f796b771a2d87d2801d0fe60b871d2" datatype="html">
         <source>Select lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">13</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="ad6affd1feb3803d26ea4c21021ad6d25b1fba13" datatype="html">
-        <source>Click to expand/collapse lesson</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">15</context>
         </context-group>
       </trans-unit>
       <trans-unit id="17da2a2b5dd4e012d364db7471ae1343b4a3266b" datatype="html">
         <source>Edit lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="05a0c6b8f78fc9a1bbfd393727abbd5a8b6e6b72" datatype="html">
         <source>Move lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">40</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d6d3fff4f6ea9c446190a02ed693facc711812fd" datatype="html">
         <source>Delete lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">47</context>
         </context-group>
       </trans-unit>
       <trans-unit id="66084384cb169b4f9d7836c16f37b8b9dfc5a049" datatype="html">
         <source>This lesson has no steps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">83</context>
+          <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2751426191436053350" datatype="html">
         <source>Are you sure you want to delete this lesson?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="9191ef5742cae8e0baaa9b0dc73d11c8525f19c3" datatype="html">
+        <source>Edit step</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
           <context context-type="linenumber">63</context>
         </context-group>
       </trans-unit>
@@ -12927,7 +12938,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>Select step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">16</context>
+          <context context-type="linenumber">20</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d01434f6aa648b854ae7dc927a315142b1e8c791" datatype="html">
@@ -12936,7 +12947,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">26,28</context>
+          <context context-type="linenumber">30,32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5d897973ca9256c890caa2df3c41e11f31b84166" datatype="html">
@@ -12945,49 +12956,42 @@ The branches will be removed but the steps will remain in the unit.</source>
       }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">38,40</context>
+          <context context-type="linenumber">43,45</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="b3b4847175a6193afa85eb431bbe16d1f04470fa" datatype="html">
-        <source>Has Rubric</source>
+      <trans-unit id="1279cec0fd1a831b632a6cfa52918641dc79b488" datatype="html">
+        <source>Has rubric/teaching tips</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">47</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="86b684959993240cec0e9ff07ca51d8b3dedbb75" datatype="html">
-        <source>Click to enter step</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">55</context>
+          <context context-type="linenumber">54</context>
         </context-group>
       </trans-unit>
       <trans-unit id="755e89f2e7a2ffda09056f509222d0e405820e4d" datatype="html">
         <source>Move step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">73</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6e3d4bf4bfb1dd3195c4e1d59b0fdbacd1d68db4" datatype="html">
         <source>Copy step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">83</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0faf7dd5b826ee951da05aaad4063e8794de757b" datatype="html">
         <source>Delete step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">86</context>
+          <context context-type="linenumber">93</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8656136323789683230" datatype="html">
         <source>Are you sure you want to delete this step?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts</context>
-          <context context-type="linenumber">144</context>
+          <context context-type="linenumber">146</context>
         </context-group>
       </trans-unit>
       <trans-unit id="57cf305f9bfd681c70dc26e914108d06384ade9f" datatype="html">
@@ -13022,21 +13026,21 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>There are no unused lessons</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">82</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1f244812aec621e93ca22f9e72ba88ffe13bb354" datatype="html">
         <source>There are no unused steps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">103</context>
+          <context context-type="linenumber">100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5775641662261420108" datatype="html">
         <source>Are you sure you want to delete the <x id="PH" equiv-text="selectedNodeIds.length"/> selected item(s)?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">91</context>
+          <context context-type="linenumber">102</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e8fb2ceb6f8d4c3e90a6a688e9024461e67f44f0" datatype="html">


### PR DESCRIPTION
## Changes
- Make all action elements/buttons on Authoring Tool Unit Home lessons and steps are keyboard accessible.
- Use MatExpansionPanel for lessons.
- Disable constraint icon click action for steps in a branch path.
- Change icon color for step action buttons to ensure contrast meets WCAG AA standard. 

## Test
- Make sure expand all and collapse all buttons in AT Unit Home work as before.
- Make sure lessons can still be expanded/collapsed by clicking on lesson.
- Make sure all action icons on lessons still work as before.
- Make sure clicking on step still opens step authoring view.
- Make sure all action icons on steps work as before.
- Make sure you can use the keyboard to navigate to lessons and steps and all their action icons and the icon buttons work using the keyboard (enter key or space bar for checkboxes).

Closes #1942.
