### PR TITLE
Exit CodeBuild with status 1 when build prod command fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
   },
   "scripts": {
     "serve-dev": "npm install && node --max_old_space_size=6144 ./node_modules/@angular/cli/bin/ng serve --hmr --host 0.0.0.0",
-    "build-prod": "node --max_old_space_size=6144 ./node_modules/@angular/cli/bin/ng build --configuration production; gulp copy-site-styles",
+    "build-prod": "node --max_old_space_size=6144 ./node_modules/@angular/cli/bin/ng build --configuration production && gulp copy-site-styles",
     "bundle-report": "node ./node_modules/webpack-bundle-analyzer/lib/bin/analyzer.js dist/stats.json",
     "prettier-format": "prettier --config .prettierrc 'src' --write",
     "watch-sass": "node ./node_modules/gulp/bin/gulp.js watch-sass",


### PR DESCRIPTION
This was allowing the codepipeline to continue execution when it should not have
