### PR TITLE
feat(a11y): Add keyboard accessibility to AT node authoring

### DIFF
--- a/src/assets/wise5/authoringTool/components/edit-component-advanced-button/edit-component-advanced-button.component.html
+++ b/src/assets/wise5/authoringTool/components/edit-component-advanced-button/edit-component-advanced-button.component.html
@@ -1,8 +1,8 @@
 <button
   class="enable-in-translation"
   mat-icon-button
-  color="primary"
   (click)="$event.stopPropagation(); showComponentAdvancedAuthoring()"
+  (keydown)="$event.stopPropagation()"
   matTooltip="Advanced"
   matTooltipPosition="above"
   i18n-matTooltip

--- a/src/assets/wise5/authoringTool/components/preview-component-button/preview-component-button.component.html
+++ b/src/assets/wise5/authoringTool/components/preview-component-button/preview-component-button.component.html
@@ -1,10 +1,10 @@
 <button
   mat-icon-button
-  color="primary"
   matTooltip="Preview component"
   matTooltipPosition="above"
   i18n-matTooltip
   (click)="$event.stopPropagation(); popUpComponentPreview()"
+  (keydown)="$event.stopPropagation()"
 >
   <mat-icon>preview</mat-icon>
 </button>

--- a/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.html
+++ b/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.html
@@ -1,7 +1,7 @@
 <button
   mat-icon-button
-  color="primary"
-  (click)="copy($event)"
+  (click)="$event.stopPropagation(); copy()"
+  (keydown)="$event.stopPropagation()"
   matTooltip="Copy component"
   matTooltipPosition="above"
   i18n-matTooltip

--- a/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.ts
+++ b/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.ts
@@ -22,8 +22,7 @@ export class CopyComponentButtonComponent {
     private projectService: TeacherProjectService
   ) {}
 
-  protected copy(event: Event): void {
-    event.stopPropagation();
+  protected copy(): void {
     const newComponents = this.node.copyComponents([this.componentId], this.componentId);
     this.projectService.saveProject();
     this.copyTranslationsService.tryCopyComponents(this.node, newComponents);

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
@@ -120,6 +120,7 @@
                 [(ngModel)]="componentsToChecked()[component.id]"
                 (change)="componentCheckboxChanged(component.id, $event.checked)"
                 (click)="$event.stopPropagation()"
+                (keydown)="$event.stopPropagation()"
                 aria-label="Select component"
                 i18n-aria-label
               >

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
@@ -1,8 +1,13 @@
-<div class="top-button-bar">
-  <div fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="16px">
+<div class="node-authoring">
+  <div
+    class="node-authoring-header"
+    fxLayout="row wrap"
+    fxLayoutAlign="start center"
+    fxLayoutGap="16px"
+  >
     <teacher-node-icon [nodeId]="nodeId" [canEdit]="true" size="18" />
     <edit-node-title [node]="node" />
-    <div class="node-buttons" fxLayoutGap="16px">
+    <div fxLayoutGap="16px">
       <button
         class="enable-in-translation"
         mat-raised-button
@@ -16,182 +21,146 @@
       </button>
     </div>
   </div>
-  <div
-    *ngIf="!isGroupNode"
-    class="components-header"
-    fxLayout="row"
-    fxLayoutAlign="start center"
-    fxLayoutGap="4px"
-  >
-    <h5 i18n>Components</h5>
-    <add-component-button
-      [node]="node"
-      (newComponentsEvent)="highlightAndExpandComponents($event)"
-    />
-    <div *ngIf="isAnyComponentSelected()">
-      <button
-        mat-icon-button
-        color="primary"
-        (click)="chooseComponentLocation('move')"
-        matTooltip="Move Components"
-        matTooltipPosition="above"
-        i18n-matTooltip
-      >
-        <mat-icon>redo</mat-icon>
-      </button>
-      <button
-        mat-icon-button
-        color="primary"
-        (click)="chooseComponentLocation('copy')"
-        matTooltip="Copy Components"
-        matTooltipPosition="above"
-        i18n-matTooltip
-      >
-        <mat-icon>content_copy</mat-icon>
-      </button>
-      <button
-        mat-icon-button
-        color="primary"
-        (click)="deleteComponents()"
-        matTooltip="Delete Components"
-        matTooltipPosition="above"
-        i18n-matTooltip
-      >
-        <mat-icon>delete</mat-icon>
-      </button>
-    </div>
-    <span fxFlex></span>
-    <div *ngIf="!isGroupNode" fxLayoutGap="16px">
-      <button
-        class="enable-in-translation"
-        mat-raised-button
-        color="primary"
-        (click)="setAllComponentsIsExpanded(true)"
-        [disabled]="getNumberOfComponentsExpanded() === components.length"
-        i18n
-      >
-        + Expand All
-      </button>
-      <button
-        class="enable-in-translation"
-        mat-raised-button
-        color="primary"
-        (click)="setAllComponentsIsExpanded(false)"
-        [disabled]="getNumberOfComponentsExpanded() === 0"
-        i18n
-      >
-        - Collapse All
-      </button>
-    </div>
+  <div class="node-authoring-controls">
+    @if (!isGroupNode) {
+      <div class="components-header" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="4px">
+        <h5 i18n>Components</h5>
+        <add-component-button
+          [node]="node"
+          (newComponentsEvent)="highlightAndExpandComponents($event)"
+        />
+        <div *ngIf="isAnyComponentSelected()">
+          <button
+            mat-icon-button
+            color="primary"
+            (click)="chooseComponentLocation('move')"
+            matTooltip="Move Components"
+            matTooltipPosition="above"
+            i18n-matTooltip
+          >
+            <mat-icon>redo</mat-icon>
+          </button>
+          <button
+            mat-icon-button
+            color="primary"
+            (click)="chooseComponentLocation('copy')"
+            matTooltip="Copy Components"
+            matTooltipPosition="above"
+            i18n-matTooltip
+          >
+            <mat-icon>content_copy</mat-icon>
+          </button>
+          <button
+            mat-icon-button
+            color="primary"
+            (click)="deleteComponents()"
+            matTooltip="Delete Components"
+            matTooltipPosition="above"
+            i18n-matTooltip
+          >
+            <mat-icon>delete</mat-icon>
+          </button>
+        </div>
+        <span fxFlex></span>
+        <div fxLayoutGap="16px">
+          <button
+            class="enable-in-translation"
+            mat-raised-button
+            color="primary"
+            (click)="setAllComponentsIsExpanded(true)"
+            [disabled]="getNumberOfComponentsExpanded() === components.length"
+            i18n
+          >
+            + Expand All
+          </button>
+          <button
+            class="enable-in-translation"
+            mat-raised-button
+            color="primary"
+            (click)="setAllComponentsIsExpanded(false)"
+            [disabled]="getNumberOfComponentsExpanded() === 0"
+            i18n
+          >
+            - Collapse All
+          </button>
+        </div>
+      </div>
+    }
   </div>
-</div>
-<div *ngIf="components.length === 0 && !isGroupNode" class="no-components-message">
-  <em i18n>This step does not have any components. Click the + button to add a component.</em>
-</div>
-<div cdkDropList (cdkDropListDropped)="dropComponent($event)" cdkScrollable>
-  <div *ngFor="let component of components; let i = index">
-    <div
-      [id]="component.id"
-      class="component"
-      cdkDrag
-      [cdkDragDisabled]="components.length < 2"
-      fxLayout="row"
-      fxLayoutAlign="start"
-      [ngClass]="{
-        'component-header-highlight': !componentsToExpanded[component.id]
-      }"
-    >
-      <div style="width: 100%">
-        <div
-          (click)="toggleComponent(component.id)"
-          class="component-header"
-          fxLayout="row"
-          fxLayoutAlign="start center"
-          fxLayoutGap="8px"
-          aria-label="Toggle component authoring"
-          i18n-aria-label
+  @if (components.length === 0 && !isGroupNode) {
+    <p i18n>This step does not have any components. Click the + button to add a component.</p>
+  }
+  <div
+    cdkDropList
+    (cdkDropListDropped)="dropComponent($event)"
+    cdkScrollable
+    fxLayout="column"
+    fxLayoutGap="8px"
+  >
+    @for (component of components; track component.id; let i = $index) {
+      <div fxLayout="row" fxLayoutGap="4px">
+        <mat-expansion-panel
+          [id]="component.id"
+          [expanded]="componentsToExpanded[component.id]"
+          class="component"
+          cdkDrag
+          [cdkDragDisabled]="components.length < 2"
+          (opened)="toggleComponent(component.id, true)"
+          (closed)="toggleComponent(component.id, false)"
         >
-          <div fxLayout="row" fxLayoutAlign="start center">
-            <mat-icon
-              class="drag-handle"
-              *ngIf="components.length > 1"
-              cdkDragHandle
-              title="Drag to reorder"
-              i18n-title
-              >drag_indicator</mat-icon
-            >
-            <mat-checkbox
-              color="primary"
-              [(ngModel)]="componentsToChecked()[component.id]"
-              (change)="componentCheckboxChanged(component.id, $event.checked)"
-              (click)="$event.stopPropagation()"
-              aria-label="Select component"
-              i18n-aria-label
-            >
-              <span class="component-label"
-                >{{ i + 1 }}. {{ getComponentTypeLabel(component.type) }}</span
+          <mat-expansion-panel-header aria-label="Expand/collapse component" i18n-aria-label>
+            <mat-panel-title fxLayout="row" fxLayoutAlign="start center">
+              @if (components.length > 1) {
+                <mat-icon class="drag-handle" cdkDragHandle title="Drag to reorder" i18n-title
+                  >drag_indicator</mat-icon
+                >
+              }
+              <mat-checkbox
+                color="primary"
+                [(ngModel)]="componentsToChecked()[component.id]"
+                (change)="componentCheckboxChanged(component.id, $event.checked)"
+                (click)="$event.stopPropagation()"
+                aria-label="Select component"
+                i18n-aria-label
               >
-            </mat-checkbox>
+                <span>{{ i + 1 }}. {{ getComponentTypeLabel(component.type) }}</span>
+              </mat-checkbox>
+            </mat-panel-title>
+            <mat-panel-description class="text" fxLayoutAlign="end center" fxLayoutGap="4px">
+              <edit-component-advanced-button [componentContent]="component" [nodeId]="nodeId" />
+              <preview-component-button
+                class="component-action"
+                [nodeId]="nodeId"
+                [componentId]="component.id"
+              />
+              <copy-component-button
+                class="component-action"
+                [node]="node"
+                [componentId]="component.id"
+                (newComponentEvent)="highlightAndExpandComponents($event)"
+              />
+              <button
+                mat-icon-button
+                class="component-action"
+                (click)="$event.stopPropagation(); deleteComponent($event, i + 1, component)"
+                (keydown)="$event.stopPropagation()"
+                matTooltip="Delete Component"
+                matTooltipPosition="above"
+                i18n-matTooltip
+              >
+                <mat-icon>delete</mat-icon>
+              </button>
+            </mat-panel-description>
+          </mat-expansion-panel-header>
+          <div>
+            @if (componentsToExpanded[component.id]) {
+              <component-authoring-component
+                [nodeId]="nodeId"
+                [componentContent]="component"
+              ></component-authoring-component>
+            }
           </div>
-          <ng-container>
-            <div
-              class="component-expand-collapse-div"
-              matTooltip="Click to expand/collapse"
-              matTooltipPosition="above"
-              i18n-matTooltip
-            ></div>
-            <edit-component-advanced-button
-              *ngIf="componentsToExpanded[component.id]"
-              [componentContent]="component"
-              [nodeId]="nodeId"
-            />
-            <preview-component-button
-              class="dynamic-component-button"
-              [ngClass]="{
-                'show-dynamic-component-button': componentsToExpanded[component.id]
-              }"
-              [nodeId]="nodeId"
-              [componentId]="component.id"
-            />
-            <copy-component-button
-              class="dynamic-component-button"
-              [ngClass]="{
-                'show-dynamic-component-button': componentsToExpanded[component.id]
-              }"
-              [node]="node"
-              [componentId]="component.id"
-              (newComponentEvent)="highlightAndExpandComponents($event)"
-            />
-            <button
-              mat-icon-button
-              color="primary"
-              class="dynamic-component-button"
-              [ngClass]="{
-                'show-dynamic-component-button': componentsToExpanded[component.id]
-              }"
-              (click)="deleteComponent($event, i + 1, component)"
-              matTooltip="Delete Component"
-              matTooltipPosition="above"
-              i18n-matTooltip
-            >
-              <mat-icon>delete</mat-icon>
-            </button>
-          </ng-container>
-          <div fxLayout="row" fxLayoutAlign="end center">
-            <div *ngIf="!componentsToExpanded[component.id]" fxLayoutAlign="end center">
-              <mat-icon>expand_more</mat-icon>
-            </div>
-            <div *ngIf="componentsToExpanded[component.id]" fxLayoutAlign="end center">
-              <mat-icon>expand_less</mat-icon>
-            </div>
-          </div>
-        </div>
-        <div *ngIf="componentsToExpanded[component.id]" class="component-authoring">
-          <component-authoring-component
-            [nodeId]="nodeId"
-            [componentContent]="component"
-          ></component-authoring-component>
-        </div>
+        </mat-expansion-panel>
         <add-component-button
           class="add-component"
           [insertAfterComponentId]="component.id"
@@ -199,6 +168,6 @@
           (newComponentsEvent)="highlightAndExpandComponents($event)"
         />
       </div>
-    </div>
+    }
   </div>
 </div>

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.scss
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.scss
@@ -57,4 +57,8 @@
   .cdk-drag-placeholder {
     opacity: .4;
   }
+
+  .mat-icon {
+    margin: 0;
+  }
 }

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.scss
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.scss
@@ -1,121 +1,60 @@
-@import
-  'style/abstracts/variables',
-  'style/abstracts/functions';
-
-.top-button-bar {
-  padding: 16px 8px 4px;
-  background-color: white;
-  position: sticky;
-  top: 26px;
-  z-index: 2;
-}
-
-.node-title {
-  width: 50%;
-}
-
-.node-buttons {
-  margin: 8px 0;
-}
-
-.insert-component-message {
-  margin-top: 10px;
-}
-
-.insert-as-first-component-div {
-  margin: 10px 30px;
-}
-
-.insert-as-first-component-message {
-  font-weight: bold;
-}
-
-.no-components-message {
-  margin-left: 45px;
-  margin-top: 45px;
-  font-size: 1em;
-  font-weight: bold;
-}
-
-.components-header {
-  margin-top: 8px;
-  margin-left: 8px;
-  margin-right: 8px;
-}
-
-.component {
-  margin: 4px 16px 16px;
-  border: 2px solid #dddddd;
-  border-radius: 6px;
-  position: relative;
-}
-
-.component-header {
-  height: 48px;
-  padding: 0px 20px 0px 10px;
-  cursor: pointer;
-}
-
-.component-header-highlight:hover {
-  background-color: #add8e6;
-}
-
-.component-label {
-  font-weight: bold;
-}
-
-.component-expand-collapse-div {
-  flex-grow: 1;
-  align-self: stretch;
-}
-
-.dynamic-component-button {
-  display: none;
-  margin-right: 20px;
-  &.show-dynamic-component-button {
-    display: block;
+.node-authoring {
+  .node-authoring-header {
+    margin: 8px 8px 0;
   }
-}
 
-.component-header:hover .dynamic-component-button {
-  display: block;
-}
+  .node-authoring-controls {
+    padding: 8px 16px;
+    background-color: white;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+  }
 
-.component-authoring {
-  padding: 0px 20px;
-}
+  .component {
+    flex: 1;
 
-.insert-after-div {
-  margin: 0px 30px;
-}
+    .mat-expansion-panel-header {
+      padding-inline-start: 8px;
+    }
 
-.mat-icon {
-  margin: 0px;
-}
+    .mat-expansion-panel-header-title {
+      flex-grow: 100;
+    }
 
-.add-component {
-  position: absolute;
-  bottom: 24px;
-  height: 0px;
-  width: 100%;
-  text-align: center;
-  z-index: 1;
-}
+    .mat-expansion-panel-body {
+      padding-left: 16px;
+      padding-right: 16px;
+    }
 
-.drag-handle {
-  cursor: move;
-  margin-right: 4px;
-  margin-left: 4px;
-}
+    &:hover, &:focus-within, &.mat-expanded {
+      .component-action {
+        display: block;
+      }
+    }
 
-.cdk-drag-placeholder {
-  opacity: .4;
-}
+    &.mat-expanded {
+      edit-component-advanced-button {
+        display: block;
+      }
+    }
+  }
 
-mat-icon[disabled=true] {
-  opacity: .5;
-}
+  edit-component-advanced-button {
+    display: none;
+  }
 
-.component-label {
-  color: rgba(0,0,0,.87);
+  .component-action {
+    display: none;
+  }
+
+  .drag-handle {
+    cursor: move;
+    margin-right: 4px;
+    margin-left: 4px;
+  }
+
+  .cdk-drag-placeholder {
+    opacity: .4;
+  }
 }

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
@@ -28,11 +28,11 @@ import { TeacherProjectTranslationService } from '../../../services/teacherProje
 import { ComponentTypeServiceModule } from '../../../services/componentTypeService.module';
 import { DeleteTranslationsService } from '../../../services/deleteTranslationsService';
 import { PreviewComponentButtonComponent } from '../../components/preview-component-button/preview-component-button.component';
-import { TranslatableInputComponent } from '../../components/translatable-input/translatable-input.component';
 import { CopyTranslationsService } from '../../../services/copyTranslationsService';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CreateComponentService } from '../../../services/createComponentService';
+import { MatExpansionModule } from '@angular/material/expansion';
 
 let component: NodeAuthoringComponent;
 let component1: any;
@@ -60,6 +60,7 @@ describe('NodeAuthoringComponent', () => {
         EditNodeTitleComponent,
         FormsModule,
         MatCheckboxModule,
+        MatExpansionModule,
         MatIconModule,
         MatInputModule,
         PreviewComponentButtonComponent,
@@ -142,7 +143,7 @@ describe('NodeAuthoringComponent', () => {
 function copyComponent() {
   describe('copyComponent()', () => {
     it('should copy component', () => {
-      clickComponentHeader(component2.id);
+      clickComponent(component2.id);
       fixture.detectChanges();
       expect(teacherProjectService.idToNode[nodeId1].components).toEqual(node1Components);
       clickComponentCopyButton(component2.id);
@@ -159,7 +160,7 @@ function copyComponent() {
 function deleteComponent() {
   describe('deleteComponent()', () => {
     it('should delete component', () => {
-      clickComponentHeader(component2.id);
+      clickComponent(component2.id);
       fixture.detectChanges();
       expect(teacherProjectService.idToNode[nodeId1].components).toEqual(node1Components);
       confirmSpy.and.returnValue(true);
@@ -200,8 +201,8 @@ function clickComponentCheckbox(componentId: string): void {
   queryByCssAndClick(`#${componentId} mat-checkbox label`);
 }
 
-function clickComponentHeader(componentId: string): void {
-  queryByCssAndClick(`#${componentId} .component-header`);
+function clickComponent(componentId: string): void {
+  queryByCssAndClick(`#${componentId}`);
 }
 
 function queryByCssAndClick(css: string): void {
@@ -210,11 +211,6 @@ function queryByCssAndClick(css: string): void {
 
 function clickComponentCopyButton(componentId: string): void {
   queryByCssAndClickCopy(`#${componentId} button`);
-}
-
-function clickCopyComponentsButton(): void {
-  queryByCssAndClickCopy('button');
-  fixture.detectChanges();
 }
 
 function queryByCssAndClickCopy(css: string): void {

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
@@ -1,4 +1,13 @@
-import { Component, Input, OnInit, Signal, WritableSignal, computed, signal } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnInit,
+  Signal,
+  ViewEncapsulation,
+  WritableSignal,
+  computed,
+  signal
+} from '@angular/core';
 import { Subscription } from 'rxjs';
 import { TeacherDataService } from '../../../services/teacherDataService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
@@ -16,7 +25,8 @@ import { copy } from '../../../common/object/object';
 @Component({
   selector: 'node-authoring',
   templateUrl: './node-authoring.component.html',
-  styleUrls: ['./node-authoring.component.scss']
+  styleUrls: ['./node-authoring.component.scss'],
+  encapsulation: ViewEncapsulation.None
 })
 export class NodeAuthoringComponent implements OnInit {
   components: ComponentContent[] = [];
@@ -261,8 +271,8 @@ export class NodeAuthoringComponent implements OnInit {
     });
   }
 
-  protected toggleComponent(componentId: string): void {
-    this.componentsToExpanded[componentId] = !this.componentsToExpanded[componentId];
+  protected toggleComponent(componentId: string, expanded: boolean = true): void {
+    this.componentsToExpanded[componentId] = expanded;
     this.projectService.uiChanged();
   }
 

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.scss
@@ -3,6 +3,10 @@
     padding-inline-start: 8px;
   }
 
+  .mat-expansion-panel-header-title {
+    flex-grow: 100;
+  }
+
   .mat-expansion-panel-body {
     padding-left: 8px;
     padding-right: 8px;
@@ -17,7 +21,6 @@
   }
 
   .no-steps-message {
-    height: 40px;
-    margin-left: 40px;
+    padding: 0 8px;
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -12131,14 +12131,14 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>Select component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">123</context>
+          <context context-type="linenumber">124</context>
         </context-group>
       </trans-unit>
       <trans-unit id="46c242cc262ba3a868dfd6bd37f555c1ada6877c" datatype="html">
         <source>Delete Component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">147</context>
+          <context context-type="linenumber">148</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7035134055292483273" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1175,7 +1175,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">119</context>
+          <context context-type="linenumber">114</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.html</context>
@@ -10244,14 +10244,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">11</context>
+          <context context-type="linenumber">16</context>
         </context-group>
       </trans-unit>
       <trans-unit id="592715f579b88977a98d277b9d6099afcd72a6fc" datatype="html">
         <source>Preview component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/preview-component-button/preview-component-button.component.html</context>
-          <context context-type="linenumber">4</context>
+          <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit>
       <trans-unit id="929954f6e28805c5a7c03aac44c9e48cad2ab3e3" datatype="html">
@@ -12063,53 +12063,65 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>Components</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7c5b499b46f7ab611026c2e07b19d8d70e51853a" datatype="html">
         <source>Move Components</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">36</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="835ab9ba787d9e73a77b6f723e200ca24a5808a9" datatype="html">
         <source>Copy Components</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">47</context>
         </context-group>
       </trans-unit>
       <trans-unit id="646e338d93a6cafb1c27766c746ce8f2fde3c2a6" datatype="html">
         <source>Delete Components</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="67145eb769f4fe04e8b9f3c24d4452cf18ac196b" datatype="html">
+      <trans-unit id="a0161b45994d017056833ae5e2fbaccb8f58e847" datatype="html">
         <source> + Expand All </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">72,74</context>
+          <context context-type="linenumber">73,75</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-grading-view/milestone-grading-view.component.html</context>
+          <context context-type="linenumber">22,24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-grading/student-grading.component.html</context>
+          <context context-type="linenumber">34,36</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="22137335ce02968992f1f2fb73c630e68be673cb" datatype="html">
+      <trans-unit id="67f47ba6318d57c0512c1cca8cfcd07670b14e36" datatype="html">
         <source> - Collapse All </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">82,84</context>
+          <context context-type="linenumber">83,85</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-grading/student-grading.component.html</context>
+          <context context-type="linenumber">45,47</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1944eaae32b2002e6f552fd9c1f5a113c412ad25" datatype="html">
         <source>This step does not have any components. Click the + button to add a component.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">89</context>
+          <context context-type="linenumber">91</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="534f4fefca77da56b8b0ea6fb63ff18bae415a92" datatype="html">
-        <source>Toggle component authoring</source>
+      <trans-unit id="8f7d9f3c64392f7c5f81b31834ae93c016889683" datatype="html">
+        <source>Expand/collapse component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
           <context context-type="linenumber">111</context>
@@ -12119,21 +12131,14 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>Select component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">128</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="47f8ae23f1be55b30a01abc41c7ca4b770f5d1b2" datatype="html">
-        <source>Click to expand/collapse</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">139</context>
+          <context context-type="linenumber">123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="46c242cc262ba3a868dfd6bd37f555c1ada6877c" datatype="html">
         <source>Delete Component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">173</context>
+          <context context-type="linenumber">147</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7035134055292483273" datatype="html">
@@ -12141,7 +12146,7 @@ The branches will be removed but the steps will remain in the unit.</source>
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">193</context>
+          <context context-type="linenumber">203</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5170405945214763287" datatype="html">
@@ -12149,7 +12154,7 @@ The branches will be removed but the steps will remain in the unit.</source>
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts</context>
-          <context context-type="linenumber">194</context>
+          <context context-type="linenumber">204</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bb39841df2c03f771748c1f986e615bffa7f2593" datatype="html">
@@ -13870,17 +13875,6 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="a0161b45994d017056833ae5e2fbaccb8f58e847" datatype="html">
-        <source> + Expand All </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-grading-view/milestone-grading-view.component.html</context>
-          <context context-type="linenumber">22,24</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-grading/student-grading.component.html</context>
-          <context context-type="linenumber">34,36</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="7cc20136d8ae69cbe796d0fd2a6b2e242d2bd061" datatype="html">
         <source>Collapse All</source>
         <context-group purpose="location">
@@ -15375,13 +15369,6 @@ Are you sure you want to proceed?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-grading/student-grading.component.html</context>
           <context context-type="linenumber">40</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="67f47ba6318d57c0512c1cca8cfcd07670b14e36" datatype="html">
-        <source> - Collapse All </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-grading/student-grading.component.html</context>
-          <context context-type="linenumber">45,47</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4e72de6762f4a3b95de1b2e2a30b6af0f91b172f" datatype="html">


### PR DESCRIPTION
## Changes
- Make all action elements/buttons on components in Authoring Tool step (node) authoring are keyboard accessible.
- Use MatExpansionPanel for components.
- Move add new component buttons next to components to match lesson and step authoring.

## Test
- Make sure expand all and collapse all buttons in AT node authoring work as before.
- Make sure components can still be expanded/collapsed by clicking on lesson.
- Make sure all action icons on components still work as before.
- Make sure you can use the keyboard to navigate to components and all their action icons and the icon buttons work using the keyboard (enter key or space bar for checkboxes).

Closes #1948.
