### PR TITLE
Improved default language switching functionality

### DIFF
--- a/src/assets/wise5/authoringTool/authoring-tool.component.ts
+++ b/src/assets/wise5/authoringTool/authoring-tool.component.ts
@@ -232,7 +232,7 @@ export class AuthoringToolComponent {
   }
 
   private getElements(): any[] {
-    const elementsToDisable = 'button,input,mat-checkbox,textarea,mat-icon[cdkdraghandle]';
+    const elementsToDisable = 'button,input,textarea,mat-radio-button,mat-checkbox,mat-icon[cdkdraghandle]';
     return Array.from(
       this.elem.nativeElement.querySelectorAll(`div.main-content ${elementsToDisable}`)
     ).concat(

--- a/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.ts
+++ b/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.ts
@@ -34,8 +34,9 @@ export class EditProjectLanguageSettingComponent {
 
   protected updateDefaultLanguage(): void {
     this.projectLocale.setDefaultLocale(this.defaultLanguage.locale);
-    this.projectService.setCurrentLanguage(this.defaultLanguage);
     this.projectService.saveProject();
+    this.projectService.setCurrentLanguage(this.defaultLanguage);
+    this.projectService.uiChanged();
     this.updateModel();
   }
 

--- a/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.ts
+++ b/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.ts
@@ -34,6 +34,7 @@ export class EditProjectLanguageSettingComponent {
 
   protected updateDefaultLanguage(): void {
     this.projectLocale.setDefaultLocale(this.defaultLanguage.locale);
+    this.projectService.setCurrentLanguage(this.defaultLanguage);
     this.projectService.saveProject();
     this.updateModel();
   }


### PR DESCRIPTION
## Changes
- Added `mat-radio-button` that needs to be disabled.
- Resolved the issue where a page refresh was required to edit after switching the default language.

## Test
After changing the default language, it will switch to the new default language.
![image](https://github.com/user-attachments/assets/73e0ef99-1fcd-4655-80d9-2100dce19184)

## Other Issues
After switching to another language, `defaultLanguage` does not change.
In the file
`src/assets/wise5/authoringTool/components/abstract-translatable-field/abstract-translatable-field.component.ts`
```typescript
protected defaultLanguage: Language = this.projectService.getLocale().getDefaultLanguage();
``` 

![image](https://github.com/user-attachments/assets/af2cb2b7-19b8-4d0c-8167-a6dd011ca40a)
