### PR TITLE
fix(Data Explorer): Properly show axis labels for categorical data

### DIFF
--- a/src/assets/wise5/components/graph/data-explorer-manager.ts
+++ b/src/assets/wise5/components/graph/data-explorer-manager.ts
@@ -5,7 +5,11 @@ import { Series } from './domain/series';
 export class DataExplorerManager {
   dataExplorerColors: string[] = ['blue', 'orange', 'purple', 'black', 'green'];
 
-  constructor(private xAxis: any, private yAxis: any, private activeTrial: any) {}
+  constructor(
+    private xAxis: any,
+    private yAxis: any,
+    private activeTrial: any
+  ) {}
 
   handleDataExplorer(studentData: any): Series[] {
     this.xAxis.title.text = studentData.dataExplorerXAxisLabel;
@@ -163,7 +167,7 @@ export class DataExplorerManager {
       typeof textValue === 'string' &&
       textValue !== '' &&
       !this.isNA(textValue) &&
-      isNaN(parseFloat(textValue))
+      isNaN(Number(textValue))
     );
   }
 


### PR DESCRIPTION
## Changes
- Axis labels for Data Explorer activities with categorical data show the proper category labels.

## Test
- Create a Data Explorer activity using the instructions in #1960.
- Preview the step and ensure that the category labels are shown properly on the x-axis of the graph:

![Screenshot 2024-10-15 at 11 16 09 AM](https://github.com/user-attachments/assets/3f982379-c1b9-4b8a-bcd7-f5ab4d8bad2f)

Closes #1960. 
