### PR TITLE
refactor(AT): Convert structure authoring components to standalone

### DIFF
--- a/src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.spec.ts
+++ b/src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.spec.ts
@@ -1,13 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { JigsawComponent } from './jigsaw.component';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { MatRadioModule } from '@angular/material/radio';
-import { FormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
-import { MatDividerModule } from '@angular/material/divider';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 
 describe('JigsawComponent', () => {
   let component: JigsawComponent;
@@ -15,14 +11,13 @@ describe('JigsawComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    declarations: [JigsawComponent],
-    imports: [FormsModule,
-        MatDividerModule,
-        MatRadioModule,
-        RouterTestingModule,
-        StudentTeacherCommonServicesModule],
-    providers: [TeacherProjectService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-}).compileComponents();
+      imports: [StudentTeacherCommonServicesModule, JigsawComponent],
+      providers: [
+        TeacherProjectService,
+        provideHttpClient(withInterceptorsFromDi()),
+        provideRouter([])
+      ]
+    }).compileComponents();
     window.history.pushState({}, '', '');
     fixture = TestBed.createComponent(JigsawComponent);
     component = fixture.componentInstance;

--- a/src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.ts
+++ b/src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.ts
@@ -1,10 +1,29 @@
 import { Component } from '@angular/core';
 import { ConfigureStructureComponent } from '../configure-structure.component';
+import { MatProgressBar } from '@angular/material/progress-bar';
+import { NgIf } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { MatButton } from '@angular/material/button';
+import { FlexModule } from '@angular/flex-layout/flex';
+import { FormsModule } from '@angular/forms';
+import { MatRadioGroup, MatRadioButton } from '@angular/material/radio';
+import { MatDivider } from '@angular/material/divider';
 
 @Component({
-  selector: 'jigsaw',
-  templateUrl: './jigsaw.component.html',
-  styleUrls: ['./jigsaw.component.scss', '../../add-content.scss']
+  imports: [
+    MatDivider,
+    MatRadioGroup,
+    FormsModule,
+    MatRadioButton,
+    FlexModule,
+    MatButton,
+    RouterLink,
+    NgIf,
+    MatProgressBar
+  ],
+  standalone: true,
+  styleUrls: ['./jigsaw.component.scss', '../../add-content.scss'],
+  templateUrl: './jigsaw.component.html'
 })
 export class JigsawComponent extends ConfigureStructureComponent {
   protected numGroups: string = '2';

--- a/src/assets/wise5/authoringTool/structure/ki-cycle-using-oer/ki-cycle-using-oer.component.spec.ts
+++ b/src/assets/wise5/authoringTool/structure/ki-cycle-using-oer/ki-cycle-using-oer.component.spec.ts
@@ -1,11 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { KiCycleUsingOerComponent } from './ki-cycle-using-oer.component';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-import { MatDividerModule } from '@angular/material/divider';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 
 describe('KiCycleUsingOERComponent', () => {
   let component: KiCycleUsingOerComponent;
@@ -13,12 +11,13 @@ describe('KiCycleUsingOERComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    declarations: [KiCycleUsingOerComponent],
-    imports: [MatDividerModule,
-        RouterTestingModule,
-        StudentTeacherCommonServicesModule],
-    providers: [TeacherProjectService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-}).compileComponents();
+      imports: [StudentTeacherCommonServicesModule, KiCycleUsingOerComponent],
+      providers: [
+        TeacherProjectService,
+        provideHttpClient(withInterceptorsFromDi()),
+        provideRouter([])
+      ]
+    }).compileComponents();
     window.history.pushState({}, '', '');
     fixture = TestBed.createComponent(KiCycleUsingOerComponent);
     component = fixture.componentInstance;

--- a/src/assets/wise5/authoringTool/structure/ki-cycle-using-oer/ki-cycle-using-oer.component.ts
+++ b/src/assets/wise5/authoringTool/structure/ki-cycle-using-oer/ki-cycle-using-oer.component.ts
@@ -1,10 +1,17 @@
 import { Component } from '@angular/core';
 import { ConfigureStructureComponent } from '../configure-structure.component';
+import { MatProgressBar } from '@angular/material/progress-bar';
+import { NgIf } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { MatButton } from '@angular/material/button';
+import { FlexModule } from '@angular/flex-layout/flex';
+import { MatDivider } from '@angular/material/divider';
 
 @Component({
-  selector: 'ki-cycle-using-oer',
-  templateUrl: './ki-cycle-using-oer.component.html',
-  styleUrls: ['./ki-cycle-using-oer.component.scss', '../../add-content.scss']
+  imports: [MatDivider, FlexModule, MatButton, RouterLink, NgIf, MatProgressBar],
+  standalone: true,
+  styleUrls: ['./ki-cycle-using-oer.component.scss', '../../add-content.scss'],
+  templateUrl: './ki-cycle-using-oer.component.html'
 })
 export class KiCycleUsingOerComponent extends ConfigureStructureComponent {
   protected groupsPath = `ki-cycle-using-oer/groups.json`;

--- a/src/assets/wise5/authoringTool/structure/peer-review-and-revision/peer-review-and-revision.component.spec.ts
+++ b/src/assets/wise5/authoringTool/structure/peer-review-and-revision/peer-review-and-revision.component.spec.ts
@@ -1,11 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PeerReviewAndRevisionComponent } from './peer-review-and-revision.component';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-import { MatDividerModule } from '@angular/material/divider';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 
 describe('PeerReviewAndRevisionComponent', () => {
   let component: PeerReviewAndRevisionComponent;
@@ -13,12 +11,13 @@ describe('PeerReviewAndRevisionComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    declarations: [PeerReviewAndRevisionComponent],
-    imports: [MatDividerModule,
-        RouterTestingModule,
-        StudentTeacherCommonServicesModule],
-    providers: [TeacherProjectService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-}).compileComponents();
+      imports: [StudentTeacherCommonServicesModule, PeerReviewAndRevisionComponent],
+      providers: [
+        TeacherProjectService,
+        provideHttpClient(withInterceptorsFromDi()),
+        provideRouter([])
+      ]
+    }).compileComponents();
     window.history.pushState({}, '', '');
     fixture = TestBed.createComponent(PeerReviewAndRevisionComponent);
     component = fixture.componentInstance;

--- a/src/assets/wise5/authoringTool/structure/peer-review-and-revision/peer-review-and-revision.component.ts
+++ b/src/assets/wise5/authoringTool/structure/peer-review-and-revision/peer-review-and-revision.component.ts
@@ -1,10 +1,17 @@
 import { Component } from '@angular/core';
 import { ConfigureStructureComponent } from '../configure-structure.component';
+import { MatProgressBar } from '@angular/material/progress-bar';
+import { NgIf } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { MatButton } from '@angular/material/button';
+import { FlexModule } from '@angular/flex-layout/flex';
+import { MatDivider } from '@angular/material/divider';
 
 @Component({
-  selector: 'peer-review-and-revision',
-  templateUrl: './peer-review-and-revision.component.html',
-  styleUrls: ['./peer-review-and-revision.component.scss', '../../add-content.scss']
+  imports: [MatDivider, FlexModule, MatButton, RouterLink, NgIf, MatProgressBar],
+  standalone: true,
+  styleUrls: ['./peer-review-and-revision.component.scss', '../../add-content.scss'],
+  templateUrl: './peer-review-and-revision.component.html'
 })
 export class PeerReviewAndRevisionComponent extends ConfigureStructureComponent {
   protected groupsPath = `peer-review-and-revision/groups.json`;

--- a/src/assets/wise5/authoringTool/structure/self-directed-investigation/self-directed-investigation.component.spec.ts
+++ b/src/assets/wise5/authoringTool/structure/self-directed-investigation/self-directed-investigation.component.spec.ts
@@ -1,24 +1,23 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SelfDirectedInvestigationComponent } from './self-directed-investigation.component';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-import { MatDividerModule } from '@angular/material/divider';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 
-describe('SelfDirectedInvestigationComponent2', () => {
+describe('SelfDirectedInvestigationComponent', () => {
   let component: SelfDirectedInvestigationComponent;
   let fixture: ComponentFixture<SelfDirectedInvestigationComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    declarations: [SelfDirectedInvestigationComponent],
-    imports: [MatDividerModule,
-        RouterTestingModule,
-        StudentTeacherCommonServicesModule],
-    providers: [TeacherProjectService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-}).compileComponents();
+      imports: [StudentTeacherCommonServicesModule, SelfDirectedInvestigationComponent],
+      providers: [
+        TeacherProjectService,
+        provideHttpClient(withInterceptorsFromDi()),
+        provideRouter([])
+      ]
+    }).compileComponents();
     window.history.pushState({}, '', '');
     fixture = TestBed.createComponent(SelfDirectedInvestigationComponent);
     component = fixture.componentInstance;

--- a/src/assets/wise5/authoringTool/structure/self-directed-investigation/self-directed-investigation.component.ts
+++ b/src/assets/wise5/authoringTool/structure/self-directed-investigation/self-directed-investigation.component.ts
@@ -1,10 +1,17 @@
 import { Component } from '@angular/core';
 import { ConfigureStructureComponent } from '../configure-structure.component';
+import { MatProgressBar } from '@angular/material/progress-bar';
+import { NgIf } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { MatButton } from '@angular/material/button';
+import { FlexModule } from '@angular/flex-layout/flex';
+import { MatDivider } from '@angular/material/divider';
 
 @Component({
-  selector: 'self-directed-investigation',
-  templateUrl: './self-directed-investigation.component.html',
-  styleUrls: ['./self-directed-investigation.component.scss', '../../add-content.scss']
+  imports: [MatDivider, FlexModule, MatButton, RouterLink, NgIf, MatProgressBar],
+  standalone: true,
+  styleUrls: ['./self-directed-investigation.component.scss', '../../add-content.scss'],
+  templateUrl: './self-directed-investigation.component.html'
 })
 export class SelfDirectedInvestigationComponent extends ConfigureStructureComponent {
   protected groupsPath = `self-directed-investigation/groups.json`;

--- a/src/assets/wise5/authoringTool/structure/structure-authoring.module.ts
+++ b/src/assets/wise5/authoringTool/structure/structure-authoring.module.ts
@@ -8,18 +8,15 @@ import { RouterModule } from '@angular/router';
 import { StructureAuthoringRoutingModule } from './structure-authoring-routing.module';
 
 @NgModule({
-  declarations: [
-    JigsawComponent,
-    KiCycleUsingOerComponent,
-    PeerReviewAndRevisionComponent,
-    SelfDirectedInvestigationComponent
-  ],
-  imports: [RouterModule, StudentTeacherCommonModule, StructureAuthoringRoutingModule],
-  exports: [
-    JigsawComponent,
-    KiCycleUsingOerComponent,
-    PeerReviewAndRevisionComponent,
-    SelfDirectedInvestigationComponent
-  ]
+    imports: [RouterModule, StudentTeacherCommonModule, StructureAuthoringRoutingModule, JigsawComponent,
+        KiCycleUsingOerComponent,
+        PeerReviewAndRevisionComponent,
+        SelfDirectedInvestigationComponent],
+    exports: [
+        JigsawComponent,
+        KiCycleUsingOerComponent,
+        PeerReviewAndRevisionComponent,
+        SelfDirectedInvestigationComponent
+    ]
 })
 export class StructureAuthoringModule {}


### PR DESCRIPTION
## Changes
- Convert lesson structure authoring components to standalone

## Test
- Test structure authoring paths under ```/add-lesson``` in AT and make sure they work as before
