### PR TITLE
refactor(MultipleChoiceStudentComponent): Convert to standalone

### DIFF
--- a/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.html
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.html
@@ -1,124 +1,98 @@
-<div [ngSwitch]="choiceType">
-  <component-header [component]="component"></component-header>
-  <mat-radio-group
-    *ngSwitchCase="'radio'"
-    [(ngModel)]="studentChoices"
-    (ngModelChange)="studentDataChanged()"
-  >
-    <div *ngFor="let choice of choices">
-      <mat-radio-button
-        aria-label="choice.text"
-        color="primary"
-        [value]="choice.id"
-        [disabled]="isDisabled"
-      >
-        <span [innerHTML]="choice.text"> </span>
-        <span
-          *ngIf="showFeedback && choice.showFeedback"
-          [ngClass]="{
-            success: componentHasCorrectAnswer && choice.isCorrect,
-            warn: componentHasCorrectAnswer && !choice.isCorrect,
-            info: !componentHasCorrectAnswer
-          }"
+<div>
+  <component-header [component]="component" />
+
+  @if (choiceType === 'radio') {
+    <mat-radio-group [(ngModel)]="studentChoices" (ngModelChange)="studentDataChanged()">
+      @for (choice of choices; track choice.id) {
+        <div>
+          <mat-radio-button
+            [attr.aria-label]="choice.text"
+            color="primary"
+            [value]="choice.id"
+            [disabled]="isDisabled"
+          >
+            <span [innerHTML]="choice.text"></span>&nbsp;
+            @if (showFeedback && choice.showFeedback) {
+              <span
+                [ngClass]="{
+                  success: componentHasCorrectAnswer && choice.isCorrect,
+                  warn: componentHasCorrectAnswer && !choice.isCorrect,
+                  info: !componentHasCorrectAnswer
+                }"
+                >{{ choice.feedbackToShow }}</span
+              >
+            }
+          </mat-radio-button>
+        </div>
+      }
+    </mat-radio-group>
+  } @else if (choiceType === 'checkbox') {
+    @for (choice of choices; track choice.id) {
+      <div>
+        <mat-checkbox
+          [(ngModel)]="choice.isChecked"
+          (change)="updateStudentChoices(choice.id)"
+          [disabled]="isDisabled"
+          [attr.aria-label]="choice.text"
+          color="primary"
         >
-          {{ choice.feedbackToShow }}
-        </span>
-      </mat-radio-button>
+          <span [innerHTML]="choice.text"></span>&nbsp;
+          @if (choice.showFeedback) {
+            <span
+              [ngClass]="{
+                success: componentHasCorrectAnswer && choice.isCorrect,
+                warn: componentHasCorrectAnswer && !choice.isCorrect,
+                info: !componentHasCorrectAnswer
+              }"
+              >{{ choice.feedbackToShow }}</span
+            >
+          }
+        </mat-checkbox>
+      </div>
+    }
+  }
+
+  @if (componentHasCorrectAnswer && componentContent.maxSubmitCount != null) {
+    <div class="attempts-left-message" i18n>
+      You have used {{ submitCounter }} of {{ componentContent.maxSubmitCount }}
+      {{ componentContent.maxSubmitCount === 1 ? 'attempt' : 'attempts' }}
     </div>
-  </mat-radio-group>
-  <div *ngSwitchCase="'checkbox'">
-    <div *ngFor="let choice of choices">
-      <mat-checkbox
-        [(ngModel)]="choice.isChecked"
-        (change)="updateStudentChoices(choice.id)"
-        [disabled]="isDisabled"
-        aria-label="choice.text"
-        color="primary"
-      >
-        <span [innerHTML]="choice.text"> </span>
-        <span
-          *ngIf="choice.showFeedback"
-          [ngClass]="{
-            success: componentHasCorrectAnswer && choice.isCorrect,
-            warn: componentHasCorrectAnswer && !choice.isCorrect,
-            info: !componentHasCorrectAnswer
-          }"
-        >
-          {{ choice.feedbackToShow }}
-        </span>
-      </mat-checkbox>
-    </div>
-  </div>
-  <div
-    class="attempts-left-message"
-    *ngIf="
-      componentHasCorrectAnswer &&
-      componentContent.maxSubmitCount != null &&
-      componentContent.maxSubmitCount === 1
-    "
-    i18n
-  >
-    You have used {{ submitCounter }} of {{ componentContent.maxSubmitCount }} attempt
-  </div>
-  <div
-    class="attempts-left-message"
-    *ngIf="
-      componentHasCorrectAnswer &&
-      componentContent.maxSubmitCount != null &&
-      componentContent.maxSubmitCount > 1
-    "
-    i18n
-  >
-    You have used {{ submitCounter }} of {{ componentContent.maxSubmitCount }} attempts
-  </div>
-  <div *ngIf="!isLatestComponentStateSubmit || !componentHasCorrectAnswer || !showFeedback">
-    <br />
-  </div>
-  <div
-    *ngIf="
-      componentHasCorrectAnswer &&
-      isLatestComponentStateSubmit &&
-      showFeedback &&
-      isCorrect != null &&
-      isCorrect
-    "
-    class="correct-text"
-    i18n
-  >
-    Correct
-  </div>
-  <div
-    *ngIf="
-      componentHasCorrectAnswer &&
-      isLatestComponentStateSubmit &&
-      showFeedback &&
-      isCorrect != null &&
-      !isCorrect
-    "
-    class="incorrect-text"
-    i18n
-  >
-    Incorrect
-  </div>
+  }
+
+  @if (!isLatestComponentStateSubmit || !componentHasCorrectAnswer || !showFeedback) {
+    <div><br /></div>
+  }
+
+  @if (
+    componentHasCorrectAnswer && isLatestComponentStateSubmit && showFeedback && isCorrect != null
+  ) {
+    @if (isCorrect) {
+      <div class="correct-text" i18n>Correct</div>
+    } @else {
+      <div class="incorrect-text" i18n>Incorrect</div>
+    }
+  }
 </div>
-<component-save-submit-buttons
-  *ngIf="isSaveOrSubmitButtonVisible"
-  [componentState]="latestComponentState"
-  [isDirty]="isDirty"
-  [isDisabled]="isDisabled"
-  [isSaveButtonVisible]="isSaveButtonVisible"
-  [isSubmitButtonDisabled]="isSubmitButtonDisabled"
-  [isSubmitButtonVisible]="isSubmitButtonVisible"
-  [isSubmitDirty]="isSubmitDirty"
-  (saveButtonClicked)="saveButtonClicked($event)"
-  (submitButtonClicked)="submitButtonClicked($event)"
->
-</component-save-submit-buttons>
-<component-annotations
-  *ngIf="mode === 'student'"
-  [annotations]="latestAnnotations"
-  [maxScore]="componentContent.maxScore"
-  [nodeId]="nodeId"
-  [componentId]="componentId"
->
-</component-annotations>
+
+@if (isSaveOrSubmitButtonVisible) {
+  <component-save-submit-buttons
+    [componentState]="latestComponentState"
+    [isDirty]="isDirty"
+    [isDisabled]="isDisabled"
+    [isSaveButtonVisible]="isSaveButtonVisible"
+    [isSubmitButtonDisabled]="isSubmitButtonDisabled"
+    [isSubmitButtonVisible]="isSubmitButtonVisible"
+    [isSubmitDirty]="isSubmitDirty"
+    (saveButtonClicked)="saveButtonClicked($event)"
+    (submitButtonClicked)="submitButtonClicked($event)"
+  />
+}
+
+@if (mode === 'student') {
+  <component-annotations
+    [annotations]="latestAnnotations"
+    [maxScore]="componentContent.maxScore"
+    [nodeId]="nodeId"
+    [componentId]="componentId"
+  />
+}

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.spec.ts
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.spec.ts
@@ -1,18 +1,11 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
-import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatRadioModule } from '@angular/material/radio';
-import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { copy } from '../../../common/object/object';
-import { ComponentHeaderComponent } from '../../../directives/component-header/component-header.component';
 import { ProjectService } from '../../../services/projectService';
 import { MultipleChoiceComponent } from '../MultipleChoiceComponent';
 import { MultipleChoiceStudent } from './multiple-choice-student.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
 const choiceId1 = 'choice1';
@@ -109,18 +102,9 @@ function createComponent(choiceType: string, choices: any[]): any {
 describe('MultipleChoiceStudentComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-    declarations: [MultipleChoiceStudent],
-    schemas: [NO_ERRORS_SCHEMA],
-    imports: [BrowserAnimationsModule,
-        BrowserModule,
-        ComponentHeaderComponent,
-        MatCheckboxModule,
-        MatDialogModule,
-        MatRadioModule,
-        ReactiveFormsModule,
-        StudentTeacherCommonServicesModule],
-    providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-});
+      imports: [BrowserAnimationsModule, MultipleChoiceStudent, StudentTeacherCommonServicesModule],
+      providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
+    });
     fixture = TestBed.createComponent(MultipleChoiceStudent);
     spyOn(TestBed.inject(ProjectService), 'getThemeSettings').and.returnValue({});
     component = fixture.componentInstance;

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.ts
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.ts
@@ -1,6 +1,8 @@
-'use strict';
-
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialog } from '@angular/material/dialog';
 import { AnnotationService } from '../../../services/annotationService';
 import { ConfigService } from '../../../services/configService';
@@ -15,11 +17,24 @@ import { MultipleChoiceService } from '../multipleChoiceService';
 import { MultipleChoiceContent } from '../MultipleChoiceContent';
 import { hasConnectedComponent } from '../../../common/ComponentContent';
 import { copy } from '../../../common/object/object';
+import { ComponentAnnotationsComponent } from '../../../directives/componentAnnotations/component-annotations.component';
+import { ComponentHeaderComponent } from '../../../directives/component-header/component-header.component';
+import { ComponentSaveSubmitButtonsComponent } from '../../../directives/component-save-submit-buttons/component-save-submit-buttons.component';
 
 @Component({
+  imports: [
+    CommonModule,
+    ComponentAnnotationsComponent,
+    ComponentHeaderComponent,
+    ComponentSaveSubmitButtonsComponent,
+    FormsModule,
+    MatCheckboxModule,
+    MatRadioModule
+  ],
   selector: 'multiple-choice-student',
-  templateUrl: 'multiple-choice-student.component.html',
-  styleUrls: ['multiple-choice-student.component.scss']
+  standalone: true,
+  styleUrl: 'multiple-choice-student.component.scss',
+  templateUrl: 'multiple-choice-student.component.html'
 })
 export class MultipleChoiceStudent extends ComponentStudent {
   choices: any[];

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.module.ts
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.module.ts
@@ -4,8 +4,7 @@ import { StudentComponentModule } from '../../../../../app/student/student.compo
 import { MultipleChoiceStudent } from './multiple-choice-student.component';
 
 @NgModule({
-  declarations: [MultipleChoiceStudent],
-  imports: [StudentTeacherCommonModule, StudentComponentModule],
+  imports: [MultipleChoiceStudent, StudentTeacherCommonModule, StudentComponentModule],
   exports: [MultipleChoiceStudent]
 })
 export class MultipleChoiceStudentModule {}

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -19621,6 +19621,10 @@ Warning: This will delete all existing choices and buckets in this component.</s
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-show-work/multiple-choice-show-work.component.html</context>
           <context context-type="linenumber">52</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="8b42d54000704393a3c06e5f8b668880014f6986" datatype="html">
         <source>Incorrect</source>
@@ -19631,6 +19635,10 @@ Warning: This will delete all existing choices and buckets in this component.</s
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-show-work/multiple-choice-show-work.component.html</context>
           <context context-type="linenumber">53</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.html</context>
+          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0f72a164f5a5d10d1fbdeeb84ac80a63c04b7e1b" datatype="html">
@@ -19683,20 +19691,12 @@ Warning: This will delete all existing choices and buckets in this component.</s
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-feedback-section/match-feedback-section.component.html</context>
           <context context-type="linenumber">15,17</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.html</context>
-          <context context-type="linenumber">87,89</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="d4d6f1510d16638d79a0e793a0ac8a11b2231a8f" datatype="html">
         <source> Incorrect </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-feedback-section/match-feedback-section.component.html</context>
           <context context-type="linenumber">22,24</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.html</context>
-          <context context-type="linenumber">100,102</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5222638645205059452" datatype="html">
@@ -19845,18 +19845,11 @@ Warning: This will delete all existing choices in this component.</source>
           <context context-type="linenumber">48,51</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="b3057aaacad80ab45d3ee394bad642b92911d122" datatype="html">
-        <source> You have used <x id="INTERPOLATION" equiv-text="{{ submitCounter }}"/> of <x id="INTERPOLATION_1" equiv-text="{{ componentContent.maxSubmitCount }}"/> attempt </source>
+      <trans-unit id="dbc49f731fa8be621ff6b95f144a8a05c18e0dc9" datatype="html">
+        <source> You have used <x id="INTERPOLATION" equiv-text="{{ submitCounter }}"/> of <x id="INTERPOLATION_1" equiv-text="{{ componentContent.maxSubmitCount }}"/> <x id="INTERPOLATION_2" equiv-text="{{ componentContent.maxSubmitCount === 1 ? &apos;attempt&apos; : &apos;attempts&apos; }}"/> </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.html</context>
-          <context context-type="linenumber">60,62</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="305089568f85e84d60510cb5b6c271a953033049" datatype="html">
-        <source> You have used <x id="INTERPOLATION" equiv-text="{{ submitCounter }}"/> of <x id="INTERPOLATION_1" equiv-text="{{ componentContent.maxSubmitCount }}"/> attempts </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.html</context>
-          <context context-type="linenumber">71,73</context>
+          <context context-type="linenumber">56,59</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7864549548500976713" datatype="html">


### PR DESCRIPTION
## Changes
This pull request refactors the `multiple-choice-student` component in the `wise5` project to improve readability and maintainability. Key changes include updating the HTML template to use modern Angular syntax, refactoring the component to be standalone, and updating the test configuration.

### Refactoring of `multiple-choice-student` component:

* Updated the HTML template to use modern Angular syntax, including the replacement of `*ngIf` and `*ngSwitch` with `@if` and `@for` directives. [[1]](diffhunk://#diff-2dcb640d6dd716a1b74accf6eebff7aa68429823afc4529cb7a3d5310486eef0L1-L105) [[2]](diffhunk://#diff-2dcb640d6dd716a1b74accf6eebff7aa68429823afc4529cb7a3d5310486eef0L115-R98)
* Refactored the component to be standalone by including necessary imports directly in the component metadata. [[1]](diffhunk://#diff-ae17a6626a158340a91e122ca018c0dd204abca5519d641abe5565bdc98453e7L1-R5) [[2]](diffhunk://#diff-ae17a6626a158340a91e122ca018c0dd204abca5519d641abe5565bdc98453e7R20-R37)

### Test configuration updates:

* Simplified the test setup by removing unnecessary imports and declarations. [[1]](diffhunk://#diff-f13637323dfcdc9312c8b057ec7fca08f542b73849c5c77e5803fdb41f62d7d6L3-L15) [[2]](diffhunk://#diff-f13637323dfcdc9312c8b057ec7fca08f542b73849c5c77e5803fdb41f62d7d6L112-R105)

### Localization updates:

* Updated localization context references in `messages.xlf` to reflect changes in the HTML template. [[1]](diffhunk://#diff-3a3cab1562515f062670a0faf4d9aae22493651b1c77a80df9055d501350421eR19624-R19627) [[2]](diffhunk://#diff-3a3cab1562515f062670a0faf4d9aae22493651b1c77a80df9055d501350421eR19639-R19642) [[3]](diffhunk://#diff-3a3cab1562515f062670a0faf4d9aae22493651b1c77a80df9055d501350421eL19686-L19700) [[4]](diffhunk://#diff-3a3cab1562515f062670a0faf4d9aae22493651b1c77a80df9055d501350421eL19848-R19852)

## Test
- MC student works as before. Test single choice and multi-choice options. Test feedback and attempt count