### PR TITLE
refactor(ChooseImportStepComponent): Convert to standalone component 

### DIFF
--- a/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html
@@ -12,37 +12,40 @@
     <mat-icon>preview</mat-icon>
   </button>
 </p>
-<div
-  *ngFor="let item of projectIdToOrder"
-  [ngClass]="{
-    groupHeader: item.node.type == 'group',
-    stepHeader: item.node.type != 'group'
-  }"
->
-  <h6 *ngIf="item.order != 0 && item.node.type == 'group'">
-    {{ item.stepNumber }}: {{ item.node.title }}
-  </h6>
-  <div fxLayout="row wrap" fxLayoutGap="8px" *ngIf="item.order != 0 && item.node.type != 'group'">
-    <mat-checkbox name="item" ngDefaultControl [(ngModel)]="item.checked">
-      <span class="step-title">{{ item.stepNumber }}: {{ item.node.title }}</span>
-    </mat-checkbox>
-    <button
-      mat-raised-button
-      color="primary"
-      class="mat-raised-button mat-primary"
-      style="margin-top: -5"
-      (click)="previewNode(item.node)"
-      aria-label="Preview Step"
-      matTooltip="Preview Step"
-      i18n-matTooltip
-      matTooltipPosition="above"
-    >
-      <mat-icon>preview</mat-icon>
-    </button>
+@for (item of projectIdToOrder; track item.order) {
+  <div
+    [ngClass]="{
+      groupHeader: item.node.type == 'group',
+      stepHeader: item.node.type != 'group'
+    }"
+  >
+    @if (item.order != 0 && item.node.type == 'group') {
+      <h6>{{ item.stepNumber }}: {{ item.node.title }}</h6>
+    }
+    @if (item.order != 0 && item.node.type != 'group') {
+      <div fxLayout="row wrap" fxLayoutGap="8px">
+        <mat-checkbox name="item" ngDefaultControl [(ngModel)]="item.checked">
+          <span class="step-title">{{ item.stepNumber }}: {{ item.node.title }}</span>
+        </mat-checkbox>
+        <button
+          mat-raised-button
+          color="primary"
+          class="mat-raised-button mat-primary"
+          style="margin-top: -5"
+          (click)="previewNode(item.node)"
+          aria-label="Preview Step"
+          matTooltip="Preview Step"
+          i18n-matTooltip
+          matTooltipPosition="above"
+        >
+          <mat-icon>preview</mat-icon>
+        </button>
+      </div>
+    }
   </div>
-</div>
+}
 <div class="nav-controls">
-  <mat-divider></mat-divider>
+  <mat-divider />
   <div fxLayout="row" fxLayoutGap="16px" fxLayoutAlign="end center">
     <button
       mat-button
@@ -64,7 +67,9 @@
       [disabled]="getSelectedNodesToImport().length == 0 || submitting"
       class="button--progress"
     >
-      <mat-progress-bar *ngIf="submitting" mode="indeterminate"/>
+      @if (submitting) {
+        <mat-progress-bar mode="indeterminate" />
+      }
       <ng-container i18n>Submit</ng-container>
     </button>
   </div>

--- a/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.ts
+++ b/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.ts
@@ -1,14 +1,31 @@
 import { Component } from '@angular/core';
-import { TeacherProjectService } from '../../../../assets/wise5/services/teacherProjectService';
-import { ActivatedRoute, Router } from '@angular/router';
-import { ConfigService } from '../../../../assets/wise5/services/configService';
-import { CopyNodesService } from '../../../../assets/wise5/services/copyNodesService';
-import { InsertNodesService } from '../../../../assets/wise5/services/insertNodesService';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { RouterModule } from '@angular/router';
 import { AbstractImportStepComponent } from '../../../../assets/wise5/authoringTool/addNode/abstract-import-step/abstract-import-step.component';
-import { InsertFirstNodeInBranchPathService } from '../../../../assets/wise5/services/insertFirstNodeInBranchPathService';
+import { FlexLayoutModule } from '@angular/flex-layout';
 
 @Component({
+  imports: [
+    CommonModule,
+    FormsModule,
+    FlexLayoutModule,
+    MatButtonModule,
+    MatCheckboxModule,
+    MatDividerModule,
+    MatIconModule,
+    MatProgressBarModule,
+    MatTooltipModule,
+    RouterModule
+  ],
   selector: 'choose-import-step',
+  standalone: true,
   styleUrls: ['choose-import-step.component.scss', '../../add-content.scss'],
   templateUrl: 'choose-import-step.component.html'
 })
@@ -16,26 +33,6 @@ export class ChooseImportStepComponent extends AbstractImportStepComponent {
   protected project: any;
   protected projectIdToOrder: any;
   private projectItems: any[] = [];
-
-  constructor(
-    protected configService: ConfigService,
-    protected copyNodesService: CopyNodesService,
-    protected insertFirstNodeInBranchPathService: InsertFirstNodeInBranchPathService,
-    protected insertNodesService: InsertNodesService,
-    protected projectService: TeacherProjectService,
-    protected route: ActivatedRoute,
-    protected router: Router
-  ) {
-    super(
-      configService,
-      copyNodesService,
-      insertFirstNodeInBranchPathService,
-      insertNodesService,
-      projectService,
-      route,
-      router
-    );
-  }
 
   ngOnInit() {
     super.ngOnInit();

--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -66,7 +66,6 @@ import { MatExpansionModule } from '@angular/material/expansion';
   declarations: [
     AdvancedProjectAuthoringComponent,
     AuthoringToolComponent,
-    ChooseImportStepComponent,
     ChooseMoveNodeLocationComponent,
     ConcurrentAuthorsMessageComponent,
     ConfigureAutomatedAssessmentComponent,
@@ -95,6 +94,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
     ChooseAutomatedAssessmentComponent,
     ChooseComponentLocationComponent,
     ChooseCopyNodeLocationComponent,
+    ChooseImportStepComponent,
     ChooseImportUnitComponent,
     ChooseNewNodeTemplateComponent,
     ChooseNewComponent,

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -401,7 +401,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">59</context>
+          <context context-type="linenumber">62</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
@@ -1431,7 +1431,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Preview Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">36</context>
+          <context context-type="linenumber">37</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
@@ -1442,7 +1442,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Back</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">55</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/node-advanced-authoring/node-advanced-authoring.component.html</context>
@@ -1485,7 +1485,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source> Back </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">55,57</context>
+          <context context-type="linenumber">58,60</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
@@ -1524,7 +1524,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Submit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
-          <context context-type="linenumber">68</context>
+          <context context-type="linenumber">73</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>


### PR DESCRIPTION
This pull request includes updates to the `ChooseImportStepComponent` in the authoring tool. The changes primarily focus on refactoring the component to use Angular's standalone components and improving the HTML template structure.

### Component Refactoring:
* [`src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.ts`](diffhunk://#diff-9e267ef1155e4c7046b92815663e39fc098ff7963e6d7a8c64a0f0e6a38011c3L2-R28): Refactored to use Angular's standalone components, replacing multiple service imports with Angular Material and Flex Layout modules. [[1]](diffhunk://#diff-9e267ef1155e4c7046b92815663e39fc098ff7963e6d7a8c64a0f0e6a38011c3L2-R28) [[2]](diffhunk://#diff-9e267ef1155e4c7046b92815663e39fc098ff7963e6d7a8c64a0f0e6a38011c3L20-L39)

### HTML Template Improvements:
* [`src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html`](diffhunk://#diff-8c37872c2c4113a558ad8654e2c9bb2b0e8809cdf32294c9592b1b31573841a2R15-R26): Updated the template to use Angular's structural directives (`@for` and `@if`) for better readability and maintainability. [[1]](diffhunk://#diff-8c37872c2c4113a558ad8654e2c9bb2b0e8809cdf32294c9592b1b31573841a2R15-R26) [[2]](diffhunk://#diff-8c37872c2c4113a558ad8654e2c9bb2b0e8809cdf32294c9592b1b31573841a2R44-R48) [[3]](diffhunk://#diff-8c37872c2c4113a558ad8654e2c9bb2b0e8809cdf32294c9592b1b31573841a2L67-R72)

### Module Adjustments:
* [`src/app/teacher/authoring-tool.module.ts`](diffhunk://#diff-c9f275ff8db689d38c04ec235e44cf7fbbb3548be9ef29399ca1d47eec0b1f2dL69): Adjusted the module declarations to accommodate the refactored `ChooseImportStepComponent`. [[1]](diffhunk://#diff-c9f275ff8db689d38c04ec235e44cf7fbbb3548be9ef29399ca1d47eec0b1f2dL69) [[2]](diffhunk://#diff-c9f275ff8db689d38c04ec235e44cf7fbbb3548be9ef29399ca1d47eec0b1f2dR97)

### Localization Updates:
* [`src/messages.xlf`](diffhunk://#diff-3a3cab1562515f062670a0faf4d9aae22493651b1c77a80df9055d501350421eL404-R404): Updated line numbers for localization references due to changes in the HTML template. [[1]](diffhunk://#diff-3a3cab1562515f062670a0faf4d9aae22493651b1c77a80df9055d501350421eL404-R404) [[2]](diffhunk://#diff-3a3cab1562515f062670a0faf4d9aae22493651b1c77a80df9055d501350421eL1434-R1434) [[3]](diffhunk://#diff-3a3cab1562515f062670a0faf4d9aae22493651b1c77a80df9055d501350421eL1445-R1445) [[4]](diffhunk://#diff-3a3cab1562515f062670a0faf4d9aae22493651b1c77a80df9055d501350421eL1488-R1488) [[5]](diffhunk://#diff-3a3cab1562515f062670a0faf4d9aae22493651b1c77a80df9055d501350421eL1527-R1527)

## Test
- In the AT, the page to choose a step to import from works as before