### PR TITLE
refactor(EditComponentComment): convert to standalone component

### DIFF
--- a/src/app/teacher/grading-common.module.ts
+++ b/src/app/teacher/grading-common.module.ts
@@ -19,6 +19,7 @@ import { NavItemProgressComponent } from '../classroom-monitor/nav-item-progress
   imports: [
     ComponentGradingModule,
     EditComponentScoreComponent,
+    EditComponentCommentComponent,
     GradingEditComponentMaxScoreComponent,
     IntersectionObserverModule,
     NavItemProgressComponent,
@@ -30,7 +31,6 @@ import { NavItemProgressComponent } from '../classroom-monitor/nav-item-progress
   ],
   declarations: [
     EditComponentAnnotationsComponent,
-    EditComponentCommentComponent,
     WorkgroupComponentGradingComponent,
     WorkgroupItemComponent,
     WorkgroupSelectAutocompleteComponent

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.spec.ts
@@ -1,12 +1,10 @@
-import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AnnotationService } from '../../../services/annotationService';
 import { EditComponentCommentComponent } from './edit-component-comment.component';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
-import { MatDialogModule } from '@angular/material/dialog';
 import { NotificationService } from '../../../services/notificationService';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 let annotationService: AnnotationService;
 let component: EditComponentCommentComponent;
@@ -16,11 +14,13 @@ let notificationService: NotificationService;
 describe('EditComponentCommentComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-    declarations: [EditComponentCommentComponent],
-    schemas: [NO_ERRORS_SCHEMA],
-    imports: [MatDialogModule, StudentTeacherCommonServicesModule],
-    providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-});
+      imports: [
+        BrowserAnimationsModule,
+        EditComponentCommentComponent,
+        StudentTeacherCommonServicesModule
+      ],
+      providers: [provideHttpClient(withInterceptorsFromDi())]
+    });
     annotationService = TestBed.inject(AnnotationService);
     notificationService = TestBed.inject(NotificationService);
     fixture = TestBed.createComponent(EditComponentCommentComponent);

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.ts
@@ -3,9 +3,16 @@ import { Subject, Subscription } from 'rxjs';
 import { debounceTime, distinctUntilChanged, tap } from 'rxjs/operators';
 import { AnnotationService } from '../../../services/annotationService';
 import { NotificationService } from '../../../services/notificationService';
+import { FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { TextFieldModule } from '@angular/cdk/text-field';
+import { FlexLayoutModule } from '@angular/flex-layout';
 
 @Component({
+  imports: [FormsModule, FlexLayoutModule, MatFormFieldModule, MatInputModule, TextFieldModule],
   selector: 'edit-component-comment',
+  standalone: true,
   styles: ['.mat-mdc-form-field { display: initial }', 'textarea { resize: none }'],
   templateUrl: 'edit-component-comment.component.html'
 })
@@ -20,23 +27,23 @@ export class EditComponentCommentComponent {
   @Input() runId: string;
   @Input() toWorkgroupId: number;
 
-  commentChanged: Subject<string> = new Subject<string>();
-  isDirty: boolean;
-  subscriptions: Subscription = new Subscription();
+  protected commentChanged: Subject<string> = new Subject<string>();
+  private isDirty: boolean;
+  private subscriptions: Subscription = new Subscription();
 
   constructor(
     private annotationService: AnnotationService,
     private notificationService: NotificationService
   ) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.subscriptions.add(
       this.commentChanged
         .pipe(
           debounceTime(1000),
           distinctUntilChanged(),
           tap(() => {
-            this.setIsDirty(true);
+            this.isDirty = true;
             this.notificationService.showSavingMessage();
           })
         )
@@ -46,7 +53,7 @@ export class EditComponentCommentComponent {
     );
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     if (this.isDirty) {
       this.saveComment(this.comment);
     }
@@ -70,12 +77,8 @@ export class EditComponentCommentComponent {
       new Date().getTime()
     );
     this.annotationService.saveAnnotation(annotation).then(() => {
-      this.setIsDirty(false);
+      this.isDirty = false;
       this.notificationService.showSavedMessage($localize`Saved comment`);
     });
-  }
-
-  setIsDirty(isDirty: boolean) {
-    this.isDirty = isDirty;
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13412,7 +13412,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>Saved comment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-comment/edit-component-comment.component.ts</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2471906abf7baa724640a079ab3d084a78462ba2" datatype="html">


### PR DESCRIPTION
## Changes
This pull request includes several changes to the `EditComponentCommentComponent` and its related files to improve modularity, encapsulation, and testing. The most important changes include updating imports and declarations, modifying access levels of class members, and removing redundant methods.

### Changes to `EditComponentCommentComponent`:

* Added necessary imports for `FormsModule`, `MatFormFieldModule`, `MatInputModule`, `TextFieldModule`, and `FlexLayoutModule` to `edit-component-comment.component.ts` to support the component's functionality.
* Updated the component to be a standalone component and included the newly added modules in the `imports` array of the `@Component` decorator.
* Changed the access levels of `commentChanged`, `isDirty`, and `subscriptions` to `protected` or `private` to improve encapsulation.
* Removed the `setIsDirty` method and updated the code to directly set the `isDirty` property.

### Changes to `EditComponentCommentComponent` Testing:

* Updated the test setup in `edit-component-comment.component.spec.ts` to use `BrowserAnimationsModule` and removed unnecessary imports and schemas.
* Modified the `TestBed` configuration to align with the updated component structure and imports.

### Changes to `Teacher Grading Module`:

* Added `EditComponentCommentComponent` to the `imports` array and removed it from the `declarations` array in `grading-common.module.ts` to reflect its standalone nature. [[1]](diffhunk://#diff-2036f64808ac0143787e8634d9e98f521b1b85cf47e7747f7825e21282a312e2R22) [[2]](diffhunk://#diff-2036f64808ac0143787e8634d9e98f521b1b85cf47e7747f7825e21282a312e2L33)

### Changes to Localization:

* Updated the line number reference for the "Saved comment" message in `messages.xlf` to reflect the changes in `edit-component-comment.component.ts`.

## Test
- In the CM, you can type in comments for student's work and have it persisted across refresh