### PR TITLE
feat(AddStepButton): New add step button menu option behavior

### DIFF
--- a/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html
+++ b/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html
@@ -25,10 +25,11 @@
     </button>
     <mat-menu #lessonMenu="matMenu">
       <button mat-menu-item (click)="addFirstLesson()">
-        <mat-icon>add_circle</mat-icon><span i18n>Add lesson before</span>
+        <mat-icon class="rotate-180 flip-vertical">subdirectory_arrow_left</mat-icon
+        ><span i18n>Add lesson before</span>
       </button>
       <button mat-menu-item (click)="goToAddLessonView(lessonId)">
-        <mat-icon>add_circle</mat-icon><span i18n>Add lesson after</span>
+        <mat-icon>subdirectory_arrow_left</mat-icon><span i18n>Add lesson after</span>
       </button>
     </mat-menu>
   </ng-container>

--- a/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.ts
+++ b/src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.ts
@@ -7,10 +7,20 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
+  imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule, MatTooltipModule],
   selector: 'add-lesson-button',
-  templateUrl: './add-lesson-button.component.html',
   standalone: true,
-  imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule, MatTooltipModule]
+  styles: [
+    `
+      .rotate-180 {
+        transform: rotate(180deg);
+      }
+      .flip-vertical {
+        transform: scaleY(-1);
+      }
+    `
+  ],
+  templateUrl: './add-lesson-button.component.html'
 })
 export class AddLessonButtonComponent {
   @Input() active: boolean;

--- a/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.html
+++ b/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.html
@@ -6,22 +6,23 @@
   matTooltip="Add step"
   matTooltipPosition="above"
   i18n-matTooltip
+  [disabled]="!canAddBefore && !canAddAfter && !canBranch"
 >
   <mat-icon>add_circle</mat-icon>
 </button>
 <mat-menu #step="matMenu">
-  @if (!branchMergePoint) {
+  @if (canAddBefore) {
     <button mat-menu-item (click)="addStepBefore()">
       <mat-icon class="rotate-180 flip-vertical">subdirectory_arrow_left</mat-icon
       ><span i18n>Add step before</span>
     </button>
   }
-  @if (!branchPoint) {
+  @if (canAddAfter) {
     <button mat-menu-item (click)="goToAddStepViewForAfter(nodeId)">
       <mat-icon>subdirectory_arrow_left</mat-icon><span i18n>Add step after</span>
     </button>
   }
-  @if (!branchPoint && !branchPathStep) {
+  @if (canBranch) {
     <button mat-menu-item (click)="goToCreateBranchView()">
       <mat-icon class="rotate-180">call_split</mat-icon><span i18n>Branch off this step</span>
     </button>

--- a/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.spec.ts
+++ b/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.spec.ts
@@ -1,32 +1,129 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AddStepButtonComponent } from './add-step-button.component';
 import { TeacherProjectService } from '../../services/teacherProjectService';
-import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
-import { provideRouter } from '@angular/router';
-
-let teacherProjectService: TeacherProjectService;
+import { ActivatedRoute, Router } from '@angular/router';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatMenuHarness } from '@angular/material/menu/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { AddStepTarget } from '../../../../app/domain/addStepTarget';
 
 describe('AddStepButtonComponent', () => {
   let component: AddStepButtonComponent;
   let fixture: ComponentFixture<AddStepButtonComponent>;
+  let loader: HarnessLoader;
+  let projectServiceSpy: jasmine.SpyObj<TeacherProjectService>;
+  let routerSpy: jasmine.SpyObj<Router>;
+  let route: ActivatedRoute;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [AddStepButtonComponent, StudentTeacherCommonServicesModule],
+  beforeEach(async () => {
+    projectServiceSpy = jasmine.createSpyObj('TeacherProjectService', [
+      'isFirstStepInLesson',
+      'isBranchPoint',
+      'isNodeInAnyBranchPath',
+      'getParentGroupId',
+      'getNodesByToNodeId',
+      'isFirstNodeInBranchPath'
+    ]);
+    routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+
+    await TestBed.configureTestingModule({
+      imports: [AddStepButtonComponent, NoopAnimationsModule],
       providers: [
-        TeacherProjectService,
-        provideHttpClient(withInterceptorsFromDi()),
-        provideRouter([])
+        { provide: TeacherProjectService, useValue: projectServiceSpy },
+        { provide: Router, useValue: routerSpy },
+        { provide: ActivatedRoute, useValue: {} }
       ]
-    });
-    teacherProjectService = TestBed.inject(TeacherProjectService);
+    }).compileComponents();
+
+    route = TestBed.inject(ActivatedRoute);
     fixture = TestBed.createComponent(AddStepButtonComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    component.nodeId = 'node1';
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should disable button when no actions are available', async () => {
+    projectServiceSpy.isFirstStepInLesson.and.returnValue(false);
+    projectServiceSpy.isBranchPoint.and.returnValue(true);
+    projectServiceSpy.isNodeInAnyBranchPath.and.returnValue(true);
+    fixture.detectChanges();
+
+    const button = await loader.getHarness(MatButtonHarness);
+    expect(await button.isDisabled()).toBeTruthy();
+  });
+
+  it('should show all menu items when all actions are available', async () => {
+    projectServiceSpy.isFirstStepInLesson.and.returnValue(true);
+    projectServiceSpy.isBranchPoint.and.returnValue(false);
+    projectServiceSpy.isNodeInAnyBranchPath.and.returnValue(false);
+    fixture.detectChanges();
+
+    const button = await loader.getHarness(MatButtonHarness);
+    await button.click();
+
+    const menu = await loader.getHarness(MatMenuHarness);
+    const items = await menu.getItems();
+    expect(items.length).toBe(3);
+  });
+
+  it('should navigate to add step before view when first in lesson', async () => {
+    projectServiceSpy.isFirstStepInLesson.and.returnValue(true);
+    projectServiceSpy.getParentGroupId.and.returnValue('group1');
+    fixture.detectChanges();
+
+    const button = await loader.getHarness(MatButtonHarness);
+    await button.click();
+    const menu = await loader.getHarness(MatMenuHarness);
+    const items = await menu.getItems();
+    expect(items.length).toBe(3);
+    await items[0].click();
+
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['add-node', 'choose-template'], {
+      relativeTo: route,
+      state: jasmine.any(AddStepTarget)
+    });
+  });
+
+  it('should navigate to add step after view', async () => {
+    projectServiceSpy.isFirstStepInLesson.and.returnValue(false);
+    projectServiceSpy.isBranchPoint.and.returnValue(false);
+    fixture.detectChanges();
+
+    const button = await loader.getHarness(MatButtonHarness);
+    await button.click();
+    const menu = await loader.getHarness(MatMenuHarness);
+    const items = await menu.getItems();
+    expect(items.length).toBe(2);
+    await items[0].click();
+
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['add-node', 'choose-template'], {
+      relativeTo: route,
+      state: jasmine.any(AddStepTarget)
+    });
+  });
+
+  it('should navigate to create branch view', async () => {
+    projectServiceSpy.isFirstStepInLesson.and.returnValue(false);
+    projectServiceSpy.isBranchPoint.and.returnValue(false);
+    projectServiceSpy.isNodeInAnyBranchPath.and.returnValue(false);
+    fixture.detectChanges();
+
+    const button = await loader.getHarness(MatButtonHarness);
+    await button.click();
+    const menu = await loader.getHarness(MatMenuHarness);
+    const items = await menu.getItems();
+    expect(items.length).toBe(2);
+    await items[1].click();
+
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['create-branch'], {
+      relativeTo: route,
+      state: { targetId: 'node1' }
+    });
   });
 });

--- a/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.spec.ts
+++ b/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.spec.ts
@@ -2,8 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AddStepButtonComponent } from './add-step-button.component';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { MatIconModule } from '@angular/material/icon';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 
@@ -15,16 +13,14 @@ describe('AddStepButtonComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [AddStepButtonComponent, MatIconModule, StudentTeacherCommonServicesModule],
+      imports: [AddStepButtonComponent, StudentTeacherCommonServicesModule],
       providers: [
         TeacherProjectService,
         provideHttpClient(withInterceptorsFromDi()),
-        provideHttpClientTesting(),
         provideRouter([])
       ]
     });
     teacherProjectService = TestBed.inject(TeacherProjectService);
-    spyOn(teacherProjectService, 'isBranchMergePoint').and.returnValue(false);
     fixture = TestBed.createComponent(AddStepButtonComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.ts
+++ b/src/assets/wise5/authoringTool/add-step-button/add-step-button.component.ts
@@ -9,8 +9,8 @@ import { MatMenuModule } from '@angular/material/menu';
 import { AddStepTarget } from '../../../../app/domain/addStepTarget';
 
 @Component({
+  imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule, MatTooltipModule],
   selector: 'add-step-button',
-  templateUrl: './add-step-button.component.html',
   standalone: true,
   styles: [
     `
@@ -22,12 +22,12 @@ import { AddStepTarget } from '../../../../app/domain/addStepTarget';
       }
     `
   ],
-  imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule, MatTooltipModule]
+  templateUrl: './add-step-button.component.html'
 })
 export class AddStepButtonComponent {
-  protected branchMergePoint: boolean;
-  protected branchPathStep: boolean;
-  protected branchPoint: boolean;
+  protected canAddAfter: boolean;
+  protected canAddBefore: boolean;
+  protected canBranch: boolean;
   @Input() nodeId: string;
 
   constructor(
@@ -37,9 +37,11 @@ export class AddStepButtonComponent {
   ) {}
 
   ngOnInit(): void {
-    this.branchPoint = this.projectService.isBranchPoint(this.nodeId);
-    this.branchPathStep = this.projectService.isNodeInAnyBranchPath(this.nodeId);
-    this.branchMergePoint = this.projectService.isBranchMergePoint(this.nodeId);
+    this.canAddBefore = this.projectService.isFirstStepInLesson(this.nodeId);
+    const isBranchPoint = this.projectService.isBranchPoint(this.nodeId);
+    const isBranchPathStep = this.projectService.isNodeInAnyBranchPath(this.nodeId);
+    this.canAddAfter = !isBranchPoint;
+    this.canBranch = !(isBranchPoint || isBranchPathStep);
   }
 
   protected addStepBefore(): void {

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -61,7 +61,7 @@
         [projectId]="projectId"
         fxFlex
       ></project-authoring-step>
-      <add-step-button [nodeId]="childId"></add-step-button>
+      <add-step-button [nodeId]="childId" />
     </div>
     <div *ngIf="lesson.ids.length === 0" class="no-steps-message" fxLayoutAlign="start center">
       <div i18n>This lesson has no steps</div>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9422,18 +9422,18 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Add lesson before</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">29</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7c096031ae7c24c22f80edb62bd25896a4cbd2e6" datatype="html">
         <source>Add lesson after</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">32</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html</context>
-          <context context-type="linenumber">40</context>
+          <context context-type="linenumber">41</context>
         </context-group>
       </trans-unit>
       <trans-unit id="372e176e8ed50173e0caa989d8c5b7ff750c4d58" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9518,21 +9518,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Add step before</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-step-button/add-step-button.component.html</context>
-          <context context-type="linenumber">16</context>
+          <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d59263511cd8dbe0a1eb9bd829aac8d827d8fd83" datatype="html">
         <source>Add step after</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-step-button/add-step-button.component.html</context>
-          <context context-type="linenumber">21</context>
+          <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit>
       <trans-unit id="66a796ca959149529fa803f5ffa9cad29b5c5c5a" datatype="html">
         <source>Branch off this step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/add-step-button/add-step-button.component.html</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8608bcf1ea8ff554000e0ac4337e7afd3cf5c3f3" datatype="html">


### PR DESCRIPTION
## Changes
This pull request includes several changes to the `add-lesson-button` and `add-step-button` components to improve the user interface and functionality. The most important changes include updating the icons and styles, adding conditions for enabling/disabling buttons, and enhancing the unit tests for the `add-step-button` component. We removed the "Add step before" option unless it's for first step in the lesson.

UI and Style Updates:

* [`src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.html`](diffhunk://#diff-9f02430ce631668623ad5ff391d8eed4c907712bc1707ae4e7fee5767f6f0d9eL28-R32): Updated icons and added classes for rotating and flipping the icons.
* [`src/assets/wise5/authoringTool/add-step-button/add-step-button.component.html`](diffhunk://#diff-fbb48f87ce7d1bb633db722d4e94243bd0ac9443aeb7950267222381033ef215R9-R25): Added conditions to disable the button when no actions are available and updated icons with new classes.

Component Logic Enhancements:

* [`src/assets/wise5/authoringTool/add-step-button/add-step-button.component.ts`](diffhunk://#diff-0258c1a0b46c4a91d7f9600e2756ae75717d74e054f2a0c1c6966ae2b2d58937L40-R44): Added new properties (`canAddBefore`, `canAddAfter`, `canBranch`) to replace the old properties and updated the `ngOnInit` method to set these new properties based on service methods.
* [`src/assets/wise5/authoringTool/add-lesson-button/add-lesson-button.component.ts`](diffhunk://#diff-19500932f81025bf706b4ed20ea8cf7b3076fd8b56f5f4c30a678effb44ce5c6R10-R23): Reorganized imports and added styles for rotating and flipping icons.

Unit Test Improvements:

* [`src/assets/wise5/authoringTool/add-step-button/add-step-button.component.spec.ts`](diffhunk://#diff-ad3ce270afa5bf8cc88bcb6e24ea234d84dde745a6b0387207350b9be0274861L4-R128): Enhanced unit tests to cover new conditions and interactions for the `add-step-button` component, including button disabling and menu item navigation.

## Test (In the AT)
- Add step before option only appears for first step in the unit
- Add step button is disabled if option to add before/after/branch is not available.
- Add lesson menu items shows the arrow icons for adding lesson before/after