### PR TITLE
refactor(WorkgroupComponentGrading): Convert to standalone

### DIFF
--- a/src/app/teacher/grading-common.module.ts
+++ b/src/app/teacher/grading-common.module.ts
@@ -23,14 +23,11 @@ import { ComponentStateInfoComponent } from '../../assets/wise5/common/component
     StatusIconComponent,
     StudentTeacherCommonModule,
     WorkgroupInfoComponent,
+    WorkgroupComponentGradingComponent,
     WorkgroupNodeScoreComponent,
     WorkgroupNodeStatusComponent
   ],
-  declarations: [
-    WorkgroupComponentGradingComponent,
-    WorkgroupItemComponent,
-    WorkgroupSelectAutocompleteComponent
-  ],
+  declarations: [WorkgroupItemComponent, WorkgroupSelectAutocompleteComponent],
   exports: [
     ComponentGradingComponent,
     ComponentStateInfoComponent,

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-workgroup-item/milestone-workgroup-item.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-workgroup-item/milestone-workgroup-item.component.html
@@ -80,7 +80,7 @@
             [componentId]="firstComponentId"
             [workgroupId]="workgroupId"
             [nodeId]="firstNodeId"
-          ></workgroup-component-grading>
+          />
         </div>
       </div>
       <div
@@ -102,7 +102,7 @@
             [componentId]="lastComponentId"
             [workgroupId]="workgroupId"
             [nodeId]="lastNodeId"
-          ></workgroup-component-grading>
+          />
         </div>
       </div>
     </div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.html
@@ -54,7 +54,7 @@
               [componentId]="component.id"
               [workgroupId]="workgroupId"
               [nodeId]="nodeId"
-            ></workgroup-component-grading>
+            />
           </div>
         </div>
       </ng-container>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.html
@@ -52,8 +52,7 @@
             [componentId]="component.id"
             [workgroupId]="workgroupId"
             [nodeId]="nodeId"
-          >
-          </workgroup-component-grading>
+          />
         </div>
       </ng-container>
     </div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.html
@@ -27,7 +27,7 @@
       class="component__actions__info component--grading__actions__info md-caption"
       fxLayout="row"
     >
-      <component-state-info [componentState]="latestComponentState"> </component-state-info>
+      <component-state-info [componentState]="latestComponentState" />
       <span *ngIf="componentStates.length > 1">
         &nbsp;&#8226;&nbsp;<a (click)="showRevisions($event)" i18n>See revisions</a>
       </span>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.html
@@ -1,47 +1,48 @@
 <div class="component__content" fxLayout="column" fxLayout.gt-sm="row" fxLayoutGap="16px">
   <div fxLayout="column" fxFlex="100" [fxFlex.gt-sm]="isGradable ? 66 : 100">
-    <ng-container
-      *ngIf="
-        latestComponentState != null ||
-        component.type === 'ShowGroupWork' ||
-        component.type === 'ShowMyWork'
-      "
-    >
+    @if (
+      latestComponentState != null ||
+      component.type === 'ShowGroupWork' ||
+      component.type === 'ShowMyWork'
+    ) {
       <component-grading-component
         [nodeId]="nodeId"
         [componentId]="component.id"
         [componentState]="latestComponentState"
         [workgroupId]="workgroupId"
       />
-    </ng-container>
+    }
     <span fxFlex></span>
-    <div
-      *ngIf="componentStates.length === 0 && component.type !== 'ShowGroupWork'"
-      class="component__actions__info component--grading__actions__info md-caption"
-      i18n
-    >
-      Team has not saved any work
-    </div>
-    <div
-      *ngIf="componentStates.length > 0"
-      class="component__actions__info component--grading__actions__info md-caption"
-      fxLayout="row"
-    >
-      <component-state-info [componentState]="latestComponentState" />
-      <span *ngIf="componentStates.length > 1">
-        &nbsp;&#8226;&nbsp;<a (click)="showRevisions($event)" i18n>See revisions</a>
-      </span>
-    </div>
+    @if (componentStates.length === 0 && component.type !== 'ShowGroupWork') {
+      <div class="component__actions__info component--grading__actions__info md-caption" i18n>
+        Team has not saved any work
+      </div>
+    }
+    @if (componentStates.length > 0) {
+      <div
+        class="component__actions__info component--grading__actions__info md-caption"
+        fxLayout="row"
+      >
+        <component-state-info [componentState]="latestComponentState" />
+        @if (componentStates.length > 1) {
+          <span>
+            &nbsp;&#8226;&nbsp;<a (click)="showRevisions($event)" i18n>See revisions</a>
+          </span>
+        }
+      </div>
+    }
   </div>
-  <div *ngIf="isGradable" fxFlex="100" fxFlex.gt-sm="33" class="component--grading__annotations">
-    <edit-component-annotations
-      [componentId]="component.id"
-      [componentStateId]="latestComponentStateId"
-      [fromWorkgroupId]="teacherWorkgroupId"
-      [isDisabled]="false"
-      [nodeId]="nodeId"
-      [showAllAnnotations]="false"
-      [toWorkgroupId]="workgroupId"
-    />
-  </div>
+  @if (isGradable) {
+    <div fxFlex="100" fxFlex.gt-sm="33" class="component--grading__annotations">
+      <edit-component-annotations
+        [componentId]="component.id"
+        [componentStateId]="latestComponentStateId"
+        [fromWorkgroupId]="teacherWorkgroupId"
+        [isDisabled]="false"
+        [nodeId]="nodeId"
+        [showAllAnnotations]="false"
+        [toWorkgroupId]="workgroupId"
+      />
+    </div>
+  }
 </div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.ts
@@ -1,14 +1,28 @@
 import { Component, Input } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { ComponentContent } from '../../../common/ComponentContent';
 import { ComponentFactory } from '../../../common/ComponentFactory';
 import { ConfigService } from '../../../services/configService';
 import { TeacherDataService } from '../../../services/teacherDataService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { ViewComponentRevisionsComponent } from '../view-component-revisions/view-component-revisions.component';
+import { CommonModule } from '@angular/common';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { ComponentStateInfoComponent } from '../../../common/component-state-info/component-state-info.component';
+import { ComponentGradingComponent } from '../component-grading.component';
+import { EditComponentAnnotationsComponent } from '../edit-component-annotations/edit-component-annotations.component';
 
 @Component({
+  imports: [
+    CommonModule,
+    ComponentGradingComponent,
+    ComponentStateInfoComponent,
+    EditComponentAnnotationsComponent,
+    FlexLayoutModule,
+    MatDialogModule
+  ],
   selector: 'workgroup-component-grading',
+  standalone: true,
   templateUrl: 'workgroup-component-grading.component.html'
 })
 export class WorkgroupComponentGradingComponent {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import { Component, Input } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ComponentContent } from '../../../common/ComponentContent';
@@ -14,45 +12,45 @@ import { ViewComponentRevisionsComponent } from '../view-component-revisions/vie
   templateUrl: 'workgroup-component-grading.component.html'
 })
 export class WorkgroupComponentGradingComponent {
+  protected component: ComponentContent;
   @Input() componentId: string;
+  protected componentStates: any[];
+  protected isGradable: boolean;
+  protected latestComponentState: any;
+  protected latestComponentStateId: number;
   @Input() nodeId: string;
+  protected teacherWorkgroupId: number;
   @Input() workgroupId: number;
 
-  component: ComponentContent;
-  componentStates: any[];
-  isGradable: boolean;
-  latestComponentState: any;
-  latestComponentStateId: number;
-  teacherWorkgroupId: number;
-
   constructor(
+    private configService: ConfigService,
+    private dataService: TeacherDataService,
     private dialog: MatDialog,
-    private ConfigService: ConfigService,
-    private ProjectService: TeacherProjectService,
-    private TeacherDataService: TeacherDataService
+    private projectService: TeacherProjectService
   ) {}
 
-  ngOnInit() {
-    this.teacherWorkgroupId = this.ConfigService.getWorkgroupId();
-    this.component = this.ProjectService.getComponent(this.nodeId, this.componentId);
+  ngOnInit(): void {
+    this.teacherWorkgroupId = this.configService.getWorkgroupId();
+    this.component = this.projectService.getComponent(this.nodeId, this.componentId);
     const factory = new ComponentFactory();
     const component = factory.getComponent(this.component, this.nodeId);
     this.isGradable = component.isGradable();
-    this.componentStates = this.TeacherDataService.getComponentStatesByWorkgroupIdAndComponentId(
+    this.componentStates = this.dataService.getComponentStatesByWorkgroupIdAndComponentId(
       this.workgroupId,
       this.componentId
     );
-    this.latestComponentState = this.TeacherDataService.getLatestComponentStateByWorkgroupIdNodeIdAndComponentId(
-      this.workgroupId,
-      this.nodeId,
-      this.componentId
-    );
+    this.latestComponentState =
+      this.dataService.getLatestComponentStateByWorkgroupIdNodeIdAndComponentId(
+        this.workgroupId,
+        this.nodeId,
+        this.componentId
+      );
     if (this.latestComponentState != null) {
       this.latestComponentStateId = this.latestComponentState.id;
     }
   }
 
-  showRevisions() {
+  protected showRevisions(): void {
     this.dialog.open(ViewComponentRevisionsComponent, {
       data: {
         workgroupId: this.workgroupId,

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -14658,18 +14658,18 @@ Are you sure you want to proceed?</source>
           <context context-type="linenumber">44</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="149546eb32bc1b69012afcd34945c180f0790dbf" datatype="html">
+      <trans-unit id="25e891de83c55fc6006c9c5c5dcb4225e095c86f" datatype="html">
         <source> Team has not saved any work </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.html</context>
-          <context context-type="linenumber">22,24</context>
+          <context context-type="linenumber">17,19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1a68048cfcd964c630f4316c43db20f0b8e3a80d" datatype="html">
         <source>See revisions</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.html</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">29</context>
         </context-group>
       </trans-unit>
       <trans-unit id="456492495567778711" datatype="html">


### PR DESCRIPTION
## Changes
This pull request includes significant changes to the `WorkgroupComponentGradingComponent` and its integration within the project. The updates involve refactoring the component to be standalone, modifying its template and TypeScript logic, and updating related HTML files to reflect these changes.

### Refactoring and Component Updates:

* [`src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.ts`](diffhunk://#diff-5533aea617ef5f2adb840f2290a7c7aa54bf98a06d0f1509aff97e26df9e990cL1-R57): Refactored the component to be standalone, added necessary imports, and updated the initialization logic to use protected members and dependency injection. [[1]](diffhunk://#diff-5533aea617ef5f2adb840f2290a7c7aa54bf98a06d0f1509aff97e26df9e990cL1-R57) [[2]](diffhunk://#diff-5533aea617ef5f2adb840f2290a7c7aa54bf98a06d0f1509aff97e26df9e990cL55-R67)
* [`src/assets/wise5/classroomMonitor/classroomMonitorComponents/workgroup-component-grading/workgroup-component-grading.component.html`](diffhunk://#diff-f86bd2cc354c04d02f6e3f424eb77a39efc79c28ef043bfe4179fbf6783acaa7L3-R36): Replaced Angular's `*ngIf` structural directives with Angular's `@if` syntax for better readability and performance. [[1]](diffhunk://#diff-f86bd2cc354c04d02f6e3f424eb77a39efc79c28ef043bfe4179fbf6783acaa7L3-R36) [[2]](diffhunk://#diff-f86bd2cc354c04d02f6e3f424eb77a39efc79c28ef043bfe4179fbf6783acaa7R47)

### Integration Updates:

* [`src/app/teacher/grading-common.module.ts`](diffhunk://#diff-2036f64808ac0143787e8634d9e98f521b1b85cf47e7747f7825e21282a312e2R26-R30): Updated the module declarations and imports to accommodate the refactored `WorkgroupComponentGradingComponent`.
* Multiple HTML files (`milestone-workgroup-item.component.html`, `workgroup-item.component.html`, `step-item.component.html`): Removed the usage of `workgroup-component-grading` tags and replaced them with self-closing tags to align with the new component structure. [[1]](diffhunk://#diff-68c2895ba4ebb096c4f2fbe3b86a317627078417813f879a3d2efe0dd37b70cbL83-R83) [[2]](diffhunk://#diff-68c2895ba4ebb096c4f2fbe3b86a317627078417813f879a3d2efe0dd37b70cbL105-R105) [[3]](diffhunk://#diff-a69b755792297258a17b344322efe7d4e0919ae09e319a017245d014c630e174L57-R57) [[4]](diffhunk://#diff-49b52de06af684f6a2c6f1991269038c1c16fd88b1a1dfedc6586bd75b00383cL55-R55)

### Translation File Updates:

* [`src/messages.xlf`](diffhunk://#diff-3a3cab1562515f062670a0faf4d9aae22493651b1c77a80df9055d501350421eL14661-R14672): Updated translation unit IDs and context information to reflect changes in the `workgroup-component-grading.component.html` file.

## Test
- Workgroup grading works as before in the CM. Be sure to test revision and Milestone views.