### PR TITLE
refactor(TeacherDataService): Move functions to OneWorkgroupPerRowExport

### DIFF
--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/OneWorkgroupPerRowDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/OneWorkgroupPerRowDataExportStrategy.ts
@@ -115,11 +115,12 @@ export class OneWorkgroupPerRowDataExportStrategy extends AbstractDataExportStra
                 var componentId = component.id;
                 if (this.exportComponent(selectedNodesMap, nodeId, componentId)) {
                   var columnIdPrefix = nodeId + '-' + componentId;
-                  var componentState = this.teacherDataService.getLatestComponentStateByWorkgroupIdNodeIdAndComponentId(
-                    workgroupId,
-                    nodeId,
-                    componentId
-                  );
+                  var componentState =
+                    this.teacherDataService.getLatestComponentStateByWorkgroupIdNodeIdAndComponentId(
+                      workgroupId,
+                      nodeId,
+                      componentId
+                    );
                   if (componentState != null) {
                     if (this.controller.includeStudentWorkIds) {
                       workgroupRow[columnIdToColumnIndex[columnIdPrefix + '-studentWorkId']] =
@@ -135,15 +136,15 @@ export class OneWorkgroupPerRowDataExportStrategy extends AbstractDataExportStra
                         ] = formattedDateTime;
                       }
                     }
-                    workgroupRow[
-                      columnIdToColumnIndex[columnIdPrefix + '-studentWork']
-                    ] = this.getStudentDataString(componentState);
+                    workgroupRow[columnIdToColumnIndex[columnIdPrefix + '-studentWork']] =
+                      this.getStudentDataString(componentState);
                     if (this.controller.includeScores || this.controller.includeComments) {
-                      var latestComponentAnnotations = this.annotationService.getLatestComponentAnnotations(
-                        nodeId,
-                        componentId,
-                        workgroupId
-                      );
+                      var latestComponentAnnotations =
+                        this.annotationService.getLatestComponentAnnotations(
+                          nodeId,
+                          componentId,
+                          workgroupId
+                        );
                       if (latestComponentAnnotations != null) {
                         var scoreAnnotation = latestComponentAnnotations.score;
                         var commentAnnotation = latestComponentAnnotations.comment;
@@ -162,9 +163,8 @@ export class OneWorkgroupPerRowDataExportStrategy extends AbstractDataExportStra
                               scoreAnnotation.data.value != null
                             ) {
                               var scoreValue = scoreAnnotation.data.value;
-                              workgroupRow[
-                                columnIdToColumnIndex[columnIdPrefix + '-score']
-                              ] = scoreValue;
+                              workgroupRow[columnIdToColumnIndex[columnIdPrefix + '-score']] =
+                                scoreValue;
                             }
                           }
                         }
@@ -183,9 +183,8 @@ export class OneWorkgroupPerRowDataExportStrategy extends AbstractDataExportStra
                               commentAnnotation.data.value != null
                             ) {
                               var commentValue = commentAnnotation.data.value;
-                              workgroupRow[
-                                columnIdToColumnIndex[columnIdPrefix + '-comment']
-                              ] = commentValue;
+                              workgroupRow[columnIdToColumnIndex[columnIdPrefix + '-comment']] =
+                                commentValue;
                             }
                           }
                         }
@@ -200,11 +199,9 @@ export class OneWorkgroupPerRowDataExportStrategy extends AbstractDataExportStra
             if (this.projectService.isBranchPoint(nodeId)) {
               var toNodeId = null;
               var stepTitle = null;
-              var eventType = 'branchPathTaken';
-              var latestBranchPathTakenEvent = this.teacherDataService.getLatestEventByWorkgroupIdAndNodeIdAndType(
+              const latestBranchPathTakenEvent = this.getLatestBranchPathTakenEvent(
                 workgroupId,
-                nodeId,
-                eventType
+                nodeId
               );
               if (
                 latestBranchPathTakenEvent != null &&
@@ -231,9 +228,8 @@ export class OneWorkgroupPerRowDataExportStrategy extends AbstractDataExportStra
               }
               if (this.controller.includeBranchPathTakenStepTitle) {
                 if (stepTitle != null) {
-                  workgroupRow[
-                    columnIdToColumnIndex[nodeId + '-branchPathTakenStepTitle']
-                  ] = stepTitle;
+                  workgroupRow[columnIdToColumnIndex[nodeId + '-branchPathTakenStepTitle']] =
+                    stepTitle;
                 } else {
                   workgroupRow[columnIdToColumnIndex[nodeId + '-branchPathTakenStepTitle']] = ' ';
                 }
@@ -247,6 +243,17 @@ export class OneWorkgroupPerRowDataExportStrategy extends AbstractDataExportStra
       this.generateCSVFile(rows, fileName);
       this.controller.hideDownloadingExportMessage();
     });
+  }
+
+  private getLatestBranchPathTakenEvent(workgroupId: number, nodeId: string): any {
+    const events = this.teacherDataService.getEventsByWorkgroupId(workgroupId);
+    for (let i = events.length - 1; i >= 0; i--) {
+      const event = events[i];
+      if (event.nodeId === nodeId && event.event === 'branchPathTaken') {
+        return event;
+      }
+    }
+    return null;
   }
 
   /**
@@ -434,22 +441,19 @@ export class OneWorkgroupPerRowDataExportStrategy extends AbstractDataExportStra
                   c + 1;
                 componentTypeRow[columnIdToColumnIndex[columnIdPrefix + '-studentWorkId']] =
                   component.type;
-                componentPromptRow[
-                  columnIdToColumnIndex[columnIdPrefix + '-studentWorkId']
-                ] = prompt;
+                componentPromptRow[columnIdToColumnIndex[columnIdPrefix + '-studentWorkId']] =
+                  prompt;
                 nodeIdRow[columnIdToColumnIndex[columnIdPrefix + '-studentWorkId']] = nodeId;
-                componentIdRow[
-                  columnIdToColumnIndex[columnIdPrefix + '-studentWorkId']
-                ] = componentId;
+                componentIdRow[columnIdToColumnIndex[columnIdPrefix + '-studentWorkId']] =
+                  componentId;
                 columnIdRow[columnIdToColumnIndex[columnIdPrefix + '-studentWorkId']] =
                   columnIdPrefix + '-studentWorkId';
                 descriptionRow[columnIdToColumnIndex[columnIdPrefix + '-studentWorkId']] =
                   'Student Work ID';
               }
               if (this.controller.includeStudentWorkTimestamps) {
-                stepTitleRow[
-                  columnIdToColumnIndex[columnIdPrefix + '-studentWorkTimestamp']
-                ] = stepTitle;
+                stepTitleRow[columnIdToColumnIndex[columnIdPrefix + '-studentWorkTimestamp']] =
+                  stepTitle;
                 componentPartNumberRow[
                   columnIdToColumnIndex[columnIdPrefix + '-studentWorkTimestamp']
                 ] = c + 1;
@@ -459,9 +463,8 @@ export class OneWorkgroupPerRowDataExportStrategy extends AbstractDataExportStra
                   columnIdToColumnIndex[columnIdPrefix + '-studentWorkTimestamp']
                 ] = prompt;
                 nodeIdRow[columnIdToColumnIndex[columnIdPrefix + '-studentWorkTimestamp']] = nodeId;
-                componentIdRow[
-                  columnIdToColumnIndex[columnIdPrefix + '-studentWorkTimestamp']
-                ] = componentId;
+                componentIdRow[columnIdToColumnIndex[columnIdPrefix + '-studentWorkTimestamp']] =
+                  componentId;
                 columnIdRow[columnIdToColumnIndex[columnIdPrefix + '-studentWorkTimestamp']] =
                   columnIdPrefix + '-studentWorkTimestamp';
                 descriptionRow[columnIdToColumnIndex[columnIdPrefix + '-studentWorkTimestamp']] =
@@ -475,9 +478,8 @@ export class OneWorkgroupPerRowDataExportStrategy extends AbstractDataExportStra
                   component.type;
                 componentPromptRow[columnIdToColumnIndex[columnIdPrefix + '-studentWork']] = prompt;
                 nodeIdRow[columnIdToColumnIndex[columnIdPrefix + '-studentWork']] = nodeId;
-                componentIdRow[
-                  columnIdToColumnIndex[columnIdPrefix + '-studentWork']
-                ] = componentId;
+                componentIdRow[columnIdToColumnIndex[columnIdPrefix + '-studentWork']] =
+                  componentId;
                 columnIdRow[columnIdToColumnIndex[columnIdPrefix + '-studentWork']] =
                   columnIdPrefix + '-studentWork';
                 descriptionRow[columnIdToColumnIndex[columnIdPrefix + '-studentWork']] =
@@ -490,13 +492,11 @@ export class OneWorkgroupPerRowDataExportStrategy extends AbstractDataExportStra
                   c + 1;
                 componentTypeRow[columnIdToColumnIndex[columnIdPrefix + '-scoreTimestamp']] =
                   component.type;
-                componentPromptRow[
-                  columnIdToColumnIndex[columnIdPrefix + '-scoreTimestamp']
-                ] = prompt;
+                componentPromptRow[columnIdToColumnIndex[columnIdPrefix + '-scoreTimestamp']] =
+                  prompt;
                 nodeIdRow[columnIdToColumnIndex[columnIdPrefix + '-scoreTimestamp']] = nodeId;
-                componentIdRow[
-                  columnIdToColumnIndex[columnIdPrefix + '-scoreTimestamp']
-                ] = componentId;
+                componentIdRow[columnIdToColumnIndex[columnIdPrefix + '-scoreTimestamp']] =
+                  componentId;
                 columnIdRow[columnIdToColumnIndex[columnIdPrefix + '-scoreTimestamp']] =
                   columnIdPrefix + '-scoreTimestamp';
                 descriptionRow[columnIdToColumnIndex[columnIdPrefix + '-scoreTimestamp']] =
@@ -514,21 +514,18 @@ export class OneWorkgroupPerRowDataExportStrategy extends AbstractDataExportStra
                 descriptionRow[columnIdToColumnIndex[columnIdPrefix + '-score']] = 'Score';
               }
               if (this.controller.includeCommentTimestamps) {
-                stepTitleRow[
-                  columnIdToColumnIndex[columnIdPrefix + '-commentTimestamp']
-                ] = stepTitle;
+                stepTitleRow[columnIdToColumnIndex[columnIdPrefix + '-commentTimestamp']] =
+                  stepTitle;
                 componentPartNumberRow[
                   columnIdToColumnIndex[columnIdPrefix + '-commentTimestamp']
                 ] = c + 1;
                 componentTypeRow[columnIdToColumnIndex[columnIdPrefix + '-commentTimestamp']] =
                   component.type;
-                componentPromptRow[
-                  columnIdToColumnIndex[columnIdPrefix + '-commentTimestamp']
-                ] = prompt;
+                componentPromptRow[columnIdToColumnIndex[columnIdPrefix + '-commentTimestamp']] =
+                  prompt;
                 nodeIdRow[columnIdToColumnIndex[columnIdPrefix + '-commentTimestamp']] = nodeId;
-                componentIdRow[
-                  columnIdToColumnIndex[columnIdPrefix + '-commentTimestamp']
-                ] = componentId;
+                componentIdRow[columnIdToColumnIndex[columnIdPrefix + '-commentTimestamp']] =
+                  componentId;
                 columnIdRow[columnIdToColumnIndex[columnIdPrefix + '-commentTimestamp']] =
                   columnIdPrefix + '-commentTimestamp';
                 descriptionRow[columnIdToColumnIndex[columnIdPrefix + '-commentTimestamp']] =

--- a/src/assets/wise5/services/teacherDataService.ts
+++ b/src/assets/wise5/services/teacherDataService.ts
@@ -509,21 +509,6 @@ export class TeacherDataService extends DataService {
     return this.studentData.eventsByNodeId[nodeId] || [];
   }
 
-  getLatestEventByWorkgroupIdAndNodeIdAndType(workgroupId, nodeId, eventType) {
-    const eventsByWorkgroupId = this.getEventsByWorkgroupId(workgroupId);
-    for (let e = eventsByWorkgroupId.length - 1; e >= 0; e--) {
-      const event = eventsByWorkgroupId[e];
-      if (this.isEventMatchingNodeIdEventType(event, nodeId, eventType)) {
-        return event;
-      }
-    }
-    return null;
-  }
-
-  isEventMatchingNodeIdEventType(event, nodeId, eventType) {
-    return event.nodeId === nodeId && event.event === eventType;
-  }
-
   getAnnotationsToWorkgroupId(workgroupId: number) {
     return this.studentData.annotationsToWorkgroupId[workgroupId] || [];
   }


### PR DESCRIPTION
## Changes
The functions were only used in OneWorkgroupPerRowExport, and didn't need to be in TeacherDataService.

This pull request includes several changes to the `OneWorkgroupPerRowDataExportStrategy` class in the `src/assets/wise5/classroomMonitor/dataExport/strategies/OneWorkgroupPerRowDataExportStrategy.ts` file. The changes primarily focus on code formatting for better readability and the addition of a new method to retrieve the latest branch path taken event. Additionally, some redundant methods have been removed from the `TeacherDataService` class.

Improvements to code readability:

* Reformatted lines to improve readability by breaking long lines into multiple lines. [[1]](diffhunk://#diff-488e3caa66f5f41abaa1099852582f39ec273e2a1990878171fad84052f75048L118-R119) [[2]](diffhunk://#diff-488e3caa66f5f41abaa1099852582f39ec273e2a1990878171fad84052f75048L138-R143) [[3]](diffhunk://#diff-488e3caa66f5f41abaa1099852582f39ec273e2a1990878171fad84052f75048L165-R167) [[4]](diffhunk://#diff-488e3caa66f5f41abaa1099852582f39ec273e2a1990878171fad84052f75048L186-R187) [[5]](diffhunk://#diff-488e3caa66f5f41abaa1099852582f39ec273e2a1990878171fad84052f75048L234-R232) [[6]](diffhunk://#diff-488e3caa66f5f41abaa1099852582f39ec273e2a1990878171fad84052f75048L437-R456) [[7]](diffhunk://#diff-488e3caa66f5f41abaa1099852582f39ec273e2a1990878171fad84052f75048L462-R467) [[8]](diffhunk://#diff-488e3caa66f5f41abaa1099852582f39ec273e2a1990878171fad84052f75048L478-R482) [[9]](diffhunk://#diff-488e3caa66f5f41abaa1099852582f39ec273e2a1990878171fad84052f75048L493-R499) [[10]](diffhunk://#diff-488e3caa66f5f41abaa1099852582f39ec273e2a1990878171fad84052f75048L517-R528)

Codebase simplification:

* Added a new method `getLatestBranchPathTakenEvent` to the `OneWorkgroupPerRowDataExportStrategy` class to encapsulate the logic for retrieving the latest branch path taken event.
* Removed the `getLatestEventByWorkgroupIdAndNodeIdAndType` and `isEventMatchingNodeIdEventType` methods from the `TeacherDataService` class as they are no longer needed.

## Test
- OneWorkgroupPerRow export, with branch path taken.