### PR TITLE
refactor(AnnotationService): Simplify getLatestAnnotation logic

### DIFF
--- a/src/assets/wise5/services/annotationService.ts
+++ b/src/assets/wise5/services/annotationService.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import { Injectable } from '@angular/core';
 import { ProjectService } from './projectService';
 import { ConfigService } from './configService';
@@ -19,9 +17,9 @@ export class AnnotationService {
   public annotationReceived$: Observable<Annotation> = this.annotationReceivedSource.asObservable();
 
   constructor(
+    private configService: ConfigService,
     private http: HttpClient,
-    private ConfigService: ConfigService,
-    private ProjectService: ProjectService
+    private projectService: ProjectService
   ) {}
 
   getAnnotations(): Annotation[] {
@@ -43,60 +41,28 @@ export class AnnotationService {
    * @param params an object containing the params to match
    * @returns the latest annotation that matches the params
    */
-  getLatestAnnotation(params) {
-    let annotation = null;
-
-    if (params != null) {
-      let nodeId = params.nodeId;
-      let componentId = params.componentId;
-      let fromWorkgroupId = params.fromWorkgroupId;
-      let toWorkgroupId = params.toWorkgroupId;
-      let type = params.type;
-
-      let annotations = this.annotations;
-
-      if (annotations != null) {
-        for (let a = annotations.length - 1; a >= 0; a--) {
-          let tempAnnotation = annotations[a];
-
-          if (tempAnnotation != null) {
-            let match = true;
-
-            if (nodeId && tempAnnotation.nodeId !== nodeId) {
-              match = false;
-            }
-            if (match && componentId && tempAnnotation.componentId !== componentId) {
-              match = false;
-            }
-            if (match && fromWorkgroupId && tempAnnotation.fromWorkgroupId !== fromWorkgroupId) {
-              match = false;
-            }
-            if (match && toWorkgroupId && tempAnnotation.toWorkgroupId !== toWorkgroupId) {
-              match = false;
-            }
-            if (match && type) {
-              if (type.constructor === Array) {
-                for (let thisType of type) {
-                  if (tempAnnotation.type !== thisType) {
-                    match = false;
-                  }
-                }
-              } else {
-                if (tempAnnotation.type !== type) {
-                  match = false;
-                }
-              }
-            }
-
-            if (match) {
-              annotation = tempAnnotation;
-              break;
-            }
-          }
+  getLatestAnnotation(params): any {
+    for (let a = this.annotations.length - 1; a >= 0; a--) {
+      const annotation = this.annotations[a];
+      let match = true;
+      if (annotation.nodeId !== params.nodeId) {
+        match = false;
+      }
+      if (match && annotation.componentId !== params.componentId) {
+        match = false;
+      }
+      if (match) {
+        if (params.type.constructor === Array) {
+          match = params.type.every((thisType) => annotation.type === thisType);
+        } else {
+          match = annotation.type === params.type;
+        }
+        if (match) {
+          return annotation;
         }
       }
     }
-    return annotation;
+    return null;
   }
 
   /**
@@ -155,7 +121,7 @@ export class AnnotationService {
     annotation.requestToken = generateRandomKey(); // use this to keep track of unsaved annotations.
     this.addOrUpdateAnnotation(annotation);
     const annotations = [annotation];
-    if (this.ConfigService.isPreview()) {
+    if (this.configService.isPreview()) {
       // if we're in preview, don't make any request to the server but pretend we did
       let savedAnnotationDataResponse = {
         annotations: annotations
@@ -164,13 +130,13 @@ export class AnnotationService {
       return Promise.resolve(annotation);
     } else {
       const params = {
-        runId: this.ConfigService.getRunId(),
-        workgroupId: this.ConfigService.getWorkgroupId(),
+        runId: this.configService.getRunId(),
+        workgroupId: this.configService.getWorkgroupId(),
         annotations: JSON.stringify(annotations)
       };
       const headers = new HttpHeaders({ 'Content-Type': 'application/x-www-form-urlencoded' });
       return this.http
-        .post(this.ConfigService.getConfigParam('teacherDataURL'), $.param(params), {
+        .post(this.configService.getConfigParam('teacherDataURL'), $.param(params), {
           headers: headers
         })
         .toPromise()
@@ -206,7 +172,7 @@ export class AnnotationService {
               localAnnotation.serverSaveTime = savedAnnotation.serverSaveTime;
               localAnnotation.requestToken = null; // requestToken is no longer needed.
 
-              if (this.ConfigService.isPreview() && localAnnotation.id == null) {
+              if (this.configService.isPreview() && localAnnotation.id == null) {
                 /*
                  * we are in preview mode so we will set a dummy
                  * annotation id into the annotation
@@ -286,7 +252,7 @@ export class AnnotationService {
     return annotations.filter((annotation) => {
       return (
         this.isScoreOrAutoScore(annotation) &&
-        this.ProjectService.shouldIncludeInTotalScore(annotation.nodeId, annotation.componentId)
+        this.projectService.shouldIncludeInTotalScore(annotation.nodeId, annotation.componentId)
       );
     });
   }

--- a/src/assets/wise5/vle/vle.component.ts
+++ b/src/assets/wise5/vle/vle.component.ts
@@ -378,12 +378,11 @@ export class VLEComponent implements AfterViewInit {
        * @returns {the|Object}
        */
       getLatestAnnotationForComponent: (nodeId, componentId, annotationType) => {
-        let params = {
+        return this.annotationService.getLatestAnnotation({
           nodeId: nodeId,
           componentId: componentId,
           type: annotationType
-        };
-        return this.annotationService.getLatestAnnotation(params);
+        });
       },
       /**
        * Updates the annotation locally and on the server


### PR DESCRIPTION
## Changes
This pull request includes several changes to the `AnnotationService` class in `src/assets/wise5/services/annotationService.ts` to improve code consistency and simplify the method `getLatestAnnotation`. Additionally, a small change was made to the `VLEComponent` class in `src/assets/wise5/vle/vle.component.ts`.  `getLatestAnnotation` is only called via embedded components that use WISEAPI.

### Code Consistency Improvements:

* Removed the redundant `'use strict';` directive from `annotationService.ts`.
* Corrected the casing of injected services in the constructor of `AnnotationService` from `ConfigService` and `ProjectService` to `configService` and `projectService`.
* Updated method calls to use the corrected service names (`configService` and `projectService`) throughout `AnnotationService`. [[1]](diffhunk://#diff-d48182301757158a9102dc504d3cb1f7b7bb92c52695d51839bf30f3ac8f1b7dL158-R124) [[2]](diffhunk://#diff-d48182301757158a9102dc504d3cb1f7b7bb92c52695d51839bf30f3ac8f1b7dL167-R139) [[3]](diffhunk://#diff-d48182301757158a9102dc504d3cb1f7b7bb92c52695d51839bf30f3ac8f1b7dL209-R175) [[4]](diffhunk://#diff-d48182301757158a9102dc504d3cb1f7b7bb92c52695d51839bf30f3ac8f1b7dL289-R255)

### Method Simplification:

* Simplified the `getLatestAnnotation` method by removing nested conditionals and using a more concise iteration and matching approach.

### Minor Change:

* Simplified the `getLatestAnnotationForComponent` method in `VLEComponent` by directly passing parameters to the `getLatestAnnotation` method of `annotationService`.

## Test
- VLE loads and works as before.