### PR TITLE
refactor(ShowNodeInfoDialog): Convert to standalone component

### DIFF
--- a/src/app/classroom-monitor/show-node-info-dialog/show-node-info-dialog.component.spec.ts
+++ b/src/app/classroom-monitor/show-node-info-dialog/show-node-info-dialog.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { ClassroomMonitorTestingModule } from '../../../assets/wise5/classroomMonitor/classroom-monitor-testing.module';
-import { NodeInfoComponent } from '../../../assets/wise5/classroomMonitor/classroomMonitorComponents/shared/node-info/node-info.component';
 import { NotebookService } from '../../../assets/wise5/services/notebookService';
 import { ProjectService } from '../../../assets/wise5/services/projectService';
 import { TeacherDataService } from '../../../assets/wise5/services/teacherDataService';
@@ -17,7 +16,6 @@ const nodeId1: string = 'node1';
 const prompt: string = 'This is the prompt.';
 const stepRubric: string = 'This is the step rubric.';
 const stepTitle: string = 'This is the title';
-
 const node: any = {
   components: [
     {
@@ -35,12 +33,10 @@ const node: any = {
 describe('ShowNodeInfoDialogComponents', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ShowNodeInfoDialogComponent],
       imports: [
         ClassroomMonitorTestingModule,
         ComponentTypeServiceModule,
-        MatDialogModule,
-        NodeInfoComponent
+        ShowNodeInfoDialogComponent
       ],
       providers: [
         { provide: MAT_DIALOG_DATA, useValue: nodeId1 },
@@ -63,7 +59,7 @@ describe('ShowNodeInfoDialogComponents', () => {
   });
 
   it('should render the step content in the dialog', () => {
-    expect(fixture.debugElement.nativeElement.innerHTML).toContain(component.stepNumberAndTitle);
+    expect(fixture.debugElement.nativeElement.innerHTML).toContain(stepTitle);
     expect(fixture.debugElement.nativeElement.innerHTML).toContain(prompt);
     expect(fixture.debugElement.nativeElement.innerHTML).toContain(stepRubric);
     expect(fixture.debugElement.nativeElement.innerHTML).toContain(componentRubric);

--- a/src/app/classroom-monitor/show-node-info-dialog/show-node-info-dialog.component.ts
+++ b/src/app/classroom-monitor/show-node-info-dialog/show-node-info-dialog.component.ts
@@ -1,15 +1,19 @@
 import { Component, ElementRef, Inject, OnInit, ViewChild } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
 import { ProjectService } from '../../../assets/wise5/services/projectService';
+import { NodeInfoComponent } from '../../../assets/wise5/classroomMonitor/classroomMonitorComponents/shared/node-info/node-info.component';
 
 @Component({
+  imports: [MatButtonModule, MatDialogModule, NodeInfoComponent],
   selector: 'show-node-info-dialog',
   templateUrl: './show-node-info-dialog.component.html',
-  styleUrls: ['./show-node-info-dialog.component.scss']
+  styleUrl: './show-node-info-dialog.component.scss',
+  standalone: true
 })
 export class ShowNodeInfoDialogComponent implements OnInit {
   @ViewChild('nodeInfoDiv') nodeInfoDiv: ElementRef;
-  stepNumberAndTitle: string;
+  protected stepNumberAndTitle: string;
 
   constructor(
     public dialogRef: MatDialogRef<ShowNodeInfoDialogComponent>,

--- a/src/app/teacher/classroom-monitor.module.ts
+++ b/src/app/teacher/classroom-monitor.module.ts
@@ -9,7 +9,6 @@ import { PeerGroupGradingModule } from './peer-group-grading.module';
 import { TeacherSummaryDisplayComponent } from '../../assets/wise5/directives/teacher-summary-display/teacher-summary-display.component';
 import { HighchartsChartModule } from 'highcharts-angular';
 import { StudentTeacherCommonModule } from '../student-teacher-common.module';
-import { NodeInfoComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/shared/node-info/node-info.component';
 import { ComponentStudentModule } from '../../assets/wise5/components/component/component-student.module';
 import { NotebookWorkgroupGradingComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/notebook/notebook-workgroup-grading/notebook-workgroup-grading.component';
 import { ProjectProgressComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/studentProgress/project-progress/project-progress.component';
@@ -49,7 +48,6 @@ import { SelectPeriodComponent } from '../../assets/wise5/classroomMonitor/class
     NotebookWorkgroupGradingComponent,
     NotificationsMenuComponent,
     PauseScreensMenuComponent,
-    ShowNodeInfoDialogComponent,
     StepItemComponent,
     StudentGradingComponent,
     StudentGradingToolsComponent,
@@ -69,13 +67,13 @@ import { SelectPeriodComponent } from '../../assets/wise5/classroomMonitor/class
     ManageStudentsModule,
     MilestoneModule,
     NavItemScoreComponent,
-    NodeInfoComponent,
     PeerGroupGradingModule,
     PreviewComponentComponent,
     ProjectProgressComponent,
     RouterModule,
     SaveIndicatorComponent,
     SelectPeriodComponent,
+    ShowNodeInfoDialogComponent,
     StepInfoComponent,
     StepToolsComponent,
     StudentTeacherCommonModule,


### PR DESCRIPTION
## Changes
This pull request includes changes to the `show-node-info-dialog` component and its related files to improve modularity and fix import issues. The most important changes include modifying imports, updating component declarations, and adjusting test cases.

### Import and Dependency Updates:

* Removed `MatDialogModule` and `NodeInfoComponent` imports from `show-node-info-dialog.component.spec.ts` and added `ShowNodeInfoDialogComponent` to the imports instead [[1]](diffhunk://#diff-c46e4d65a98f53181d023905480997d24e4a81531f58c6f7e153bef62d353844L2-L4) [[2]](diffhunk://#diff-c46e4d65a98f53181d023905480997d24e4a81531f58c6f7e153bef62d353844L38-R39).
* Added `MatDialogModule`, `MatButtonModule`, and `NodeInfoComponent` imports to `show-node-info-dialog.component.ts` and marked the component as standalone.

### Component and Module Adjustments:

* Moved `ShowNodeInfoDialogComponent` import from `classroom-monitor.module.ts` to the correct position and removed unnecessary `NodeInfoComponent` import [[1]](diffhunk://#diff-4b38e3e43e6e84c102ecb4815d66373138357a501dbf85a6903b2045fd1e0c51L12) [[2]](diffhunk://#diff-4b38e3e43e6e84c102ecb4815d66373138357a501dbf85a6903b2045fd1e0c51L52) [[3]](diffhunk://#diff-4b38e3e43e6e84c102ecb4815d66373138357a501dbf85a6903b2045fd1e0c51L72-R76).

### Test Case Updates:

* Updated test case to check for `stepTitle` instead of `component.stepNumberAndTitle` in `show-node-info-dialog.component.spec.ts`.
* Removed unnecessary blank line in the `node` object definition in `show-node-info-dialog.component.spec.ts`.

## Test
- Show node info dialog works as before from step grading and milestone views