### PR TITLE
refactor(TeacherDataService): Move getVisiblePeriodsById() to PeerGroupDialog

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/peer-group/peer-group-dialog/peer-group-dialog.component.ts
@@ -7,38 +7,38 @@ import { TeacherProjectService } from '../../../../services/teacherProjectServic
 @Component({
   selector: 'peer-group-dialog',
   templateUrl: './peer-group-dialog.component.html',
-  styleUrls: ['./peer-group-dialog.component.scss']
+  styleUrl: './peer-group-dialog.component.scss'
 })
 export class PeerGroupDialogComponent implements OnInit {
-  currentPeriodChangedSubscription: Subscription;
-  peerGroupingName: string;
-  periods: any[];
+  private currentPeriodChangedSubscription: Subscription;
+  protected peerGroupingName: string;
+  protected periods: any[];
 
   constructor(
+    private dataService: TeacherDataService,
     @Inject(MAT_DIALOG_DATA) public peerGroupingTag: string,
-    private teacherDataService: TeacherDataService,
-    private teacherProjectService: TeacherProjectService
+    private projectService: TeacherProjectService
   ) {}
 
-  ngOnInit() {
-    this.setPeriods(this.teacherDataService.getCurrentPeriodId());
-    this.peerGroupingName = this.teacherProjectService.getPeerGrouping(this.peerGroupingTag).name;
-    this.subscribeToPeriodChanged();
-  }
-
-  subscribeToPeriodChanged(): void {
-    this.currentPeriodChangedSubscription = this.teacherDataService.currentPeriodChanged$.subscribe(
+  ngOnInit(): void {
+    this.setPeriods(this.dataService.getCurrentPeriodId());
+    this.peerGroupingName = this.projectService.getPeerGrouping(this.peerGroupingTag).name;
+    this.currentPeriodChangedSubscription = this.dataService.currentPeriodChanged$.subscribe(
       ({ currentPeriod }) => {
         this.setPeriods(currentPeriod.periodId);
       }
     );
   }
 
-  setPeriods(periodId: number): void {
-    this.periods = this.teacherDataService.getVisiblePeriodsById(periodId);
+  ngOnDestroy(): void {
+    this.currentPeriodChangedSubscription.unsubscribe();
   }
 
-  ngOnDestroy() {
-    this.currentPeriodChangedSubscription.unsubscribe();
+  private setPeriods(periodId: number): void {
+    const allPeriods = this.dataService.getPeriods();
+    this.periods =
+      periodId === -1
+        ? allPeriods.slice(1)
+        : [allPeriods.find((period) => period.periodId === periodId)];
   }
 }

--- a/src/assets/wise5/services/teacherDataService.ts
+++ b/src/assets/wise5/services/teacherDataService.ts
@@ -578,14 +578,6 @@ export class TeacherDataService extends DataService {
     this.periods = periods;
   }
 
-  getVisiblePeriodsById(currentPeriodId: number): any {
-    if (currentPeriodId === -1) {
-      return this.getPeriods().slice(1);
-    } else {
-      return [this.getPeriodById(currentPeriodId)];
-    }
-  }
-
   setCurrentWorkgroup(workgroup) {
     this.currentWorkgroup = workgroup;
     this.broadcastCurrentWorkgroupChanged({ currentWorkgroup: this.currentWorkgroup });
@@ -611,10 +603,6 @@ export class TeacherDataService extends DataService {
     return this.AnnotationService.getTotalScore(
       this.studentData.annotationsToWorkgroupId[workgroupId]
     );
-  }
-
-  private getPeriodById(periodId: number): any {
-    return this.getPeriods().find((period) => period.periodId === periodId);
   }
 
   isWorkgroupShown(workgroup): boolean {


### PR DESCRIPTION
## Changes
This pull request includes several changes to improve the encapsulation and code quality of the `PeerGroupDialogComponent` and `TeacherDataService` classes. The most important changes include modifying access levels for class members, refactoring methods for better readability, and removing redundant code.

Encapsulation improvements in `PeerGroupDialogComponent`:

* Changed the access levels of `currentPeriodChangedSubscription`, `peerGroupingName`, and `periods` from public to private or protected.
* Updated the constructor to use `dataService` and `projectService` instead of `teacherDataService` and `teacherProjectService`.

Refactoring methods in `PeerGroupDialogComponent`:

* Moved the `unsubscribe` call to the `ngOnDestroy` lifecycle hook and refactored the `setPeriods` method for better readability.

Removal of redundant code in `TeacherDataService`:

* Removed the `getVisiblePeriodsById` and `getPeriodById` methods as they were no longer needed. [[1]](diffhunk://#diff-dc617e1b9ce7d685436d2bd41ad383ca06a684a2eae028811daaa48dcc43b0a9L581-L588) [[2]](diffhunk://#diff-dc617e1b9ce7d685436d2bd41ad383ca06a684a2eae028811daaa48dcc43b0a9L616-L619)

## Test
- Peer Grouping dialog appears and you can change the period as before