### PR TITLE
refactor(StudentDataService, VLEParentComponent): simplify logic for node retrieval

### DIFF
--- a/src/app/services/studentDataService.spec.ts
+++ b/src/app/services/studentDataService.spec.ts
@@ -40,7 +40,6 @@ describe('StudentDataService', () => {
   shouldGetComponentStatesByNodeId();
   shouldGetComponentStatesByNodeIdAndComponentId();
   shouldGetEventsByNodeId();
-  shouldGetLatestNodeEnteredEventNodeIdWithExistingNode();
   shouldCalculateCanVisitNode();
   shouldGetNodeStatusByNodeId();
   shouldGetLatestComponentStatesByNodeId();
@@ -425,30 +424,6 @@ function shouldGetEventsByNodeId() {
     expect(events[0].id).toEqual(1);
     expect(events[1].id).toEqual(2);
     expect(events[2].id).toEqual(5);
-  });
-}
-
-function shouldGetLatestNodeEnteredEventNodeIdWithExistingNode() {
-  it('should get latest node entered event node id with existing node', () => {
-    service.studentData = {
-      events: [
-        createEvent(1, 'node1', 'component1', 'nodeEntered'),
-        createEvent(2, 'node1', 'component2', 'nodeEntered'),
-        createEvent(3, 'node2', 'component3', 'nodeEntered'),
-        createEvent(4, 'node3', 'component4', 'nodeEntered'),
-        createEvent(5, 'node1', 'component1', 'nodeEntered')
-      ]
-    };
-    spyOn(projectService, 'getNodeById').and.callFake((nodeId) => {
-      return {
-        id: nodeId
-      };
-    });
-    spyOn(projectService, 'isActive').and.callFake((nodeId) => {
-      return nodeId === 'node1';
-    });
-    const nodeId = service.getLatestNodeEnteredEventNodeIdWithExistingNode();
-    expect(nodeId).toEqual('node1');
   });
 }
 

--- a/src/assets/wise5/services/studentDataService.ts
+++ b/src/assets/wise5/services/studentDataService.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import { Injectable } from '@angular/core';
 import { ConfigService } from './configService';
 import { AnnotationService } from './annotationService';
@@ -567,26 +565,6 @@ export class StudentDataService extends DataService {
 
   getEventsByNodeId(nodeId: string): any[] {
     return this.studentData.events.filter((event) => event.nodeId === nodeId);
-  }
-
-  /**
-   * Get the node id of the latest node entered event for an active node that
-   * exists in the project. We need to check if the node exists in the project
-   * in case the node has been deleted from the project. We also need to check
-   * that the node is active in case the node has been moved to the inactive
-   * section of the project.
-   * @return the node id of the latest node entered event for an active node
-   * that exists in the project
-   */
-  getLatestNodeEnteredEventNodeIdWithExistingNode(): string {
-    const event = this.studentData.events.findLast(
-      (event) => event.event === 'nodeEntered' && this.isNodeExistAndActive(event.nodeId)
-    );
-    return event?.nodeId ?? null;
-  }
-
-  private isNodeExistAndActive(nodeId: string): boolean {
-    return this.ProjectService.getNodeById(nodeId) != null && this.ProjectService.isActive(nodeId);
   }
 
   getTotalScore() {

--- a/src/assets/wise5/vle/tsconfig.json
+++ b/src/assets/wise5/vle/tsconfig.json
@@ -8,9 +8,18 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es5",
-    "typeRoots": ["node_modules/@types"],
-    "lib": ["es2017", "dom"]
+    "target": "es2023",
+    "typeRoots": [
+      "node_modules/@types"
+    ],
+    "lib": [
+      "es2023",
+      "dom"
+    ]
   },
-  "include": ["src/**/*.ts", "../services/projectService.ts", "**/*.ts"]
+  "include": [
+    "src/**/*.ts",
+    "../services/projectService.ts",
+    "**/*.ts"
+  ]
 }

--- a/src/assets/wise5/vle/vle-parent/vle-parent.component.spec.ts
+++ b/src/assets/wise5/vle/vle-parent/vle-parent.component.spec.ts
@@ -1,8 +1,6 @@
-import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
-import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter, Router, RouterModule } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 import { StudentTeacherCommonServicesModule } from '../../../../app/student-teacher-common-services.module';
 import { InitializeVLEService } from '../../services/initializeVLEService';
@@ -17,30 +15,31 @@ import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
 let component: VLEParentComponent;
 let fixture: ComponentFixture<VLEParentComponent>;
 let initializeVLEService: InitializeVLEService;
+let dataService: StudentDataService;
+let projectService: VLEProjectService;
 const nodeId1: string = 'node1';
 let router: Router;
 const runId1: string = '1';
-
 describe('VLEParentComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    declarations: [VLEParentComponent],
-    imports: [MatDialogModule,
-        RouterTestingModule,
-        StudentTeacherCommonServicesModule],
-    providers: [
+      declarations: [VLEParentComponent],
+      imports: [MatDialogModule, RouterModule, StudentTeacherCommonServicesModule],
+      providers: [
         InitializeVLEService,
         PauseScreenService,
         ProjectService,
         StudentNotificationService,
         VLEProjectService,
         provideHttpClient(withInterceptorsFromDi()),
-        provideHttpClientTesting()
-    ]
-}).compileComponents();
+        provideRouter([])
+      ]
+    }).compileComponents();
     fixture = TestBed.createComponent(VLEParentComponent);
     component = fixture.componentInstance;
     initializeVLEService = TestBed.inject(InitializeVLEService);
+    dataService = TestBed.inject(StudentDataService);
+    projectService = TestBed.inject(VLEProjectService);
     router = TestBed.inject(Router);
   });
   ngOnInit();
@@ -50,6 +49,7 @@ function ngOnInit() {
   describe('ngOnInit()', () => {
     initialize();
     previewConstraints();
+    initializeStudent();
   });
 }
 
@@ -73,11 +73,27 @@ function expectInitialize(functionName: any, runId: string): void {
 function previewConstraints() {
   it('should set the starting node id when constraints are enabled', () => {
     setRouterUrl(`/preview/unit/${runId1}/${nodeId1}`);
-    expectSetCurrentNode(nodeId1);
+    expectSetCurrentNode(nodeId1, true);
   });
   it('should set the starting node id when constraints are disabled', () => {
     setRouterUrl(`/preview/unit/${runId1}/${nodeId1}?constraints=false`);
-    expectSetCurrentNode(nodeId1);
+    expectSetCurrentNode(nodeId1, true);
+  });
+}
+
+function initializeStudent() {
+  it('should set the starting node id when there is no last NodeEntered event', () => {
+    setRouterUrl(`/unit/${runId1}`);
+    spyOn(dataService, 'getEvents').and.returnValue([]);
+    spyOn(projectService, 'getStartNodeId').and.returnValue('node2');
+    expectSetCurrentNode('node2', false);
+  });
+  it('should set the starting node id when there is last NodeEntered event', () => {
+    setRouterUrl(`/unit/${runId1}`);
+    spyOn(dataService, 'getEvents').and.returnValue([{ event: 'nodeEntered', nodeId: 'node32' }]);
+    spyOn(projectService, 'getNodeById').and.returnValue({});
+    spyOn(projectService, 'isActive').and.returnValue(true);
+    expectSetCurrentNode('node32', false);
   });
 }
 
@@ -85,11 +101,14 @@ function setRouterUrl(url: string): void {
   spyOnProperty(router, 'url', 'get').and.returnValue(url);
 }
 
-function expectSetCurrentNode(nodeId: string) {
-  spyOn(initializeVLEService, 'initializePreview').and.callFake(() => {
-    setInitialized(true);
-    return Promise.resolve();
-  });
+function expectSetCurrentNode(nodeId: string, isPreview: boolean) {
+  spyOn(initializeVLEService, isPreview ? 'initializePreview' : 'initializeStudent').and.callFake(
+    () => {
+      setInitialized(true);
+      return Promise.resolve();
+    }
+  );
+
   const setCurrentNodeIdSpy = spyOn(TestBed.inject(StudentDataService), 'setCurrentNodeByNodeId');
   spyOn(router, 'navigate').and.callFake(() => {
     return Promise.resolve(true);

--- a/src/assets/wise5/vle/vle-parent/vle-parent.component.ts
+++ b/src/assets/wise5/vle/vle-parent/vle-parent.component.ts
@@ -9,18 +9,18 @@ import { VLEProjectService } from '../vleProjectService';
 })
 export class VLEParentComponent implements OnInit {
   constructor(
+    private dataService: StudentDataService,
     private initializeVLEService: InitializeVLEService,
     private projectService: VLEProjectService,
     private route: ActivatedRoute,
-    private router: Router,
-    private studentDataService: StudentDataService
+    private router: Router
   ) {}
 
   ngOnInit(): void {
     this.initializeVLEService.initialized$.subscribe((initialized: boolean) => {
       if (initialized) {
         const startingNodeId = this.getStartingNodeId();
-        this.studentDataService.setCurrentNodeByNodeId(startingNodeId);
+        this.dataService.setCurrentNodeByNodeId(startingNodeId);
         this.router.navigate([startingNodeId], { relativeTo: this.route.parent });
       }
     });
@@ -34,13 +34,27 @@ export class VLEParentComponent implements OnInit {
 
   private getStartingNodeId(): string {
     const urlMatch = this.router.url.match(/unit\/[0-9]*\/([^?]*)/);
-    let nodeId =
-      urlMatch != null
-        ? urlMatch[1]
-        : this.studentDataService.getLatestNodeEnteredEventNodeIdWithExistingNode();
-    if (nodeId == null) {
-      nodeId = this.projectService.getStartNodeId();
-    }
-    return nodeId;
+    return urlMatch != null
+      ? urlMatch[1]
+      : (this.getLastNodeEnteredEvent()?.nodeId ?? this.projectService.getStartNodeId());
+  }
+
+  /**
+   * Get the last node entered event for an active node that exists in the project.
+   * We need to check if the node exists in the project in case the node has been deleted
+   * from the project. We also need to check that the node is active in case the node has been
+   * moved to the inactive section of the project.
+   * @return the last node entered event for an active node that exists in the project
+   */
+  private getLastNodeEnteredEvent(): any {
+    return this.dataService
+      .getEvents()
+      .findLast(
+        (event) => event.event === 'nodeEntered' && this.isNodeExistAndActive(event.nodeId)
+      );
+  }
+
+  private isNodeExistAndActive(nodeId: string): boolean {
+    return this.projectService.getNodeById(nodeId) != null && this.projectService.isActive(nodeId);
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -22022,28 +22022,28 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Preview Student</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">78</context>
+          <context context-type="linenumber">76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1967824796880640028" datatype="html">
         <source>StudentDataService.saveComponentEvent: component, category, event args must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">245</context>
+          <context context-type="linenumber">243</context>
         </context-group>
       </trans-unit>
       <trans-unit id="944638387659785956" datatype="html">
         <source>StudentDataService.saveComponentEvent: nodeId, componentId, componentType must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">255</context>
+          <context context-type="linenumber">253</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4924640921903672943" datatype="html">
         <source>StudentDataService.saveVLEEvent: category and event args must not be null</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/studentDataService.ts</context>
-          <context context-type="linenumber">264</context>
+          <context context-type="linenumber">262</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3178064088723974543" datatype="html">


### PR DESCRIPTION
## Changes
This pull request includes several changes to improve the `StudentDataService` and related components. The most important changes involve the removal of the `getLatestNodeEnteredEventNodeIdWithExistingNode` method, updates to the `VLEParentComponent` to enhance initialization logic, and the upgrade of the TypeScript target version.

Removal of unnecessary method:

* [`src/app/services/studentDataService.spec.ts`](diffhunk://#diff-58daadecb97493cee20cba1131a4fd847b68cb4736fae46c26307fe5afd5bafbL43): Removed the test case for `shouldGetLatestNodeEnteredEventNodeIdWithExistingNode` and its associated method. [[1]](diffhunk://#diff-58daadecb97493cee20cba1131a4fd847b68cb4736fae46c26307fe5afd5bafbL43) [[2]](diffhunk://#diff-58daadecb97493cee20cba1131a4fd847b68cb4736fae46c26307fe5afd5bafbL431-L454)
* [`src/assets/wise5/services/studentDataService.ts`](diffhunk://#diff-d37ac7906c355a3b23b769c7eb109b048d55e40093132753931fe3d21d4872acL572-L591): Removed the `getLatestNodeEnteredEventNodeIdWithExistingNode` method and its helper `isNodeExistAndActive`.

Enhancements to `VLEParentComponent`:

* [`src/assets/wise5/vle/vle-parent/vle-parent.component.spec.ts`](diffhunk://#diff-c11084f5a3154a010ee2b815cbd7f3231728cf5cb347e4df9806c937cbc2c725L1-R3): Added initialization logic for student data and updated the `expectSetCurrentNode` function to handle both preview and student initialization. [[1]](diffhunk://#diff-c11084f5a3154a010ee2b815cbd7f3231728cf5cb347e4df9806c937cbc2c725L1-R3) [[2]](diffhunk://#diff-c11084f5a3154a010ee2b815cbd7f3231728cf5cb347e4df9806c937cbc2c725R18-R42) [[3]](diffhunk://#diff-c11084f5a3154a010ee2b815cbd7f3231728cf5cb347e4df9806c937cbc2c725R52) [[4]](diffhunk://#diff-c11084f5a3154a010ee2b815cbd7f3231728cf5cb347e4df9806c937cbc2c725L76-R111)
* [`src/assets/wise5/vle/vle-parent/vle-parent.component.ts`](diffhunk://#diff-e86859d71339c7a8d2a78e9ec8a504e5df0413c853cf8fdcef1e67b6248ead9cR12-R23): Refactored the `getStartingNodeId` method to use the new `getLastNodeEnteredEvent` method and updated the data service references. [[1]](diffhunk://#diff-e86859d71339c7a8d2a78e9ec8a504e5df0413c853cf8fdcef1e67b6248ead9cR12-R23) [[2]](diffhunk://#diff-e86859d71339c7a8d2a78e9ec8a504e5df0413c853cf8fdcef1e67b6248ead9cL37-R58)

TypeScript configuration update:

* [`src/assets/wise5/vle/tsconfig.json`](diffhunk://#diff-c640349ee7c8b9ed8bdd698c2a08989ed719101766c24ebc26769e9807264417L11-R24): Updated the TypeScript target version to `es2023` and adjusted the `lib` and `include` settings accordingly.

Minor changes:

* [`src/assets/wise5/services/studentDataService.ts`](diffhunk://#diff-d37ac7906c355a3b23b769c7eb109b048d55e40093132753931fe3d21d4872acL1-L2): Removed the `'use strict';` directive.
* [`src/messages.xlf`](diffhunk://#diff-3a3cab1562515f062670a0faf4d9aae22493651b1c77a80df9055d501350421eL22025-R22046): Updated line numbers in translation context due to code changes.

## Test
- Launching VLE in preview works as before. Try with&without specifying node id.
- Launching VLE in student works as before. Try fresh student and student with NodeEntered