### PR TITLE
refactor(StudentWorkDataExportStrategy, TeacherDataService): move and simplify logic for component state retrieval

### DIFF
--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/StudentWorkDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/StudentWorkDataExportStrategy.ts
@@ -95,11 +95,10 @@ export class StudentWorkDataExportStrategy extends AbstractDataExportStrategy {
         if (this.exportType === 'allStudentWork') {
           componentStates = this.teacherDataService.getComponentStatesByWorkgroupId(workgroupId);
         } else if (this.exportType === 'latestStudentWork') {
-          this.teacherDataService.injectRevisionCounterIntoComponentStates(
+          this.injectRevisionCounterIntoComponentStates(
             this.teacherDataService.getComponentStatesByWorkgroupId(workgroupId)
           );
-          componentStates =
-            this.teacherDataService.getLatestComponentStatesByWorkgroupId(workgroupId);
+          componentStates = this.getLatestComponentStatesByWorkgroupId(workgroupId);
         }
         if (componentStates != null) {
           for (var c = 0; c < componentStates.length; c++) {
@@ -149,6 +148,40 @@ export class StudentWorkDataExportStrategy extends AbstractDataExportStrategy {
       this.generateCSVFile(rows, fileName);
       this.controller.hideDownloadingExportMessage();
     });
+  }
+
+  private injectRevisionCounterIntoComponentStates(componentStates: any[]): void {
+    const componentRevisionCounter = {};
+    componentStates.forEach((componentState) => {
+      const key = componentState.nodeId + '-' + componentState.componentId;
+      if (componentRevisionCounter[key] == null) {
+        componentRevisionCounter[key] = 1;
+      }
+      componentState.revisionCounter = componentRevisionCounter[key];
+      componentRevisionCounter[key]++;
+    });
+  }
+
+  /**
+   * @param workgroupId the workgroup id
+   * @return An array of component states. Each component state will be the latest component state
+   * for a component.
+   */
+  private getLatestComponentStatesByWorkgroupId(workgroupId: number): any[] {
+    const componentStates = [];
+    const componentsFound = {};
+    const componentStatesForWorkgroup =
+      this.teacherDataService.getComponentStatesByWorkgroupId(workgroupId);
+    for (let csb = componentStatesForWorkgroup.length - 1; csb >= 0; csb--) {
+      const componentState = componentStatesForWorkgroup[csb];
+      const key = componentState.nodeId + '-' + componentState.componentId;
+      if (componentsFound[key] == null) {
+        componentStates.push(componentState);
+        componentsFound[key] = true;
+      }
+    }
+    componentStates.reverse();
+    return componentStates;
   }
 
   /**

--- a/src/assets/wise5/services/teacherDataService.ts
+++ b/src/assets/wise5/services/teacherDataService.ts
@@ -430,44 +430,6 @@ export class TeacherDataService extends DataService {
     return getIntersectOfArrays(componentStatesByWorkgroupId, componentStatesByNodeId);
   }
 
-  /**
-   * @param workgroupId the workgroup id
-   * @return An array of component states. Each component state will be the latest component state
-   * for a component.
-   */
-  getLatestComponentStatesByWorkgroupId(workgroupId) {
-    const componentStates = [];
-    const componentsFound = {};
-    const componentStatesForWorkgroup = this.getComponentStatesByWorkgroupId(workgroupId);
-    for (let csb = componentStatesForWorkgroup.length - 1; csb >= 0; csb--) {
-      const componentState = componentStatesForWorkgroup[csb];
-      const key = this.getComponentStateNodeIdComponentIdKey(componentState);
-      if (componentsFound[key] == null) {
-        componentStates.push(componentState);
-        componentsFound[key] = true;
-      }
-    }
-    componentStates.reverse();
-    return componentStates;
-  }
-
-  injectRevisionCounterIntoComponentStates(componentStates) {
-    const componentRevisionCounter = {};
-    for (const componentState of componentStates) {
-      const key = this.getComponentStateNodeIdComponentIdKey(componentState);
-      if (componentRevisionCounter[key] == null) {
-        componentRevisionCounter[key] = 1;
-      }
-      const revisionCounter = componentRevisionCounter[key];
-      componentState.revisionCounter = revisionCounter;
-      componentRevisionCounter[key] = revisionCounter + 1;
-    }
-  }
-
-  getComponentStateNodeIdComponentIdKey(componentState) {
-    return componentState.nodeId + '-' + componentState.componentId;
-  }
-
   getComponentStatesByWorkgroupIdAndComponentId(workgroupId, componentId) {
     const componentStatesByWorkgroupId = this.getComponentStatesByWorkgroupId(workgroupId);
     const componentStatesByComponentId = this.getComponentStatesByComponentId(componentId);


### PR DESCRIPTION
## Changes
This pull request refactors the `StudentWorkDataExportStrategy` class by moving some methods from `TeacherDataService` to `StudentWorkDataExportStrategy`. This change aims to improve the organization and encapsulation of the code.

Refactoring and code organization:

* [`src/assets/wise5/classroomMonitor/dataExport/strategies/StudentWorkDataExportStrategy.ts`](diffhunk://#diff-479b47f10e0eb4a7de1ff9b6659f05310dd4e104269290a1fd730afe72ab13b1L98-R101): Moved the `injectRevisionCounterIntoComponentStates` method from `TeacherDataService` to `StudentWorkDataExportStrategy` and renamed the call to this method accordingly. [[1]](diffhunk://#diff-479b47f10e0eb4a7de1ff9b6659f05310dd4e104269290a1fd730afe72ab13b1L98-R101) [[2]](diffhunk://#diff-479b47f10e0eb4a7de1ff9b6659f05310dd4e104269290a1fd730afe72ab13b1R153-R186)
* [`src/assets/wise5/classroomMonitor/dataExport/strategies/StudentWorkDataExportStrategy.ts`](diffhunk://#diff-479b47f10e0eb4a7de1ff9b6659f05310dd4e104269290a1fd730afe72ab13b1R153-R186): Added a new private method `getLatestComponentStatesByWorkgroupId` to handle fetching the latest component states, which was previously in `TeacherDataService`.
* [`src/assets/wise5/services/teacherDataService.ts`](diffhunk://#diff-dc617e1b9ce7d685436d2bd41ad383ca06a684a2eae028811daaa48dcc43b0a9L433-L470): Removed the `getLatestComponentStatesByWorkgroupId` and `injectRevisionCounterIntoComponentStates` methods since they have been moved to `StudentWorkDataExportStrategy`.

## Test
- In CM, data export > latest student work works as before.