### PR TITLE
feat(MultipleChoiceAuthoring): Add starter choices and prompt

### DIFF
--- a/src/app/services/multipleChoiceService.spec.ts
+++ b/src/app/services/multipleChoiceService.spec.ts
@@ -26,8 +26,8 @@ let componentId1: string = 'abcdefghij';
 describe('MultipleChoiceService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-    imports: [],
-    providers: [
+      imports: [],
+      providers: [
         AnnotationService,
         ConfigService,
         MultipleChoiceService,
@@ -37,8 +37,8 @@ describe('MultipleChoiceService', () => {
         TagService,
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting()
-    ]
-});
+      ]
+    });
     service = TestBed.inject(MultipleChoiceService);
     choice1 = createChoice(choiceId1, choiceText1, '', false);
     choice2 = createChoice(choiceId2, choiceText2, '', false);
@@ -58,7 +58,7 @@ function createComponent() {
     const component = service.createComponent();
     expect(component.type).toEqual('MultipleChoice');
     expect(component.choiceType).toEqual('radio');
-    expect(component.choices).toEqual([]);
+    expect(component.choices.length).toEqual(2);
     expect(component.showFeedback).toEqual(true);
   });
 }

--- a/src/assets/wise5/components/multipleChoice/Choice.ts
+++ b/src/assets/wise5/components/multipleChoice/Choice.ts
@@ -1,6 +1,13 @@
-export interface Choice {
+export class Choice {
   feedbackToShow: string;
   id: string;
   isCorrect: boolean;
   text: string;
+
+  constructor(id: string, text: string, isCorrect: boolean, feedbackToShow: string) {
+    this.id = id;
+    this.text = text;
+    this.isCorrect = isCorrect;
+    this.feedbackToShow = feedbackToShow;
+  }
 }

--- a/src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.ts
+++ b/src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.ts
@@ -18,6 +18,7 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-component-prompt/edit-component-prompt.component';
 import { TranslatableAssetChooserComponent } from '../../../authoringTool/components/translatable-asset-chooser/translatable-asset-chooser.component';
 import { TranslatableInputComponent } from '../../../authoringTool/components/translatable-input/translatable-input.component';
+import { Choice } from '../Choice';
 
 @Component({
   imports: [
@@ -80,13 +81,7 @@ export class MultipleChoiceAuthoring extends AbstractComponentAuthoring {
   }
 
   protected addChoice(): void {
-    const newChoice = {
-      id: generateRandomKey(),
-      text: '',
-      feedback: '',
-      isCorrect: false
-    };
-    this.componentContent.choices.push(newChoice);
+    this.componentContent.choices.push(new Choice(generateRandomKey(), '', false, ''));
     this.componentChanged();
   }
 

--- a/src/assets/wise5/components/multipleChoice/multipleChoiceService.ts
+++ b/src/assets/wise5/components/multipleChoice/multipleChoiceService.ts
@@ -1,8 +1,8 @@
-'use strict';
-
 import { ComponentService } from '../componentService';
 import { Injectable } from '@angular/core';
 import { arraysContainSameValues } from '../../common/array/array';
+import { Choice } from './Choice';
+import { generateRandomKey } from '../../common/string/string';
 
 @Injectable()
 export class MultipleChoiceService extends ComponentService {
@@ -10,11 +10,15 @@ export class MultipleChoiceService extends ComponentService {
     return $localize`Multiple Choice`;
   }
 
-  createComponent() {
+  createComponent(): any {
     const component: any = super.createComponent();
     component.type = 'MultipleChoice';
+    component.prompt = $localize`Choose an option from below`;
     component.choiceType = 'radio';
-    component.choices = [];
+    component.choices = [
+      new Choice(generateRandomKey(), $localize`Choice 1`, false, ''),
+      new Choice(generateRandomKey(), $localize`Choice 2`, false, '')
+    ];
     component.showFeedback = true;
     return component;
   }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -19593,7 +19593,7 @@ Warning: This will delete all existing choices and buckets in this component.</s
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.ts</context>
-          <context context-type="linenumber">94</context>
+          <context context-type="linenumber">89</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6683126302760629027" datatype="html">
@@ -19827,6 +19827,27 @@ Warning: This will delete all existing choices in this component.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-student/multiple-choice-student.component.html</context>
           <context context-type="linenumber">25,28</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4018977700600303269" datatype="html">
+        <source>Choose an option from below</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multipleChoiceService.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1267813701388263700" datatype="html">
+        <source>Choice 1</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multipleChoiceService.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="169678945905320246" datatype="html">
+        <source>Choice 2</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multipleChoiceService.ts</context>
+          <context context-type="linenumber">20</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7864549548500976713" datatype="html">


### PR DESCRIPTION
## Changes
New MC components now comes with default prompt and 2 choices. This will make it easier for the authors to author new MC components.

This pull request includes changes to the `MultipleChoice` component, focusing on refactoring the `Choice` interface into a class, updating related methods, and adding new translations. The most important changes include modifying the `Choice` structure, updating the `createComponent` method, and adding new translation entries.

Refactoring and structural changes:

* [`src/assets/wise5/components/multipleChoice/Choice.ts`](diffhunk://#diff-1f1eca5df52b6ff724954f6abf5f0a4daf7f8f74d7270bd57465409ad3c3ff9bL1-R12): Changed `Choice` from an interface to a class and added a constructor.
* [`src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.ts`](diffhunk://#diff-9a0957324673809444080b0f1aa98c124aa8405f0b63c185695828191727c781L83-R84): Updated the `addChoice` method to use the new `Choice` class.
* [`src/assets/wise5/components/multipleChoice/multipleChoiceService.ts`](diffhunk://#diff-9522aee663a166272be361fde4518d9d4e058e257a35cdf6aa1deca8e2b2e6a8L1-R21): Updated the `createComponent` method to initialize `choices` with two default `Choice` instances and added a prompt.

Test updates:

* [`src/app/services/multipleChoiceService.spec.ts`](diffhunk://#diff-8a2fcc7ce7576e2807a27d9afad9572f0efb990111039ec44d1709d19404257cL61-R61): Modified the test to check for the length of `choices` instead of an empty array.

## Test
- In the AT, creating a new MC component creates it with a sample prompt and 2 default choices