### PR TITLE
refactor(WorkgroupItemComponent): Convert workgroup to standalone

### DIFF
--- a/src/app/teacher/grading-common.module.ts
+++ b/src/app/teacher/grading-common.module.ts
@@ -23,11 +23,12 @@ import { ComponentStateInfoComponent } from '../../assets/wise5/common/component
     StatusIconComponent,
     StudentTeacherCommonModule,
     WorkgroupInfoComponent,
+    WorkgroupItemComponent,
     WorkgroupComponentGradingComponent,
     WorkgroupNodeScoreComponent,
     WorkgroupNodeStatusComponent
   ],
-  declarations: [WorkgroupItemComponent, WorkgroupSelectAutocompleteComponent],
+  declarations: [WorkgroupSelectAutocompleteComponent],
   exports: [
     ComponentGradingComponent,
     ComponentStateInfoComponent,

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.html
@@ -32,32 +32,35 @@
       </div>
     </div>
   </button>
-  <mat-list-item *ngIf="expanded && !disabled" class="grading__item-container">
-    <div class="grading__item" style="width: 100%">
-      <ng-container *ngFor="let component of components; let i = index">
-        <div
-          *ngIf="componentIdToIsVisible[component.id]"
-          id="component_{{ component.id }}_{{ workgroupId }}"
-          class="component component--grading"
-        >
-          <div [hidden]="!isComponentVisible(component.id)">
-            <h3 class="accent-1 gray-lightest-bg component__header">
-              {{ i + 1 + '. ' + getComponentTypeLabel(component.type) }}&nbsp;
-              <component-new-work-badge
-                [componentId]="component.id"
-                [workgroupId]="workgroupId"
-                [nodeId]="nodeId"
-              />
-            </h3>
-            <workgroup-component-grading
-              class="component--grading__response__content"
-              [componentId]="component.id"
-              [workgroupId]="workgroupId"
-              [nodeId]="nodeId"
-            />
-          </div>
-        </div>
-      </ng-container>
-    </div>
-  </mat-list-item>
+  @if (expanded && !disabled) {
+    <mat-list-item class="grading__item-container">
+      <div class="grading__item" style="width: 100%">
+        @for (component of components; track component.id; let i = $index) {
+          @if (componentIdToIsVisible[component.id]) {
+            <div
+              id="component_{{ component.id }}_{{ workgroupId }}"
+              class="component component--grading"
+            >
+              <div [hidden]="!isComponentVisible(component.id)">
+                <h3 class="accent-1 gray-lightest-bg component__header">
+                  {{ i + 1 + '. ' + getComponentTypeLabel(component.type) }}&nbsp;
+                  <component-new-work-badge
+                    [componentId]="component.id"
+                    [workgroupId]="workgroupId"
+                    [nodeId]="nodeId"
+                  />
+                </h3>
+                <workgroup-component-grading
+                  class="component--grading__response__content"
+                  [componentId]="component.id"
+                  [workgroupId]="workgroupId"
+                  [nodeId]="nodeId"
+                />
+              </div>
+            </div>
+          }
+        }
+      </div>
+    </mat-list-item>
+  }
 </div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.spec.ts
@@ -2,21 +2,17 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ClassroomMonitorTestingModule } from '../../../classroom-monitor-testing.module';
 import { WorkgroupItemComponent } from './workgroup-item.component';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentTypeServiceModule } from '../../../../services/componentTypeService.module';
 
 let component: WorkgroupItemComponent;
 let fixture: ComponentFixture<WorkgroupItemComponent>;
 let getComponentsSpy: jasmine.Spy;
 let teacherProjectService: TeacherProjectService;
-
 describe('WorkgroupItemComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [WorkgroupItemComponent],
-      imports: [ClassroomMonitorTestingModule, ComponentTypeServiceModule],
-      providers: [TeacherProjectService],
-      schemas: [NO_ERRORS_SCHEMA]
+      imports: [WorkgroupItemComponent, ClassroomMonitorTestingModule, ComponentTypeServiceModule],
+      providers: [TeacherProjectService]
     }).compileComponents();
   });
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts
@@ -2,30 +2,51 @@ import { Component, EventEmitter, Input, Output, SimpleChanges } from '@angular/
 import { ComponentTypeService } from '../../../../services/componentTypeService';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
 import { calculateComponentVisibility } from '../../shared/grading-helpers/grading-helpers';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatListModule } from '@angular/material/list';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { WorkgroupInfoComponent } from '../workgroupInfo/workgroup-info.component';
+import { WorkgroupNodeStatusComponent } from '../../../../../../app/classroom-monitor/workgroup-node-status/workgroup-node-status.component';
+import { WorkgroupNodeScoreComponent } from '../../shared/workgroupNodeScore/workgroup-node-score.component';
+import { ComponentNewWorkBadgeComponent } from '../../../../../../app/classroom-monitor/component-new-work-badge/component-new-work-badge.component';
+import { WorkgroupComponentGradingComponent } from '../../workgroup-component-grading/workgroup-component-grading.component';
 
 @Component({
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatListModule,
+    FlexLayoutModule,
+    WorkgroupInfoComponent,
+    WorkgroupNodeStatusComponent,
+    WorkgroupNodeScoreComponent,
+    ComponentNewWorkBadgeComponent,
+    WorkgroupComponentGradingComponent
+  ],
   selector: 'workgroup-item',
-  templateUrl: 'workgroup-item.component.html',
-  styleUrls: ['workgroup-item.component.scss']
+  standalone: true,
+  styleUrl: 'workgroup-item.component.scss',
+  templateUrl: 'workgroup-item.component.html'
 })
 export class WorkgroupItemComponent {
-  componentIdToHasWork: { [componentId: string]: boolean } = {};
-  componentIdToIsVisible: { [componentId: string]: boolean } = {};
-  components: any[] = [];
-  disabled: boolean;
+  private componentIdToHasWork: { [componentId: string]: boolean } = {};
+  protected componentIdToIsVisible: { [componentId: string]: boolean } = {};
+  protected components: any[] = [];
+  protected disabled: boolean;
   @Input() expanded: boolean;
-  hasAlert: boolean;
-  hasNewAlert: boolean;
+  protected hasAlert: boolean;
+  protected hasNewAlert: boolean;
   @Input() hiddenComponents: string[] = [];
   @Input() maxScore: number;
-  nodeHasWork: boolean;
+  private nodeHasWork: boolean;
   @Input() nodeId: string;
   @Output() onUpdateExpand: EventEmitter<any> = new EventEmitter();
-  score: any;
+  protected score: any;
   @Input() showScore: boolean;
-  status: any;
-  statusClass: string;
-  statusText: string = '';
+  private status: any;
+  protected statusClass: string;
+  protected statusText: string = '';
   @Input() workgroupId: number;
   @Input() workgroupData: any;
 
@@ -39,7 +60,7 @@ export class WorkgroupItemComponent {
     this.updateStatus();
   }
 
-  updateNode(): void {
+  private updateNode(): void {
     this.nodeHasWork = this.projectService.nodeHasWork(this.nodeId);
     this.components = this.projectService.getComponents(this.nodeId);
     this.componentIdToHasWork = this.projectService.calculateComponentIdToHasWork(this.components);
@@ -69,11 +90,11 @@ export class WorkgroupItemComponent {
     }
   }
 
-  isComponentVisible(componentId: string): boolean {
+  protected isComponentVisible(componentId: string): boolean {
     return !this.hiddenComponents.includes(componentId);
   }
 
-  getComponentTypeLabel(componentType): string {
+  protected getComponentTypeLabel(componentType): string {
     return this.componentTypeService.getComponentTypeLabel(componentType);
   }
 
@@ -109,10 +130,9 @@ export class WorkgroupItemComponent {
     this.disabled = this.status === -1;
   }
 
-  toggleExpand(): void {
+  protected toggleExpand(): void {
     if (this.showScore) {
-      let expand = !this.expanded;
-      this.onUpdateExpand.emit({ workgroupId: this.workgroupId, value: expand });
+      this.onUpdateExpand.emit({ workgroupId: this.workgroupId, value: !this.expanded });
     }
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -14102,7 +14102,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">105</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts</context>
@@ -14117,7 +14117,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts</context>
-          <context context-type="linenumber">89</context>
+          <context context-type="linenumber">110</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts</context>
@@ -14132,7 +14132,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">117</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts</context>
@@ -14154,7 +14154,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts</context>
-          <context context-type="linenumber">101</context>
+          <context context-type="linenumber">122</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts</context>
@@ -14246,7 +14246,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>Visited</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts</context>
-          <context context-type="linenumber">91</context>
+          <context context-type="linenumber">112</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts</context>
@@ -14257,7 +14257,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>Not Visited</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts</context>
-          <context context-type="linenumber">103</context>
+          <context context-type="linenumber">124</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts</context>


### PR DESCRIPTION
## Changes
This pull request includes several important changes to the `WorkgroupItemComponent` and its related files to improve modularity, maintainability, and functionality. The changes include refactoring the component to make it standalone, updating its imports, modifying the visibility of its properties and methods, and updating the corresponding test file.

### Component and Module Updates:
* [`src/app/teacher/grading-common.module.ts`](diffhunk://#diff-2036f64808ac0143787e8634d9e98f521b1b85cf47e7747f7825e21282a312e2R26-R31): Removed `WorkgroupItemComponent` from the `declarations` array and added it to the `imports` array.
* [`src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.ts`](diffhunk://#diff-6677bd9cc5b89bad681050eb58d0ab8c4d2d18b00818b5a231f5d8fcdfd8ecaaR5-R49): Refactored `WorkgroupItemComponent` to be a standalone component with updated imports and modified visibility of properties and methods. [[1]](diffhunk://#diff-6677bd9cc5b89bad681050eb58d0ab8c4d2d18b00818b5a231f5d8fcdfd8ecaaR5-R49) [[2]](diffhunk://#diff-6677bd9cc5b89bad681050eb58d0ab8c4d2d18b00818b5a231f5d8fcdfd8ecaaL42-R63) [[3]](diffhunk://#diff-6677bd9cc5b89bad681050eb58d0ab8c4d2d18b00818b5a231f5d8fcdfd8ecaaL72-R97) [[4]](diffhunk://#diff-6677bd9cc5b89bad681050eb58d0ab8c4d2d18b00818b5a231f5d8fcdfd8ecaaL112-R135)

### Template Changes:
* [`src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.html`](diffhunk://#diff-a69b755792297258a17b344322efe7d4e0919ae09e319a017245d014c630e174L35-L39): Updated the template to use Angular's structural directives with the new syntax. [[1]](diffhunk://#diff-a69b755792297258a17b344322efe7d4e0919ae09e319a017245d014c630e174L35-L39) [[2]](diffhunk://#diff-a69b755792297258a17b344322efe7d4e0919ae09e319a017245d014c630e174L60-R65)

### Test File Updates:
* [`src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/workgroup-item/workgroup-item.component.spec.ts`](diffhunk://#diff-abb01536cbede2d9956204de5bb69e4cdddbdbf7114a8b240d14990b8cad7d3bL5-R15): Updated the test configuration to import `WorkgroupItemComponent` directly and removed unnecessary declarations and schemas.

## Test
- In the CM > node grading view, workgroup item component works as before. Test expanding/collapsing items