### PR TITLE
refactor(MainMenuComponent): convert to standalone

### DIFF
--- a/src/app/student-teacher-common.module.ts
+++ b/src/app/student-teacher-common.module.ts
@@ -37,11 +37,10 @@ import { EditNotebookItemDialogModule } from '../assets/wise5/themes/default/not
 import { StudentTeacherCommonServicesModule } from './student-teacher-common-services.module';
 import { MathModule } from './math/math.module';
 import { MatMenuModule } from '@angular/material/menu';
-import { MainMenuComponent } from '../assets/wise5/common/main-menu/main-menu.component';
 import { ScrollingModule } from '@angular/cdk/scrolling';
 
 @NgModule({
-  declarations: [DialogResponseComponent, DialogResponsesComponent, MainMenuComponent],
+  declarations: [DialogResponseComponent, DialogResponsesComponent],
   imports: [
     CommonModule,
     DragDropModule,
@@ -88,7 +87,6 @@ import { ScrollingModule } from '@angular/cdk/scrolling';
     EditorModule,
     FlexLayoutModule,
     FormsModule,
-    MainMenuComponent,
     MatAutocompleteModule,
     MatButtonModule,
     MatButtonToggleModule,

--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -60,6 +60,7 @@ import { ComponentTypeButtonComponent } from '../../assets/wise5/authoringTool/c
 import { MatExpansionModule } from '@angular/material/expansion';
 import { AddComponentComponent } from '../../assets/wise5/authoringTool/node/add-component/add-component.component';
 import { SideMenuComponent } from '../../assets/wise5/common/side-menu/side-menu.component';
+import { MainMenuComponent } from '../../assets/wise5/common/main-menu/main-menu.component';
 
 @NgModule({
   declarations: [
@@ -110,6 +111,7 @@ import { SideMenuComponent } from '../../assets/wise5/common/side-menu/side-menu
     ImportComponentModule,
     InsertNodeAfterButtonComponent,
     InsertNodeInsideButtonComponent,
+    MainMenuComponent,
     NgSelectModule,
     NodeAdvancedAuthoringModule,
     NodeIconAndTitleComponent,

--- a/src/app/teacher/classroom-monitor.module.ts
+++ b/src/app/teacher/classroom-monitor.module.ts
@@ -32,6 +32,7 @@ import { ComponentGradingComponent } from '../../assets/wise5/classroomMonitor/c
 import { SelectPeriodComponent } from '../../assets/wise5/classroomMonitor/classroomMonitorComponents/select-period/select-period.component';
 import { GradingNodeService } from '../../assets/wise5/services/gradingNodeService';
 import { SideMenuComponent } from '../../assets/wise5/common/side-menu/side-menu.component';
+import { MainMenuComponent } from '../../assets/wise5/common/main-menu/main-menu.component';
 
 @NgModule({
   declarations: [
@@ -52,6 +53,7 @@ import { SideMenuComponent } from '../../assets/wise5/common/side-menu/side-menu
     DataExportModule,
     GradingCommonModule,
     HighchartsChartModule,
+    MainMenuComponent,
     ManageStudentsModule,
     MilestoneModule,
     NavItemScoreComponent,

--- a/src/assets/wise5/classroomMonitor/classroom-monitor.component.html
+++ b/src/assets/wise5/classroomMonitor/classroom-monitor.component.html
@@ -3,7 +3,7 @@
 <div class="app-styles monitor-theme monitor" disable-delete-keypress role="main">
   <mat-sidenav-container>
     <mat-sidenav #drawer [(opened)]="menuOpen" mode="over" class="mat-elevation-z4">
-      <main-menu [title]="title" [views]="views"></main-menu>
+      <main-menu [title]="title" [views]="views" />
     </mat-sidenav>
     <mat-sidenav-content>
       <top-bar
@@ -13,7 +13,7 @@
         [projectTitle]="projectTitle"
         [runId]="runId"
         [runCode]="runCode"
-      ></top-bar>
+      />
       <tool-bar [workgroupId]="workgroupId" (onMenuToggle)="toggleMenu()" />
       <content id="content" fxFlex role="main" fxLayout="column" class="l-main">
         <router-outlet></router-outlet>

--- a/src/assets/wise5/common/main-menu/main-menu.component.html
+++ b/src/assets/wise5/common/main-menu/main-menu.component.html
@@ -1,40 +1,28 @@
+<ng-template #viewTemplate let-type="type">
+  <mat-list class="menu-sidenav">
+    @for (view of views; track view.name) {
+      @if (view.type === type && view.active) {
+        <mat-list-item
+          role="button"
+          tabindex="0"
+          aria-label="{{ view.name }}"
+          (click)="goToView(view)"
+          (keyup.enter)="goToView(view)"
+          class="menu-sidenav__list-item mat-mdc-list-item-interactive"
+        >
+          <span fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
+            <mat-icon class="secondary-text"> {{ view.icon }} </mat-icon>
+            <span class="mat-caption">{{ view.name }}</span>
+          </span>
+        </mat-list-item>
+      }
+    }
+  </mat-list>
+</ng-template>
+
 <mat-toolbar class="md-toolbar--sidenav">
   <div class="md-toolbar-tools dark-theme" i18n>{{ title }}</div>
 </mat-toolbar>
-<mat-list class="menu-sidenav">
-  <ng-container *ngFor="let view of views">
-    <mat-list-item
-      *ngIf="view.type === 'primary' && view.active"
-      role="button"
-      tabindex="0"
-      aria-label="{{ view.name }}"
-      (click)="goToView(view)"
-      (keyup.enter)="goToView(view)"
-      class="menu-sidenav__list-item mat-mdc-list-item-interactive"
-    >
-      <span fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
-        <mat-icon class="secondary-text"> {{ view.icon }} </mat-icon>
-        <span class="mat-caption">{{ view.name }}</span>
-      </span>
-    </mat-list-item>
-  </ng-container>
-</mat-list>
-<mat-divider class="menu-sidenav__divider"></mat-divider>
-<mat-list class="menu-sidenav">
-  <ng-container *ngFor="let view of views">
-    <mat-list-item
-      *ngIf="view.type === 'secondary' && view.active"
-      role="button"
-      tabindex="0"
-      aria-label="{{ view.name }}"
-      (click)="goToView(view)"
-      (keyup.enter)="goToView(view)"
-      class="menu-sidenav__list-item mat-mdc-list-item-interactive"
-    >
-      <span fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
-        <mat-icon class="secondary-text"> {{ view.icon }} </mat-icon>
-        <span class="mat-caption">{{ view.name }}</span>
-      </span>
-    </mat-list-item>
-  </ng-container>
-</mat-list>
+<ng-container [ngTemplateOutlet]="viewTemplate" [ngTemplateOutletContext]="{ type: 'primary' }" />
+<mat-divider class="menu-sidenav__divider" />
+<ng-container [ngTemplateOutlet]="viewTemplate" [ngTemplateOutletContext]="{ type: 'secondary' }" />

--- a/src/assets/wise5/common/main-menu/main-menu.component.spec.ts
+++ b/src/assets/wise5/common/main-menu/main-menu.component.spec.ts
@@ -1,9 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatDividerModule } from '@angular/material/divider';
-import { MatListModule } from '@angular/material/list';
-import { MatToolbarModule } from '@angular/material/toolbar';
 import { MainMenuComponent } from './main-menu.component';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 
 describe('MainMenuComponent', () => {
   let component: MainMenuComponent;
@@ -11,8 +8,8 @@ describe('MainMenuComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [MainMenuComponent],
-      imports: [MatDividerModule, MatListModule, MatToolbarModule, RouterTestingModule]
+      imports: [MainMenuComponent],
+      providers: [provideRouter([])]
     }).compileComponents();
   });
 

--- a/src/assets/wise5/common/main-menu/main-menu.component.ts
+++ b/src/assets/wise5/common/main-menu/main-menu.component.ts
@@ -1,10 +1,25 @@
 import { Component, Input } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatListModule } from '@angular/material/list';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDividerModule } from '@angular/material/divider';
+import { CommonModule } from '@angular/common';
+import { FlexLayoutModule } from '@angular/flex-layout';
 
 @Component({
+  imports: [
+    CommonModule,
+    FlexLayoutModule,
+    MatDividerModule,
+    MatIconModule,
+    MatToolbarModule,
+    MatListModule
+  ],
   selector: 'main-menu',
-  templateUrl: './main-menu.component.html',
-  styleUrls: ['./main-menu.component.scss']
+  standalone: true,
+  styleUrl: './main-menu.component.scss',
+  templateUrl: './main-menu.component.html'
 })
 export class MainMenuComponent {
   @Input() title: string;

--- a/src/assets/wise5/common/side-menu/side-menu.component.ts
+++ b/src/assets/wise5/common/side-menu/side-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 import { MainMenuComponent } from '../main-menu/main-menu.component';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
@@ -7,11 +7,10 @@ import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   imports: [CommonModule, MatButtonModule, MatIconModule, MatTooltipModule],
+  inputs: ['views'],
   selector: 'side-menu',
   standalone: true,
   styleUrl: './side-menu.component.scss',
   templateUrl: './side-menu.component.html'
 })
-export class SideMenuComponent extends MainMenuComponent {
-  @Input() views: any[];
-}
+export class SideMenuComponent extends MainMenuComponent {}

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15420,7 +15420,7 @@ Are you sure you want to proceed?</source>
         <source><x id="INTERPOLATION" equiv-text="{{ title }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/main-menu/main-menu.component.html</context>
-          <context context-type="linenumber">2</context>
+          <context context-type="linenumber">24</context>
         </context-group>
       </trans-unit>
       <trans-unit id="058b73757ea9dc14dee9cb48d52bf312fbb8ab15" datatype="html">


### PR DESCRIPTION
## Changes
- convert MainMenuComponent to standalone
- organize template using ng=template and ```@if``` and ```@for```
- declare inputs in SideMenuComponent to inherit the property from parent

## Test
- in CM and AT, the main menu and side menu work as before
