### PR TITLE
feat(LibraryFiltersComponent): add research project filtering functionality

### DIFF
--- a/src/app/domain/projectFilterValues.ts
+++ b/src/app/domain/projectFilterValues.ts
@@ -1,6 +1,9 @@
+import { ResearchProjectTypes } from '../modules/library/standard';
+
 export class ProjectFilterValues {
   searchValue: string = '';
   disciplineValue: string[] = [];
   dciArrangementValue: string[] = [];
   peValue: string[] = [];
+  researchProjectValue: ResearchProjectTypes[] = [];
 }

--- a/src/app/modules/library/library-filters/library-filters.component.html
+++ b/src/app/modules/library/library-filters/library-filters.component.html
@@ -84,5 +84,20 @@
         [multiple]="true"
       />
     </div>
+    @if (researchProjectOptions.length > 0) {
+      <div class="library-filter" fxFlex.gt-sm="{{ isSplitScreen ? 100 : 33 }}">
+        <app-select-menu
+          id="researchProjectSelectMenu"
+          [options]="researchProjectOptions"
+          i18n-placeholderText
+          placeholderText="Research Project"
+          [value]="researchProjectValue"
+          (update)="filterUpdated($event, 'researchProject')"
+          [valueProp]="'id'"
+          [viewValueProp]="'name'"
+          [multiple]="true"
+        />
+      </div>
+    }
   </div>
 </div>

--- a/src/app/modules/library/library-filters/library-filters.component.ts
+++ b/src/app/modules/library/library-filters/library-filters.component.ts
@@ -1,14 +1,8 @@
-import {
-  Component,
-  OnInit,
-  Input,
-  SimpleChanges,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, OnInit, Input, SimpleChanges, ViewEncapsulation } from '@angular/core';
 import { LibraryProject } from '../libraryProject';
 import { LibraryService } from '../../../services/library.service';
 import { NGSSStandards } from '../ngssStandards';
-import { Standard } from '../standard';
+import { ResearchProject, ResearchProjectTypes, Standard } from '../standard';
 import { ProjectFilterValues } from '../../../domain/projectFilterValues';
 import { UtilService } from '../../../services/util.service';
 
@@ -34,9 +28,14 @@ export class LibraryFiltersComponent implements OnInit {
   disciplineValue = [];
   peOptions: Standard[] = [];
   peValue = [];
+  protected researchProjectOptions: ResearchProject[] = [];
+  private researchProjectValue: ResearchProjectTypes[] = [];
   showFilters: boolean = false;
 
-  constructor(private libraryService: LibraryService, private utilService: UtilService) {
+  constructor(
+    private libraryService: LibraryService,
+    private utilService: UtilService
+  ) {
     libraryService.officialLibraryProjectsSource$.subscribe((libraryProjects: LibraryProject[]) => {
       this.libraryProjects = libraryProjects;
       this.populateFilterOptions();
@@ -96,8 +95,22 @@ export class LibraryFiltersComponent implements OnInit {
           }
         }
       }
+      this.populateResearchProjects(project);
     }
     this.removeDuplicatesAndSortAlphabetically();
+  }
+
+  private populateResearchProjects(project: LibraryProject): void {
+    project.metadata.researchProjects?.forEach((researchProjectTypes: ResearchProjectTypes) => {
+      const researchProject: ResearchProject = {
+        id: researchProjectTypes,
+        name: researchProjectTypes,
+        children: []
+      };
+      if (!this.researchProjectOptions.map((option) => option.id).includes(researchProject.id)) {
+        this.researchProjectOptions.push(researchProject);
+      }
+    });
   }
 
   getAllProjects() {
@@ -156,7 +169,7 @@ export class LibraryFiltersComponent implements OnInit {
     this.emitFilterValues();
   }
 
-  filterUpdated(value: string[] = [], context: string = ''): void {
+  filterUpdated(value: string[] | ResearchProjectTypes[] = [], context: string = ''): void {
     switch (context) {
       case 'discipline':
         this.disciplineValue = value;
@@ -167,6 +180,9 @@ export class LibraryFiltersComponent implements OnInit {
       case 'pe':
         this.peValue = value;
         break;
+      case 'researchProject':
+        this.researchProjectValue = value as ResearchProjectTypes[];
+        break;
     }
     this.emitFilterValues();
   }
@@ -176,7 +192,8 @@ export class LibraryFiltersComponent implements OnInit {
       searchValue: this.searchValue,
       disciplineValue: this.disciplineValue,
       dciArrangementValue: this.dciArrangementValue,
-      peValue: this.peValue
+      peValue: this.peValue,
+      researchProjectValue: this.researchProjectValue
     };
     this.libraryService.setFilterValues(filterOptions);
   }

--- a/src/app/modules/library/library/library.component.ts
+++ b/src/app/modules/library/library/library.component.ts
@@ -1,7 +1,7 @@
 import { EventEmitter, OnInit, Output, QueryList, ViewChildren, Directive } from '@angular/core';
 import { ProjectFilterValues } from '../../../domain/projectFilterValues';
 import { LibraryService } from '../../../services/library.service';
-import { Standard } from '../standard';
+import { ResearchProjectTypes, Standard } from '../standard';
 import { LibraryProject } from '../libraryProject';
 import { PageEvent, MatPaginator } from '@angular/material/paginator';
 import { Subscription } from 'rxjs';
@@ -19,6 +19,7 @@ export abstract class LibraryComponent implements OnInit {
   peOptions: Standard[] = [];
   peValue = [];
   filterValues: ProjectFilterValues = new ProjectFilterValues();
+  private researchProjectValue: ResearchProjectTypes[] = [];
   showFilters: boolean = false;
   subscriptions: Subscription = new Subscription();
   pageSizeOptions: number[] = [12, 24, 48, 96];
@@ -31,7 +32,10 @@ export abstract class LibraryComponent implements OnInit {
 
   @ViewChildren(MatPaginator) paginators!: QueryList<MatPaginator>;
 
-  constructor(protected dialog: MatDialog, protected libraryService: LibraryService) {}
+  constructor(
+    protected dialog: MatDialog,
+    protected libraryService: LibraryService
+  ) {}
 
   ngOnInit() {
     this.subscriptions.add(
@@ -81,6 +85,7 @@ export abstract class LibraryComponent implements OnInit {
     this.searchValue = this.filterValues.searchValue;
     this.disciplineValue = this.filterValues.disciplineValue;
     this.dciArrangementValue = this.filterValues.dciArrangementValue;
+    this.researchProjectValue = this.filterValues.researchProjectValue;
     this.peValue = this.filterValues.peValue;
     for (let project of this.projects) {
       let filterMatch = false;
@@ -102,9 +107,11 @@ export abstract class LibraryComponent implements OnInit {
 
   hasFilters(): boolean {
     return (
-      this.dciArrangementValue.length > 0 ||
-      this.peValue.length > 0 ||
-      this.disciplineValue.length > 0
+      this.dciArrangementValue.length +
+        this.peValue.length +
+        this.disciplineValue.length +
+        this.researchProjectValue.length >
+      0
     );
   }
 
@@ -168,6 +175,16 @@ export abstract class LibraryComponent implements OnInit {
               }
             }
           }
+        }
+      }
+      if (this.researchProjectValue.length > 0) {
+        const researchProjects: ResearchProjectTypes[] = project.metadata.researchProjects ?? [];
+        if (
+          researchProjects.some((researchProject) =>
+            this.researchProjectValue.includes(researchProject)
+          )
+        ) {
+          return true;
         }
       }
       return false;

--- a/src/app/modules/library/personal-library/personal-library.component.spec.ts
+++ b/src/app/modules/library/personal-library/personal-library.component.spec.ts
@@ -268,7 +268,8 @@ function projectsAreSelected_performSearch_allProjectsAreUnselected() {
           searchValue: 'world',
           dciArrangementValue: [],
           disciplineValue: [],
-          peValue: []
+          peValue: [],
+          researchProjectValue: []
         });
         expect(await harness.getSelectedProjectIds()).toEqual([]);
       });

--- a/src/app/modules/library/standard.ts
+++ b/src/app/modules/library/standard.ts
@@ -3,3 +3,9 @@ export class Standard {
   name: string = '';
   children: Standard[] = [];
 }
+
+export type ResearchProjectTypes = 'ARISE' | 'NLP-TIPS';
+
+export class ResearchProject extends Standard {
+  name: ResearchProjectTypes;
+}

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -5615,6 +5615,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">79</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="cc85ab242c98fa038219eb59fbe2941a5cbfa109" datatype="html">
+        <source>Research Project</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/library/library-filters/library-filters.component.html</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="07ab43ffb10e6bed417b203bfdc02cdda6aa1b61" datatype="html">
         <source>Grade level:</source>
         <context-group purpose="location">


### PR DESCRIPTION
## Changes
- This change set allows authors to specify ResearchProject (RP) tags ("NLP-TIPS", "ARISE", etc) to library units. This is represented in the project JSON in ```metadata.researchProjects``` array. This will allow teachers and grant reviewers to quickly search for units that were created for certain research projects.
- Add select menu that appears only when there are library units with RP tags
- Update the filtered units according to the users' selections of the new RP tags

## Setup
- To add RP tag to a unit, open the unit's JSON editing view in the AT and add the following field to the metadata block:
```
        "researchProjects": [
            "ARISE",
            "NLP-TIPS"
        ],
```

## Test
- Test with https://github.com/WISE-Community/WISE-API/pull/284
- When no units with RP tags exists
- When one or more units with RP tags exist

Closes #2035 
