### PR TITLE
style(Import Component): Use same UI/UX flow as Import Step

### DIFF
--- a/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html
@@ -1,4 +1,4 @@
-<h5 i18n>Choose the step(s) that you want to import, then select Next.</h5>
+<h5 i18n>Choose the step(s) that you want to import, then select Submit.</h5>
 <p fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="8px">
   <strong i18n>Selected unit: {{ project?.metadata.title }}</strong>
   <button

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
@@ -17,8 +17,7 @@
       <ng-container
         [ngTemplateOutlet]="projects"
         [ngTemplateOutletContext]="{ projects: myProjects }"
-      >
-      </ng-container>
+      />
     }
   </mat-tab>
   <mat-tab label="Library Units" i18n-label>
@@ -26,8 +25,7 @@
       <ng-container
         [ngTemplateOutlet]="projects"
         [ngTemplateOutletContext]="{ projects: libraryProjects }"
-      >
-      </ng-container>
+      />
     }
   </mat-tab>
 </mat-tab-group>

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
@@ -32,10 +32,8 @@
 <div class="nav-controls">
   <mat-divider />
   <div fxLayout="row" fxLayoutGap="16px" fxLayoutAlign="end center">
-    <button mat-button color="primary" routerLink="../../choose-template" [state]="target" i18n>
-      Back
-    </button>
+    <button mat-button color="primary" (click)="goBack()" i18n>Back</button>
     <span fxFlex></span>
-    <button mat-button color="primary" routerLink="../../.." i18n>Cancel</button>
+    <button mat-button color="primary" (click)="cancel()" i18n>Cancel</button>
   </div>
 </div>

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
@@ -10,7 +10,11 @@
     }
   </div>
 </ng-template>
-<h5 i18n>Choose a unit from which to import step(s).</h5>
+@if (importType === 'step') {
+  <h5 i18n>Choose a unit from which to import step(s).</h5>
+} @else {
+  <h5 i18n>Choose a unit from which to import component(s).</h5>
+}
 <mat-tab-group mat-stretch-tabs="false">
   <mat-tab label="My Units" i18n-label>
     @if (myProjects) {

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.ts
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.ts
@@ -55,24 +55,19 @@ export class ChooseImportUnitComponent {
 
   protected chooseProject(project: any): void {
     this.target.importProjectId = project.id;
-    this.router.navigate(
-      [this.importType === 'component' ? '../choose-component' : '../choose-step'],
-      {
-        relativeTo: this.route,
-        state: this.target
-      }
-    );
+    this.navigate('../choose-component', '../choose-step');
   }
 
   protected goBack(): void {
-    this.router.navigate([this.importType === 'component' ? '../..' : '../../choose-template'], {
-      relativeTo: this.route,
-      state: this.target
-    });
+    this.navigate('../..', '../../choose-template');
   }
 
   protected cancel(): void {
-    this.router.navigate([this.importType === 'component' ? '../..' : '../../..'], {
+    this.navigate('../..', '../../..');
+  }
+
+  private navigate(componentUrl: string, stepUrl: string): void {
+    this.router.navigate([this.importType === 'component' ? componentUrl : stepUrl], {
       relativeTo: this.route,
       state: this.target
     });

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.ts
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.ts
@@ -25,6 +25,7 @@ import { FlexLayoutModule } from '@angular/flex-layout';
   templateUrl: './choose-import-unit.component.html'
 })
 export class ChooseImportUnitComponent {
+  private importType: 'step' | 'component';
   protected libraryProjects: any[];
   protected myProjects: any[];
   private subscriptions: Subscription = new Subscription();
@@ -38,12 +39,13 @@ export class ChooseImportUnitComponent {
   ) {}
 
   ngOnInit(): void {
+    this.importType = history.state.importType;
     this.target = history.state;
     this.myProjects = this.configService.getAuthorableProjects();
     this.subscriptions.add(
-      this.projectLibraryService.getLibraryProjects().subscribe((libraryProjects) => {
-        this.libraryProjects = libraryProjects;
-      })
+      this.projectLibraryService
+        .getLibraryProjects()
+        .subscribe((libraryProjects) => (this.libraryProjects = libraryProjects))
     );
   }
 
@@ -53,9 +55,12 @@ export class ChooseImportUnitComponent {
 
   protected chooseProject(project: any): void {
     this.target.importProjectId = project.id;
-    this.router.navigate(['../choose-step'], {
-      relativeTo: this.route,
-      state: this.target
-    });
+    this.router.navigate(
+      [this.importType === 'component' ? '../choose-component' : '../choose-step'],
+      {
+        relativeTo: this.route,
+        state: this.target
+      }
+    );
   }
 }

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.ts
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.ts
@@ -63,4 +63,18 @@ export class ChooseImportUnitComponent {
       }
     );
   }
+
+  protected goBack(): void {
+    this.router.navigate([this.importType === 'component' ? '../..' : '../../choose-template'], {
+      relativeTo: this.route,
+      state: this.target
+    });
+  }
+
+  protected cancel(): void {
+    this.router.navigate([this.importType === 'component' ? '../..' : '../../..'], {
+      relativeTo: this.route,
+      state: this.target
+    });
+  }
 }

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.ts
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.ts
@@ -25,7 +25,7 @@ import { FlexLayoutModule } from '@angular/flex-layout';
   templateUrl: './choose-import-unit.component.html'
 })
 export class ChooseImportUnitComponent {
-  private importType: 'step' | 'component';
+  protected importType: 'step' | 'component';
   protected libraryProjects: any[];
   protected myProjects: any[];
   private subscriptions: Subscription = new Subscription();

--- a/src/app/teacher/authoring-routing.module.ts
+++ b/src/app/teacher/authoring-routing.module.ts
@@ -154,7 +154,16 @@ const routes: Routes = [
               },
               {
                 path: 'import-component',
-                children: [{ path: 'choose-component', component: ChooseImportComponentComponent }]
+                children: [
+                  {
+                    path: 'choose-component',
+                    component: ChooseImportComponentComponent
+                  },
+                  {
+                    path: 'choose-unit',
+                    component: ChooseImportUnitComponent
+                  }
+                ]
               }
             ]
           },

--- a/src/app/teacher/authoring-tool.module.ts
+++ b/src/app/teacher/authoring-tool.module.ts
@@ -13,7 +13,6 @@ import { StudentTeacherCommonModule } from '../student-teacher-common.module';
 import { RecoveryAuthoringComponent } from '../../assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component';
 import { AddLessonConfigureComponent } from '../../assets/wise5/authoringTool/addLesson/add-lesson-configure/add-lesson-configure.component';
 import { ConcurrentAuthorsMessageComponent } from '../../assets/wise5/authoringTool/concurrent-authors-message/concurrent-authors-message.component';
-import { ImportComponentModule } from '../../assets/wise5/authoringTool/importComponent/import-component-module';
 import { NodeAdvancedAuthoringModule } from '../../assets/wise5/authoringTool/node/advanced/node-advanced-authoring.module';
 import { NodeAuthoringComponent } from '../../assets/wise5/authoringTool/node/node-authoring/node-authoring.component';
 import { TeacherNodeIconComponent } from '../../assets/wise5/authoringTool/teacher-node-icon/teacher-node-icon.component';
@@ -61,6 +60,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { AddComponentComponent } from '../../assets/wise5/authoringTool/node/add-component/add-component.component';
 import { SideMenuComponent } from '../../assets/wise5/common/side-menu/side-menu.component';
 import { MainMenuComponent } from '../../assets/wise5/common/main-menu/main-menu.component';
+import { ChooseImportComponentComponent } from '../../assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component';
 
 @NgModule({
   declarations: [
@@ -93,6 +93,7 @@ import { MainMenuComponent } from '../../assets/wise5/common/main-menu/main-menu
     AuthoringToolBarComponent,
     ChooseAutomatedAssessmentComponent,
     ChooseCopyNodeLocationComponent,
+    ChooseImportComponentComponent,
     ChooseImportStepComponent,
     ChooseImportUnitComponent,
     ChooseNewNodeTemplateComponent,
@@ -108,7 +109,6 @@ import { MainMenuComponent } from '../../assets/wise5/common/main-menu/main-menu
     MatBadgeModule,
     MatChipsModule,
     MatExpansionModule,
-    ImportComponentModule,
     InsertNodeAfterButtonComponent,
     InsertNodeInsideButtonComponent,
     MainMenuComponent,

--- a/src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html
+++ b/src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html
@@ -1,132 +1,95 @@
-<h4 i18n>Import Component(s)</h4>
-<div fxLayoutGap="20px">
-  <span i18n>Choose a unit to import from and then choose which component(s) to import</span>
-</div>
-<mat-form-field class="unit-select">
-  <mat-label i18n>My Units</mat-label>
-  <mat-select
-    [(ngModel)]="importMyProjectId"
-    (ngModelChange)="showMyImportProject(importMyProjectId)"
-  >
-    <mat-option *ngFor="let project of myProjectsList" [value]="project.id" i18n>
-      {{
-        project.id +
-          ' - ' +
-          project.name +
-          (project.runId ? ' (Run ID: ' + project.runId + ')' : '')
-      }}
-    </mat-option>
-  </mat-select>
-</mat-form-field>
-<br />
-<mat-form-field class="unit-select">
-  <mat-label i18n>Library Units</mat-label>
-  <mat-select
-    [(ngModel)]="importLibraryProjectId"
-    (ngModelChange)="showLibraryImportProject(importLibraryProjectId)"
-  >
-    <mat-option *ngFor="let project of libraryProjectsList" [value]="project.id" i18n>
-      {{
-        project.id +
-          ' - ' +
-          project.name +
-          (project.runId ? ' (Run ID: ' + project.runId + ')' : '')
-      }}
-    </mat-option>
-  </mat-select>
-</mat-form-field>
-<br />
-<span *ngIf="importProject != null">
-  <div class="import-message-bar" fxLayoutGap="20px">
-    <span i18n
-      >After you have chosen the component(s) you want to import, click this button to import
-      them</span
-    >
-    <button
-      mat-raised-button
-      color="primary"
-      (click)="importComponents()"
-      matTooltip="Import Component(s)"
-      matTooltipPosition="above"
-      i18n-matTooltip
-    >
-      <mat-icon>vertical_align_bottom</mat-icon>
-    </button>
-  </div>
-  <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="20px">
-    <h4>{{ importProject.metadata.title }}</h4>
-    <button
-      mat-raised-button
-      color="primary"
-      (click)="previewImportProject()"
-      matTooltip="Preview Project"
-      matTooltipPosition="above"
-      i18n-matTooltip
-    >
-      <mat-icon>preview</mat-icon>
-    </button>
-  </div>
-  <div
-    *ngFor="let importItem of nodesInOrder"
-    [ngClass]="{
-      groupHeader: importItem.node.type === 'group',
-      stepHeader: importItem.node.type !== 'group'
-    }"
-  >
-    <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="20px">
-      <h6 *ngIf="importItem.order !== 0">
-        {{ importItem.stepNumber }}: {{ importItem.node.title }}
-      </h6>
-      <button
-        mat-raised-button
-        color="primary"
-        *ngIf="importItem.node.type !== 'group'"
-        (click)="previewImportNode(importItem.node)"
-        matTooltip="Preview Step"
-        matTooltipPosition="above"
-        i18n-matTooltip
-      >
-        <mat-icon>preview</mat-icon>
-      </button>
-    </div>
-    <div
-      *ngFor="let component of importItem.node.components; let i = index"
-      class="componentHeader"
-    >
-      <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="20px">
-        <div>
-          <mat-checkbox [(ngModel)]="component.checked" color="primary">
-            <span>{{ i + 1 }}. {{ component.type }}</span>
-          </mat-checkbox>
-        </div>
-        <div>
-          <button
-            mat-raised-button
-            color="primary"
-            *ngIf="importItem.node.type !== 'group'"
-            (click)="previewImportNode(importItem.node)"
-            matTooltip="Preview Component"
-            matTooltipPosition="above"
-            i18n-matTooltip
-          >
-            <mat-icon>preview</mat-icon>
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
+<h5 i18n>Choose the component(s) that you want to import, then select Submit.</h5>
+<p fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="8px">
+  <strong i18n>Selected unit: {{ project?.metadata.title }}</strong>
   <button
     mat-raised-button
     color="primary"
-    (click)="importComponents()"
-    matTooltip="Import Component(s)"
+    (click)="previewProject()"
+    matTooltip="Preview unit"
     matTooltipPosition="above"
     i18n-matTooltip
   >
-    <mat-icon>vertical_align_bottom</mat-icon>
+    <mat-icon>preview</mat-icon>
   </button>
-</span>
-<hr />
-<div fxLayout="row">
-  <button mat-button color="primary" (click)="cancel()" aria-label="Cancel" i18n>Cancel</button>
+</p>
+@for (item of projectIdToOrder; track item.order) {
+  <div
+    [ngClass]="{
+      groupHeader: item.node.type == 'group',
+      stepHeader: item.node.type != 'group'
+    }"
+  >
+    @if (item.node.type == 'group') {
+      <h6>{{ item.stepNumber }}: {{ item.node.title }}</h6>
+    } @else {
+      <div fxLayout="row wrap" fxLayoutGap="8px">
+        <span class="step-title">{{ item.stepNumber }}: {{ item.node.title }}</span>
+        <button
+          mat-raised-button
+          color="primary"
+          class="mat-raised-button mat-primary"
+          style="margin-top: -5"
+          (click)="previewNode(item.node)"
+          matTooltip="Preview step"
+          matTooltipPosition="above"
+          i18n-matTooltip
+        >
+          <mat-icon>preview</mat-icon>
+        </button>
+      </div>
+      @for (component of item.node.components; track component.id; let i = $index) {
+        <div class="componentHeader">
+          <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="20px">
+            <div>
+              <mat-checkbox [(ngModel)]="component.checked" color="primary">
+                <span>{{ i + 1 }}. {{ component.type }}</span>
+              </mat-checkbox>
+            </div>
+            <div>
+              <button
+                mat-raised-button
+                color="primary"
+                (click)="previewNode(item.node)"
+                matTooltip="Preview component"
+                matTooltipPosition="above"
+                i18n-matTooltip
+              >
+                <mat-icon>preview</mat-icon>
+              </button>
+            </div>
+          </div>
+        </div>
+      }
+    }
+  </div>
+}
+<div class="nav-controls">
+  <mat-divider />
+  <div fxLayout="row" fxLayoutGap="16px" fxLayoutAlign="end center">
+    <button
+      mat-button
+      color="primary"
+      routerLink="../choose-unit"
+      [state]="state"
+      aria-label="Back"
+      i18n-aria-label
+      i18n
+    >
+      Back
+    </button>
+    <span fxFlex></span>
+    <button mat-button color="primary" routerLink="../.." i18n>Cancel</button>
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="import()"
+      [disabled]="getSelectedComponentsToImport().length == 0 || submitting"
+      class="button--progress"
+    >
+      @if (submitting) {
+        <mat-progress-bar mode="indeterminate" />
+      }
+      <ng-container i18n>Submit</ng-container>
+    </button>
+  </div>
 </div>

--- a/src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.spec.ts
+++ b/src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.spec.ts
@@ -1,24 +1,19 @@
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ChooseImportComponentComponent } from './choose-import-component.component';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { ConfigService } from '../../../services/configService';
 import { ProjectLibraryService } from '../../../services/projectLibraryService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
 import { TeacherDataService } from '../../../services/teacherDataService';
 import { TeacherWebSocketService } from '../../../services/teacherWebSocketService';
-import { ClassroomStatusService } from '../../../services/classroomStatusService';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectModule } from '@angular/material/select';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { FormsModule } from '@angular/forms';
 import { ImportComponentService } from '../../../services/importComponentService';
 import { CopyNodesService } from '../../../services/copyNodesService';
 import { InsertComponentService } from '../../../services/insertComponentService';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
-import { RouterTestingModule } from '@angular/router/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatButtonHarness } from '@angular/material/button/testing';
 
 let component: ChooseImportComponentComponent;
 const component1 = { id: 'component1', type: 'OpenResponse' };
@@ -29,11 +24,12 @@ const group1 = { id: 'group1', type: 'group', title: '', startId: 'node1', ids: 
 const node1 = {
   id: 'node1',
   type: 'node',
-  title: '',
+  title: 'First step',
   components: [component1, component2]
 };
 const project: any = {
   startGroupId: 'group0',
+  metadata: { title: 'Project Title' },
   nodes: [group0, group1, node1],
   inactiveNodes: []
 };
@@ -42,17 +38,12 @@ let projectService: TeacherProjectService;
 describe('ChooseImportComponentComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    declarations: [ChooseImportComponentComponent],
-    imports: [BrowserAnimationsModule,
-        FormsModule,
-        MatDialogModule,
-        MatFormFieldModule,
-        MatSelectModule,
-        RouterTestingModule,
-        StudentTeacherCommonServicesModule],
-    providers: [
-        ClassroomStatusService,
-        ConfigService,
+      imports: [
+        BrowserAnimationsModule,
+        ChooseImportComponentComponent,
+        StudentTeacherCommonServicesModule
+      ],
+      providers: [
         CopyNodesService,
         ImportComponentService,
         InsertComponentService,
@@ -62,80 +53,37 @@ describe('ChooseImportComponentComponent', () => {
         TeacherProjectService,
         TeacherWebSocketService,
         provideHttpClient(withInterceptorsFromDi()),
-        provideHttpClientTesting()
-    ]
-}).compileComponents();
+        provideRouter([])
+      ]
+    }).compileComponents();
   });
 
   beforeEach(() => {
     projectService = TestBed.inject(TeacherProjectService);
+    spyOn(projectService, 'retrieveProjectById').and.resolveTo(project);
+    window.history.pushState({ importType: 'component' }, '', '');
     fixture = TestBed.createComponent(ChooseImportComponentComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
-
-  showMyImportProject();
-  showLibraryImportProject();
-  importComponents();
+  ngOnInit();
 });
 
-function showMyImportProject() {
-  describe('showMyImportProject()', () => {
-    it('should set my import project', fakeAsync(() => {
-      spyOn(projectService, 'retrieveProjectById').and.returnValue(Promise.resolve(project));
-      component.importLibraryProjectId = 1;
-      component.showMyImportProject(2);
-      expect(component.importLibraryProjectId).toBeNull();
+function ngOnInit() {
+  describe('ngOnInit()', () => {
+    it('should create', fakeAsync(async () => {
+      component.ngOnInit();
       tick();
-      expectNodesInOrder();
-      expectImportProjectItems();
+      expect(component).toBeTruthy();
+      const loader = TestbedHarnessEnvironment.loader(fixture);
+      const previewStepButton = await loader.getHarness(
+        MatButtonHarness.with({ selector: '[mattooltip="Preview step"]' })
+      );
+      expect(previewStepButton).toBeTruthy();
+      const previewComponentButton = await loader.getHarness(
+        MatButtonHarness.with({ selector: '[mattooltip="Preview component"]' })
+      );
+      expect(previewComponentButton).toBeTruthy();
     }));
-  });
-}
-
-function showLibraryImportProject() {
-  describe('showLibraryImportProject()', () => {
-    it('should set library import project', fakeAsync(() => {
-      spyOn(projectService, 'retrieveProjectById').and.returnValue(Promise.resolve(project));
-      component.importMyProjectId = 1;
-      component.showLibraryImportProject(2);
-      expect(component.importMyProjectId).toBeNull();
-      tick();
-      expectNodesInOrder();
-      expectImportProjectItems();
-    }));
-  });
-}
-
-function expectNodesInOrder() {
-  expect(component.nodesInOrder).toEqual([
-    { order: 0, node: group0, stepNumber: '' },
-    { order: 1, node: group1, stepNumber: '1' },
-    { order: 2, node: node1, stepNumber: '1.1' }
-  ]);
-}
-
-function expectImportProjectItems() {
-  expect(component.importProjectItems).toEqual([{ order: 2, node: node1, stepNumber: '1.1' }]);
-}
-
-function importComponents() {
-  describe('importComponents()', () => {
-    it('when no components are selected, should alert message', () => {
-      const alertSpy = spyOn(window, 'alert');
-      component.importComponents();
-      expect(alertSpy).toHaveBeenCalledWith('Please select a component to import.');
-    });
-
-    xit('when a component is selected, should import component', () => {
-      const importProjectId = 1;
-      const spy = spyOn(TestBed.inject(ImportComponentService), 'importComponents').and.stub();
-      component.importProjectId = importProjectId;
-      const node = JSON.parse(JSON.stringify(node1));
-      node.components[0].checked = true;
-      component.importProjectItems = [{ order: 2, node: node, stepNumber: '1.1' }];
-      component.importComponents();
-      expect(spy).toHaveBeenCalled();
-    });
   });
 }

--- a/src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.ts
+++ b/src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.ts
@@ -1,136 +1,105 @@
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { ConfigService } from '../../../services/configService';
 import { TeacherDataService } from '../../../services/teacherDataService';
-import { ProjectLibraryService } from '../../../services/projectLibraryService';
 import { Component, OnInit } from '@angular/core';
 import { ImportComponentService } from '../../../services/importComponentService';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
-import { ActivatedRoute, Router } from '@angular/router';
-import { Subscription } from 'rxjs';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
+  imports: [
+    CommonModule,
+    FormsModule,
+    FlexLayoutModule,
+    MatButtonModule,
+    MatCheckboxModule,
+    MatDividerModule,
+    MatIconModule,
+    MatProgressBarModule,
+    MatTooltipModule,
+    RouterModule
+  ],
   selector: 'choose-import-component',
-  templateUrl: './choose-import-component.component.html',
-  styleUrls: ['./choose-import-component.component.scss']
+  standalone: true,
+  styleUrl: './choose-import-component.component.scss',
+  templateUrl: './choose-import-component.component.html'
 })
 export class ChooseImportComponentComponent implements OnInit {
-  importLibraryProjectId: number;
-  importMyProjectId: number;
   protected importProject: any = null;
-  importProjectId: number;
-  importProjectItems: any = [];
-  protected libraryProjectsList: any = [];
+  private importProjectId: number;
   protected myProjectsList: any = [];
-  nodesInOrder: any[] = [];
-  private subscriptions: Subscription = new Subscription();
+  protected project: any;
+  protected projectIdToOrder: any;
+  private projectItems: any[] = [];
+  protected state: any;
+  protected submitting: boolean;
 
   constructor(
     private configService: ConfigService,
     private dataService: TeacherDataService,
     private importComponentService: ImportComponentService,
     private projectAssetService: ProjectAssetService,
-    private projectLibraryService: ProjectLibraryService,
     private projectService: TeacherProjectService,
     private route: ActivatedRoute,
     private router: Router
   ) {}
 
   ngOnInit(): void {
-    this.importProjectItems = [];
-    this.importMyProjectId = null;
-    this.importLibraryProjectId = null;
-    this.importProjectId = null;
-    this.importProject = null;
-    this.myProjectsList = this.configService.getAuthorableProjects();
-    this.subscriptions.add(
-      this.projectLibraryService.getLibraryProjects().subscribe((libraryProjects) => {
-        this.libraryProjectsList = libraryProjects;
-      })
-    );
-  }
-
-  ngOnDestroy(): void {
-    this.subscriptions.unsubscribe();
-  }
-
-  showMyImportProject(importProjectId: number): void {
-    this.importLibraryProjectId = null;
-    this.showImportProject(importProjectId);
-  }
-
-  showLibraryImportProject(importProjectId: number): void {
-    this.importMyProjectId = null;
-    this.showImportProject(importProjectId);
-  }
-
-  private showImportProject(importProjectId: number): void {
-    this.importProjectId = importProjectId;
-    this.projectService.retrieveProjectById(this.importProjectId).then((projectJSON: any) => {
-      this.importProject = projectJSON;
-      const orderData = this.projectService.getNodeOrderOfProject(this.importProject);
-      this.nodesInOrder = Object.values(orderData.idToOrder);
-      this.importProjectItems = orderData.nodes.filter((nodeOrder: any) => {
-        return nodeOrder.node.type !== 'group';
-      });
+    this.state = history.state;
+    this.importProjectId = this.state.importProjectId;
+    this.projectService.retrieveProjectById(this.importProjectId).then((projectJSON) => {
+      this.project = projectJSON;
+      const nodeOrderOfProject = this.projectService.getNodeOrderOfProject(this.project);
+      this.projectIdToOrder = Object.values(nodeOrderOfProject.idToOrder)
+        .slice(1)
+        .filter((item: any) => item.node.components?.length > 0);
+      this.projectItems = nodeOrderOfProject.nodes;
     });
   }
 
-  importComponents(): void {
-    const selectedComponents = this.getSelectedComponentsToImport();
-    if (selectedComponents.length === 0) {
-      alert($localize`Please select a component to import.`);
-    } else {
-      this.importComponentService
-        .importComponents(
-          selectedComponents,
-          this.importProjectId,
-          this.dataService.getCurrentNodeId(),
-          history.state.insertAfterComponentId
-        )
-        .subscribe((newComponents) => {
-          this.projectService.saveProject();
-          // refresh the project assets in case any of the imported components also imported assets
-          this.projectAssetService.retrieveProjectAssets();
-          this.router.navigate(['../..'], {
-            relativeTo: this.route,
-            state: {
-              projectId: this.configService.getProjectId(),
-              nodeId: this.dataService.getCurrentNodeId(),
-              newComponents: newComponents
-            }
-          });
+  protected previewProject(): void {
+    window.open(`${this.project.previewProjectURL}`);
+  }
+
+  protected previewNode(node: any): void {
+    window.open(`${this.project.previewProjectURL}/${node.id}`);
+  }
+
+  protected import(): void {
+    this.importComponentService
+      .importComponents(
+        this.getSelectedComponentsToImport(),
+        this.importProjectId,
+        this.dataService.getCurrentNodeId(),
+        history.state.insertAfterComponentId
+      )
+      .subscribe((newComponents) => {
+        this.projectService.saveProject();
+        // refresh the project assets in case any of the imported components also imported assets
+        this.projectAssetService.retrieveProjectAssets();
+        this.router.navigate(['../..'], {
+          relativeTo: this.route,
+          state: {
+            projectId: this.configService.getProjectId(),
+            nodeId: this.dataService.getCurrentNodeId(),
+            newComponents: newComponents
+          }
         });
-    }
+      });
   }
 
-  private getSelectedComponentsToImport(): any[] {
-    const selectedComponents = [];
-    for (const item of this.importProjectItems) {
-      for (const component of item.node.components) {
-        if (component.checked) {
-          delete component.checked;
-          selectedComponents.push(component);
-        }
-      }
-    }
-    return selectedComponents;
-  }
-
-  protected previewImportProject(): void {
-    window.open(`${this.importProject.previewProjectURL}`);
-  }
-
-  protected previewImportNode(node: any): void {
-    window.open(`${this.importProject.previewProjectURL}/${node.id}`);
-  }
-
-  protected cancel(): void {
-    this.router.navigate(['../..'], {
-      relativeTo: this.route,
-      state: {
-        projectId: this.configService.getProjectId(),
-        nodeId: this.dataService.getCurrentNodeId()
-      }
-    });
+  protected getSelectedComponentsToImport(): any[] {
+    return this.projectItems
+      .flatMap((item) => item.node.components)
+      .filter((component) => component?.checked);
   }
 }

--- a/src/assets/wise5/authoringTool/importComponent/import-component-module.ts
+++ b/src/assets/wise5/authoringTool/importComponent/import-component-module.ts
@@ -1,9 +1,0 @@
-import { NgModule } from '@angular/core';
-import { ChooseImportComponentComponent } from './choose-import-component/choose-import-component.component';
-import { StudentTeacherCommonModule } from '../../../../app/student-teacher-common.module';
-
-@NgModule({
-  exports: [ChooseImportComponentComponent],
-  imports: [ChooseImportComponentComponent, StudentTeacherCommonModule]
-})
-export class ImportComponentModule {}

--- a/src/assets/wise5/authoringTool/importComponent/import-component-module.ts
+++ b/src/assets/wise5/authoringTool/importComponent/import-component-module.ts
@@ -3,8 +3,7 @@ import { ChooseImportComponentComponent } from './choose-import-component/choose
 import { StudentTeacherCommonModule } from '../../../../app/student-teacher-common.module';
 
 @NgModule({
-  declarations: [ChooseImportComponentComponent],
   exports: [ChooseImportComponentComponent],
-  imports: [StudentTeacherCommonModule]
+  imports: [ChooseImportComponentComponent, StudentTeacherCommonModule]
 })
 export class ImportComponentModule {}

--- a/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.ts
+++ b/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.ts
@@ -64,9 +64,10 @@ export class AddComponentButtonComponent {
       .pipe(filter((componentType) => componentType != null))
       .subscribe(({ action, componentType }) => {
         if (action === 'import') {
-          this.router.navigate(['import-component/choose-component'], {
+          this.router.navigate(['import-component/choose-unit'], {
             relativeTo: this.route,
             state: {
+              importType: 'component',
               insertAfterComponentId: afterComponent
             }
           });

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -401,7 +401,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">37</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
@@ -481,7 +481,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
-          <context context-type="linenumber">131</context>
+          <context context-type="linenumber">81</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/create-new-peer-grouping-dialog/create-new-peer-grouping-dialog.component.html</context>
@@ -1398,8 +1398,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">34</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="aebe90fbb61e57f4a4ea689e1f155a3f58cea25a" datatype="html">
-        <source>Choose the step(s) that you want to import, then select Next.</source>
+      <trans-unit id="c95b122e952942dd5bb4ed9ce932d9b5f23e2453" datatype="html">
+        <source>Choose the step(s) that you want to import, then select Submit.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
           <context context-type="linenumber">1</context>
@@ -1409,6 +1409,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Selected unit: <x id="INTERPOLATION" equiv-text="{{ project?.metadata.title }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
           <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit>
@@ -1433,16 +1437,20 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
           <context context-type="linenumber">37</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
-          <context context-type="linenumber">85</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="cda31dbd724cf5f4fa7a4274d9120651490c8a8c" datatype="html">
         <source>Back</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
           <context context-type="linenumber">55</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
+          <context context-type="linenumber">74</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/node-advanced-authoring/node-advanced-authoring.component.html</context>
@@ -1488,10 +1496,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">58,60</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">35,37</context>
-        </context-group>
-        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
           <context context-type="linenumber">40,42</context>
         </context-group>
@@ -1502,6 +1506,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/configure-automated-assessment/configure-automated-assessment.component.html</context>
           <context context-type="linenumber">31,33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
+          <context context-type="linenumber">77,79</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.html</context>
@@ -1583,6 +1591,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">58</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
+          <context context-type="linenumber">92</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/structure/jigsaw/jigsaw.component.html</context>
           <context context-type="linenumber">34</context>
         </context-group>
@@ -1640,10 +1652,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">1</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
-          <context context-type="linenumber">6</context>
-        </context-group>
-        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-list/project-list.component.html</context>
           <context context-type="linenumber">55</context>
         </context-group>
@@ -1652,10 +1660,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Library Units</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">23</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
           <context context-type="linenumber">23</context>
         </context-group>
       </trans-unit>
@@ -10968,70 +10972,32 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">162</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="549db7a4a511ef9e23b17fa3cd8781e3d8ef45d4" datatype="html">
-        <source>Import Component(s)</source>
+      <trans-unit id="b1ab0950f9676641e46e363ff6a5767fb4c333ef" datatype="html">
+        <source>Choose the component(s) that you want to import, then select Submit.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
           <context context-type="linenumber">1</context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="80a6d9b67649d0c8c4d2eadbced9d10ff7a7ab15" datatype="html">
+        <source>Preview unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
-          <context context-type="linenumber">49</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
-          <context context-type="linenumber">122</context>
+          <context context-type="linenumber">8</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="49ec12864452b1c9eacceae061885c6a935d0235" datatype="html">
-        <source>Choose a unit to import from and then choose which component(s) to import</source>
+      <trans-unit id="af6b86e1f2a86d77c7134ee5691c9fbba1be335b" datatype="html">
+        <source>Preview step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
-          <context context-type="linenumber">3</context>
+          <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8a564c577184aa5b7fda023e8150f397a9ccf2b4" datatype="html">
-        <source> <x id="INTERPOLATION" equiv-text="{{
-        project.id +
-          &apos; - &apos; +
-          project.name +
-          (project.runId ? &apos; (Run ID: &apos; + project.runId + &apos;)&apos; : &apos;&apos;)
-      }}"/> </source>
+      <trans-unit id="592715f579b88977a98d277b9d6099afcd72a6fc" datatype="html">
+        <source>Preview component</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
-          <context context-type="linenumber">11,18</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
-          <context context-type="linenumber">28,35</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="007d097a175986bba7109ee6bc1b8d3a644467d6" datatype="html">
-        <source>After you have chosen the component(s) you want to import, click this button to import them</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
-          <context context-type="linenumber">42,43</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="ecef2eaad0b70f5bda647b521aa8549d1d0d697c" datatype="html">
-        <source>Preview Project</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
-          <context context-type="linenumber">62</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="929954f6e28805c5a7c03aac44c9e48cad2ab3e3" datatype="html">
-        <source>Preview Component</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
-          <context context-type="linenumber">108</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3282250240446159022" datatype="html">
-        <source>Please select a component to import.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.ts</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="22f5f4e7d0b3708e7ffceeea8b93b27e8f09ed7b" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -401,7 +401,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">37</context>
+          <context context-type="linenumber">41</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
@@ -1446,7 +1446,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">39</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
@@ -1638,14 +1638,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Choose a unit from which to import step(s).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">13</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="b19d914474f892407ba0da88fef235cef896f171" datatype="html">
+        <source>Choose a unit from which to import component(s).</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
+          <context context-type="linenumber">16</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c4058ff063f874b650aca76a5d972f11323bb6fb" datatype="html">
         <source>My Units</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="linenumber">19</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library-details.html</context>
@@ -1660,7 +1667,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Library Units</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">23</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e78170d2eb79d84d7927b8df23950715263ae478" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -401,7 +401,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">41</context>
+          <context context-type="linenumber">39</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/copy-project-dialog/copy-project-dialog.component.html</context>
@@ -1489,7 +1489,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">37,39</context>
+          <context context-type="linenumber">35,37</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
@@ -1652,7 +1652,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Library Units</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">23</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
@@ -4523,8 +4523,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">4</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/match/match-status-icon/match-status-icon.component.html</context>
-          <context context-type="linenumber">6</context>
+          <context context-type="sourcefile">src/assets/wise5/components/match/match-status-icon/match-status-icon.component.ts</context>
+          <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4ad84d4f3bbc9a37b27cd1ff908aea5fa83dccf3" datatype="html">
@@ -19501,8 +19501,8 @@ Warning: This will delete all existing choices and buckets in this component.</s
       <trans-unit id="3db39135c783da4bb320d5826f4de893f62c7e1b" datatype="html">
         <source>Correct</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/match/match-status-icon/match-status-icon.component.html</context>
-          <context context-type="linenumber">3</context>
+          <context context-type="sourcefile">src/assets/wise5/components/match/match-status-icon/match-status-icon.component.ts</context>
+          <context context-type="linenumber">11</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-feedback-section/match-feedback-section.component.html</context>
@@ -19520,8 +19520,8 @@ Warning: This will delete all existing choices and buckets in this component.</s
       <trans-unit id="8b42d54000704393a3c06e5f8b668880014f6986" datatype="html">
         <source>Incorrect</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/match/match-status-icon/match-status-icon.component.html</context>
-          <context context-type="linenumber">9</context>
+          <context context-type="sourcefile">src/assets/wise5/components/match/match-status-icon/match-status-icon.component.ts</context>
+          <context context-type="linenumber">17</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-feedback-section/match-feedback-section.component.html</context>


### PR DESCRIPTION
## Notes
- @breity Please style as you see fit

## Changes
- Change UI/UX of the import component feature to match that of the import step feature
   - Step 1: select unit. Units are organized in "My Units" and "Library Units" tabs
   - Step 2: select component(s), and submit
   - (before, these steps were combined in one page)
- Clean up surrounding code
   - Convert ChooseImportComponentComponent to standalone
   - Remove ImportComponentModule

## Test
- Import component works as described above
- Import step works as before
- Try going back and canceling while going through the above scenarios. 
   - Note: when you click back on the the import component, we take them back to the step authoring view, but we don't show the "Add new component" popup again. Showing the popup involves a bit more book-keeping/code and I wasn't sure if this was worth the added complexity. Let me know if you think we should add this in.

Closes #2056 
