### PR TITLE
fix(CRater): Responses without ideas are throwing NPE

### DIFF
--- a/src/assets/wise5/services/cRaterService.ts
+++ b/src/assets/wise5/services/cRaterService.ts
@@ -260,7 +260,7 @@ export class CRaterService {
 
   private getIdeas(responses: RawCRaterResponse): CRaterIdea[] {
     const ideas = [];
-    for (const key in responses.feedback.ideas) {
+    for (const key in responses.feedback?.ideas) {
       const value = responses.feedback.ideas[key];
       ideas.push(new CRaterIdea(key, value.detected));
     }


### PR DESCRIPTION
## Changes
- When CRater endpoint returned a response without ideas, (in older units like SPOONS-II), the code threw a NPE and the client just hung. I fixed this by adding an optional chaining to exit the loop in such cases.

## Test
- SPOONS-II item works as before.