### PR TITLE
feat(MatchComponentDataExportStrategy): Include ideas detected by C-Rater

### DIFF
--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/AbstractComponentDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/AbstractComponentDataExportStrategy.ts
@@ -101,10 +101,15 @@ export abstract class AbstractComponentDataExportStrategy extends AbstractDataEx
 
   protected abstract getComponentTypeWithUnderscore(): string;
 
-  protected getComponentStates(component: any): ComponentState[] {
+  protected getComponentStates(
+    component: any,
+    calculateRevisions: boolean = true
+  ): ComponentState[] {
     let componentStates = this.dataService.getComponentStatesByComponentId(component.id);
     this.sortByWorkgroupIdAndTimestamp(componentStates);
-    this.calculateRevisionNumbers(componentStates);
+    if (calculateRevisions) {
+      this.calculateRevisionNumbers(componentStates);
+    }
     if (this.allOrLatest === 'latest') {
       componentStates = this.getLatestRevisions(componentStates);
     }

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/MatchComponentDataExportStrategy.spec.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/MatchComponentDataExportStrategy.spec.ts
@@ -64,9 +64,9 @@ function exportAllRevisions(): void {
       ]);
       setUpExportStrategy('all');
       exportStrategyTester.componentExportStrategy.export();
-      const headerRow = exportStrategyTester.createHeaderRowAddAdditionalColumnsAtEnd(
-        additionalColumns
-      );
+      const headerRow =
+        exportStrategyTester.createHeaderRowAddAdditionalColumnsAtEnd(additionalColumns);
+
       expect(exportStrategyTester.componentExportStrategy.generateCSVFile).toHaveBeenCalledWith(
         [
           headerRow,
@@ -241,9 +241,8 @@ function exportLatestRevisions(): void {
       ]);
       setUpExportStrategy('latest');
       exportStrategyTester.componentExportStrategy.export();
-      const headerRow = exportStrategyTester.createHeaderRowAddAdditionalColumnsAtEnd(
-        additionalColumns
-      );
+      const headerRow =
+        exportStrategyTester.createHeaderRowAddAdditionalColumnsAtEnd(additionalColumns);
       expect(exportStrategyTester.componentExportStrategy.generateCSVFile).toHaveBeenCalledWith(
         [
           headerRow,
@@ -339,9 +338,8 @@ function exportMatchComponentWithChoiceReuse(): void {
       exportStrategyTester.setStudentData([componentState1]);
       setUpExportStrategy('all');
       exportStrategyTester.componentExportStrategy.export();
-      const headerRow = exportStrategyTester.createHeaderRowAddAdditionalColumnsAtEnd(
-        additionalColumns
-      );
+      const headerRow =
+        exportStrategyTester.createHeaderRowAddAdditionalColumnsAtEnd(additionalColumns);
       expect(exportStrategyTester.componentExportStrategy.generateCSVFile).toHaveBeenCalledWith(
         [
           headerRow,
@@ -399,9 +397,8 @@ function exportMatchComponentWithCorrectPosition(): void {
       exportStrategyTester.setStudentData([componentState1]);
       setUpExportStrategy('all');
       exportStrategyTester.componentExportStrategy.export();
-      const headerRow = exportStrategyTester.createHeaderRowAddAdditionalColumnsAtEnd(
-        additionalColumns
-      );
+      const headerRow =
+        exportStrategyTester.createHeaderRowAddAdditionalColumnsAtEnd(additionalColumns);
       expect(exportStrategyTester.componentExportStrategy.generateCSVFile).toHaveBeenCalledWith(
         [
           headerRow,

--- a/src/assets/wise5/classroomMonitor/dataExport/strategies/MatchComponentDataExportStrategy.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/strategies/MatchComponentDataExportStrategy.ts
@@ -27,12 +27,24 @@ export class MatchComponentDataExportStrategy extends AbstractComponentDataExpor
     for (const choice of component.choices) {
       headerRow.push(choice.value);
     }
+    headerRow = this.addCRaterChoices(component, headerRow);
     if (this.componentHasCorrectAnswer(component)) {
       for (const choice of component.choices) {
         headerRow.push(`${choice.value} ${this.correctnessLabel}`);
       }
       headerRow.push(this.isCorrectLabel);
     }
+  }
+
+  private addCRaterChoices(component: any, headerRow: string[]): string[] {
+    this.getComponentStates(component, false).forEach((componentState: any) =>
+      componentState.studentData.buckets.forEach((bucket: Bucket) =>
+        bucket.items
+          .filter((item) => !item.studentCreated && !headerRow.includes(item.value))
+          .forEach((item: Choice) => headerRow.push(item.value))
+      )
+    );
+    return headerRow;
   }
 
   private componentHasCorrectAnswer(component: MatchContent): boolean {


### PR DESCRIPTION
## Changes
When C-Rater ideas are used as choices in the Match component, they will be exported when the user requests the the Match item export.

## Test Prep
- Use the same run as https://github.com/WISE-Community/WISE-Client/pull/2054. 
- Make sure you've done some work on this run with multiple students who had different ideas.

## Test
- Try exporting a Match component that contains C-Rater items as choices. Go to CM > Data Export > Export Item Data > Match. Try exporting in both Latest and All 
   - Every detected idea by all students in the class should have a column in the header row.
   - If a student had that idea, the cell should contain which bucket that idea is in.
   - If a student didn't have that idea, the cell should be blank.
   - Check other fields in the export and make sure they look correct
      - component revision number looks ok
      - correctness looks ok, etc
- Regression tests
   - Try exporting a Match component that doesn't contain C-Rater item, and verify that it works as before
   - Try exporting another component item (e.g., OR, Label) and verify that it works as before

Closes #2080
