### PR TITLE
refactor(ManageUserComponent): Convert to standalone

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-students.module.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-students.module.ts
@@ -16,7 +16,12 @@ import { ChangeTeamPeriodDialogComponent } from './change-team-period-dialog/cha
 import { PasswordModule } from '../../../../../app/password/password.module';
 
 @NgModule({
-  imports: [PasswordModule, ShowStudentInfoComponent, StudentTeacherCommonModule],
+  imports: [
+    ManageUserComponent,
+    PasswordModule,
+    ShowStudentInfoComponent,
+    StudentTeacherCommonModule
+  ],
   declarations: [
     AddTeamButtonComponent,
     AddTeamDialogComponent,
@@ -27,7 +32,6 @@ import { PasswordModule } from '../../../../../app/password/password.module';
     ManageStudentsComponent,
     ManageTeamComponent,
     ManageTeamsComponent,
-    ManageUserComponent,
     MoveUserConfirmDialogComponent,
     RemoveUserConfirmDialogComponent
   ],

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html
@@ -1,5 +1,5 @@
 <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="4px" class="manage-user">
-  <show-student-info [user]="user"></show-student-info>
+  <show-student-info [user]="user" />
   <span fxFlex></span>
   <button
     class="userInfoLink"
@@ -11,27 +11,28 @@
   >
     <mat-icon class="text-secondary">info</mat-icon>
   </button>
-  <button
-    *ngIf="user.isGoogleUser"
-    class="googleUserButton"
-    mat-icon-button
-    matTooltip="Student signs in with Google"
-    i18n-matTooltip
-    matTooltipPosition="above"
-  >
-    <mat-icon svgIcon="google"></mat-icon>
-  </button>
-  <button
-    *ngIf="!user.isGoogleUser"
-    class="userInfoLink"
-    mat-icon-button
-    matTooltip="Change student password"
-    i18n-matTooltip
-    matTooltipPosition="above"
-    (click)="changePassword($event)"
-  >
-    <mat-icon class="text-secondary">vpn_key</mat-icon>
-  </button>
+  @if (user.isGoogleUser) {
+    <button
+      class="googleUserButton"
+      mat-icon-button
+      matTooltip="Student signs in with Google"
+      i18n-matTooltip
+      matTooltipPosition="above"
+    >
+      <mat-icon svgIcon="google"></mat-icon>
+    </button>
+  } @else {
+    <button
+      class="userInfoLink"
+      mat-icon-button
+      matTooltip="Change student password"
+      i18n-matTooltip
+      matTooltipPosition="above"
+      (click)="changePassword($event)"
+    >
+      <mat-icon class="text-secondary">vpn_key</mat-icon>
+    </button>
+  }
   <button
     class="userInfoLink"
     mat-icon-button

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.spec.ts
@@ -5,7 +5,6 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ConfigService } from '../../../../services/configService';
 import { ManageUserComponent } from './manage-user.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { of } from 'rxjs';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
@@ -27,16 +26,14 @@ let http: HttpTestingController;
 describe('ManageUserComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-    declarations: [ManageUserComponent],
-    schemas: [NO_ERRORS_SCHEMA],
-    imports: [BrowserAnimationsModule, MatSnackBarModule],
-    providers: [
+      imports: [BrowserAnimationsModule, ManageUserComponent, MatSnackBarModule],
+      providers: [
         { provide: ConfigService, useClass: ConfigServiceStub },
         { provide: MatDialog, useValue: {} },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting()
-    ]
-});
+      ]
+    });
     configService = TestBed.inject(ConfigService);
     http = TestBed.inject(HttpTestingController);
     fixture = TestBed.createComponent(ManageUserComponent);

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts
@@ -5,7 +5,7 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 import { HttpClient } from '@angular/common/http';
 import { $localize } from '@angular/localize/init';
 import { ManageShowStudentInfoComponent } from '../manage-show-student-info/manage-show-student-info.component';
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -71,7 +71,7 @@ export class ManageUserComponent {
     this.openDialog(event, ChangeStudentPasswordDialogComponent);
   }
 
-  private openDialog(event: Event, dialogComponent: any): any {
+  private openDialog(event: Event, dialogComponent: any): MatDialogRef<any, any> {
     event.preventDefault();
     return this.dialog.open(dialogComponent, {
       data: this.user,

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts
@@ -1,17 +1,24 @@
-import { HttpClient } from '@angular/common/http';
-import { Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
-import { MatSnackBar } from '@angular/material/snack-bar';
-import { ConfigService } from '../../../../services/configService';
 import { ChangeStudentPasswordDialogComponent } from '../change-student-password-dialog/change-student-password-dialog.component';
+import { Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
+import { ConfigService } from '../../../../services/configService';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { HttpClient } from '@angular/common/http';
+import { $localize } from '@angular/localize/init';
 import { ManageShowStudentInfoComponent } from '../manage-show-student-info/manage-show-student-info.component';
+import { MatDialog } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { RemoveUserConfirmDialogComponent } from '../remove-user-confirm-dialog/remove-user-confirm-dialog.component';
+import { ShowStudentInfoComponent } from '../show-student-info/show-student-info.component';
 
 @Component({
+  encapsulation: ViewEncapsulation.None,
+  imports: [FlexLayoutModule, MatIconModule, MatTooltipModule, ShowStudentInfoComponent],
   selector: 'manage-user',
-  styleUrls: ['manage-user.component.scss'],
-  templateUrl: 'manage-user.component.html',
-  encapsulation: ViewEncapsulation.None
+  standalone: true,
+  styleUrl: 'manage-user.component.scss',
+  templateUrl: 'manage-user.component.html'
 })
 export class ManageUserComponent {
   @Input() user: any;
@@ -24,7 +31,7 @@ export class ManageUserComponent {
     private snackBar: MatSnackBar
   ) {}
 
-  viewUserInfo(event: Event) {
+  protected viewUserInfo(event: Event): void {
     event.preventDefault();
     this.dialog.open(ManageShowStudentInfoComponent, {
       data: this.user,
@@ -32,7 +39,7 @@ export class ManageUserComponent {
     });
   }
 
-  removeUser(event: Event) {
+  protected removeUser(event: Event): void {
     event.preventDefault();
     this.dialog
       .open(RemoveUserConfirmDialogComponent, {
@@ -47,7 +54,7 @@ export class ManageUserComponent {
       });
   }
 
-  performRemoveUser() {
+  performRemoveUser(): void {
     const runId = this.configService.getRunId();
     const studentId = this.user.id;
     this.http.delete(`/api/teacher/run/${runId}/student/${studentId}/remove`).subscribe({
@@ -69,7 +76,7 @@ export class ManageUserComponent {
     });
   }
 
-  changePassword(event: Event) {
+  protected changePassword(event: Event): void {
     event.preventDefault();
     this.dialog.open(ChangeStudentPasswordDialogComponent, {
       data: this.user,

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts
@@ -32,20 +32,11 @@ export class ManageUserComponent {
   ) {}
 
   protected viewUserInfo(event: Event): void {
-    event.preventDefault();
-    this.dialog.open(ManageShowStudentInfoComponent, {
-      data: this.user,
-      panelClass: 'dialog-sm'
-    });
+    this.openDialog(event, ManageShowStudentInfoComponent);
   }
 
   protected removeUser(event: Event): void {
-    event.preventDefault();
-    this.dialog
-      .open(RemoveUserConfirmDialogComponent, {
-        data: this.user,
-        panelClass: 'dialog-sm'
-      })
+    this.openDialog(event, RemoveUserConfirmDialogComponent)
       .afterClosed()
       .subscribe((doRemoveUser: boolean) => {
         if (doRemoveUser) {
@@ -77,8 +68,12 @@ export class ManageUserComponent {
   }
 
   protected changePassword(event: Event): void {
+    this.openDialog(event, ChangeStudentPasswordDialogComponent);
+  }
+
+  private openDialog(event: Event, dialogComponent: any): any {
     event.preventDefault();
-    this.dialog.open(ChangeStudentPasswordDialogComponent, {
+    return this.dialog.open(dialogComponent, {
       data: this.user,
       panelClass: 'dialog-sm'
     });

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts
@@ -11,10 +11,17 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { RemoveUserConfirmDialogComponent } from '../remove-user-confirm-dialog/remove-user-confirm-dialog.component';
 import { ShowStudentInfoComponent } from '../show-student-info/show-student-info.component';
+import { CommonModule } from '@angular/common';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
-  imports: [FlexLayoutModule, MatIconModule, MatTooltipModule, ShowStudentInfoComponent],
+  imports: [
+    CommonModule,
+    FlexLayoutModule,
+    MatIconModule,
+    MatTooltipModule,
+    ShowStudentInfoComponent
+  ],
   selector: 'manage-user',
   standalone: true,
   styleUrl: 'manage-user.component.scss',

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13558,52 +13558,6 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">109</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="9b83b532c3f74e3d6e25a6ba749eef54324bea48" datatype="html">
-        <source>View student info</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html</context>
-          <context context-type="linenumber">7</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="db832a97c58e639a3cb0592e79871d0ab07a7732" datatype="html">
-        <source>Student signs in with Google</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html</context>
-          <context context-type="linenumber">18</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="cb5ce15b39de2cce06da00d7ef457c057c629741" datatype="html">
-        <source>Change student password</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html</context>
-          <context context-type="linenumber">28</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="70657e4a6c92b1e6e7c6a72a6ed3eedf5cbb0fe2" datatype="html">
-        <source>Remove student</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html</context>
-          <context context-type="linenumber">38</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html</context>
-          <context context-type="linenumber">41</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3255676199172660043" datatype="html">
-        <source>Removed <x id="PH" equiv-text="this.user.name"/> (<x id="PH_1" equiv-text="this.user.username"/>) from unit.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts</context>
-          <context context-type="linenumber">59</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="213219330219823977" datatype="html">
-        <source>Error: Could not remove <x id="PH" equiv-text="this.user.name"/> (<x id="PH_1" equiv-text="this.user.username"/>) from unit.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts</context>
-          <context context-type="linenumber">66</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="8e728195d4eb16b80063b74eecea8f498762d1ef" datatype="html">
         <source>Move Student</source>
         <context-group purpose="location">


### PR DESCRIPTION
## Changes
- Converted ManageUserComponent to standalone.

## Test
- ManageUserComponent displays the following:
    - StudentInfoComponent (Name and ID)
    - View student info button
    - Change student password button for regular users
        - Unclickable Google logo for students signed in through Google account
    - Remove student button
- See tip messages when hovering over those three buttons

Closes #2088 
