### PR TITLE
refactor(MatchStudentChoiceReuse): Convert to standalone

### DIFF
--- a/src/assets/wise5/components/match/match-student/match-student-choice-reuse/match-student-choice-reuse.component.ts
+++ b/src/assets/wise5/components/match/match-student/match-student-choice-reuse/match-student-choice-reuse.component.ts
@@ -1,6 +1,5 @@
 import { AddChoiceButtonComponent } from '../add-choice-button/add-choice-button.component';
 import { Bucket } from '../../bucket';
-import { CdkDropList } from '@angular/cdk/drag-drop';
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { ComponentAnnotationsComponent } from '../../../../directives/componentAnnotations/component-annotations.component';
@@ -21,7 +20,6 @@ import { moveItem } from '../move-item';
 @Component({
   imports: [
     AddChoiceButtonComponent,
-    CdkDropList,
     CommonModule,
     ComponentAnnotationsComponent,
     ComponentHeaderComponent,

--- a/src/assets/wise5/components/match/match-student/match-student-choice-reuse/match-student-choice-reuse.ts
+++ b/src/assets/wise5/components/match/match-student/match-student-choice-reuse/match-student-choice-reuse.ts
@@ -1,29 +1,54 @@
+import { AddChoiceButtonComponent } from '../add-choice-button/add-choice-button.component';
+import { Bucket } from '../../bucket';
+import { CdkDropList } from '@angular/cdk/drag-drop';
+import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
+import { ComponentAnnotationsComponent } from '../../../../directives/componentAnnotations/component-annotations.component';
+import { ComponentHeaderComponent } from '../../../../directives/component-header/component-header.component';
+import { ComponentSaveSubmitButtonsComponent } from '../../../../directives/component-save-submit-buttons/component-save-submit-buttons.component';
+import { ComponentState } from '../../../../../../app/domain/componentState';
+import { Container } from '../container';
+import { copy } from '../../../../common/object/object';
+import { DragDropModule } from '@angular/cdk/drag-drop';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { Item } from '../item';
+import { MatchCdkDragDrop } from '../MatchCdkDragDrop';
+import { MatchChoiceItemComponent } from '../../match-choice-item/match-choice-item.component';
+import { MatchFeedbackSectionComponent } from '../match-feedback-section/match-feedback-section.component';
 import { MatchStudentDefaultComponent } from '../match-student-default/match-student-default.component';
 import { moveItem } from '../move-item';
-import { MatchCdkDragDrop } from '../MatchCdkDragDrop';
-import { Container } from '../container';
-import { Item } from '../item';
-import { copy } from '../../../../common/object/object';
 
 @Component({
-  styleUrls: ['../match-student-default/match-student-default.component.scss'],
+  imports: [
+    AddChoiceButtonComponent,
+    CdkDropList,
+    CommonModule,
+    ComponentAnnotationsComponent,
+    ComponentHeaderComponent,
+    ComponentSaveSubmitButtonsComponent,
+    DragDropModule,
+    FlexLayoutModule,
+    MatchChoiceItemComponent,
+    MatchFeedbackSectionComponent
+  ],
+  standalone: true,
+  styleUrl: '../match-student-default/match-student-default.component.scss',
   templateUrl: '../match-student-default/match-student-default.component.html'
 })
-export class MatchStudentChoiceReuse extends MatchStudentDefaultComponent {
+export class MatchStudentChoiceReuseComponent extends MatchStudentDefaultComponent {
   protected drop(event: MatchCdkDragDrop<Container, Item>): void {
     moveItem(event);
     event.container.element.nativeElement.classList.remove('primary-bg');
     this.studentDataChanged();
   }
 
-  protected addAuthoredChoiceToBucket(choiceId: string, bucket: any): void {
+  protected addAuthoredChoiceToBucket(choiceId: string, bucket: Bucket): void {
     bucket.items.push(copy(this.choices.find((choice) => choice.id === choiceId)));
   }
 
-  protected getUpdatedChoicesSinceLastSubmit(latestSubmitComponentState: any): string[] {
+  protected getUpdatedChoicesSinceLastSubmit(latestSubmitComponentState: ComponentState): string[] {
     const previousBuckets = latestSubmitComponentState.studentData.buckets;
-    const removedChoices = this.getNonSourceBuckets().flatMap((bucket: any) => {
+    const removedChoices = this.getNonSourceBuckets().flatMap((bucket: Bucket) => {
       const { currentBucketChoiceIds, previousBucketChoiceIds } =
         this.getPreviousAndCurrentChoiceIds(previousBuckets, bucket);
       return previousBucketChoiceIds.filter(
@@ -37,12 +62,12 @@ export class MatchStudentChoiceReuse extends MatchStudentDefaultComponent {
 
   protected checkAnswer(
     choiceIdsExcludedFromFeedback: string[] = [],
-    buckets: any[] = this.getNonSourceBuckets()
+    buckets: Bucket[] = this.getNonSourceBuckets()
   ): void {
     super.checkAnswer(choiceIdsExcludedFromFeedback, buckets);
   }
 
-  private getNonSourceBuckets(): any[] {
-    return this.buckets.filter((bucket: any) => bucket.id !== this.sourceBucketId);
+  private getNonSourceBuckets(): Bucket[] {
+    return this.buckets.filter((bucket: Bucket) => bucket.id !== this.sourceBucketId);
   }
 }

--- a/src/assets/wise5/components/match/match-student/match-student.component.ts
+++ b/src/assets/wise5/components/match/match-student/match-student.component.ts
@@ -9,7 +9,7 @@ import {
   ViewChild,
   createComponent
 } from '@angular/core';
-import { MatchStudentChoiceReuseComponent } from './match-student-choice-reuse/match-student-choice-reuse';
+import { MatchStudentChoiceReuseComponent } from './match-student-choice-reuse/match-student-choice-reuse.component';
 import { MatchStudentDefaultComponent } from './match-student-default/match-student-default.component';
 import { MatchContent } from '../MatchContent';
 

--- a/src/assets/wise5/components/match/match-student/match-student.component.ts
+++ b/src/assets/wise5/components/match/match-student/match-student.component.ts
@@ -9,7 +9,7 @@ import {
   ViewChild,
   createComponent
 } from '@angular/core';
-import { MatchStudentChoiceReuse } from './match-student-choice-reuse/match-student-choice-reuse';
+import { MatchStudentChoiceReuseComponent } from './match-student-choice-reuse/match-student-choice-reuse';
 import { MatchStudentDefaultComponent } from './match-student-default/match-student-default.component';
 import { MatchContent } from '../MatchContent';
 
@@ -34,7 +34,7 @@ export class MatchStudent {
   ngAfterViewInit(): void {
     this.componentRef = createComponent(
       (this.component.content as MatchContent).choiceReuseEnabled
-        ? MatchStudentChoiceReuse
+        ? MatchStudentChoiceReuseComponent
         : MatchStudentDefaultComponent,
       {
         hostElement: this.componentElementRef.nativeElement,

--- a/src/assets/wise5/components/match/match-student/match-student.module.ts
+++ b/src/assets/wise5/components/match/match-student/match-student.module.ts
@@ -4,14 +4,15 @@ import { AddMatchChoiceDialogComponent } from './add-match-choice-dialog/add-mat
 import { MatchStudent } from './match-student.component';
 import { StudentComponentModule } from '../../../../../app/student/student.component.module';
 import { MatchCommonModule } from '../match-common.module';
-import { MatchStudentChoiceReuse } from './match-student-choice-reuse/match-student-choice-reuse';
+import { MatchStudentChoiceReuseComponent } from './match-student-choice-reuse/match-student-choice-reuse';
 import { MatchStudentDefaultComponent } from './match-student-default/match-student-default.component';
 
 @NgModule({
-  declarations: [MatchStudent, MatchStudentChoiceReuse],
+  declarations: [MatchStudent],
   imports: [
     AddChoiceButtonComponent,
     MatchCommonModule,
+    MatchStudentChoiceReuseComponent,
     MatchStudentDefaultComponent,
     StudentComponentModule,
     AddMatchChoiceDialogComponent

--- a/src/assets/wise5/components/match/match-student/match-student.module.ts
+++ b/src/assets/wise5/components/match/match-student/match-student.module.ts
@@ -4,7 +4,7 @@ import { AddMatchChoiceDialogComponent } from './add-match-choice-dialog/add-mat
 import { MatchStudent } from './match-student.component';
 import { StudentComponentModule } from '../../../../../app/student/student.component.module';
 import { MatchCommonModule } from '../match-common.module';
-import { MatchStudentChoiceReuseComponent } from './match-student-choice-reuse/match-student-choice-reuse';
+import { MatchStudentChoiceReuseComponent } from './match-student-choice-reuse/match-student-choice-reuse.component';
 import { MatchStudentDefaultComponent } from './match-student-default/match-student-default.component';
 
 @NgModule({


### PR DESCRIPTION
## Changes
- Converted MatchStudentChoiceReuse to standalone.
- Replaced "any" types with more specific types.

## Test
- Should still have all the normal functionality of a Match component.
- When a choice is dragged from the source bucket and dropped in another bucket, that choice is also replaced in the source bucket.
- When a choice is dragged from a non-source bucket and dropped in another bucket, that choice is not replaced in the bucket it came from.
- When a choice is dropped in a bucket that already contains a copy of it, it should not duplicate the choice in that bucket.
- Student-created choices can also be reused, and deleting any copy deletes all copies.

Closes #2089 
