### PR TITLE
refactor(ManageTeamComponent): Convert to standalone

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-students.module.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-students.module.ts
@@ -4,7 +4,6 @@ import { ManageStudentsComponent } from './manage-students/manage-students.compo
 import { ManageTeamsComponent } from './manage-teams/manage-teams.component';
 import { ManagePeriodComponent } from './manage-period/manage-period.component';
 import { ManageTeamComponent } from './manage-team/manage-team.component';
-import { ManageUserComponent } from './manage-user/manage-user.component';
 import { ShowStudentInfoComponent } from './show-student-info/show-student-info.component';
 import { ManageShowStudentInfoComponent } from './manage-show-student-info/manage-show-student-info.component';
 import { RemoveUserConfirmDialogComponent } from './remove-user-confirm-dialog/remove-user-confirm-dialog.component';
@@ -18,7 +17,6 @@ import { PasswordModule } from '../../../../../app/password/password.module';
 @NgModule({
   imports: [
     ManageTeamComponent,
-    ManageUserComponent,
     PasswordModule,
     ShowStudentInfoComponent,
     StudentTeacherCommonModule

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-students.module.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-students.module.ts
@@ -17,6 +17,7 @@ import { PasswordModule } from '../../../../../app/password/password.module';
 
 @NgModule({
   imports: [
+    ManageTeamComponent,
     ManageUserComponent,
     PasswordModule,
     ShowStudentInfoComponent,
@@ -30,7 +31,6 @@ import { PasswordModule } from '../../../../../app/password/password.module';
     ManagePeriodComponent,
     ManageShowStudentInfoComponent,
     ManageStudentsComponent,
-    ManageTeamComponent,
     ManageTeamsComponent,
     MoveUserConfirmDialogComponent,
     RemoveUserConfirmDialogComponent

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html
@@ -3,25 +3,23 @@
   [class]="{ 'disabled-text': team.users.length === 0, warn: isUnassigned }"
 >
   <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="4px">
-    <mat-icon
-      *ngIf="team.workgroupId"
-      class="mat-24 secondary-text"
-      [ngStyle]="{ color: avatarColor }"
-      >account_circle</mat-icon
-    >
-    <h4 class="mat-subtitle-2 warn" *ngIf="isUnassigned" i18n>Students without a team</h4>
-    <h4 class="mat-subtitle-2" *ngIf="!isUnassigned" i18n>Team {{ team.workgroupId }}</h4>
+    @if (team.workGroupId) {
+      <mat-icon class="mat-24 secondary-text" [ngStyle]="{ color: avatarColor }"
+        >account_circle</mat-icon
+      >
+    }
+    @if (isUnassigned) {
+      <h4 class="mat-subtitle-2 warn" i18n>Students without a team</h4>
+    } @else {
+      <h4 class="mat-subtitle-2" i18n>Team {{ team.workgroupId }}</h4>
+    }
     <span fxFlex></span>
     <span class="mat-small">
-      <a
-        *ngIf="canGradeStudentWork && team.users.length > 0 && !isUnassigned"
-        class="change-period"
-        href="#"
-        (click)="changePeriod($event)"
-        i18n
-        >Change Period</a
-      >
-      <span *ngIf="this.team.users.length === 0" i18n>No students</span>
+      @if (this.team.users.length === 0) {
+        <span i18n>No students</span>
+      } @else if (canGradeStudentWork && !isUnassigned) {
+        <a class="change-period" href="#" (click)="changePeriod($event)" i18n>Change Period</a>
+      }
     </span>
   </div>
   <mat-card-content>
@@ -36,7 +34,7 @@
       [ngStyle.gt-sm]="{ columns: isUnassigned ? 2 : '' }"
       [ngStyle.gt-md]="{ columns: isUnassigned ? 3 : '' }"
     >
-      <ng-container *ngFor="let user of team.users">
+      @for (user of team.users; track $index) {
         <li
           cdkDrag
           [cdkDragData]="{ user: user, workgroupId: team.workgroupId }"
@@ -50,7 +48,7 @@
             (removeUserEvent)="removeUser($event)"
           ></manage-user>
         </li>
-      </ng-container>
+      }
     </ul>
   </mat-card-content>
 </mat-card>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html
@@ -46,7 +46,7 @@
             class="user control-bg-bg mat-elevation-z1"
             [user]="user"
             (removeUserEvent)="removeUser($event)"
-          ></manage-user>
+          />
         </li>
       }
     </ul>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.spec.ts
@@ -5,7 +5,6 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { UpdateWorkgroupService } from '../../../../../../app/services/updateWorkgroupService';
 import { ConfigService } from '../../../../services/configService';
 import { ManageTeamComponent } from './manage-team.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ManageTeamHarness } from './manage-team.harness';
 import { ManageStudentsModule } from '../manage-students.module';
@@ -28,15 +27,21 @@ const studentUsername = 'aa0101';
 describe('ManageTeamComponent', () => {
   beforeEach(async () => {
     TestBed.configureTestingModule({
-    declarations: [ManageTeamComponent],
-    schemas: [NO_ERRORS_SCHEMA],
-    imports: [BrowserAnimationsModule,
+      imports: [
+        BrowserAnimationsModule,
         ManageStudentsModule,
+        ManageTeamComponent,
         MatCardModule,
         MatDialogModule,
-        MatSnackBarModule],
-    providers: [ConfigService, UpdateWorkgroupService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-});
+        MatSnackBarModule
+      ],
+      providers: [
+        ConfigService,
+        UpdateWorkgroupService,
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting()
+      ]
+    });
     configService = TestBed.inject(ConfigService);
     dialog = TestBed.inject(MatDialog);
     fixture = TestBed.createComponent(ManageTeamComponent);

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts
@@ -1,29 +1,44 @@
-import { Component, Input } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
-import { ConfigService } from '../../../../services/configService';
-import { UpdateWorkgroupService } from '../../../../../../app/services/updateWorkgroupService';
-import { ChangeTeamPeriodDialogComponent } from '../change-team-period-dialog/change-team-period-dialog.component';
 import {
   CdkDrag,
   CdkDragDrop,
   CdkDragEnter,
   CdkDragExit,
   CdkDropList,
+  DragDropModule,
   transferArrayItem
 } from '@angular/cdk/drag-drop';
-import { MoveUserConfirmDialogComponent } from '../move-user-confirm-dialog/move-user-confirm-dialog.component';
-import { MatSnackBar } from '@angular/material/snack-bar';
+import { ChangeTeamPeriodDialogComponent } from '../change-team-period-dialog/change-team-period-dialog.component';
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { ConfigService } from '../../../../services/configService';
+import { FlexLayoutModule } from '@angular/flex-layout';
 import { getAvatarColorForWorkgroupId } from '../../../../common/workgroup/workgroup';
+import { ManageUserComponent } from '../manage-user/manage-user.component';
+import { MatCardModule } from '@angular/material/card';
+import { MatDialog } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MoveUserConfirmDialogComponent } from '../move-user-confirm-dialog/move-user-confirm-dialog.component';
+import { UpdateWorkgroupService } from '../../../../../../app/services/updateWorkgroupService';
 
 @Component({
+  imports: [
+    CommonModule,
+    DragDropModule,
+    FlexLayoutModule,
+    ManageUserComponent,
+    MatCardModule,
+    MatIconModule
+  ],
   selector: 'manage-team',
-  styleUrls: ['manage-team.component.scss'],
+  standalone: true,
+  styleUrl: 'manage-team.component.scss',
   templateUrl: 'manage-team.component.html'
 })
 export class ManageTeamComponent {
-  avatarColor: string;
-  canGradeStudentWork: boolean;
-  isUnassigned: boolean;
+  protected avatarColor: string;
+  protected canGradeStudentWork: boolean;
+  protected isUnassigned: boolean;
   @Input() team: any;
 
   constructor(
@@ -33,13 +48,13 @@ export class ManageTeamComponent {
     private updateWorkgroupService: UpdateWorkgroupService
   ) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.avatarColor = getAvatarColorForWorkgroupId(this.team.workgroupId);
     this.canGradeStudentWork = this.configService.getPermissions().canGradeStudentWork;
     this.isUnassigned = this.team.workgroupId == null;
   }
 
-  changePeriod(event: Event) {
+  protected changePeriod(event: Event): void {
     event.preventDefault();
     this.dialog.open(ChangeTeamPeriodDialogComponent, {
       data: this.team,
@@ -47,15 +62,15 @@ export class ManageTeamComponent {
     });
   }
 
-  dragEnter(event: CdkDragEnter) {
+  protected dragEnter(event: CdkDragEnter): void {
     event.container.element.nativeElement.classList.add('primary-bg');
   }
 
-  dragExit(event: CdkDragExit) {
+  protected dragExit(event: CdkDragExit): void {
     event.container.element.nativeElement.classList.remove('primary-bg');
   }
 
-  canDrop(drag: CdkDrag, drop: CdkDropList): boolean {
+  protected canDrop(drag: CdkDrag, drop: CdkDropList): boolean {
     return !drop.element.nativeElement.classList.contains('unassigned') && drop.data.length < 3;
   }
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts
@@ -3,7 +3,6 @@ import { Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angu
 import { ConfigService } from '../../../../services/configService';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { HttpClient } from '@angular/common/http';
-import { $localize } from '@angular/localize/init';
 import { ManageShowStudentInfoComponent } from '../manage-show-student-info/manage-show-student-info.component';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13558,6 +13558,52 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">124</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="9b83b532c3f74e3d6e25a6ba749eef54324bea48" datatype="html">
+        <source>View student info</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="db832a97c58e639a3cb0592e79871d0ab07a7732" datatype="html">
+        <source>Student signs in with Google</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="cb5ce15b39de2cce06da00d7ef457c057c629741" datatype="html">
+        <source>Change student password</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="70657e4a6c92b1e6e7c6a72a6ed3eedf5cbb0fe2" datatype="html">
+        <source>Remove student</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3255676199172660043" datatype="html">
+        <source>Removed <x id="PH" equiv-text="this.user.name"/> (<x id="PH_1" equiv-text="this.user.username"/>) from unit.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="213219330219823977" datatype="html">
+        <source>Error: Could not remove <x id="PH" equiv-text="this.user.name"/> (<x id="PH_1" equiv-text="this.user.username"/>) from unit.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-user/manage-user.component.ts</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="8e728195d4eb16b80063b74eecea8f498762d1ef" datatype="html">
         <source>Move Student</source>
         <context-group purpose="location">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13445,7 +13445,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html</context>
-          <context context-type="linenumber">22</context>
+          <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f4c42ea42ec642ccfddbf5ba0b28f85f5911b980" datatype="html">
@@ -13534,28 +13534,28 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>Team <x id="INTERPOLATION" equiv-text="{{ team.workgroupId }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html</context>
-          <context context-type="linenumber">13</context>
+          <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
       <trans-unit id="406a3b0511483e31076d1b0a968c377c91e6163c" datatype="html">
         <source>No students</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.html</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="513458985182639179" datatype="html">
         <source>Moved student to Team <x id="PH" equiv-text="workgroupId"/>.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts</context>
-          <context context-type="linenumber">104</context>
+          <context context-type="linenumber">119</context>
         </context-group>
       </trans-unit>
       <trans-unit id="784919496056996013" datatype="html">
         <source>Error: Could not move student.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/manageStudents/manage-team/manage-team.component.ts</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">124</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8e728195d4eb16b80063b74eecea8f498762d1ef" datatype="html">


### PR DESCRIPTION
## Changes
- Converted ManageTeamComponent to standalone.

## Test
- All ManageUserComponents are displayed in the correct teams.
- Allow users to be dragged and dropped between different teams.
- Show Move Student warning when dragging and dropping users to a new team.
    - "Cancel" returns the student to their original team.
    - "Proceed" moves the student to a new team.
- Change Period button brings up the Change Period dialog.
- Empty teams have no Change Period button.
    - Should display "No students" instead.

Closes #2092 
