### PR TITLE
build(Node): Update from v20 to v22 for Docker dev profile

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:20.16.0
+FROM node:22.14.0
 RUN apt-get update && apt-get install build-essential \
     chromium libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev -y
 ENV CHROME_BIN='/usr/bin/chromium'


### PR DESCRIPTION
## Description
- This version will update the Node version in the Docker dev container (used for development) from v20 to v22.
- Node 22 announcement: https://nodejs.org/en/blog/announcements/v22-release-announce

## Test setup
1. Stop Docker processes ```docker-compose down```
2. Change wise-client-dev-image version in docker-compose.yml in WISE-Docker-Dev. Change from ```latest``` to ```node22```:
```
 wise-client:
    image: wiseberkeley/wise-client-dev:node22
```
3. Run ```docker-compose up``` to bring up Docker

## Test
- Verify that Docker pulls the wise-client-dev with tag "node22" and starts up wise-client as before. 
   - Run ```docker image ls``` to see your images
   - Run ```docker container ls``` to see your containers
- Make sure that the WISE application starts up and works as before. 
- WISE client development should work as before: make changes in a file and verify that it is compiled and reflected in the browser.

Closes #2106 