### PR TITLE
feat(Grade By Component): Show component average score

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: [develop]
   pull_request:
-    branches: [develop]
 jobs:
   test-coverage:
     runs-on: ubuntu-latest

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-average-score/component-average-score.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-average-score/component-average-score.component.spec.ts
@@ -38,10 +38,10 @@ function ngChanges_NoScoresAvailable_ShowNA() {
         [] as Annotation[]
       )
     );
-    it('should show "N/A"', () => {
+    it('should show "-"', () => {
       component.ngOnChanges();
       fixture.detectChanges();
-      expect(fixture.nativeElement.textContent.trim()).toEqual('N/A');
+      expect(fixture.nativeElement.textContent.trim()).toEqual('-');
     });
   });
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-average-score/component-average-score.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-average-score/component-average-score.component.spec.ts
@@ -1,0 +1,79 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentAverageScoreComponent } from './component-average-score.component';
+import { AnnotationService } from '../../../services/annotationService';
+import { MockProvider } from 'ng-mocks';
+import { Node } from '../../../common/Node';
+import { Annotation } from '../../../common/Annotation';
+
+let component: ComponentAverageScoreComponent;
+let fixture: ComponentFixture<ComponentAverageScoreComponent>;
+describe('ComponentAverageScoreComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ComponentAverageScoreComponent],
+      providers: [MockProvider(AnnotationService)]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ComponentAverageScoreComponent);
+    component = fixture.componentInstance;
+    component.component = { id: 'component1', maxScore: 10 };
+    component.node = { id: 'node1' } as Node;
+    component.periodId = 1;
+  });
+
+  ngOnChanges();
+});
+
+function ngOnChanges() {
+  describe('ngOnChanges()', () => {
+    ngChanges_NoScoresAvailable_ShowNA();
+    ngChanges_ScoresAvailable_ShowAverage();
+  });
+}
+
+function ngChanges_NoScoresAvailable_ShowNA() {
+  describe('no scores available', () => {
+    beforeEach(() =>
+      spyOn(TestBed.inject(AnnotationService), 'getAnnotationsByNodeIdComponentId').and.returnValue(
+        [] as Annotation[]
+      )
+    );
+    it('should show "N/A"', () => {
+      component.ngOnChanges();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent.trim()).toEqual('N/A');
+    });
+  });
+}
+
+function ngChanges_ScoresAvailable_ShowAverage() {
+  describe('scores available', () => {
+    beforeEach(() => {
+      spyOn(TestBed.inject(AnnotationService), 'getAnnotationsByNodeIdComponentId').and.returnValue(
+        [
+          {
+            nodeId: 'node1',
+            componentId: 'component1',
+            type: 'score',
+            toWorkgroupId: 1,
+            periodId: 1,
+            data: { value: 3 }
+          },
+          {
+            nodeId: 'node1',
+            componentId: 'component1',
+            type: 'autoScore',
+            toWorkgroupId: 2,
+            periodId: 1,
+            data: { value: 5 }
+          }
+        ] as Annotation[]
+      );
+      component.ngOnChanges();
+      fixture.detectChanges();
+    });
+    it('should show average score', () => {
+      expect(fixture.nativeElement.textContent.trim()).toEqual('4');
+    });
+  });
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-average-score/component-average-score.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-average-score/component-average-score.component.spec.ts
@@ -65,15 +65,47 @@ function ngChanges_ScoresAvailable_ShowAverage() {
             type: 'autoScore',
             toWorkgroupId: 2,
             periodId: 1,
+            data: { value: 4 }
+          },
+          {
+            nodeId: 'node1',
+            componentId: 'component1',
+            type: 'score',
+            toWorkgroupId: 5,
+            periodId: 2,
+            data: { value: 10 }
+          },
+          {
+            nodeId: 'node1',
+            componentId: 'component1',
+            type: 'score',
+            toWorkgroupId: 2,
+            periodId: 1,
             data: { value: 5 }
           }
         ] as Annotation[]
       );
-      component.ngOnChanges();
-      fixture.detectChanges();
     });
-    it('should show average score', () => {
-      expect(fixture.nativeElement.textContent.trim()).toEqual('4');
+
+    describe('period 1 is chosen', () => {
+      beforeEach(() => {
+        component.ngOnChanges();
+        fixture.detectChanges();
+      });
+      it('should show average score for period 1', () => {
+        expect(fixture.nativeElement.textContent.trim()).toEqual('4');
+      });
+    });
+
+    describe('all periods is chosen', () => {
+      beforeEach(() => {
+        component.periodId = -1;
+        component.ngOnChanges();
+        fixture.detectChanges();
+      });
+      it('should show average score for all periods', () => {
+        expect(fixture.nativeElement.textContent.trim()).toEqual('6');
+      });
     });
   });
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-average-score/component-average-score.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-average-score/component-average-score.component.ts
@@ -33,10 +33,8 @@ export class ComponentAverageScoreComponent {
   private getLatestScoreAnnotations() {
     return this.annotationService
       .getAnnotationsByNodeIdComponentId(this.node.id, this.component.id)
-      .filter(
-        (annotation) =>
-          annotation.periodId === this.periodId && ['score', 'autoScore'].includes(annotation.type)
-      )
+      .filter((annotation) => this.periodId === -1 || annotation.periodId === this.periodId)
+      .filter((annotation) => ['score', 'autoScore'].includes(annotation.type))
       .reduceRight((soFar, currentA) => {
         if (!soFar.some((soFarA) => soFarA.toWorkgroupId === currentA.toWorkgroupId)) {
           soFar.push(currentA);

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-average-score/component-average-score.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-average-score/component-average-score.component.ts
@@ -1,0 +1,47 @@
+import { Component, Input } from '@angular/core';
+import { Node } from '../../../common/Node';
+import { AnnotationService } from '../../../services/annotationService';
+import { DecimalPipe } from '@angular/common';
+
+@Component({
+  imports: [DecimalPipe],
+  selector: 'component-average-score',
+  template: `
+    @if (avgScore) {
+      {{ avgScore | number: '1.0-1' }}
+    } @else {
+      N/A
+    }
+  `
+})
+export class ComponentAverageScoreComponent {
+  protected avgScore: number | 'NA';
+  @Input() component: any;
+  @Input() node: Node;
+  @Input() periodId: number;
+
+  constructor(private annotationService: AnnotationService) {}
+
+  ngOnChanges(): void {
+    if (this.component && this.node) {
+      const annotations = this.getLatestScoreAnnotations();
+      const totalScore = annotations.reduce((sumSoFar, a) => sumSoFar + a.data.value, 0);
+      this.avgScore = totalScore / annotations.length;
+    }
+  }
+
+  private getLatestScoreAnnotations() {
+    return this.annotationService
+      .getAnnotationsByNodeIdComponentId(this.node.id, this.component.id)
+      .filter(
+        (annotation) =>
+          annotation.periodId === this.periodId && ['score', 'autoScore'].includes(annotation.type)
+      )
+      .reduceRight((soFar, currentA) => {
+        if (!soFar.some((soFarA) => soFarA.toWorkgroupId === currentA.toWorkgroupId)) {
+          soFar.push(currentA);
+        }
+        return soFar;
+      }, []);
+  }
+}

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-average-score/component-average-score.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-average-score/component-average-score.component.ts
@@ -10,7 +10,7 @@ import { DecimalPipe } from '@angular/common';
     @if (avgScore) {
       {{ avgScore | number: '1.0-1' }}
     } @else {
-      N/A
+      -
     }
   `
 })

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-grading-view/component-grading-view.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-grading-view/component-grading-view.component.html
@@ -1,5 +1,8 @@
 <milestone-report-button [node]="node" [component]="component" [periodId]="periodId" />
 <peer-group-button [node]="node" [component]="component" />
+<component-average-score [node]="node" [component]="component" [periodId]="periodId" />
+/ {{ component?.maxScore ?? 0 }}
+<span i18n>Mean Score</span>
 @if (component?.type === 'MultipleChoice' && hasStudentWork) {
   <teacher-summary-display
     [nodeId]="node.id"

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-grading-view/component-grading-view.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-grading-view/component-grading-view.component.ts
@@ -12,9 +12,11 @@ import { ComponentClassResponsesComponent } from '../component-class-responses/c
 import { ActivatedRoute } from '@angular/router';
 import { MilestoneReportButtonComponent } from '../milestone-report-button/milestone-report-button.component';
 import { PeerGroupButtonComponent } from '../peer-group-button/peer-group-button.component';
+import { ComponentAverageScoreComponent } from '../component-average-score/component-average-score.component';
 
 @Component({
   imports: [
+    ComponentAverageScoreComponent,
     ComponentClassResponsesComponent,
     MilestoneReportButtonComponent,
     PeerGroupButtonComponent,

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13357,6 +13357,13 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">97,100</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="5112680841574435656" datatype="html">
+        <source>Mean Score</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-grading-view/component-grading-view.component.html</context>
+          <context context-type="linenumber">5,7</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="6319945351508934188" datatype="html">
         <source>Show/hide team&apos;s work for this step</source>
         <context-group purpose="location">


### PR DESCRIPTION
This is a new feature for the grade by component feature branch.

This PR adds a new component, ComponentAverageScoreComponent, that shows the average score of the students in the period for the component. Previously, we were only able to show the average score for a node.

## Changes
- ComponentAverageScoreComponent shows
  - average score for the current period, if available
     - we only count workgroups that have a score 
  - shows "N/A", if not available

## Test
- Choose different nodes, components, and periods (including all periods). The average score should display as described above.