### PR TITLE
feat(OpenResponse): Allow authors to specify student-friendly text for ideas

### DIFF
--- a/src/assets/wise5/components/common/cRater/CRaterIdea.ts
+++ b/src/assets/wise5/components/common/cRater/CRaterIdea.ts
@@ -1,11 +1,13 @@
 export class CRaterIdea {
   name: string;
-  detected: boolean;
+  detected?: boolean;
   characterOffsets: any[];
   text?: string;
 
-  constructor(name: string, detected: boolean) {
+  constructor(name: string, detected?: boolean) {
     this.name = name;
-    this.detected = detected;
+    if (detected) {
+      this.detected = detected;
+    }
   }
 }

--- a/src/assets/wise5/components/common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component.html
+++ b/src/assets/wise5/components/common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component.html
@@ -1,10 +1,10 @@
 <div class="idea-descriptions notice-bg-bg">
   <h5 class="flex flex-row items-center gap-1 !text-xl">
-    <span i18n>Idea Names</span>
+    <span i18n>Idea Descriptions</span>
     <button
       mat-icon-button
       color="primary"
-      matTooltip="Add a new idea name"
+      matTooltip="Add a new idea description"
       i18n-matTooltip
       matTooltipPosition="after"
       (click)="addNewIdeaDescription(true)"
@@ -35,7 +35,7 @@
                 />
               </mat-form-field>
               <mat-form-field class="idea-input form-field-no-hint" appearance="fill">
-                <mat-label i18n>User-Friendly Name</mat-label>
+                <mat-label i18n>User-Friendly Description</mat-label>
                 <textarea
                   matInput
                   [(ngModel)]="idea.text"

--- a/src/assets/wise5/components/common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component.ts
+++ b/src/assets/wise5/components/common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component.ts
@@ -4,15 +4,15 @@ import { ComponentContent } from '../../../../common/ComponentContent';
 import { CRaterIdea } from '../CRaterIdea';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { FlexLayoutModule } from '@angular/flex-layout';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { FormsModule } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { Subject, Subscription } from 'rxjs';
 import { TeacherProjectService } from '../../../../services/teacherProjectService';
-import { MatButtonModule } from '@angular/material/button';
 
 @Component({
   imports: [
@@ -34,6 +34,7 @@ import { MatButtonModule } from '@angular/material/button';
 export class EditCRaterIdeaDescriptionsComponent implements OnInit {
   @Input() componentContent: ComponentContent;
   @Input() ideaDescriptions: CRaterIdea[] = [];
+  @Input() enableAutoscrolling: boolean = true;
   protected inputChanged: Subject<string> = new Subject<string>();
   private subscriptions: Subscription = new Subscription();
 
@@ -59,7 +60,7 @@ export class EditCRaterIdeaDescriptionsComponent implements OnInit {
       newIdeaDescription
     );
     this.projectService.nodeChanged();
-    if (!addToTop) {
+    if (!addToTop && this.enableAutoscrolling) {
       this.scrollToBottomOfList();
     }
   }
@@ -84,7 +85,7 @@ export class EditCRaterIdeaDescriptionsComponent implements OnInit {
   }
 
   protected deleteIdeaDescription(ideaIndex: number): void {
-    if (confirm($localize`Are you sure you want to delete this idea name?`)) {
+    if (confirm($localize`Are you sure you want to delete this idea description?`)) {
       this.ideaDescriptions.splice(ideaIndex, 1);
       this.projectService.nodeChanged();
     }

--- a/src/assets/wise5/components/common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component.ts
+++ b/src/assets/wise5/components/common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component.ts
@@ -66,7 +66,7 @@ export class EditCRaterIdeaDescriptionsComponent implements OnInit {
   }
 
   private createNewIdea(): CRaterIdea {
-    const idea = new CRaterIdea('', null);
+    const idea = new CRaterIdea('');
     idea.text = '';
     return idea;
   }

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-advanced/edit-dialog-guidance-advanced.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-advanced/edit-dialog-guidance-advanced.component.ts
@@ -3,9 +3,9 @@ import { CRaterIdea } from '../../common/cRater/CRaterIdea';
 import { EditAdvancedComponentComponent } from '../../../../../app/authoring-tool/edit-advanced-component/edit-advanced-component.component';
 
 @Component({
-    selector: 'edit-dialog-guidance-advanced',
-    templateUrl: 'edit-dialog-guidance-advanced.component.html',
-    standalone: false
+  selector: 'edit-dialog-guidance-advanced',
+  templateUrl: 'edit-dialog-guidance-advanced.component.html',
+  standalone: false
 })
 export class EditDialogGuidanceAdvancedComponent extends EditAdvancedComponentComponent {
   @Input() ideaDescriptions: CRaterIdea[] = [];

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
@@ -586,9 +586,9 @@
         [ideaDescriptions]="componentContent.cRater.rubric.ideas"
         [enableAutoscrolling]="false"
       />
-      <a (click)="toggleShowIdeaDescriptionsClicked()">Hide</a>
+      <a (click)="toggleShowIdeaDescriptions()" i18n>Hide</a>
     } @else {
-      <a (click)="toggleShowIdeaDescriptionsClicked()">Show Idea Descriptions</a>
+      <a (click)="toggleShowIdeaDescriptions()" i18n>Show Idea Descriptions</a>
     }
   </div>
 }

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
@@ -581,20 +581,14 @@
     }
   </div>
   <div class="section-container">
-    <mat-checkbox
-      color="primary"
-      class="checkbox"
-      [(ngModel)]="componentContent.cRater.enableIdeaDescriptions"
-      (click)="enableIdeaDescriptionsClicked($event)"
-      i18n
-    >
-      Enable Student-Friendly Idea Descriptions
-    </mat-checkbox>
-    @if (componentContent.cRater.enableIdeaDescriptions) {
+    @if (showIdeaDescriptions) {
       <edit-crater-idea-descriptions
         [ideaDescriptions]="componentContent.cRater.rubric.ideas"
         [enableAutoscrolling]="false"
       />
+      <a (click)="toggleShowIdeaDescriptionsClicked()">Hide</a>
+    } @else {
+      <a (click)="toggleShowIdeaDescriptionsClicked()">Show Idea Descriptions</a>
     }
   </div>
 }

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
@@ -27,7 +27,7 @@
     Enable CRater
   </mat-checkbox>
 </div>
-<div *ngIf="componentContent.enableCRater">
+@if (componentContent.enableCRater) {
   <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="20px">
     <mat-form-field>
       <mat-label i18n>Item Id</mat-label>
@@ -47,9 +47,14 @@
         Verify
       </button>
     </div>
-    <span *ngIf="isVerifyingCRaterItemId === true" i18n>Verifying...</span>
-    <span *ngIf="cRaterItemIdIsValid === true" class="valid" i18n>Valid</span>
-    <span *ngIf="cRaterItemIdIsValid === false" class="invalid" i18n>Invalid</span>
+    @if (isVerifyingCRaterItemId) {
+      <span i18n>Verifying...</span>
+    }
+    @if (cRaterItemIdIsValid) {
+      <span class="valid" i18n>Valid</span>
+    } @else {
+      <span class="invalid" i18n>Invalid</span>
+    }
   </div>
   <div>
     <mat-form-field>
@@ -94,97 +99,97 @@
     >
       Enable Feedback Rules
     </mat-checkbox>
-    <edit-feedback-rules
-      *ngIf="componentContent.cRater.feedback?.enabled"
-      [feedbackRules]="componentContent.cRater.feedback.rules"
-    >
-    </edit-feedback-rules>
+    @if (componentContent.cRater.feedback?.enabled) {
+      <edit-feedback-rules [feedbackRules]="componentContent.cRater.feedback.rules" />
+    }
   </div>
-  <div
-    class="section-container"
-    *ngIf="
-      !componentContent.cRater.feedback?.enabled && componentContent.cRater.scoringRules.length > 0
-    "
-  >
-    <div fxLayoutGap="10px" class="section-label">
-      <span i18n>Scoring Rule</span>
-      <button
-        mat-raised-button
-        color="primary"
-        (click)="addScoringRule()"
-        matTooltip="Add Scoring Rule"
-        matTooltipPosition="above"
-        i18n-matTooltip
-      >
-        <mat-icon>add</mat-icon>
-      </button>
-    </div>
-    <div
-      *ngFor="
-        let scoringRule of componentContent.cRater.scoringRules;
-        index as scoringRuleIndex;
-        first as isFirst;
-        last as isLast
-      "
-      fxLayout="row wrap"
-      fxLayoutAlign="start start"
-      fxLayoutGap="20px"
-      class="section-item"
-    >
-      <mat-form-field class="scoring-rule-score">
-        <mat-label i18n>Score</mat-label>
-        <input
-          matInput
-          type="number"
-          min="0"
-          [(ngModel)]="scoringRule.score"
-          (ngModelChange)="componentChanged()"
-        />
-      </mat-form-field>
-      <translatable-textarea
-        [content]="scoringRule"
-        key="feedbackText"
-        label="Feedback Text"
-        i18n-label
-        (defaultLanguageTextChanged)="componentChanged()"
-        class="scoring-rule-feedback-text"
-      />
-      <div fxLayoutGap="10px">
+  @if (
+    !componentContent.cRater.feedback?.enabled && componentContent.cRater.scoringRules.length > 0
+  ) {
+    <div class="section-container">
+      <div fxLayoutGap="10px" class="section-label">
+        <span i18n>Scoring Rule</span>
         <button
           mat-raised-button
           color="primary"
-          (click)="moveObjectUp(componentContent.cRater.scoringRules, scoringRuleIndex)"
-          [disabled]="isFirst"
-          matTooltip="Move Scoring Rule Up"
+          (click)="addScoringRule()"
+          matTooltip="Add Scoring Rule"
           matTooltipPosition="above"
           i18n-matTooltip
         >
-          <mat-icon>arrow_upward</mat-icon>
-        </button>
-        <button
-          mat-raised-button
-          color="primary"
-          (click)="moveObjectDown(componentContent.cRater.scoringRules, scoringRuleIndex)"
-          [disabled]="isLast"
-          matTooltip="Move Scoring Rule Down"
-          matTooltipPosition="above"
-          i18n-matTooltip
-        >
-          <mat-icon>arrow_downward</mat-icon>
-        </button>
-        <button
-          mat-raised-button
-          color="primary"
-          (click)="scoringRuleDeleteClicked(scoringRuleIndex)"
-          matTooltip="Delete Scoring Rule"
-          matTooltipPosition="above"
-          i18n-matTooltip
-        >
-          <mat-icon>delete</mat-icon>
+          <mat-icon>add</mat-icon>
         </button>
       </div>
+      @for (
+        scoringRule of componentContent.cRater.scoringRules;
+        track $index;
+        let scoringRuleIndex = $index;
+        let isFirst = $first;
+        let isLast = $last
+      ) {
+        <div
+          fxLayout="row wrap"
+          fxLayoutAlign="start start"
+          fxLayoutGap="20px"
+          class="section-item"
+        >
+          <mat-form-field class="scoring-rule-score">
+            <mat-label i18n>Score</mat-label>
+            <input
+              matInput
+              type="number"
+              min="0"
+              [(ngModel)]="scoringRule.score"
+              (ngModelChange)="componentChanged()"
+            />
+          </mat-form-field>
+          <translatable-textarea
+            [content]="scoringRule"
+            key="feedbackText"
+            label="Feedback Text"
+            i18n-label
+            (defaultLanguageTextChanged)="componentChanged()"
+            class="scoring-rule-feedback-text"
+          />
+          <div fxLayoutGap="10px">
+            <button
+              mat-raised-button
+              color="primary"
+              (click)="moveObjectUp(componentContent.cRater.scoringRules, scoringRuleIndex)"
+              [disabled]="isFirst"
+              matTooltip="Move Scoring Rule Up"
+              matTooltipPosition="above"
+              i18n-matTooltip
+            >
+              <mat-icon>arrow_upward</mat-icon>
+            </button>
+            <button
+              mat-raised-button
+              color="primary"
+              (click)="moveObjectDown(componentContent.cRater.scoringRules, scoringRuleIndex)"
+              [disabled]="isLast"
+              matTooltip="Move Scoring Rule Down"
+              matTooltipPosition="above"
+              i18n-matTooltip
+            >
+              <mat-icon>arrow_downward</mat-icon>
+            </button>
+            <button
+              mat-raised-button
+              color="primary"
+              (click)="scoringRuleDeleteClicked(scoringRuleIndex)"
+              matTooltip="Delete Scoring Rule"
+              matTooltipPosition="above"
+              i18n-matTooltip
+            >
+              <mat-icon>delete</mat-icon>
+            </button>
+          </div>
+        </div>
+      }
     </div>
-  </div>
+  }
+
   <div class="section-container">
     <div>
       <mat-checkbox
@@ -197,7 +202,7 @@
         Enable Multiple Attempt Feedback
       </mat-checkbox>
     </div>
-    <div *ngIf="componentContent.cRater.enableMultipleAttemptScoringRules">
+    @if (componentContent.cRater.enableMultipleAttemptScoringRules) {
       <div fxLayoutGap="10px" class="section-label">
         <span i18n>Multiple Attempt Scoring Rules</span>
         <button
@@ -211,90 +216,92 @@
           <mat-icon>add</mat-icon>
         </button>
       </div>
-      <div
-        *ngFor="
-          let multipleAttemptScoringRule of componentContent.cRater.multipleAttemptScoringRules;
-          index as multipleAttemptScoringRuleIndex;
-          first as isFirst;
-          last as isLast
-        "
-        fxLayout="row wrap"
-        fxLayoutAlign="start center"
-        fxLayoutGap="20px"
-        class="section-item"
-      >
-        <mat-form-field class="previous-score">
-          <mat-label i18n>Previous Score</mat-label>
-          <input
-            matInput
-            [(ngModel)]="multipleAttemptScoringRule.scoreSequence[0]"
-            (ngModelChange)="componentChanged()"
-            min="0"
+      @for (
+        multipleAttemptScoringRule of componentContent.cRater.multipleAttemptScoringRules;
+        track $index;
+        let multipleAttemptScoringRuleIndex = $index;
+        let isFirst = $first;
+        let isLast = $last
+      ) {
+        <div
+          fxLayout="row wrap"
+          fxLayoutAlign="start center"
+          fxLayoutGap="20px"
+          class="section-item"
+        >
+          <mat-form-field class="previous-score">
+            <mat-label i18n>Previous Score</mat-label>
+            <input
+              matInput
+              [(ngModel)]="multipleAttemptScoringRule.scoreSequence[0]"
+              (ngModelChange)="componentChanged()"
+              min="0"
+            />
+          </mat-form-field>
+          <mat-form-field class="current-score">
+            <mat-label i18n>Current Score</mat-label>
+            <input
+              matInput
+              [(ngModel)]="multipleAttemptScoringRule.scoreSequence[1]"
+              (ngModelChange)="componentChanged()"
+              min="0"
+            />
+          </mat-form-field>
+          <translatable-textarea
+            [content]="multipleAttemptScoringRule"
+            key="feedbackText"
+            label="Feedback to Student"
+            i18n-label
+            (defaultLanguageTextChanged)="componentChanged()"
+            class="multiple-attempt-feedback"
           />
-        </mat-form-field>
-        <mat-form-field class="current-score">
-          <mat-label i18n>Current Score</mat-label>
-          <input
-            matInput
-            [(ngModel)]="multipleAttemptScoringRule.scoreSequence[1]"
-            (ngModelChange)="componentChanged()"
-            min="0"
-          />
-        </mat-form-field>
-        <translatable-textarea
-          [content]="multipleAttemptScoringRule"
-          key="feedbackText"
-          label="Feedback to Student"
-          i18n-label
-          (defaultLanguageTextChanged)="componentChanged()"
-          class="multiple-attempt-feedback"
-        />
-        <div fxLayoutGap="10px">
-          <button
-            mat-raised-button
-            color="primary"
-            (click)="
-              moveObjectUp(
-                componentContent.cRater.multipleAttemptScoringRules,
-                multipleAttemptScoringRuleIndex
-              )
-            "
-            [disabled]="isFirst"
-            matTooltip="Move Multiple Attempt Scoring Rule Up"
-            matTooltipPosition="above"
-            i18n-matTooltip
-          >
-            <mat-icon>arrow_upward</mat-icon>
-          </button>
-          <button
-            mat-raised-button
-            color="primary"
-            (click)="
-              moveObjectDown(
-                componentContent.cRater.multipleAttemptScoringRules,
-                multipleAttemptScoringRuleIndex
-              )
-            "
-            [disabled]="isLast"
-            matTooltip="Move Multiple Attempt Scoring Rule Down"
-            matTooltipPosition="above"
-            i18n-matTooltip
-          >
-            <mat-icon>arrow_downward</mat-icon>
-          </button>
-          <button
-            mat-raised-button
-            color="primary"
-            (click)="multipleAttemptScoringRuleDeleteClicked(multipleAttemptScoringRuleIndex)"
-            matTooltip="Delet Multiple Attempt Scoring"
-            matTooltipPosition="above"
-            i18n-matTooltip
-          >
-            <mat-icon>delete</mat-icon>
-          </button>
+          <div fxLayoutGap="10px">
+            <button
+              mat-raised-button
+              color="primary"
+              (click)="
+                moveObjectUp(
+                  componentContent.cRater.multipleAttemptScoringRules,
+                  multipleAttemptScoringRuleIndex
+                )
+              "
+              [disabled]="isFirst"
+              matTooltip="Move Multiple Attempt Scoring Rule Up"
+              matTooltipPosition="above"
+              i18n-matTooltip
+            >
+              <mat-icon>arrow_upward</mat-icon>
+            </button>
+            <button
+              mat-raised-button
+              color="primary"
+              (click)="
+                moveObjectDown(
+                  componentContent.cRater.multipleAttemptScoringRules,
+                  multipleAttemptScoringRuleIndex
+                )
+              "
+              [disabled]="isLast"
+              matTooltip="Move Multiple Attempt Scoring Rule Down"
+              matTooltipPosition="above"
+              i18n-matTooltip
+            >
+              <mat-icon>arrow_downward</mat-icon>
+            </button>
+            <button
+              mat-raised-button
+              color="primary"
+              (click)="multipleAttemptScoringRuleDeleteClicked(multipleAttemptScoringRuleIndex)"
+              matTooltip="Delet Multiple Attempt Scoring"
+              matTooltipPosition="above"
+              i18n-matTooltip
+            >
+              <mat-icon>delete</mat-icon>
+            </button>
+          </div>
         </div>
-      </div>
-    </div>
+      }
+    }
   </div>
   <div class="section-container">
     <div>
@@ -308,7 +315,7 @@
         Enable Notifications
       </mat-checkbox>
     </div>
-    <div *ngIf="componentContent.enableNotifications">
+    @if (componentContent.enableNotifications) {
       <div fxLayoutGap="10px" class="section-label">
         <span i18n>Notifications</span>
         <button
@@ -322,132 +329,144 @@
           <mat-icon>add</mat-icon>
         </button>
       </div>
-      <div
-        *ngFor="
-          let notification of componentContent.notificationSettings.notifications;
-          index as notificationIndex;
-          first as isFirst;
-          last as isLast
-        "
-        class="section-item"
-      >
-        <div fxLayoutGap="20px">
-          <mat-form-field class="notification-score">
-            <mat-label i18n>Previous Score</mat-label>
-            <input
-              matInput
-              type="number"
-              min="0"
-              [(ngModel)]="notification.enableCriteria.scoreSequence[0]"
-              (ngModelChange)="componentChanged()"
-            />
-          </mat-form-field>
-          <mat-form-field class="notification-score">
-            <mat-label i18n>Current Score</mat-label>
-            <input
-              matInput
-              type="number"
-              min="0"
-              [(ngModel)]="notification.enableCriteria.scoreSequence[1]"
-              (ngModelChange)="componentChanged()"
-            />
-          </mat-form-field>
-          <div fxFlex></div>
-          <div fxLayoutGap="10px">
-            <button
-              mat-raised-button
+      @for (
+        notification of componentContent.notificationSettings.notifications;
+        track $index;
+        let notificationIndex = $index;
+        let isFirst = $first;
+        let isLast = $last
+      ) {
+        <div class="section-item">
+          <div fxLayoutGap="20px">
+            <mat-form-field class="notification-score">
+              <mat-label i18n>Previous Score</mat-label>
+              <input
+                matInput
+                type="number"
+                min="0"
+                [(ngModel)]="notification.enableCriteria.scoreSequence[0]"
+                (ngModelChange)="componentChanged()"
+              />
+            </mat-form-field>
+            <mat-form-field class="notification-score">
+              <mat-label i18n>Current Score</mat-label>
+              <input
+                matInput
+                type="number"
+                min="0"
+                [(ngModel)]="notification.enableCriteria.scoreSequence[1]"
+                (ngModelChange)="componentChanged()"
+              />
+            </mat-form-field>
+            <div fxFlex></div>
+            <div fxLayoutGap="10px">
+              <button
+                mat-raised-button
+                color="primary"
+                (click)="
+                  moveObjectUp(
+                    componentContent.notificationSettings.notifications,
+                    notificationIndex
+                  )
+                "
+                [disabled]="isFirst"
+                matTooltip="Move Notification Up"
+                matTooltipPosition="above"
+                i18n-matTooltip
+              >
+                <mat-icon>arrow_upward</mat-icon>
+              </button>
+              <button
+                mat-raised-button
+                color="primary"
+                (click)="
+                  moveObjectDown(
+                    componentContent.notificationSettings.notifications,
+                    notificationIndex
+                  )
+                "
+                [disabled]="isLast"
+                matTooltip="Move Notification Down"
+                matTooltipPosition="above"
+                i18n-matTooltip
+              >
+                <mat-icon>arrow_downward</mat-icon>
+              </button>
+              <button
+                mat-raised-button
+                color="primary"
+                (click)="notificationDeleteClicked(notificationIndex)"
+                matTooltip="Delete Notification"
+                matTooltipPosition="above"
+                i18n-matTooltip
+              >
+                <mat-icon>delete</mat-icon>
+              </button>
+            </div>
+          </div>
+          <div fxLayoutAlign="start start" fxLayoutGap="20px">
+            <mat-checkbox
               color="primary"
-              (click)="
-                moveObjectUp(componentContent.notificationSettings.notifications, notificationIndex)
-              "
-              [disabled]="isFirst"
-              matTooltip="Move Notification Up"
-              matTooltipPosition="above"
-              i18n-matTooltip
+              class="checkbox"
+              [(ngModel)]="notification.isAmbient"
+              i18n
             >
-              <mat-icon>arrow_upward</mat-icon>
-            </button>
-            <button
-              mat-raised-button
+              Enable Ambient Display Dismiss Mode
+            </mat-checkbox>
+            @if (notification.isAmbient) {
+              <mat-form-field>
+                <mat-label i18n>Dismiss Code</mat-label>
+                <input
+                  matInput
+                  [(ngModel)]="notification.dismissCode"
+                  (ngModelChange)="componentChanged()"
+                />
+              </mat-form-field>
+            }
+          </div>
+          <div fxLayoutAlign="start start" fxLayoutGap="20px">
+            <mat-checkbox
               color="primary"
-              (click)="
-                moveObjectDown(
-                  componentContent.notificationSettings.notifications,
-                  notificationIndex
-                )
-              "
-              [disabled]="isLast"
-              matTooltip="Move Notification Down"
-              matTooltipPosition="above"
-              i18n-matTooltip
+              class="checkbox"
+              [(ngModel)]="notification.isNotifyStudent"
+              i18n
             >
-              <mat-icon>arrow_downward</mat-icon>
-            </button>
-            <button
-              mat-raised-button
+              Notify Student
+            </mat-checkbox>
+            @if (notification.isNotifyStudent) {
+              <translatable-textarea
+                [content]="notification"
+                key="notificationMessageToStudent"
+                label="Feedback to Student"
+                i18n-label
+                (defaultLanguageTextChanged)="componentChanged()"
+                class="notification-feedback"
+              />
+            }
+          </div>
+          <div fxLayoutAlign="start start" fxLayoutGap="20px">
+            <mat-checkbox
               color="primary"
-              (click)="notificationDeleteClicked(notificationIndex)"
-              matTooltip="Delete Notification"
-              matTooltipPosition="above"
-              i18n-matTooltip
+              class="checkbox"
+              [(ngModel)]="notification.isNotifyTeacher"
+              i18n
             >
-              <mat-icon>delete</mat-icon>
-            </button>
+              Notify Teacher
+            </mat-checkbox>
+            @if (notification.isNotifyTeacher) {
+              <translatable-textarea
+                [content]="notification"
+                key="notificationMessageToTeacher"
+                label="Feedback to Teacher"
+                i18n-label
+                (defaultLanguageTextChanged)="componentChanged()"
+                class="notification-feedback"
+              />
+            }
           </div>
         </div>
-        <div fxLayoutAlign="start start" fxLayoutGap="20px">
-          <mat-checkbox color="primary" class="checkbox" [(ngModel)]="notification.isAmbient" i18n>
-            Enable Ambient Display Dismiss Mode
-          </mat-checkbox>
-          <mat-form-field *ngIf="notification.isAmbient">
-            <mat-label i18n>Dismiss Code</mat-label>
-            <input
-              matInput
-              [(ngModel)]="notification.dismissCode"
-              (ngModelChange)="componentChanged()"
-            />
-          </mat-form-field>
-        </div>
-        <div fxLayoutAlign="start start" fxLayoutGap="20px">
-          <mat-checkbox
-            color="primary"
-            class="checkbox"
-            [(ngModel)]="notification.isNotifyStudent"
-            i18n
-          >
-            Notify Student
-          </mat-checkbox>
-          <translatable-textarea
-            *ngIf="notification.isNotifyStudent"
-            [content]="notification"
-            key="notificationMessageToStudent"
-            label="Feedback to Student"
-            i18n-label
-            (defaultLanguageTextChanged)="componentChanged()"
-            class="notification-feedback"
-          />
-        </div>
-        <div fxLayoutAlign="start start" fxLayoutGap="20px">
-          <mat-checkbox
-            color="primary"
-            class="checkbox"
-            [(ngModel)]="notification.isNotifyTeacher"
-            i18n
-          >
-            Notify Teacher
-          </mat-checkbox>
-          <translatable-textarea
-            *ngIf="notification.isNotifyTeacher"
-            [content]="notification"
-            key="notificationMessageToTeacher"
-            label="Feedback to Teacher"
-            i18n-label
-            (defaultLanguageTextChanged)="componentChanged()"
-            class="notification-feedback"
-          />
-        </div>
-      </div>
-    </div>
+      }
+    }
   </div>
   <div class="section-container">
     <mat-checkbox
@@ -459,7 +478,7 @@
     >
       Use Custom Completion Criteria
     </mat-checkbox>
-    <div *ngIf="useCustomCompletionCriteria && componentContent.completionCriteria != null">
+    @if (useCustomCompletionCriteria && componentContent.completionCriteria != null) {
       <div fxLayoutGap="10px" class="section-label">
         <span i18n>Custom Completion Criteria</span>
         <button
@@ -473,90 +492,99 @@
           <mat-icon>add</mat-icon>
         </button>
       </div>
-      <div
-        *ngFor="
-          let criteria of componentContent.completionCriteria.criteria;
-          index as criteriaIndex;
-          first as isFirst;
-          last as isLast
-        "
-        fxLayout="row wrap"
-        fxLayoutAlign="start center"
-        fxLayoutGap="20px"
-        class="section-item"
-      >
-        <mat-form-field class="custom-completion-criteria-step">
-          <mat-label i18n>Step</mat-label>
-          <mat-select [(ngModel)]="criteria.nodeId" (ngModelChange)="componentChanged()">
-            <ng-container *ngFor="let nodeId of nodeIds">
-              <mat-option *ngIf="isApplicationNode(nodeId)" [value]="nodeId">
-                {{ getNodePositionAndTitle(nodeId) }}
-              </mat-option>
-            </ng-container>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field class="custom-completion-criteria-component">
-          <mat-label i18n>Component</mat-label>
-          <mat-select [(ngModel)]="criteria.componentId" (ngModelChange)="componentChanged()">
-            <mat-option
-              *ngFor="let component of getComponents(criteria.nodeId); index as componentIndex"
-              [value]="component.id"
+      @for (
+        criteria of componentContent.completionCriteria.criteria;
+        track $index;
+        let criteriaIndex = $index;
+        let isFirst = $first;
+        let isLast = $last
+      ) {
+        <div
+          fxLayout="row wrap"
+          fxLayoutAlign="start center"
+          fxLayoutGap="20px"
+          class="section-item"
+        >
+          <mat-form-field class="custom-completion-criteria-step">
+            <mat-label i18n>Step</mat-label>
+            <mat-select [(ngModel)]="criteria.nodeId" (ngModelChange)="componentChanged()">
+              @for (nodeId of nodeIds; track $index) {
+                @if (isApplicationNode(nodeId)) {
+                  <mat-option [value]="nodeId">
+                    {{ getNodePositionAndTitle(nodeId) }}
+                  </mat-option>
+                }
+              }
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field class="custom-completion-criteria-component">
+            <mat-label i18n>Component</mat-label>
+            <mat-select [(ngModel)]="criteria.componentId" (ngModelChange)="componentChanged()">
+              @for (
+                component of getComponents(criteria.nodeId);
+                let componentIndex = $index;
+                track component.id
+              ) {
+                <mat-option [value]="component.id">
+                  {{ componentIndex + 1 }}. {{ component.type }}
+                  @if (component.id === componentId) {
+                    <span i18n>(This Component)</span>
+                  }
+                </mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field class="custom-completion-criteria-action">
+            <mat-label>Action</mat-label>
+            <mat-select [(ngModel)]="criteria.name" (ngModelChange)="componentChanged()">
+              <mat-option value="isSubmitted" i18n>Submit</mat-option>
+              <mat-option value="isSaved" i18n>Save</mat-option>
+            </mat-select>
+          </mat-form-field>
+          <div fxFlex></div>
+          <div fxLayoutGap="10px">
+            <button
+              mat-raised-button
+              color="primary"
+              (click)="moveObjectUp(componentContent.completionCriteria.criteria, criteriaIndex)"
+              [disabled]="isFirst"
+              matTooltip="Move Completion Criteria Up"
+              matTooltipPosition="above"
+              i18n-matTooltip
             >
-              {{ componentIndex + 1 }}. {{ component.type }}
-              <span *ngIf="component.id === componentId" i18n>(This Component)</span>
-            </mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field class="custom-completion-criteria-action">
-          <mat-label>Action</mat-label>
-          <mat-select [(ngModel)]="criteria.name" (ngModelChange)="componentChanged()">
-            <mat-option value="isSubmitted" i18n>Submit</mat-option>
-            <mat-option value="isSaved" i18n>Save</mat-option>
-          </mat-select>
-        </mat-form-field>
-        <div fxFlex></div>
-        <div fxLayoutGap="10px">
-          <button
-            mat-raised-button
-            color="primary"
-            (click)="moveObjectUp(componentContent.completionCriteria.criteria, criteriaIndex)"
-            [disabled]="isFirst"
-            matTooltip="Move Completion Criteria Up"
-            matTooltipPosition="above"
-            i18n-matTooltip
-          >
-            <mat-icon>arrow_upward</mat-icon>
-          </button>
-          <button
-            mat-raised-button
-            color="primary"
-            (click)="moveObjectDown(componentContent.completionCriteria.criteria, criteriaIndex)"
-            [disabled]="isLast"
-            matTooltip="Move Completion Criteria Down"
-            matTooltipPosition="above"
-            i18n-matTooltip
-          >
-            <mat-icon>arrow_downward</mat-icon>
-          </button>
-          <button
-            mat-raised-button
-            color="primary"
-            (click)="deleteCompletionCriteria(criteriaIndex)"
-            matTooltip="Delete Completion Criteria"
-            matTooltipPosition="above"
-            i18n-matTooltip
-          >
-            <mat-icon>delete</mat-icon>
-          </button>
+              <mat-icon>arrow_upward</mat-icon>
+            </button>
+            <button
+              mat-raised-button
+              color="primary"
+              (click)="moveObjectDown(componentContent.completionCriteria.criteria, criteriaIndex)"
+              [disabled]="isLast"
+              matTooltip="Move Completion Criteria Down"
+              matTooltipPosition="above"
+              i18n-matTooltip
+            >
+              <mat-icon>arrow_downward</mat-icon>
+            </button>
+            <button
+              mat-raised-button
+              color="primary"
+              (click)="deleteCompletionCriteria(criteriaIndex)"
+              matTooltip="Delete Completion Criteria"
+              matTooltipPosition="above"
+              i18n-matTooltip
+            >
+              <mat-icon>delete</mat-icon>
+            </button>
+          </div>
         </div>
-      </div>
-    </div>
+      }
+    }
   </div>
-</div>
-<div *ngIf="isNotebookEnabled()">
+}
+@if (isNotebookEnabled) {
   <edit-component-add-to-notebook-button [componentContent]="componentContent">
   </edit-component-add-to-notebook-button>
-</div>
+}
 <edit-common-advanced
   [component]="component"
   [allowedConnectedComponentTypes]="allowedConnectedComponentTypes"

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
@@ -580,6 +580,23 @@
       }
     }
   </div>
+  <div class="section-container">
+    <mat-checkbox
+      color="primary"
+      class="checkbox"
+      [(ngModel)]="componentContent.cRater.enableIdeaDescriptions"
+      (click)="enableIdeaDescriptionsClicked($event)"
+      i18n
+    >
+      Enable Student-Friendly Idea Descriptions
+    </mat-checkbox>
+    @if (componentContent.cRater.enableIdeaDescriptions) {
+      <edit-crater-idea-descriptions
+        [ideaDescriptions]="componentContent.cRater.rubric.ideas"
+        [enableAutoscrolling]="false"
+      />
+    }
+  </div>
 }
 @if (isNotebookEnabled) {
   <edit-component-add-to-notebook-button [componentContent]="componentContent">

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { ComponentContent } from '../../../common/ComponentContent';
+import { CRaterIdea } from '../../common/cRater/CRaterIdea';
 import { CRaterService } from '../../../services/cRaterService';
 import { EditAdvancedComponentComponent } from '../../../../../app/authoring-tool/edit-advanced-component/edit-advanced-component.component';
 import { NotebookService } from '../../../services/notebookService';
@@ -24,9 +25,10 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
       feedback: [$localize`Default feedback`]
     }
   ];
-  isVerifyingCRaterItemId: boolean = false;
+  isVerifyingCRaterItemId: boolean;
   nodeIds: string[] = [];
-  useCustomCompletionCriteria: boolean = false;
+  useCustomCompletionCriteria: boolean;
+  ideaDescriptions: CRaterIdea[] = [];
 
   constructor(
     protected cRaterService: CRaterService,
@@ -47,14 +49,18 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
 
   enableCRaterClicked(): void {
     if (this.componentContent.enableCRater) {
-      if (this.componentContent.cRater == null) {
-        this.componentContent.cRater = this.createCRaterObject();
-      }
+      this.createCRaterIfNull();
       this.setShowSubmitButtonValue(true);
     } else {
       this.setShowSubmitButtonValue(false);
     }
     this.componentChanged();
+  }
+
+  private createCRaterIfNull() {
+    if (this.componentContent.cRater == null) {
+      this.componentContent.cRater = this.createCRaterObject();
+    }
   }
 
   createCRaterObject() {
@@ -70,7 +76,11 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
         rules: this.initialFeedbackRules
       },
       enableMultipleAttemptScoringRules: false,
-      multipleAttemptScoringRules: []
+      multipleAttemptScoringRules: [],
+      enableIdeaDescriptions: false,
+      rubric: {
+        ideas: []
+      }
     };
   }
 
@@ -259,6 +269,14 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
       this.componentContent.completionCriteria.criteria.splice(index, 1);
       this.componentChanged();
     }
+  }
+
+  enableIdeaDescriptionsClicked(): void {
+    this.createCRaterIfNull();
+    if (!this.componentContent.cRater.rubric) {
+      this.componentContent.cRater.rubric = { ideas: [] };
+    }
+    this.componentChanged();
   }
 
   getComponents(nodeId: string): ComponentContent[] {

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
@@ -27,7 +27,7 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
   ];
   protected isVerifyingCRaterItemId: boolean;
   protected nodeIds: string[] = [];
-  protected useCustomCompletionCriteria: boolean;
+  useCustomCompletionCriteria: boolean;
   protected showIdeaDescriptions = true;
 
   constructor(

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
@@ -45,7 +45,6 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
       this.useCustomCompletionCriteria = true;
     }
     this.nodeIds = this.teacherProjectService.getFlattenedProjectAsNodeIds();
-    this.createCRaterAndRubricIfNull();
   }
 
   private createCRaterAndRubricIfNull() {
@@ -59,6 +58,7 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
 
   enableCRaterClicked(): void {
     if (this.componentContent.enableCRater) {
+      this.createCRaterAndRubricIfNull();
       this.setShowSubmitButtonValue(true);
     } else {
       this.setShowSubmitButtonValue(false);

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
@@ -15,20 +15,20 @@ import { TeacherProjectService } from '../../../services/teacherProjectService';
   standalone: false
 })
 export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComponent {
-  allowedConnectedComponentTypes = ['OpenResponse'];
+  protected allowedConnectedComponentTypes = ['OpenResponse'];
   componentContent: OpenResponseContent;
-  cRaterItemIdIsValid: boolean = null;
-  initialFeedbackRules = [
+  protected cRaterItemIdIsValid: boolean = null;
+  private initialFeedbackRules = [
     {
       id: 'isDefault',
       expression: 'isDefault',
       feedback: [$localize`Default feedback`]
     }
   ];
-  isVerifyingCRaterItemId: boolean;
-  nodeIds: string[] = [];
-  useCustomCompletionCriteria: boolean;
-  ideaDescriptions: CRaterIdea[] = [];
+  protected isVerifyingCRaterItemId: boolean;
+  protected nodeIds: string[] = [];
+  protected useCustomCompletionCriteria: boolean;
+  protected showIdeaDescriptions = true;
 
   constructor(
     protected cRaterService: CRaterService,
@@ -45,22 +45,25 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
       this.useCustomCompletionCriteria = true;
     }
     this.nodeIds = this.teacherProjectService.getFlattenedProjectAsNodeIds();
+    this.createCRaterAndRubricIfNull();
+  }
+
+  private createCRaterAndRubricIfNull() {
+    if (this.componentContent.cRater == null) {
+      this.componentContent.cRater = this.createCRaterObject();
+    }
+    if (!this.componentContent.cRater.rubric) {
+      this.componentContent.cRater.rubric = { ideas: [] };
+    }
   }
 
   enableCRaterClicked(): void {
     if (this.componentContent.enableCRater) {
-      this.createCRaterIfNull();
       this.setShowSubmitButtonValue(true);
     } else {
       this.setShowSubmitButtonValue(false);
     }
     this.componentChanged();
-  }
-
-  private createCRaterIfNull() {
-    if (this.componentContent.cRater == null) {
-      this.componentContent.cRater = this.createCRaterObject();
-    }
   }
 
   createCRaterObject() {
@@ -77,7 +80,6 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
       },
       enableMultipleAttemptScoringRules: false,
       multipleAttemptScoringRules: [],
-      enableIdeaDescriptions: false,
       rubric: {
         ideas: []
       }
@@ -271,12 +273,8 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
     }
   }
 
-  enableIdeaDescriptionsClicked(): void {
-    this.createCRaterIfNull();
-    if (!this.componentContent.cRater.rubric) {
-      this.componentContent.cRater.rubric = { ideas: [] };
-    }
-    this.componentChanged();
+  protected toggleShowIdeaDescriptionsClicked(): void {
+    this.showIdeaDescriptions = !this.showIdeaDescriptions;
   }
 
   getComponents(nodeId: string): ComponentContent[] {

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
 import { ComponentContent } from '../../../common/ComponentContent';
-import { CRaterIdea } from '../../common/cRater/CRaterIdea';
 import { CRaterService } from '../../../services/cRaterService';
 import { EditAdvancedComponentComponent } from '../../../../../app/authoring-tool/edit-advanced-component/edit-advanced-component.component';
 import { NotebookService } from '../../../services/notebookService';
@@ -273,7 +272,7 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
     }
   }
 
-  protected toggleShowIdeaDescriptionsClicked(): void {
+  protected toggleShowIdeaDescriptions(): void {
     this.showIdeaDescriptions = !this.showIdeaDescriptions;
   }
 

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
@@ -1,16 +1,17 @@
 import { Component } from '@angular/core';
-import { EditAdvancedComponentComponent } from '../../../../../app/authoring-tool/edit-advanced-component/edit-advanced-component.component';
+import { ComponentContent } from '../../../common/ComponentContent';
 import { CRaterService } from '../../../services/cRaterService';
+import { EditAdvancedComponentComponent } from '../../../../../app/authoring-tool/edit-advanced-component/edit-advanced-component.component';
 import { NotebookService } from '../../../services/notebookService';
-import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { OpenResponseContent } from '../OpenResponseContent';
 import { TeacherNodeService } from '../../../services/teacherNodeService';
+import { TeacherProjectService } from '../../../services/teacherProjectService';
 
 @Component({
-    selector: 'edit-open-response-advanced',
-    templateUrl: 'edit-open-response-advanced.component.html',
-    styleUrls: ['edit-open-response-advanced.component.scss'],
-    standalone: false
+  selector: 'edit-open-response-advanced',
+  templateUrl: 'edit-open-response-advanced.component.html',
+  styleUrls: ['edit-open-response-advanced.component.scss'],
+  standalone: false
 })
 export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComponent {
   allowedConnectedComponentTypes = ['OpenResponse'];
@@ -129,9 +130,8 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
   }
 
   multipleAttemptScoringRuleDeleteClicked(index: number): void {
-    const multipleAttemptScoringRule = this.componentContent.cRater.multipleAttemptScoringRules[
-      index
-    ];
+    const multipleAttemptScoringRule =
+      this.componentContent.cRater.multipleAttemptScoringRules[index];
     const scoreSequence = multipleAttemptScoringRule.scoreSequence;
     let previousScore = '';
     let currentScore = '';
@@ -261,7 +261,7 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
     }
   }
 
-  getComponents(nodeId: string): any[] {
+  getComponents(nodeId: string): ComponentContent[] {
     return this.teacherProjectService.getComponents(nodeId);
   }
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -16457,18 +16457,22 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">285</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6468116689332890293" datatype="html">
-        <source>Idea Names</source>
+      <trans-unit id="6050147698447258490" datatype="html">
+        <source>Idea Descriptions</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component.html</context>
           <context context-type="linenumber">3,7</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2517228276717136307" datatype="html">
-        <source>Add a new idea name</source>
+      <trans-unit id="4572902223495707288" datatype="html">
+        <source>Add a new idea description</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component.html</context>
           <context context-type="linenumber">7,10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component.html</context>
+          <context context-type="linenumber">68,71</context>
         </context-group>
       </trans-unit>
       <trans-unit id="275818851315293243" datatype="html">
@@ -16478,8 +16482,8 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">30,33</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="314152887019216557" datatype="html">
-        <source>User-Friendly Name</source>
+      <trans-unit id="5849203454479447363" datatype="html">
+        <source>User-Friendly Description</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component.html</context>
           <context context-type="linenumber">38,41</context>
@@ -16492,18 +16496,11 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">52,54</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4572902223495707288" datatype="html">
-        <source>Add a new idea description</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component.html</context>
-          <context context-type="linenumber">68,71</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7862038253187581980" datatype="html">
-        <source>Are you sure you want to delete this idea name?</source>
+      <trans-unit id="7728068163356050294" datatype="html">
+        <source>Are you sure you want to delete this idea description?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component.ts</context>
-          <context context-type="linenumber">87</context>
+          <context context-type="linenumber">88</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5596810972110629301" datatype="html">
@@ -19954,6 +19951,20 @@ Warning: This will delete all existing choices in this component.</source>
           <context context-type="linenumber">572,575</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="8461609631969932886" datatype="html">
+        <source>Hide</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
+          <context context-type="linenumber">590,591</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="493950846706766768" datatype="html">
+        <source>Show Idea Descriptions</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
+          <context context-type="linenumber">591,596</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="8705933649296793690" datatype="html">
         <source>Default feedback</source>
         <context-group purpose="location">
@@ -19969,7 +19980,7 @@ Score: <x id="PH" equiv-text="score"/>
 Feedback Text: <x id="PH_1" equiv-text="feedbackText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">107</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1461861786609911168" datatype="html">
@@ -19982,28 +19993,28 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/>
 Feedback Text: <x id="PH_2" equiv-text="feedbackText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">144</context>
+          <context context-type="linenumber">155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846244999760672149" datatype="html">
         <source>you got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">174</context>
+          <context context-type="linenumber">185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7599226289089492371" datatype="html">
         <source>Please talk to your teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">176</context>
+          <context context-type="linenumber">187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5580639382077453513" datatype="html">
         <source>got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">178</context>
+          <context context-type="linenumber">189</context>
         </context-group>
       </trans-unit>
       <trans-unit id="867656616658826137" datatype="html">
@@ -20014,21 +20025,21 @@ Previous Score: <x id="PH" equiv-text="previousScore"/>
 Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">192</context>
+          <context context-type="linenumber">203</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3689003016353565518" datatype="html">
         <source>Are you sure you want to delete the custom completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">226</context>
+          <context context-type="linenumber">237</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2986030604058491184" datatype="html">
         <source>Are you sure you want to delete this completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">258</context>
+          <context context-type="linenumber">269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8648892006027324370" datatype="html">


### PR DESCRIPTION
## Changes
- Added an EditCRaterIdeaDescriptions component to the advanced settings of an Open Response component.
- Made autoscrolling on the idea description authoring component turned on by default but with the option to turn it off since it is unnecessary (and doesn't work properly) in Open Response settings.
- Changed references to "idea name" in EditCRaterIdeaDescriptions to "idea description" because that's a more descriptive name and I think should be less confusing given how CRaterIdea.name is referring to the ID. Also it matches the name of the class now which seems good.
- Made CRaterIdea.detected optional to allow for ideas outside of the context of being detected or not. (I thought it already was optional, but maybe it got changed back or I'm just imagining it?)

## Test
- Make sure checking "Enable Student-Friendly Idea Descriptions" opens the EditCRaterIdeaDescriptions component.
- Make sure that unchecking "Enable Student-Friendly Idea Descriptions" hides the EditCRaterIdeaDescriptions component but doesn't delete any created idea descriptions from the JSON.
- Make sure that you can add and delete idea descriptions and that all changes are saved to the JSON.

Closes #2117 
