### PR TITLE
fix(Session): Make renewSession requests on mouse move

### DIFF
--- a/src/assets/wise5/vle/vle.component.ts
+++ b/src/assets/wise5/vle/vle.component.ts
@@ -32,25 +32,25 @@ import { NavigationComponent } from '../themes/default/navigation/navigation.com
 import { ChooseBranchPathDialogComponent } from '../../../app/preview/modules/choose-branch-path-dialog/choose-branch-path-dialog.component';
 
 @Component({
-    imports: [
-        CommonModule,
-        ChooseBranchPathDialogComponent,
-        GroupTabsComponent,
-        MatSidenavModule,
-        NavigationComponent,
-        NodeComponent,
-        NodeNavigationComponent,
-        NotebookLauncherComponent,
-        NotebookNotesComponent,
-        NotebookReportComponent,
-        RunEndedAndLockedMessageComponent,
-        SafeUrl,
-        StepToolsComponent,
-        TopBarComponent
-    ],
-    selector: 'vle',
-    styleUrl: './vle.component.scss',
-    templateUrl: './vle.component.html'
+  imports: [
+    CommonModule,
+    ChooseBranchPathDialogComponent,
+    GroupTabsComponent,
+    MatSidenavModule,
+    NavigationComponent,
+    NodeComponent,
+    NodeNavigationComponent,
+    NotebookLauncherComponent,
+    NotebookNotesComponent,
+    NotebookReportComponent,
+    RunEndedAndLockedMessageComponent,
+    SafeUrl,
+    StepToolsComponent,
+    TopBarComponent
+  ],
+  selector: 'vle',
+  styleUrl: './vle.component.scss',
+  templateUrl: './vle.component.html'
 })
 export class VLEComponent implements AfterViewInit {
   protected currentNode: Node;
@@ -301,6 +301,11 @@ export class VLEComponent implements AfterViewInit {
 
   private scrollToTop() {
     document.querySelector('.top').scrollIntoView();
+  }
+
+  @HostListener('document:mousemove')
+  protected renewSession(): void {
+    this.sessionService.mouseMoved();
   }
 
   /**


### PR DESCRIPTION
## Changes
- Added renewSession pings whenever the student moves the mouse while on the VLE. This will prevent the session from timing out

## Test
- moving the mouse pings the server to keep the session alive