### PR TITLE
Added library filter for grade level

### DIFF
--- a/src/app/domain/projectFilterValues.ts
+++ b/src/app/domain/projectFilterValues.ts
@@ -2,6 +2,7 @@ import { ResearchProjectType } from '../modules/library/ResearchProject';
 
 export class ProjectFilterValues {
   disciplineValue: string[] = [];
+  gradeLevelValue: number[] = [];
   publicUnitType?: ('wiseTested' | 'communityBuilt')[] = [];
   researchProjectValue: ResearchProjectType[] = [];
   searchValue: string = '';

--- a/src/app/modules/library/GradeLevel.ts
+++ b/src/app/modules/library/GradeLevel.ts
@@ -1,0 +1,19 @@
+export enum Grade {
+  Six = 6,
+  Seven = 7,
+  Eight = 8,
+  Nine = 9,
+  Ten = 10,
+  Eleven = 11,
+  Twelve = 12
+}
+
+export class GradeLevel {
+  id: Grade;
+  grade: Grade;
+
+  constructor(grade: Grade) {
+    this.id = grade;
+    this.grade = grade;
+  }
+}

--- a/src/app/modules/library/home-page-project-library/home-page-project-library.component.html
+++ b/src/app/modules/library/home-page-project-library/home-page-project-library.component.html
@@ -1,7 +1,7 @@
 <div class="library library-home notice-bg-bg">
   <div class="flex flex-col md:flex-row">
     <div class="content-block dark-theme library__header primary-bg md:w-1/3">
-      <app-library-filters [isSplitScreen]="true" />
+      <app-library-filters [isSplitScreen]="true" [showAdvancedFilteringOptions]="false" />
     </div>
     <div class="library__content library-home__content content-block md:w-2/3">
       <div class="notice center" i18n>

--- a/src/app/modules/library/library-filters/library-filters.component.html
+++ b/src/app/modules/library/library-filters/library-filters.component.html
@@ -57,6 +57,24 @@
         />
       </div>
     }
+    @if (gradeLevelOptions.length > 0 && showAdvancedFilteringOptions) {
+      <div
+        class="library-filter"
+        [ngClass]="{ 'md:w-full': isSplitScreen, 'md:w-1/4': !isSplitScreen }"
+      >
+        <app-select-menu
+          id="gradeLevelSelectMenu"
+          [options]="gradeLevelOptions"
+          i18n-placeholderText
+          placeholderText="Grade Level"
+          [value]="gradeLevelValue"
+          (update)="filterUpdated($event, 'gradeLevel')"
+          [valueProp]="'grade'"
+          [viewValueProp]="'grade'"
+          [multiple]="true"
+        />
+      </div>
+    }
     @if (standardOptions.length > 0) {
       <div
         class="library-filter"

--- a/src/app/modules/library/library-filters/library-filters.component.html
+++ b/src/app/modules/library/library-filters/library-filters.component.html
@@ -69,8 +69,8 @@
           placeholderText="Grade Level"
           [value]="gradeLevelValue"
           (update)="filterUpdated($event, 'gradeLevel')"
-          [valueProp]="'grade'"
-          [viewValueProp]="'grade'"
+          valueProp="grade"
+          viewValueProp="grade"
           [multiple]="true"
         />
       </div>

--- a/src/app/modules/library/library-filters/library-filters.component.ts
+++ b/src/app/modules/library/library-filters/library-filters.component.ts
@@ -13,6 +13,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatBadgeModule } from '@angular/material/badge';
 import { SelectMenuComponent } from '../../shared/select-menu/select-menu.component';
 import { StandardsSelectMenuComponent } from '../../shared/standards-select-menu/standards-select-menu.component';
+import { Grade, GradeLevel } from '../GradeLevel';
 
 @Component({
   imports: [
@@ -33,6 +34,9 @@ export class LibraryFiltersComponent implements OnInit {
   private communityProjects: LibraryProject[] = [];
   protected disciplineOptions: Discipline[] = [];
   protected disciplineValue = [];
+  protected gradeLevelOptions: GradeLevel[] = [];
+  protected gradeLevelValue = [];
+  @Input() showAdvancedFilteringOptions: boolean = true;
   @Input() isSplitScreen: boolean = false;
   private libraryProjects: LibraryProject[] = [];
   private personalProjects: LibraryProject[] = [];
@@ -88,10 +92,12 @@ export class LibraryFiltersComponent implements OnInit {
     this.allProjects = this.getAllProjects();
     this.standardOptions = [];
     this.disciplineOptions = [];
+    this.gradeLevelOptions = [];
     for (let project of this.allProjects) {
       project.metadata.disciplines?.forEach((discipline: any) =>
         this.disciplineOptions.push(new Discipline(discipline.id, discipline.name))
       );
+      this.populateGradeLevels(project);
       const standards = project.metadata.standards;
       [
         ['ngss', 'NGSS'],
@@ -107,6 +113,14 @@ export class LibraryFiltersComponent implements OnInit {
       this.populateResearchProjects(project);
     }
     this.removeDuplicatesAndSortAlphabetically();
+  }
+
+  private populateGradeLevels(project: LibraryProject) {
+    project.metadata.grades?.forEach((gradeLevel: any) => {
+      if (!isNaN(Number(gradeLevel)) && Object.values(Grade).includes(Number(gradeLevel))) {
+        this.gradeLevelOptions.push(new GradeLevel(Number(gradeLevel)));
+      }
+    });
   }
 
   private populateResearchProjects(project: LibraryProject): void {
@@ -135,10 +149,19 @@ export class LibraryFiltersComponent implements OnInit {
       'id'
     );
     this.utilService.sortObjectArrayByProperty(this.disciplineOptions, 'name');
+    this.gradeLevelOptions = this.utilService.removeObjectArrayDuplicatesByProperty(
+      this.gradeLevelOptions,
+      'grade'
+    );
+    this.utilService.sortObjectArrayByProperty(this.gradeLevelOptions, 'grade');
   }
 
   protected hasFilters(): boolean {
-    return this.standardValue.length > 0 || this.disciplineValue.length > 0;
+    return (
+      this.standardValue.length > 0 ||
+      this.disciplineValue.length > 0 ||
+      this.gradeLevelValue.length > 0
+    );
   }
 
   protected searchUpdated(value: string): void {
@@ -154,6 +177,9 @@ export class LibraryFiltersComponent implements OnInit {
       case 'discipline':
         this.disciplineValue = value;
         break;
+      case 'gradeLevel':
+        this.gradeLevelValue = value;
+        break;
       case 'standard':
         this.standardValue = value;
         break;
@@ -168,6 +194,7 @@ export class LibraryFiltersComponent implements OnInit {
     const filterOptions: ProjectFilterValues = {
       searchValue: this.searchValue,
       disciplineValue: this.disciplineValue,
+      gradeLevelValue: this.gradeLevelValue,
       standardValue: this.standardValue,
       researchProjectValue: this.researchProjectValue
     };
@@ -177,6 +204,7 @@ export class LibraryFiltersComponent implements OnInit {
   protected clearFilterValues(): void {
     this.standardValue = [];
     this.disciplineValue = [];
+    this.gradeLevelValue = [];
     this.emitFilterValues();
   }
 }

--- a/src/app/modules/library/library-filters/library-filters.component.ts
+++ b/src/app/modules/library/library-filters/library-filters.component.ts
@@ -116,11 +116,12 @@ export class LibraryFiltersComponent implements OnInit {
   }
 
   private populateGradeLevels(project: LibraryProject) {
-    project.metadata.grades?.forEach((gradeLevel: any) => {
-      if (!isNaN(Number(gradeLevel)) && Object.values(Grade).includes(Number(gradeLevel))) {
-        this.gradeLevelOptions.push(new GradeLevel(Number(gradeLevel)));
-      }
-    });
+    project.metadata.grades
+      ?.map((gradeLevel: string) => Number(gradeLevel))
+      .filter((gradeLevel: number) => Object.values(Grade).includes(gradeLevel))
+      .forEach((gradeLevel: number) => {
+        this.gradeLevelOptions.push(new GradeLevel(gradeLevel));
+      });
   }
 
   private populateResearchProjects(project: LibraryProject): void {
@@ -153,7 +154,7 @@ export class LibraryFiltersComponent implements OnInit {
       this.gradeLevelOptions,
       'grade'
     );
-    this.gradeLevelOptions.sort((a, b) => Number(a.grade) - Number(b.grade));
+    this.gradeLevelOptions.sort((a, b) => a.grade - b.grade);
   }
 
   protected hasFilters(): boolean {

--- a/src/app/modules/library/library-filters/library-filters.component.ts
+++ b/src/app/modules/library/library-filters/library-filters.component.ts
@@ -153,7 +153,7 @@ export class LibraryFiltersComponent implements OnInit {
       this.gradeLevelOptions,
       'grade'
     );
-    this.utilService.sortObjectArrayByProperty(this.gradeLevelOptions, 'grade');
+    this.gradeLevelOptions.sort((a, b) => Number(a.grade) - Number(b.grade));
   }
 
   protected hasFilters(): boolean {

--- a/src/app/modules/library/library-project-details/library-project-details.component.html
+++ b/src/app/modules/library/library-project-details/library-project-details.component.html
@@ -20,7 +20,7 @@
             @if (project.metadata.grades.length || project.metadata.totalTime) {
               <div>
                 @if (project.metadata.grades.length) {
-                  <span i18n>Grade level:</span>
+                  <span i18n>Grade level{{ project.metadata.grades.length > 1 ? 's' : '' }}: </span>
                 }
                 @for (grade of project.metadata.grades; track grade; let last = $last) {
                   <span>{{ grade }}{{ last ? '' : ', ' }}</span>
@@ -81,7 +81,9 @@
         <p><strong i18n>Features:</strong> {{ project.metadata.features }}</p>
       }
       @if (
-        standards.commonCore.length + standards.ngss.length + standards.learningForJustice.length >
+        standards.commonCore?.length +
+          standards.ngss?.length +
+          standards.learningForJustice?.length >
         0
       ) {
         <p>

--- a/src/app/modules/library/library/library.component.ts
+++ b/src/app/modules/library/library/library.component.ts
@@ -7,6 +7,7 @@ import { PageEvent, MatPaginator } from '@angular/material/paginator';
 import { Subscription } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { ResearchProjectType } from '../ResearchProject';
+import { GradeLevel } from '../GradeLevel';
 
 @Directive()
 export abstract class LibraryComponent implements OnInit {
@@ -16,6 +17,8 @@ export abstract class LibraryComponent implements OnInit {
   protected disciplineValue = [];
   protected filteredProjects: LibraryProject[] = [];
   protected filterValues: ProjectFilterValues = new ProjectFilterValues();
+  protected gradeLevelOptions: GradeLevel[] = [];
+  protected gradeLevelValue = [];
   protected highIndex: number = 0;
   protected lowIndex: number = 0;
   protected pageSizeOptions: number[] = [12, 24, 48, 96];
@@ -78,6 +81,7 @@ export abstract class LibraryComponent implements OnInit {
     this.filteredProjects = [];
     this.searchValue = this.filterValues.searchValue;
     this.disciplineValue = this.filterValues.disciplineValue;
+    this.gradeLevelValue = this.filterValues.gradeLevelValue;
     this.standardValue = this.filterValues.standardValue;
     this.researchProjectValue = this.filterValues.researchProjectValue;
     this.projects.forEach((project) => {
@@ -123,7 +127,8 @@ export abstract class LibraryComponent implements OnInit {
       this.matchesPublicUnitType(project) ||
       this.matchesStandard(project) ||
       this.matchesDiscipline(project) ||
-      this.matchesResearchProject(project)
+      this.matchesResearchProject(project) ||
+      this.matchesGradeLevel(project)
     );
   }
 
@@ -150,6 +155,15 @@ export abstract class LibraryComponent implements OnInit {
     );
   }
 
+  private matchesGradeLevel(project: LibraryProject): boolean {
+    return (
+      this.gradeLevelValue.length > 0 &&
+      project.metadata.grades?.some((gradeLevel) =>
+        this.gradeLevelValue.includes(Number(gradeLevel))
+      )
+    );
+  }
+
   private matchesResearchProject(project: LibraryProject): boolean {
     return (
       this.researchProjectValue.length > 0 &&
@@ -164,6 +178,7 @@ export abstract class LibraryComponent implements OnInit {
       this.standardValue.length +
         this.disciplineValue.length +
         this.researchProjectValue.length +
+        this.gradeLevelValue.length +
         this.publicUnitTypeValue.length >
       0
     );

--- a/src/app/modules/library/personal-library/personal-library.component.spec.ts
+++ b/src/app/modules/library/personal-library/personal-library.component.spec.ts
@@ -269,7 +269,8 @@ function projectsAreSelected_performSearch_allProjectsAreUnselected() {
           searchValue: 'world',
           standardValue: [],
           disciplineValue: [],
-          researchProjectValue: []
+          researchProjectValue: [],
+          gradeLevelValue: []
         });
         expect(await harness.getSelectedProjectIds()).toEqual([]);
       });

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -287,7 +287,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">180,184</context>
+          <context context-type="linenumber">182,186</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/official-library/official-library-details.html</context>
@@ -5622,6 +5622,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">1,5</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/library/public-library/public-library.component.html</context>
+          <context context-type="linenumber">12,17</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/teacher-project-library/teacher-project-library.component.ts</context>
           <context context-type="linenumber">21</context>
         </context-group>
@@ -5644,10 +5648,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>What is Community Built?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/community-library/community-library.component.html</context>
-          <context context-type="linenumber">3,6</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/library/unit-library/unit-library.component.html</context>
           <context context-type="linenumber">3,6</context>
         </context-group>
       </trans-unit>
@@ -5762,18 +5762,25 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">51,53</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="8145360837871676566" datatype="html">
+        <source>Grade Level</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/library/library-filters/library-filters.component.html</context>
+          <context context-type="linenumber">69,71</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="3619090494724957216" datatype="html">
         <source>Standard </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-filters/library-filters.component.html</context>
-          <context context-type="linenumber">70,72</context>
+          <context context-type="linenumber">88,90</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7445116165758648758" datatype="html">
         <source>Research Project</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-filters/library-filters.component.html</context>
-          <context context-type="linenumber">88,90</context>
+          <context context-type="linenumber">106,108</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2247270192251966992" datatype="html">
@@ -5783,11 +5790,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">4,5</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2054850261792078221" datatype="html">
-        <source>Grade level:</source>
+      <trans-unit id="1465761986819034423" datatype="html">
+        <source>Grade level<x id="INTERPOLATION" equiv-text="{{ project.metadata.grades.length &gt; 1 ? &apos;s&apos; : &apos;&apos; }}"/>: </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">23,25</context>
+          <context context-type="linenumber">23,24</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5226613065122074953" datatype="html">
@@ -5844,63 +5851,63 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Standards</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">88,90</context>
+          <context context-type="linenumber">90,92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4849120309760741886" datatype="html">
         <source>Resources:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">114,115</context>
+          <context context-type="linenumber">116,117</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8316240444829030702" datatype="html">
         <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;{{ project.uri }}&quot; target=&quot;_blank&quot;&gt;"/>This unit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> is a copy of <x id="START_LINK_1" equiv-text="&lt;a href=&quot;{{ parentProject.uri }}&quot; target=&quot;_blank&quot;&gt;"/><x id="INTERPOLATION" equiv-text="{{ parentProject.title }}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (used under <x id="START_LINK_2" equiv-text="&lt;a href=&quot;{{ licenseUrl }}&quot; target=&quot;_blank&quot;&gt;"/>CC BY-SA<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">134,136</context>
+          <context context-type="linenumber">136,138</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1086545303898503399" datatype="html">
         <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;{{ project.uri }}&quot; target=&quot;_blank&quot;&gt;"/>This unit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> is a copy of <x id="START_LINK_1" equiv-text="&lt;a href=&quot;{{ parentProject.uri }}&quot; target=&quot;_blank&quot;&gt;"/><x id="INTERPOLATION" equiv-text="{{ parentProject.title }}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> by <x id="INTERPOLATION_1" equiv-text="{{ parentAuthorsString }}"/> (used under <x id="START_LINK_2" equiv-text="&lt;a href=&quot;{{ licenseUrl }}&quot; target=&quot;_blank&quot;&gt;"/>CC BY-SA<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">140,143</context>
+          <context context-type="linenumber">142,145</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3737944794522555155" datatype="html">
         <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;{{ project.uri }}&quot; target=&quot;_blank&quot;&gt;"/>This unit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> is licensed under <x id="START_LINK_1" equiv-text="&lt;a href=&quot;{{ licenseUrl }}&quot; target=&quot;_blank&quot;&gt;"/>CC BY-SA<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">151,152</context>
+          <context context-type="linenumber">153,154</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7963479120224965794" datatype="html">
         <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;{{ project.uri }}&quot; target=&quot;_blank&quot;&gt;"/>This unit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> is licensed under <x id="START_LINK_1" equiv-text="&lt;a href=&quot;{{ licenseUrl }}&quot; target=&quot;_blank&quot;&gt;"/>CC BY-SA<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> by <x id="INTERPOLATION" equiv-text="{{ authorsString }}"/>.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">156,159</context>
+          <context context-type="linenumber">158,161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7138375215763430051" datatype="html">
         <source>View License</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">165,169</context>
+          <context context-type="linenumber">167,171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5937251202465808296" datatype="html">
         <source>More</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">173,179</context>
+          <context context-type="linenumber">175,181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5537658691712388681" datatype="html">
         <source>Use with Class</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">189,193</context>
+          <context context-type="linenumber">191,195</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/create-run-dialog/create-run-dialog.component.html</context>
@@ -5911,7 +5918,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Preview</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">195,199</context>
+          <context context-type="linenumber">197,201</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-menu/run-menu.component.html</context>
@@ -6101,6 +6108,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">1,4</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/library/public-library/public-library.component.html</context>
+          <context context-type="linenumber">7,11</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/teacher-project-library/teacher-project-library.component.ts</context>
           <context context-type="linenumber">20</context>
         </context-group>
@@ -6212,6 +6223,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/personal-library/personal-library.component.ts</context>
           <context context-type="linenumber">31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7324430587474574661" datatype="html">
+        <source>No community designed units found.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/library/public-library/public-library.component.html</context>
+          <context context-type="linenumber">33,38</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6028472408314831177" datatype="html">
@@ -6380,13 +6398,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/teacher-project-library/teacher-project-library.component.html</context>
           <context context-type="linenumber">6,9</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7324430587474574661" datatype="html">
-        <source>No community designed units found.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/library/unit-library/unit-library.component.html</context>
-          <context context-type="linenumber">20,25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1556270137829928334" datatype="html">


### PR DESCRIPTION
## Changes
- Added a filter option for the existing metadata.grades field.

## Test
- Grade level filtering only appears in the teacher library and curriculum library, not on the home page.
- Grade level filtering options are unique and sorted numerically.