### PR TITLE
fix(AT): Clicking lesson/step title does not check checkbox

### DIFF
--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -14,9 +14,8 @@
         [disabled]="nodeTypeSelected() === 'step'"
         aria-label="Select lesson"
         i18n-aria-label
-      >
-        <node-icon-and-title [nodeId]="lesson.id" [showPosition]="showPosition" />
-      </mat-checkbox>
+      />
+      <node-icon-and-title [nodeId]="lesson.id" [showPosition]="showPosition" />
     </mat-panel-title>
     <mat-panel-description class="text" fxLayoutAlign="end center" fxLayoutGap="4px">
       <button

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
@@ -19,9 +19,10 @@
     [disabled]="nodeTypeSelected() === 'lesson'"
     aria-label="Select step"
     i18n-aria-label
-  >
+  />
+  <strong>
     <node-icon-and-title [nodeId]="step.id" [showPosition]="showPosition" />
-  </mat-checkbox>
+  </strong>
   <div fxLayoutAlign="start center" fxLayoutGap="8px">
     @if (isBranchPoint(step.id)) {
       <button

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9686,7 +9686,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">72,76</context>
+          <context context-type="linenumber">71,75</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2229114339431741749" datatype="html">
@@ -12640,28 +12640,28 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>Edit lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">27,31</context>
+          <context context-type="linenumber">26,30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6802950642532163491" datatype="html">
         <source>Move lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">37,41</context>
+          <context context-type="linenumber">36,40</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2385664129371928026" datatype="html">
         <source>Delete lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">47,51</context>
+          <context context-type="linenumber">46,50</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8466479820430643655" datatype="html">
         <source>This lesson has no steps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">67,71</context>
+          <context context-type="linenumber">66,70</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2751426191436053350" datatype="html">
@@ -12679,14 +12679,14 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">63,67</context>
+          <context context-type="linenumber">64,68</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5945303094335274412" datatype="html">
         <source>Select step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">20,23</context>
+          <context context-type="linenumber">20,24</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2586703779914969213" datatype="html">
@@ -12695,7 +12695,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">30,33</context>
+          <context context-type="linenumber">31,34</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1566882762026396179" datatype="html">
@@ -12704,35 +12704,35 @@ The branches will be removed but the steps will remain in the unit.</source>
       }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">43,46</context>
+          <context context-type="linenumber">44,47</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2277347790216751711" datatype="html">
         <source>Has rubric/teaching tips</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">54,57</context>
+          <context context-type="linenumber">55,58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="643328772010674978" datatype="html">
         <source>Move step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">73,77</context>
+          <context context-type="linenumber">74,78</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4169620043010477030" datatype="html">
         <source>Copy step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">83,87</context>
+          <context context-type="linenumber">84,88</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7892527662707586368" datatype="html">
         <source>Delete step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">93,97</context>
+          <context context-type="linenumber">94,98</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8656136323789683230" datatype="html">


### PR DESCRIPTION
## Changes
- For lessons, clicking the title expands/collapses the lesson instead of checking the checkbox.
- For steps, clicking the title opens the step editor instead of checking the checkbox.

## Test
- Clicking the titles no longer checks the checkbox, and instead does its new expected behavior.

Closes #2127 
