### PR TITLE
fix(Grading Tool): Hide detectable ideas if missing rubric data

### DIFF
--- a/src/assets/wise5/components/common/cRater/CRaterRubric.ts
+++ b/src/assets/wise5/components/common/cRater/CRaterRubric.ts
@@ -12,6 +12,10 @@ export class CRaterRubric {
   getIdea(ideaId: string): CRaterIdea {
     return this.ideas.find((idea) => idea.name === ideaId);
   }
+
+  hasRubricData(): boolean {
+    return (this.description ?? '') !== '' || this.ideas.length > 0;
+  }
 }
 
 export function getUniqueIdeas(responses: any[], rubric: CRaterRubric): CRaterIdea[] {

--- a/src/assets/wise5/components/common/cRater/crater-rubric/crater-rubric.component.html
+++ b/src/assets/wise5/components/common/cRater/crater-rubric/crater-rubric.component.html
@@ -9,20 +9,22 @@
   @if (cRaterRubric.description && cRaterRubric.description !== '') {
     <p>{{ cRaterRubric.description }}</p>
   }
-  <table class="text-sm">
-    <thead>
-      <tr>
-        <th i18n>ID</th>
-        <th i18n>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      @for (idea of ideas; track idea.name) {
+  @if (cRaterRubric.ideas.length > 0) {
+    <table class="text-sm">
+      <thead>
         <tr>
-          <td>{{ idea.name }}</td>
-          <td>{{ idea.text }}</td>
+          <th i18n>ID</th>
+          <th i18n>Description</th>
         </tr>
-      }
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        @for (idea of ideas; track idea.name) {
+          <tr>
+            <td>{{ idea.name }}</td>
+            <td>{{ idea.text }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  }
 </mat-dialog-content>

--- a/src/assets/wise5/components/common/cRater/crater-rubric/crater-rubric.component.spec.ts
+++ b/src/assets/wise5/components/common/cRater/crater-rubric/crater-rubric.component.spec.ts
@@ -21,10 +21,6 @@ describe('LibraryProjectDetailsComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-
   it('should close dialog when X is clicked', () => {
     closeDialogSpy = spyOn(component['dialogRef'], 'close');
     fixture.nativeElement.querySelector('button').click();

--- a/src/assets/wise5/components/common/cRater/crater-rubric/crater-rubric.component.ts
+++ b/src/assets/wise5/components/common/cRater/crater-rubric/crater-rubric.component.ts
@@ -29,6 +29,7 @@ export class CRaterRubricComponent {
     this.ideas = this.ideasSortingService
       .sortById(this.cRaterRubric.ideas.map(cRaterIdeaToIdeaData))
       .map(ideaDataToCRaterIdea);
+    this.rubricEventService.rubricToggled();
   }
 
   ngOnDestroy(): void {

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-show-work/dialog-guidance-show-work.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-show-work/dialog-guidance-show-work.component.spec.ts
@@ -24,7 +24,7 @@ describe('DialogGuidanceShowWorkComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(DialogGuidanceShowWorkComponent);
     component = fixture.componentInstance;
-    spyOn(TestBed.inject(CRaterService), 'getCRaterRubric').and.returnValue({} as CRaterRubric);
+    spyOn(TestBed.inject(CRaterService), 'getCRaterRubric').and.returnValue(new CRaterRubric());
     component.componentState = {
       studentData: {}
     };

--- a/src/assets/wise5/components/dialogGuidance/dialog-responses/dialog-responses.component.html
+++ b/src/assets/wise5/components/dialogGuidance/dialog-responses/dialog-responses.component.html
@@ -1,4 +1,4 @@
-@if (showDetectedIdeas) {
+@if (showDetectedIdeas && hasRubricData) {
   <div class="flex items-center justify-end">
     <mat-icon class="mat-18" color="primary">auto_awesome</mat-icon>&nbsp;<a
       tabindex="0"

--- a/src/assets/wise5/components/dialogGuidance/dialog-responses/dialog-responses.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-responses/dialog-responses.component.ts
@@ -37,7 +37,7 @@ export class DialogResponsesComponent {
   ) {}
 
   ngOnInit(): void {
-    this.hasRubricData = this.cRaterRubric.hasRubricData();
+    this.hasRubricData = this.cRaterRubric?.hasRubricData() ?? false;
   }
 
   ngOnDestroy(): void {

--- a/src/assets/wise5/components/dialogGuidance/dialog-responses/dialog-responses.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-responses/dialog-responses.component.ts
@@ -6,7 +6,7 @@ import { CRaterRubricComponent } from '../../common/cRater/crater-rubric/crater-
 import { DetectedIdeasComponent } from '../detected-ideas/detected-ideas.component';
 import { DialogResponse } from '../DialogResponse';
 import { DialogResponseComponent } from '../dialog-response/dialog-response.component';
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { RubricEventService } from '../../common/cRater/crater-rubric/RubricEventService';
 
@@ -25,8 +25,10 @@ import { RubricEventService } from '../../common/cRater/crater-rubric/RubricEven
 export class DialogResponsesComponent {
   @Input() computerAvatar: ComputerAvatar;
   @Input() cRaterRubric: CRaterRubric;
+  protected hasRubricData: boolean;
   @Input() isWaitingForComputerResponse: boolean;
   @Input() responses: DialogResponse[] = [];
+  private rubricDialog: MatDialogRef<CRaterRubricComponent>;
   @Input() showDetectedIdeas: boolean = false;
 
   constructor(
@@ -34,16 +36,25 @@ export class DialogResponsesComponent {
     protected rubricEventService: RubricEventService
   ) {}
 
+  ngOnInit(): void {
+    this.hasRubricData = this.cRaterRubric.hasRubricData();
+  }
+
+  ngOnDestroy(): void {
+    if (this.rubricEventService.getIsRubricOpen()) {
+      this.rubricDialog.close();
+    }
+  }
+
   protected openIdeasRubric(): void {
     if (!this.rubricEventService.getIsRubricOpen()) {
-      this.dialog.open(CRaterRubricComponent, {
+      this.rubricDialog = this.dialog.open(CRaterRubricComponent, {
         panelClass: 'dialog-sm',
         position: { right: '0', bottom: '0' },
         hasBackdrop: false,
         data: this.cRaterRubric,
         autoFocus: false
       });
-      this.rubricEventService.rubricToggled();
     }
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -2172,7 +2172,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/crater-rubric/crater-rubric.component.html</context>
-          <context context-type="linenumber">16,20</context>
+          <context context-type="linenumber">17,21</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
@@ -16627,7 +16627,7 @@ Are you ready to receive feedback on this answer?</source>
         <source>ID</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/crater-rubric/crater-rubric.component.html</context>
-          <context context-type="linenumber">16,19</context>
+          <context context-type="linenumber">17,20</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1859914769947265531" datatype="html">


### PR DESCRIPTION
## Changes
- Hide the link to the idea detection rubric if there is no model description and no idea descriptions.
- Hide the table in the idea detection rubric if there are no idea descriptions.
- Close the dialog if you leave the step.

## Test
- The three changes above work as described.

Closes #2166
