### PR TITLE
feat(AIChat): Connect to Open Response

### DIFF
--- a/src/assets/wise5/components/aiChat/AiChatMessage.ts
+++ b/src/assets/wise5/components/aiChat/AiChatMessage.ts
@@ -1,9 +1,11 @@
 export class AiChatMessage {
   content: string;
+  hidden: boolean;
   role: 'assistant' | 'system' | 'user';
 
-  constructor(role: 'assistant' | 'system' | 'user', content: string) {
+  constructor(role: 'assistant' | 'system' | 'user', content: string, hidden: boolean = false) {
     this.content = content;
     this.role = role;
+    this.hidden = hidden;
   }
 }

--- a/src/assets/wise5/components/aiChat/ai-chat-bot-message/ai-chat-bot-message.component.spec.ts
+++ b/src/assets/wise5/components/aiChat/ai-chat-bot-message/ai-chat-bot-message.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AiChatBotMessageComponent } from './ai-chat-bot-message.component';
 import { MatIconModule } from '@angular/material/icon';
 import { ComputerAvatarService } from '../../../services/computerAvatarService';
+import { AiChatMessage } from '../AiChatMessage';
 
 describe('AiChatBotMessageComponent', () => {
   let component: AiChatBotMessageComponent;
@@ -15,7 +16,7 @@ describe('AiChatBotMessageComponent', () => {
     });
     fixture = TestBed.createComponent(AiChatBotMessageComponent);
     component = fixture.componentInstance;
-    component.message = { content: 'Hello', role: 'assistant' };
+    component.message = new AiChatMessage('assistant', 'Hello');
     component.computerAvatar = {
       id: 'robot1',
       name: 'Robot',

--- a/src/assets/wise5/components/aiChat/ai-chat-messages/ai-chat-messages.component.html
+++ b/src/assets/wise5/components/aiChat/ai-chat-messages/ai-chat-messages.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngFor="let message of messages">
   <ai-chat-student-message
-    *ngIf="message.role === 'user'"
+    *ngIf="message.role === 'user' && !message.hidden"
     class="ai-chat-message"
     [message]="message"
     [workgroupId]="workgroupId"

--- a/src/assets/wise5/components/aiChat/ai-chat-student-message/ai-chat-student-message.component.spec.ts
+++ b/src/assets/wise5/components/aiChat/ai-chat-student-message/ai-chat-student-message.component.spec.ts
@@ -3,6 +3,7 @@ import { AiChatStudentMessageComponent } from './ai-chat-student-message.compone
 import { ConfigService } from '../../../services/configService';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { AiChatMessage } from '../AiChatMessage';
 
 describe('AiChatStudentMessageComponent', () => {
   let component: AiChatStudentMessageComponent;
@@ -10,13 +11,16 @@ describe('AiChatStudentMessageComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-    declarations: [AiChatStudentMessageComponent],
-    imports: [],
-    providers: [ConfigService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-});
+      declarations: [AiChatStudentMessageComponent],
+      providers: [
+        ConfigService,
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting()
+      ]
+    });
     fixture = TestBed.createComponent(AiChatStudentMessageComponent);
     component = fixture.componentInstance;
-    component.message = { content: 'Hello', role: 'user' };
+    component.message = new AiChatMessage('user', 'Hello');
     fixture.detectChanges();
   });
 

--- a/src/assets/wise5/components/aiChat/ai-chat-student/ai-chat-student.component.spec.ts
+++ b/src/assets/wise5/components/aiChat/ai-chat-student/ai-chat-student.component.spec.ts
@@ -49,17 +49,18 @@ describe('AiChatStudentComponent', () => {
     fixture = TestBed.createComponent(AiChatStudentComponent);
     component = fixture.componentInstance;
     component.component = new AiChatComponent({ id: 'component1', type: 'aiChat' }, 'node1');
+    component.componentState = { studentData: { messages: [{ role: 'user' }] } };
     spyOn(component, 'isNotebookEnabled').and.returnValue(false);
     spyOn(TestBed.inject(ProjectService), 'getThemeSettings').and.returnValue({});
     fixture.detectChanges();
   });
 
   it('should not show response from a connected component', async () => {
+    const studentMessages = fixture.debugElement.queryAll(By.css('ai-chat-student-message'));
+    expect(studentMessages.length).toBe(1);
     component.processConnectedComponentState({ studentData: { response: 'test response' } });
     const loader = TestbedHarnessEnvironment.loader(fixture);
     await (await loader.getHarness(MatButtonHarness)).click();
-    const messages = fixture.debugElement.queryAll(By.css('a-chat-student-message'));
-    expect(messages.length).toBe(0);
-    expect(component).toBeTruthy();
+    expect(studentMessages.length).toBe(1); // no new message should be added
   });
 });

--- a/src/assets/wise5/components/aiChat/ai-chat-student/ai-chat-student.component.spec.ts
+++ b/src/assets/wise5/components/aiChat/ai-chat-student/ai-chat-student.component.spec.ts
@@ -16,6 +16,9 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { ChatInputComponent } from '../../../common/chat-input/chat-input.component';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { By } from '@angular/platform-browser';
 
 describe('AiChatStudentComponent', () => {
   let component: AiChatStudentComponent;
@@ -23,8 +26,9 @@ describe('AiChatStudentComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-    declarations: [AiChatStudentComponent],
-    imports: [AiChatModule,
+      declarations: [AiChatStudentComponent],
+      imports: [
+        AiChatModule,
         BrowserAnimationsModule,
         ChatInputComponent,
         ComponentHeaderComponent,
@@ -34,9 +38,14 @@ describe('AiChatStudentComponent', () => {
         MatFormFieldModule,
         MatInputModule,
         MatSnackBarModule,
-        StudentTeacherCommonServicesModule],
-    providers: [AiChatService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-});
+        StudentTeacherCommonServicesModule
+      ],
+      providers: [
+        AiChatService,
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting()
+      ]
+    });
     fixture = TestBed.createComponent(AiChatStudentComponent);
     component = fixture.componentInstance;
     component.component = new AiChatComponent({ id: 'component1', type: 'aiChat' }, 'node1');
@@ -45,7 +54,12 @@ describe('AiChatStudentComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should not show response from a connected component', async () => {
+    component.processConnectedComponentState({ studentData: { response: 'test response' } });
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    await (await loader.getHarness(MatButtonHarness)).click();
+    const messages = fixture.debugElement.queryAll(By.css('a-chat-student-message'));
+    expect(messages.length).toBe(0);
     expect(component).toBeTruthy();
   });
 });

--- a/src/assets/wise5/components/aiChat/ai-chat-student/ai-chat-student.component.ts
+++ b/src/assets/wise5/components/aiChat/ai-chat-student/ai-chat-student.component.ts
@@ -19,15 +19,16 @@ import { ComputerAvatarService } from '../../../services/computerAvatarService';
 import { StudentStatusService } from '../../../services/studentStatusService';
 
 @Component({
-    selector: 'ai-chat-student',
-    templateUrl: './ai-chat-student.component.html',
-    styleUrls: ['./ai-chat-student.component.scss'],
-    standalone: false
+  selector: 'ai-chat-student',
+  templateUrl: './ai-chat-student.component.html',
+  styleUrls: ['./ai-chat-student.component.scss'],
+  standalone: false
 })
 export class AiChatStudentComponent extends ComponentStudent {
   component: AiChatComponent;
   protected computerAvatar: ComputerAvatar;
   protected computerAvatarSelectorVisible: boolean = false;
+  private connectedComponentResponse: string;
   protected messages: AiChatMessage[] = [];
   protected studentResponse: string = '';
   protected submitEnabled: boolean = false;
@@ -82,6 +83,10 @@ export class AiChatStudentComponent extends ComponentStudent {
 
   protected async submitStudentResponse(response: string): Promise<void> {
     this.waitingForComputerResponse = true;
+    if (this.connectedComponentResponse != null) {
+      this.messages.push(new AiChatMessage('user', this.connectedComponentResponse, true));
+      this.connectedComponentResponse = null;
+    }
     this.messages.push(new AiChatMessage('user', response));
     try {
       const response = await this.aiChatService.sendChatMessage(
@@ -117,6 +122,10 @@ export class AiChatStudentComponent extends ComponentStudent {
       );
     });
     return promise;
+  }
+
+  processConnectedComponentState(componentState: any): void {
+    this.connectedComponentResponse = componentState.studentData.response;
   }
 
   initializeComputerAvatar: () => void;

--- a/src/assets/wise5/components/aiChat/edit-ai-chat-advanced/edit-ai-chat-advanced.component.html
+++ b/src/assets/wise5/components/aiChat/edit-ai-chat-advanced/edit-ai-chat-advanced.component.html
@@ -4,4 +4,12 @@
     <mat-option *ngFor="let model of models" [value]="model">{{ model }}</mat-option>
   </mat-select>
 </mat-form-field>
+<edit-connected-components
+  [nodeId]="component.nodeId"
+  [componentId]="component.id"
+  [allowedConnectedComponentTypes]="allowedConnectedComponentTypes"
+  [componentContent]="component.content"
+  [connectedComponents]="component.content.connectedComponents"
+  (connectedComponentsChanged)="connectedComponentsChanged($event)"
+/>
 <edit-component-json [component]="component"></edit-component-json>

--- a/src/assets/wise5/components/aiChat/edit-ai-chat-advanced/edit-ai-chat-advanced.component.spec.ts
+++ b/src/assets/wise5/components/aiChat/edit-ai-chat-advanced/edit-ai-chat-advanced.component.spec.ts
@@ -15,13 +15,20 @@ describe('EditAiChatAdvancedComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-    declarations: [EditAiChatAdvancedComponent],
-    imports: [BrowserAnimationsModule,
+      declarations: [EditAiChatAdvancedComponent],
+      imports: [
+        BrowserAnimationsModule,
         ComponentAuthoringModule,
         MatDialogModule,
-        StudentTeacherCommonServicesModule],
-    providers: [TeacherNodeService, TeacherProjectService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-});
+        StudentTeacherCommonServicesModule
+      ],
+      providers: [
+        TeacherNodeService,
+        TeacherProjectService,
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting()
+      ]
+    });
     fixture = TestBed.createComponent(EditAiChatAdvancedComponent);
     component = fixture.componentInstance;
     component.nodeId = 'node1';

--- a/src/assets/wise5/components/aiChat/edit-ai-chat-advanced/edit-ai-chat-advanced.component.ts
+++ b/src/assets/wise5/components/aiChat/edit-ai-chat-advanced/edit-ai-chat-advanced.component.ts
@@ -3,11 +3,12 @@ import { EditAdvancedComponentComponent } from '../../../../../app/authoring-too
 import { AiChatContent } from '../AiChatContent';
 
 @Component({
-    selector: 'edit-ai-chat-advanced',
-    templateUrl: './edit-ai-chat-advanced.component.html',
-    standalone: false
+  selector: 'edit-ai-chat-advanced',
+  templateUrl: './edit-ai-chat-advanced.component.html',
+  standalone: false
 })
 export class EditAiChatAdvancedComponent extends EditAdvancedComponentComponent {
+  protected allowedConnectedComponentTypes = ['OpenResponse'];
   componentContent: AiChatContent;
   protected models: string[] = ['gpt-3.5-turbo', 'gpt-4'];
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15795,7 +15795,7 @@ Are you sure you want to proceed?</source>
         <source>An error occurred.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/aiChat/ai-chat-student/ai-chat-student.component.ts</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1141886420788473147" datatype="html">


### PR DESCRIPTION
## Changes
- Add a feature to the AIChat component that can see what the student types in the Open Response component and send it to the AI, but does not show it in the chat transcript that is displayed to the student.
- Add connected component authoring in the AIChat advanced editing view

## Test Prep
1. Make sure you have the OpenAI API key set in your properties file
2. Make sure that you're logged in to WISE (API key won't work unless you're logged in)
3. Import this unit: 
[680.zip](https://github.com/user-attachments/files/20093394/680.zip)
4. Set up a run with the unit and associate a student with it

## Test
1. Log in as a student and work on the run. You should expect the AI to be able to read what you type in the OR component as you chat with it in the AIChat component.
2. Log in as a teacher and make sure that you can see the work in the Teacher Tools
   - try exporting data and make sure that the data is present in the export 
3. Try authoring your own step with this OR-AIChat connection and make sure that it behaves as you'd expect
   - to connect AIChat to OR, go to AIChat's advanced authoring and use the connected component authoring. Choose the "Import Work" option.

Closes #2168
