### PR TITLE
fix(OpenResponse): Show idea description authoring

### DIFF
--- a/src/app/teacher/component-authoring.module.ts
+++ b/src/app/teacher/component-authoring.module.ts
@@ -90,6 +90,7 @@ import { AiChatAuthoringComponent } from '../../assets/wise5/components/aiChat/a
 import { EditAiChatAdvancedComponent } from '../../assets/wise5/components/aiChat/edit-ai-chat-advanced/edit-ai-chat-advanced.component';
 import { RequiredErrorLabelComponent } from '../../assets/wise5/authoringTool/node/advanced/required-error-label/required-error-label.component';
 import { EditCRaterInfoComponent } from '../../assets/wise5/components/common/cRater/edit-crater-info/edit-crater-info.component';
+import { EditCRaterIdeaDescriptionsComponent } from '../../assets/wise5/components/common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component';
 
 @NgModule({
   declarations: [
@@ -173,6 +174,7 @@ import { EditCRaterInfoComponent } from '../../assets/wise5/components/common/cR
     EditComponentConstraintsComponent,
     EditComponentPrompt,
     EditComponentWidthComponent,
+    EditCRaterIdeaDescriptionsComponent,
     EditCRaterInfoComponent,
     MatchAuthoringComponent,
     MultipleChoiceAuthoring,
@@ -221,6 +223,7 @@ import { EditCRaterInfoComponent } from '../../assets/wise5/components/common/cR
     EditConnectedComponentsWithBackgroundComponent,
     EditConnectedComponentDeleteButtonComponent,
     EditConnectedComponentTypeSelectComponent,
+    EditCRaterIdeaDescriptionsComponent,
     EditCRaterInfoComponent,
     EditDialogGuidanceAdvancedComponent,
     EditDiscussionAdvancedComponent,


### PR DESCRIPTION
## Description
- I noticed that even when you click "Show idea descriptions" in the Open Response advanced settings, nothing is showing up anymore.

## Changes
- Import/Export EditCRaterIdeaDescriptionsComponent in ComponentAuthoringModule.

## Test
- Make sure you can see idea description authoring component in OR advanced settings.
