### PR TITLE
feat(ContactForm): Share units for community library

### DIFF
--- a/src/app/contact/contact-form/contact-form.component.html
+++ b/src/app/contact/contact-form/contact-form.component.html
@@ -82,11 +82,17 @@
               </mat-form-field>
             </p>
           }
-          @if (!isShareIssueType()) {
+          @if (!isShare) {
             <p>
               <mat-form-field appearance="fill" class="w-full">
                 <mat-label i18n>Summary</mat-label>
-                <input matInput id="summary" name="summary" formControlName="summary" />
+                <input
+                  matInput
+                  id="summary"
+                  name="summary"
+                  formControlName="summary"
+                  value="test"
+                />
                 @if (contactFormGroup.controls['summary'].hasError('required')) {
                   <mat-error i18n>Summary required</mat-error>
                 }

--- a/src/app/contact/contact-form/contact-form.component.html
+++ b/src/app/contact/contact-form/contact-form.component.html
@@ -82,15 +82,17 @@
               </mat-form-field>
             </p>
           }
-          <p>
-            <mat-form-field appearance="fill" class="w-full">
-              <mat-label i18n>Summary</mat-label>
-              <input matInput id="summary" name="summary" formControlName="summary" />
-              @if (contactFormGroup.controls['summary'].hasError('required')) {
-                <mat-error i18n>Summary required</mat-error>
-              }
-            </mat-form-field>
-          </p>
+          @if (!isShareIssueType()) {
+            <p>
+              <mat-form-field appearance="fill" class="w-full">
+                <mat-label i18n>Summary</mat-label>
+                <input matInput id="summary" name="summary" formControlName="summary" />
+                @if (contactFormGroup.controls['summary'].hasError('required')) {
+                  <mat-error i18n>Summary required</mat-error>
+                }
+              </mat-form-field>
+            </p>
+          }
           <p>
             <mat-form-field appearance="fill" class="w-full">
               <mat-label i18n>Description</mat-label>
@@ -101,6 +103,11 @@
                 formControlName="description"
                 rows="10"
                 cols="10"
+                [placeholder]="
+                  isShareIssueType()
+                    ? 'Why do you want to share this unit with the WISE community?'
+                    : ''
+                "
               >
               </textarea>
               @if (contactFormGroup.controls['description'].hasError('required')) {
@@ -139,7 +146,7 @@
               @if (isSendingRequest) {
                 <mat-progress-bar mode="indeterminate"></mat-progress-bar>
               }
-              <ng-container i18n>Submit</ng-container>
+              <ng-container i18n>Submit{{ isShareIssueType() ? ' for Review' : '' }}</ng-container>
             </button>
           </p>
         </form>

--- a/src/app/contact/contact-form/contact-form.component.html
+++ b/src/app/contact/contact-form/contact-form.component.html
@@ -6,136 +6,144 @@
   </div>
   <mat-card appearance="outlined" class="standalone__content mat-elevation-z4">
     <mat-card-content>
-      <div *ngIf="complete" class="center">
-        <p class="mat-subtitle-2" i18n>Thank you for contacting WISE!</p>
-        <p i18n>Your message has been sent. We will get back to you as soon as possible.</p>
-        <br />
-        <div>
-          <a mat-flat-button color="accent" routerLink="/" i18n>Return to WISE Home</a>
+      @if (complete) {
+        <div class="center">
+          <p class="mat-subtitle-2" i18n>Thank you for contacting WISE!</p>
+          <p i18n>Your message has been sent. We will get back to you as soon as possible.</p>
+          <br />
+          <div>
+            <a mat-flat-button color="accent" routerLink="/" i18n>Return to WISE Home</a>
+          </div>
         </div>
-      </div>
-      <form
-        *ngIf="!complete"
-        role="form"
-        (submit)="submit()"
-        [formGroup]="contactFormGroup"
-        class="flex flex-col"
-      >
-        <h2 class="accent center" i18n>Contact WISE</h2>
-        <p>
-          <mat-form-field appearance="fill" class="w-full">
-            <mat-label i18n>Name</mat-label>
-            <input matInput id="name" name="name" formControlName="name" />
-            <mat-error *ngIf="contactFormGroup.controls['name'].hasError('required')" i18n
-              >Name required</mat-error
-            >
-          </mat-form-field>
-        </p>
-        <p *ngIf="!isStudent">
-          <mat-form-field appearance="fill" class="w-full">
-            <mat-label i18n>Email</mat-label>
-            <input matInput id="email" name="email" formControlName="email" />
-            <mat-error *ngIf="contactFormGroup.controls['email'].hasError('required')" i18n
-              >Email required</mat-error
-            >
-            <mat-error *ngIf="contactFormGroup.controls['email'].hasError('email')" i18n
-              >Invalid Email</mat-error
-            >
-          </mat-form-field>
-        </p>
-        <p *ngIf="isStudent && teachers.length > 0">
-          <mat-form-field appearance="fill" class="w-full">
-            <mat-label i18n>Teacher</mat-label>
-            <mat-select formControlName="teacher">
-              <mat-option *ngFor="let teacher of teachers" [value]="teacher.username">
-                {{ teacher.displayName }}
-              </mat-option>
-            </mat-select>
-            <mat-error *ngIf="contactFormGroup.controls['teacher'].hasError('required')" i18n
-              >Teacher required</mat-error
-            >
-          </mat-form-field>
-        </p>
-        <p>
-          <mat-form-field appearance="fill" class="w-full">
-            <mat-label i18n>Issue Type</mat-label>
-            <mat-select formControlName="issueType">
-              <mat-option *ngFor="let issueType of issueTypes" [value]="issueType.key">
-                {{ issueType.value }}
-              </mat-option>
-            </mat-select>
-            <mat-error *ngIf="contactFormGroup.controls['issueType'].hasError('required')" i18n
-              >Issue Type required</mat-error
-            >
-          </mat-form-field>
-        </p>
-        <p *ngIf="projectName">
-          <mat-form-field appearance="fill" class="w-full">
-            <mat-label i18n>Project Name</mat-label>
-            <input matInput name="projectName" [value]="projectName" disabled />
-          </mat-form-field>
-        </p>
-        <p>
-          <mat-form-field appearance="fill" class="w-full">
-            <mat-label i18n>Summary</mat-label>
-            <input matInput id="summary" name="summary" formControlName="summary" />
-            <mat-error *ngIf="contactFormGroup.controls['summary'].hasError('required')" i18n
-              >Summary required</mat-error
-            >
-          </mat-form-field>
-        </p>
-        <p>
-          <mat-form-field appearance="fill" class="w-full">
-            <mat-label i18n>Description</mat-label>
-            <textarea
-              matInput
-              id="description"
-              name="description"
-              formControlName="description"
-              rows="10"
-              cols="10"
-            >
-            </textarea>
-            <mat-error *ngIf="contactFormGroup.controls['description'].hasError('required')" i18n
-              >Description required</mat-error
-            >
-          </mat-form-field>
-        </p>
-        <p *ngIf="isRecaptchaEnabled" i18n>
-          This site is protected by reCAPTCHA and the Google
-          <a href="https://policies.google.com/privacy">Privacy Policy</a> and
-          <a href="https://policies.google.com/terms">Terms of Service</a> apply.
-        </p>
-        <ng-container *ngIf="!isError; else error">
-          <div>&nbsp;</div>
-        </ng-container>
-        <ng-template #error>
-          <p
-            *ngIf="isRecaptchaEnabled && isRecaptchaError; else genericError"
-            class="center warn"
-            i18n
-          >
-            Recaptcha failed. Please reload the page and try again!
+      } @else {
+        <form role="form" (submit)="submit()" [formGroup]="contactFormGroup" class="flex flex-col">
+          <h2 class="accent center" i18n>Contact WISE</h2>
+          <p>
+            <mat-form-field appearance="fill" class="w-full">
+              <mat-label i18n>Name</mat-label>
+              <input matInput id="name" name="name" formControlName="name" />
+              @if (contactFormGroup.controls['name'].hasError('required')) {
+                <mat-error i18n>Name required</mat-error>
+              }
+            </mat-form-field>
           </p>
-        </ng-template>
-        <ng-template #genericError>
-          <p class="center warn" i18n>
-            Sorry, there was a problem submitting the form. Please try again.
+          @if (!isStudent) {
+            <p>
+              <mat-form-field appearance="fill" class="w-full">
+                <mat-label i18n>Email</mat-label>
+                <input matInput id="email" name="email" formControlName="email" />
+                @if (contactFormGroup.controls['email'].hasError('required')) {
+                  <mat-error i18n>Email required</mat-error>
+                }
+                @if (contactFormGroup.controls['email'].hasError('email')) {
+                  <mat-error i18n>Invalid Email</mat-error>
+                }
+              </mat-form-field>
+            </p>
+          } @else {
+            @if (teachers.length > 0) {
+              <p>
+                <mat-form-field appearance="fill" class="w-full">
+                  <mat-label i18n>Teacher</mat-label>
+                  <mat-select formControlName="teacher">
+                    @for (teacher of teachers; track teacher.username) {
+                      <mat-option [value]="teacher.username">
+                        {{ teacher.displayName }}
+                      </mat-option>
+                    }
+                  </mat-select>
+                  @if (contactFormGroup.controls['teacher'].hasError('required')) {
+                    <mat-error i18n>Teacher required</mat-error>
+                  }
+                </mat-form-field>
+              </p>
+            }
+          }
+          <p>
+            <mat-form-field appearance="fill" class="w-full">
+              <mat-label i18n>Issue Type</mat-label>
+              <mat-select formControlName="issueType">
+                @for (issueType of issueTypes; track issueType.key) {
+                  <mat-option [value]="issueType.key">
+                    {{ issueType.value }}
+                  </mat-option>
+                }
+              </mat-select>
+              @if (contactFormGroup.controls['issueType'].hasError('required')) {
+                <mat-error i18n>Issue Type required</mat-error>
+              }
+            </mat-form-field>
           </p>
-        </ng-template>
-        <p>
-          <button
-            mat-flat-button
-            color="primary"
-            type="submit"
-            [disabled]="!contactFormGroup.valid || isSendingRequest"
-            class="button--progress w-full"
-          >
-            <mat-progress-bar *ngIf="isSendingRequest" mode="indeterminate"></mat-progress-bar>
-            <ng-container i18n>Submit</ng-container>
-          </button>
-        </p>
-      </form>
+          @if (projectName) {
+            <p>
+              <mat-form-field appearance="fill" class="w-full">
+                <mat-label i18n>Project Name</mat-label>
+                <input matInput name="projectName" [value]="projectName" disabled />
+              </mat-form-field>
+            </p>
+          }
+          <p>
+            <mat-form-field appearance="fill" class="w-full">
+              <mat-label i18n>Summary</mat-label>
+              <input matInput id="summary" name="summary" formControlName="summary" />
+              @if (contactFormGroup.controls['summary'].hasError('required')) {
+                <mat-error i18n>Summary required</mat-error>
+              }
+            </mat-form-field>
+          </p>
+          <p>
+            <mat-form-field appearance="fill" class="w-full">
+              <mat-label i18n>Description</mat-label>
+              <textarea
+                matInput
+                id="description"
+                name="description"
+                formControlName="description"
+                rows="10"
+                cols="10"
+              >
+              </textarea>
+              @if (contactFormGroup.controls['description'].hasError('required')) {
+                <mat-error i18n>Description required</mat-error>
+              }
+            </mat-form-field>
+          </p>
+          @if (isRecaptchaEnabled) {
+            <p i18n>
+              This site is protected by reCAPTCHA and the Google
+              <a href="https://policies.google.com/privacy">Privacy Policy</a> and
+              <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+            </p>
+          }
+          @if (!isError) {
+            <div>&nbsp;</div>
+          } @else {
+            @if (isRecaptchaEnabled && isRecaptchaError) {
+              <p class="center warn" i18n>
+                Recaptcha failed. Please reload the page and try again!
+              </p>
+            } @else {
+              <p class="center warn" i18n>
+                Sorry, there was a problem submitting the form. Please try again.
+              </p>
+            }
+          }
+          <p>
+            <button
+              mat-flat-button
+              color="primary"
+              type="submit"
+              [disabled]="!contactFormGroup.valid || isSendingRequest"
+              class="button--progress w-full"
+            >
+              @if (isSendingRequest) {
+                <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+              }
+              <ng-container i18n>Submit</ng-container>
+            </button>
+          </p>
+        </form>
+      }
     </mat-card-content>
   </mat-card>
 </div>

--- a/src/app/contact/contact-form/contact-form.component.html
+++ b/src/app/contact/contact-form/contact-form.component.html
@@ -120,9 +120,7 @@
               <a href="https://policies.google.com/terms">Terms of Service</a> apply.
             </p>
           }
-          @if (!isError) {
-            <div>&nbsp;</div>
-          } @else {
+          @if (isError) {
             @if (isRecaptchaEnabled && isRecaptchaError) {
               <p class="center warn" i18n>
                 Recaptcha failed. Please reload the page and try again!
@@ -134,12 +132,13 @@
             }
           }
           @if (isPublishIssueType()) {
-            <p>
-              By submitting, you will be sending your unit to WISE to be reviewed. If approved, your
-              unit will be added to the Community Built library. Make sure you have finished filling
-              out all appropriate fields on your project's Unit Info page before submitting it for
-              review.
+            <p class="center mat-caption" i18n>
+              By submitting, you will be sending your unit to be reviewed. If approved, it will be
+              added to the Community Built library. Make sure you have filled out all appropriate
+              fields in the Unit Info page in the authoring tool. We will be in touch if we require
+              any more information.
             </p>
+            <p class="center mat-caption" i18n>Thank you!</p>
           }
           <p>
             <button

--- a/src/app/contact/contact-form/contact-form.component.html
+++ b/src/app/contact/contact-form/contact-form.component.html
@@ -82,23 +82,15 @@
               </mat-form-field>
             </p>
           }
-          @if (!isShare) {
-            <p>
-              <mat-form-field appearance="fill" class="w-full">
-                <mat-label i18n>Summary</mat-label>
-                <input
-                  matInput
-                  id="summary"
-                  name="summary"
-                  formControlName="summary"
-                  value="test"
-                />
-                @if (contactFormGroup.controls['summary'].hasError('required')) {
-                  <mat-error i18n>Summary required</mat-error>
-                }
-              </mat-form-field>
-            </p>
-          }
+          <p>
+            <mat-form-field appearance="fill" class="w-full">
+              <mat-label i18n>Summary</mat-label>
+              <input matInput id="summary" name="summary" formControlName="summary" value="test" />
+              @if (contactFormGroup.controls['summary'].hasError('required')) {
+                <mat-error i18n>Summary required</mat-error>
+              }
+            </mat-form-field>
+          </p>
           <p>
             <mat-form-field appearance="fill" class="w-full">
               <mat-label i18n>Description</mat-label>
@@ -110,7 +102,7 @@
                 rows="10"
                 cols="10"
                 [placeholder]="
-                  isShareIssueType()
+                  isPublishIssueType()
                     ? 'Why do you want to share this unit with the WISE community?'
                     : ''
                 "
@@ -141,6 +133,14 @@
               </p>
             }
           }
+          @if (isPublishIssueType()) {
+            <p>
+              By submitting, you will be sending your unit to WISE to be reviewed. If approved, your
+              unit will be added to the Community Built library. Make sure you have finished filling
+              out all appropriate fields on your project's Unit Info page before submitting it for
+              review.
+            </p>
+          }
           <p>
             <button
               mat-flat-button
@@ -152,7 +152,11 @@
               @if (isSendingRequest) {
                 <mat-progress-bar mode="indeterminate"></mat-progress-bar>
               }
-              <ng-container i18n>Submit{{ isShareIssueType() ? ' for Review' : '' }}</ng-container>
+              @if (isPublishIssueType()) {
+                <ng-container i18n>Submit for Review</ng-container>
+              } @else {
+                <ng-container i18n>Submit</ng-container>
+              }
             </button>
           </p>
         </form>

--- a/src/app/contact/contact-form/contact-form.component.ts
+++ b/src/app/contact/contact-form/contact-form.component.ts
@@ -1,43 +1,43 @@
+import { ActivatedRoute } from '@angular/router';
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
-import { FormControl, FormGroup, Validators, FormBuilder } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
-import { finalize } from 'rxjs/operators';
-import { UserService } from '../../services/user.service';
-import { Teacher } from '../../domain/teacher';
-import { Student } from '../../domain/student';
 import { ConfigService } from '../../services/config.service';
-import { StudentService } from '../../student/student.service';
+import { finalize } from 'rxjs/operators';
+import { FormControl, FormGroup, Validators, FormBuilder } from '@angular/forms';
 import { LibraryService } from '../../services/library.service';
 import { ReCaptchaV3Service } from 'ng-recaptcha-2';
+import { Student } from '../../domain/student';
+import { StudentService } from '../../student/student.service';
 import { Subscription, lastValueFrom } from 'rxjs';
+import { Teacher } from '../../domain/teacher';
+import { UserService } from '../../services/user.service';
 
 @Component({
-  selector: 'app-contact-form',
-  templateUrl: './contact-form.component.html',
-  styleUrls: ['./contact-form.component.scss'],
   encapsulation: ViewEncapsulation.None,
-  standalone: false
+  selector: 'app-contact-form',
+  standalone: false,
+  styleUrls: ['./contact-form.component.scss'],
+  templateUrl: './contact-form.component.html'
 })
 export class ContactFormComponent implements OnInit {
-  issueTypes: object[] = [];
-  contactFormGroup: FormGroup = this.fb.group({
+  protected complete: boolean = false;
+  protected contactFormGroup: FormGroup = this.fb.group({
     name: new FormControl('', [Validators.required]),
     issueType: new FormControl('', [Validators.required]),
     summary: new FormControl('', [Validators.required]),
     description: new FormControl('', [Validators.required])
   });
-  runId: number;
-  projectId: number;
-  projectName: string;
-  isError: boolean = false;
+  protected isError: boolean = false;
+  protected isSendingRequest: boolean = false;
+  private isSignedIn: boolean = false;
+  protected isStudent: boolean = false;
+  protected issueTypes: object[] = [];
   private isPublish: boolean = false;
-  isStudent: boolean = false;
-  isSignedIn: boolean = false;
-  isSendingRequest: boolean = false;
-  isRecaptchaEnabled: boolean = false;
-  isRecaptchaError: boolean = false;
-  teachers: any[] = [];
-  complete: boolean = false;
+  protected isRecaptchaEnabled: boolean = false;
+  protected isRecaptchaError: boolean = false;
+  private projectId: number;
+  protected projectName: string;
+  private runId: number;
+  protected teachers: any[] = [];
 
   constructor(
     private fb: FormBuilder,
@@ -46,11 +46,10 @@ export class ContactFormComponent implements OnInit {
     private studentService: StudentService,
     private libraryService: LibraryService,
     private recaptchaV3Service: ReCaptchaV3Service,
-    private route: ActivatedRoute,
-    private router: Router
+    private route: ActivatedRoute
   ) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.isSignedIn = this.userService.isSignedIn();
     this.isStudent = this.userService.isStudent();
     this.obtainRunIdOrProjectIdIfNecessary();
@@ -64,7 +63,7 @@ export class ContactFormComponent implements OnInit {
     this.setIssueTypeIfNecessary();
   }
 
-  obtainRunIdOrProjectIdIfNecessary() {
+  private obtainRunIdOrProjectIdIfNecessary(): void {
     this.route.queryParams.subscribe((params) => {
       this.runId = params['runId'];
       this.projectId = params['projectId'];
@@ -81,7 +80,7 @@ export class ContactFormComponent implements OnInit {
     });
   }
 
-  obtainTeacherListIfNecessary() {
+  private obtainTeacherListIfNecessary(): void {
     if (this.isStudent && this.runId == null && this.projectId == null) {
       this.studentService.getTeacherList().subscribe((teacherList) => {
         this.teachers = teacherList;
@@ -93,7 +92,7 @@ export class ContactFormComponent implements OnInit {
     }
   }
 
-  studentHasTeacher() {
+  private studentHasTeacher(): boolean {
     return this.teachers.length > 0;
   }
 
@@ -108,7 +107,7 @@ export class ContactFormComponent implements OnInit {
     }
   }
 
-  populateFieldsIfSignedIn() {
+  private populateFieldsIfSignedIn(): void {
     if (this.isSignedIn) {
       if (this.isStudent) {
         const user = <Student>this.userService.getUser().getValue();
@@ -124,7 +123,7 @@ export class ContactFormComponent implements OnInit {
     }
   }
 
-  populateIssueTypes() {
+  private populateIssueTypes(): void {
     if (this.isStudent) {
       this.issueTypes = [
         { key: 'TROUBLE_LOGGING_IN', value: $localize`Trouble Signing In` },
@@ -147,7 +146,7 @@ export class ContactFormComponent implements OnInit {
     }
   }
 
-  private setDefaultPublishSummary() {
+  private setDefaultPublishSummary(): void {
     this.contactFormGroup.get('issueType').valueChanges.subscribe(() => {
       if (this.getControlFieldValue('issueType') === 'PUBLISH') {
         const summaryControl = this.contactFormGroup.get('summary');
@@ -156,13 +155,7 @@ export class ContactFormComponent implements OnInit {
     });
   }
 
-  private setIsPublish() {
-    this.route.queryParams.subscribe((params) => {
-      this.isPublish = params['publish'];
-    });
-  }
-
-  setIssueTypeIfNecessary() {
+  private setIssueTypeIfNecessary(): void {
     if (this.runId != null) {
       this.setControlFieldValue('issueType', 'PROJECT_PROBLEMS');
     } else if (this.isPublish) {
@@ -170,30 +163,27 @@ export class ContactFormComponent implements OnInit {
     }
   }
 
+  private setIsPublish(): void {
+    this.route.queryParams.subscribe((params) => {
+      this.isPublish = params['publish'];
+    });
+  }
+
   async submit(): Promise<Subscription> {
     this.isError = false;
-    const name = this.getName();
-    const email = this.getEmail();
-    const teacherUsername = this.getTeacherUsername();
-    const issueType = this.getIssueType();
-    const summary = this.getSummary();
-    const description = this.getDescription();
-    const runId = this.getRunId();
-    const projectId = this.getProjectId();
-    const userAgent = this.getUserAgent();
     const recaptchaResponse = await this.getRecaptchaResponse();
     this.setIsSendingRequest(true);
     return this.userService
       .sendContactMessage(
-        name,
-        email,
-        teacherUsername,
-        issueType,
-        summary,
-        description,
-        runId,
-        projectId,
-        userAgent,
+        this.getControlFieldValue('name'),
+        this.getControlFieldValueOrNull('email', !this.isStudent),
+        this.getControlFieldValueOrNull('teacher', this.isStudent && this.studentHasTeacher()),
+        this.getControlFieldValue('issueType'),
+        this.getControlFieldValue('summary'),
+        this.getControlFieldValue('description'),
+        this.runId,
+        this.projectId,
+        this.getUserAgent(),
         recaptchaResponse
       )
       .pipe(
@@ -206,7 +196,7 @@ export class ContactFormComponent implements OnInit {
       });
   }
 
-  handleSendContactMessageResponse(response: any) {
+  private handleSendContactMessageResponse(response: any): void {
     if (response.status === 'success') {
       this.complete = true;
     } else if (response.status === 'error') {
@@ -218,64 +208,24 @@ export class ContactFormComponent implements OnInit {
     this.setIsSendingRequest(false);
   }
 
-  setControlFieldValue(name: string, value: string) {
+  setControlFieldValue(name: string, value: string): void {
     this.contactFormGroup.controls[name].setValue(value);
   }
 
-  markControlFieldAsDisabled(name: string) {
+  private markControlFieldAsDisabled(name: string): void {
     this.contactFormGroup.controls[name].disable();
   }
 
-  getControlFieldValue(fieldName) {
+  private getControlFieldValue(fieldName: string): any {
     return this.contactFormGroup.get(fieldName).value;
   }
 
-  getName() {
-    return this.getControlFieldValue('name');
+  private getControlFieldValueOrNull(fieldName: string, condition: boolean): any {
+    return condition ? this.getControlFieldValue(fieldName) : null;
   }
 
-  getEmail() {
-    let email = null;
-    if (!this.isStudent) {
-      email = this.getControlFieldValue('email');
-    }
-    return email;
-  }
-
-  getIssueType() {
-    return this.getControlFieldValue('issueType');
-  }
-
-  getSummary() {
-    return this.getControlFieldValue('summary');
-  }
-
-  getDescription() {
-    return this.getControlFieldValue('description');
-  }
-
-  getRunId() {
-    return this.runId;
-  }
-
-  getProjectId() {
-    return this.projectId;
-  }
-
-  getTeacherUsername() {
-    if (this.isStudent && this.studentHasTeacher()) {
-      return this.getControlFieldValue('teacher');
-    } else {
-      return null;
-    }
-  }
-
-  getUserAgent() {
+  private getUserAgent(): string {
     return navigator.userAgent;
-  }
-
-  routeToContactCompletePage() {
-    this.router.navigate(['contact/complete', {}]);
   }
 
   private async getRecaptchaResponse(): Promise<string> {
@@ -284,7 +234,7 @@ export class ContactFormComponent implements OnInit {
       : '';
   }
 
-  setIsSendingRequest(value: boolean) {
+  private setIsSendingRequest(value: boolean): void {
     this.isSendingRequest = value;
   }
 

--- a/src/app/contact/contact-form/contact-form.component.ts
+++ b/src/app/contact/contact-form/contact-form.component.ts
@@ -30,7 +30,7 @@ export class ContactFormComponent implements OnInit {
   projectId: number;
   projectName: string;
   isError: boolean = false;
-  isShare: boolean = false;
+  private isPublish: boolean = false;
   isStudent: boolean = false;
   isSignedIn: boolean = false;
   isSendingRequest: boolean = false;
@@ -59,8 +59,8 @@ export class ContactFormComponent implements OnInit {
     this.isRecaptchaEnabled = this.configService.isRecaptchaEnabled();
     this.populateFieldsIfSignedIn();
     this.populateIssueTypes();
-    this.adjustSummaryRequiredOnIssueTypeChange();
-    this.setIsShare();
+    this.setDefaultPublishSummary();
+    this.setIsPublish();
     this.setIssueTypeIfNecessary();
   }
 
@@ -140,38 +140,33 @@ export class ContactFormComponent implements OnInit {
         { key: 'PROJECT_PROBLEMS', value: $localize`Problems with a WISE Unit` },
         { key: 'STUDENT_MANAGEMENT', value: $localize`Student Management` },
         { key: 'AUTHORING', value: $localize`Need Help with Authoring` },
-        { key: 'SHARE', value: $localize`Share Unit` },
+        { key: 'PUBLISH', value: $localize`Publish Unit to the WISE Community` },
         { key: 'FEEDBACK', value: $localize`Feedback to WISE` },
         { key: 'OTHER', value: $localize`Other` }
       ];
     }
   }
 
-  private adjustSummaryRequiredOnIssueTypeChange() {
+  private setDefaultPublishSummary() {
     this.contactFormGroup.get('issueType').valueChanges.subscribe(() => {
-      const summaryControl = this.contactFormGroup.get('summary');
-      if (this.getControlFieldValue('issueType') === 'SHARE') {
-        summaryControl.clearValidators();
-        summaryControl.updateValueAndValidity();
-        this.isShare = true;
-      } else if (this.isShare) {
-        summaryControl.addValidators(Validators.required);
-        this.isShare = false;
+      if (this.getControlFieldValue('issueType') === 'PUBLISH') {
+        const summaryControl = this.contactFormGroup.get('summary');
+        summaryControl.setValue($localize`Publish my unit to the WISE Community Built library`);
       }
     });
   }
 
-  private setIsShare() {
+  private setIsPublish() {
     this.route.queryParams.subscribe((params) => {
-      this.isShare = params['share'];
+      this.isPublish = params['publish'];
     });
   }
 
   setIssueTypeIfNecessary() {
     if (this.runId != null) {
       this.setControlFieldValue('issueType', 'PROJECT_PROBLEMS');
-    } else if (this.isShare) {
-      this.setControlFieldValue('issueType', 'SHARE');
+    } else if (this.isPublish) {
+      this.setControlFieldValue('issueType', 'PUBLISH');
     }
   }
 
@@ -181,8 +176,7 @@ export class ContactFormComponent implements OnInit {
     const email = this.getEmail();
     const teacherUsername = this.getTeacherUsername();
     const issueType = this.getIssueType();
-    const summary =
-      this.getControlFieldValue('issueType') === 'SHARE' ? this.projectName : this.getSummary();
+    const summary = this.getSummary();
     const description = this.getDescription();
     const runId = this.getRunId();
     const projectId = this.getProjectId();
@@ -294,7 +288,7 @@ export class ContactFormComponent implements OnInit {
     this.isSendingRequest = value;
   }
 
-  protected isShareIssueType(): boolean {
-    return this.getControlFieldValue('issueType') === 'SHARE';
+  protected isPublishIssueType(): boolean {
+    return this.getControlFieldValue('issueType') === 'PUBLISH';
   }
 }

--- a/src/app/contact/contact-form/contact-form.component.ts
+++ b/src/app/contact/contact-form/contact-form.component.ts
@@ -181,7 +181,8 @@ export class ContactFormComponent implements OnInit {
     const email = this.getEmail();
     const teacherUsername = this.getTeacherUsername();
     const issueType = this.getIssueType();
-    const summary = this.getSummary();
+    const summary =
+      this.getControlFieldValue('issueType') === 'SHARE' ? this.projectName : this.getSummary();
     const description = this.getDescription();
     const runId = this.getRunId();
     const projectId = this.getProjectId();

--- a/src/app/contact/contact-form/contact-form.component.ts
+++ b/src/app/contact/contact-form/contact-form.component.ts
@@ -59,14 +59,9 @@ export class ContactFormComponent implements OnInit {
     this.isRecaptchaEnabled = this.configService.isRecaptchaEnabled();
     this.populateFieldsIfSignedIn();
     this.populateIssueTypes();
+    this.adjustSummaryRequiredOnIssueTypeChange();
     this.setIsShare();
     this.setIssueTypeIfNecessary();
-  }
-
-  private setIsShare() {
-    this.route.queryParams.subscribe((params) => {
-      this.isShare = params['share'];
-    });
   }
 
   obtainRunIdOrProjectIdIfNecessary() {
@@ -150,6 +145,26 @@ export class ContactFormComponent implements OnInit {
         { key: 'OTHER', value: $localize`Other` }
       ];
     }
+  }
+
+  private adjustSummaryRequiredOnIssueTypeChange() {
+    this.contactFormGroup.get('issueType').valueChanges.subscribe(() => {
+      const summaryControl = this.contactFormGroup.get('summary');
+      if (this.getControlFieldValue('issueType') === 'SHARE') {
+        summaryControl.clearValidators();
+        summaryControl.updateValueAndValidity();
+        this.isShare = true;
+      } else if (this.isShare) {
+        summaryControl.addValidators(Validators.required);
+        this.isShare = false;
+      }
+    });
+  }
+
+  private setIsShare() {
+    this.route.queryParams.subscribe((params) => {
+      this.isShare = params['share'];
+    });
   }
 
   setIssueTypeIfNecessary() {
@@ -279,6 +294,6 @@ export class ContactFormComponent implements OnInit {
   }
 
   protected isShareIssueType(): boolean {
-    return this.contactFormGroup.get('issueType').value === 'SHARE';
+    return this.getControlFieldValue('issueType') === 'SHARE';
   }
 }

--- a/src/app/contact/contact-form/contact-form.component.ts
+++ b/src/app/contact/contact-form/contact-form.component.ts
@@ -139,7 +139,7 @@ export class ContactFormComponent implements OnInit {
         { key: 'PROJECT_PROBLEMS', value: $localize`Problems with a WISE Unit` },
         { key: 'STUDENT_MANAGEMENT', value: $localize`Student Management` },
         { key: 'AUTHORING', value: $localize`Need Help with Authoring` },
-        { key: 'PUBLISH', value: $localize`Publish Unit to the WISE Community` },
+        { key: 'PUBLISH', value: $localize`Publish Unit` },
         { key: 'FEEDBACK', value: $localize`Feedback to WISE` },
         { key: 'OTHER', value: $localize`Other` }
       ];

--- a/src/app/contact/contact-form/contact-form.component.ts
+++ b/src/app/contact/contact-form/contact-form.component.ts
@@ -12,11 +12,11 @@ import { ReCaptchaV3Service } from 'ng-recaptcha-2';
 import { Subscription, lastValueFrom } from 'rxjs';
 
 @Component({
-    selector: 'app-contact-form',
-    templateUrl: './contact-form.component.html',
-    styleUrls: ['./contact-form.component.scss'],
-    encapsulation: ViewEncapsulation.None,
-    standalone: false
+  selector: 'app-contact-form',
+  templateUrl: './contact-form.component.html',
+  styleUrls: ['./contact-form.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+  standalone: false
 })
 export class ContactFormComponent implements OnInit {
   issueTypes: object[] = [];
@@ -30,6 +30,7 @@ export class ContactFormComponent implements OnInit {
   projectId: number;
   projectName: string;
   isError: boolean = false;
+  isShare: boolean = false;
   isStudent: boolean = false;
   isSignedIn: boolean = false;
   isSendingRequest: boolean = false;
@@ -58,7 +59,14 @@ export class ContactFormComponent implements OnInit {
     this.isRecaptchaEnabled = this.configService.isRecaptchaEnabled();
     this.populateFieldsIfSignedIn();
     this.populateIssueTypes();
+    this.setIsShare();
     this.setIssueTypeIfNecessary();
+  }
+
+  private setIsShare() {
+    this.route.queryParams.subscribe((params) => {
+      this.isShare = params['share'];
+    });
   }
 
   obtainRunIdOrProjectIdIfNecessary() {
@@ -137,6 +145,7 @@ export class ContactFormComponent implements OnInit {
         { key: 'PROJECT_PROBLEMS', value: $localize`Problems with a WISE Unit` },
         { key: 'STUDENT_MANAGEMENT', value: $localize`Student Management` },
         { key: 'AUTHORING', value: $localize`Need Help with Authoring` },
+        { key: 'SHARE', value: $localize`Share Unit` },
         { key: 'FEEDBACK', value: $localize`Feedback to WISE` },
         { key: 'OTHER', value: $localize`Other` }
       ];
@@ -146,6 +155,8 @@ export class ContactFormComponent implements OnInit {
   setIssueTypeIfNecessary() {
     if (this.runId != null) {
       this.setControlFieldValue('issueType', 'PROJECT_PROBLEMS');
+    } else if (this.isShare) {
+      this.setControlFieldValue('issueType', 'SHARE');
     }
   }
 
@@ -265,5 +276,9 @@ export class ContactFormComponent implements OnInit {
 
   setIsSendingRequest(value: boolean) {
     this.isSendingRequest = value;
+  }
+
+  protected isShareIssueType(): boolean {
+    return this.contactFormGroup.get('issueType').value === 'SHARE';
   }
 }

--- a/src/app/modules/library/library-project-details/library-project-details.component.html
+++ b/src/app/modules/library/library-project-details/library-project-details.component.html
@@ -198,7 +198,7 @@
   <button mat-button cdkFocusInitial (click)="close()" i18n>Close</button>
   @if (isMyUnit) {
     <a href="{{ shareUnitUrl }}">
-      <button mat-flat-button color="success">
+      <button mat-flat-button class="share-button">
         <mat-icon>upload</mat-icon>&nbsp;<ng-container i18n>Share with Community</ng-container>
       </button>
     </a>

--- a/src/app/modules/library/library-project-details/library-project-details.component.html
+++ b/src/app/modules/library/library-project-details/library-project-details.component.html
@@ -196,6 +196,13 @@
 </div>
 <div mat-dialog-actions class="flex flex-col sm:flex-row gap-2 sm:gap-4 !items-stretch" align="end">
   <button mat-button cdkFocusInitial (click)="close()" i18n>Close</button>
+  @if (isMyUnit) {
+    <a href="{{ shareUnitUrl }}">
+      <button mat-flat-button color="success">
+        <mat-icon>upload</mat-icon>&nbsp;<ng-container i18n>Share with Community</ng-container>
+      </button>
+    </a>
+  }
   @if (
     isTeacher &&
     !isRunProject &&

--- a/src/app/modules/library/library-project-details/library-project-details.component.html
+++ b/src/app/modules/library/library-project-details/library-project-details.component.html
@@ -53,7 +53,7 @@
     </div>
     <span class="flex-auto"></span>
     @if (isTeacher && project.wiseVersion !== 4) {
-      <app-library-project-menu [project]="project" [isRun]="isRunProject" />
+      <app-library-project-menu [project]="project" [isMyUnit]="isMyUnit" [isRun]="isRunProject" />
     }
   </div>
   <div class="info-block">
@@ -206,13 +206,6 @@
 </div>
 <div mat-dialog-actions class="flex flex-col sm:flex-row gap-2 sm:gap-4 !items-stretch" align="end">
   <button mat-button cdkFocusInitial (click)="close()" i18n>Close</button>
-  @if (isMyUnit) {
-    <a href="{{ shareUnitUrl }}">
-      <button mat-flat-button class="share-button">
-        <mat-icon>upload</mat-icon>&nbsp;<ng-container i18n>Share with Community</ng-container>
-      </button>
-    </a>
-  }
   @if (
     isTeacher &&
     !isRunProject &&

--- a/src/app/modules/library/library-project-details/library-project-details.component.scss
+++ b/src/app/modules/library/library-project-details/library-project-details.component.scss
@@ -58,15 +58,6 @@
   }
 }
 
-.share-button {
-  background-color: #099A09;
-  color: white;
-}
-
-.share-button > maticon {
-  color: white;
-}
-
 discourse-category-activity, unit-tags {
   margin-bottom: 12px;
   display: block;

--- a/src/app/modules/library/library-project-details/library-project-details.component.scss
+++ b/src/app/modules/library/library-project-details/library-project-details.component.scss
@@ -58,6 +58,15 @@
   }
 }
 
+.share-button {
+  background-color: #099A09;
+  color: white;
+}
+
+.share-button > maticon {
+  color: white;
+}
+
 discourse-category-activity, unit-tags {
   margin-bottom: 12px;
   display: block;

--- a/src/app/modules/library/library-project-details/library-project-details.component.scss
+++ b/src/app/modules/library/library-project-details/library-project-details.component.scss
@@ -58,6 +58,16 @@
   }
 }
 
+.share-button {
+  background-color: #099A09;
+  color: white;
+}
+
+.share-button > maticon {
+  // background-color: white;
+  color: white;
+}
+
 discourse-category-activity, unit-tags {
   margin-bottom: 12px;
   display: block;

--- a/src/app/modules/library/library-project-details/library-project-details.component.spec.ts
+++ b/src/app/modules/library/library-project-details/library-project-details.component.spec.ts
@@ -42,6 +42,7 @@ describe('LibraryProjectDetailsComponent', () => {
         { provide: MAT_DIALOG_DATA, useValue: { project: project } }
       ]
     });
+    spyOn(TestBed.inject(UserService), 'getUserId').and.returnValue(10);
 
     fixture = TestBed.createComponent(LibraryProjectDetailsComponent);
     component = fixture.componentInstance;

--- a/src/app/modules/library/library-project-details/library-project-details.component.ts
+++ b/src/app/modules/library/library-project-details/library-project-details.component.ts
@@ -39,6 +39,7 @@ export class LibraryProjectDetailsComponent implements OnInit {
   protected authorsString: string = '';
   protected canPreview: boolean;
   protected isCopy: boolean;
+  protected isMyUnit: boolean;
   protected isTeacher: boolean;
   protected isRunProject: false;
   protected licenseInfo = $localize`License pertains to original content created by the author(s). Authors are responsible for the usage and attribution of any third-party content linked to or included in this work.`;
@@ -46,6 +47,7 @@ export class LibraryProjectDetailsComponent implements OnInit {
   protected parentAuthorsString: string = '';
   protected parentProject: ParentProject;
   protected project: Project;
+  protected shareUnitUrl: string;
   protected standardLabels: any = {
     commonCore: $localize`Common Core`,
     learningForJustice: $localize`Learning For Justice`,
@@ -78,6 +80,8 @@ export class LibraryProjectDetailsComponent implements OnInit {
         this.project.metadata.unitType === 'Other' && this.project.metadata.resources.length === 0
       );
     }
+    this.isMyUnit = this.project.isOwner(this.userService.getUserId());
+    this.shareUnitUrl = `${this.configService.getContextPath()}/contact?projectId=${this.project.id}&share=true`;
   }
 
   private setLicenseInfo(): void {

--- a/src/app/modules/library/library-project-details/library-project-details.component.ts
+++ b/src/app/modules/library/library-project-details/library-project-details.component.ts
@@ -83,9 +83,8 @@ export class LibraryProjectDetailsComponent implements OnInit {
   }
 
   private userIsAuthor(): boolean {
-    return (
-      this.project.metadata.authors.find((author) => author.id === this.userService.getUserId()) !==
-      undefined
+    return this.project.metadata.authors.some(
+      (author) => author.id === this.userService.getUserId()
     );
   }
 

--- a/src/app/modules/library/library-project-details/library-project-details.component.ts
+++ b/src/app/modules/library/library-project-details/library-project-details.component.ts
@@ -80,8 +80,15 @@ export class LibraryProjectDetailsComponent implements OnInit {
         this.project.metadata.unitType === 'Other' && this.project.metadata.resources.length === 0
       );
     }
-    this.isMyUnit = this.project.isOwner(this.userService.getUserId());
+    this.isMyUnit = this.userIsAuthor();
     this.shareUnitUrl = `${this.configService.getContextPath()}/contact?projectId=${this.project.id}&share=true`;
+  }
+
+  private userIsAuthor(): boolean {
+    return (
+      this.project.metadata.authors.find((author) => author.id === this.userService.getUserId()) !==
+      undefined
+    );
   }
 
   private setLicenseInfo(): void {

--- a/src/app/modules/library/library-project-details/library-project-details.component.ts
+++ b/src/app/modules/library/library-project-details/library-project-details.component.ts
@@ -47,7 +47,6 @@ export class LibraryProjectDetailsComponent implements OnInit {
   protected parentAuthorsString: string = '';
   protected parentProject: ParentProject;
   protected project: Project;
-  protected shareUnitUrl: string;
   protected standardLabels: any = {
     commonCore: $localize`Common Core`,
     learningForJustice: $localize`Learning For Justice`,
@@ -81,7 +80,6 @@ export class LibraryProjectDetailsComponent implements OnInit {
       );
     }
     this.isMyUnit = this.userIsAuthor();
-    this.shareUnitUrl = `${this.configService.getContextPath()}/contact?projectId=${this.project.id}&share=true`;
   }
 
   private userIsAuthor(): boolean {

--- a/src/app/modules/library/library-project-menu/library-project-menu.component.html
+++ b/src/app/modules/library/library-project-menu/library-project-menu.component.html
@@ -20,6 +20,11 @@
         <mat-icon>share</mat-icon> <ng-container i18n>Share</ng-container>
       </a>
     }
+    @if (isMyUnit) {
+      <a mat-menu-item href="{{ publishUnitUrl }}">
+        <mat-icon>public</mat-icon> <ng-container i18n>Publish</ng-container>
+      </a>
+    }
     @if (archived) {
       <a mat-menu-item (click)="archive(false)">
         <mat-icon>unarchive</mat-icon>

--- a/src/app/modules/library/library-project-menu/library-project-menu.component.ts
+++ b/src/app/modules/library/library-project-menu/library-project-menu.component.ts
@@ -24,8 +24,10 @@ export class LibraryProjectMenuComponent {
   protected canEdit: boolean;
   protected canShare: boolean;
   protected isChild: boolean;
+  @Input() isMyUnit: boolean;
   @Input() isRun: boolean;
   @Input() project: Project;
+  protected publishUnitUrl: string;
 
   constructor(
     private archiveProjectService: ArchiveProjectService,
@@ -40,6 +42,7 @@ export class LibraryProjectMenuComponent {
     this.canShare = this.isOwner() && !this.isRun;
     this.isChild = this.project.isChild();
     this.archived = this.project.hasTagWithText('archived');
+    this.publishUnitUrl = `${this.configService.getContextPath()}/contact?projectId=${this.project.id}&publish=true`;
   }
 
   private isOwner(): boolean {

--- a/src/app/modules/library/public-unit-type-selector/community-library-details.html
+++ b/src/app/modules/library/public-unit-type-selector/community-library-details.html
@@ -3,8 +3,8 @@
   <div class="info-block">
     <p i18n>
       "Community Built" units are designed and contributed by WISE community members. Want to
-      publicly share your custom unit?
-      <a routerLink="/contact" target="_blank">Contact Us</a>!
+      publicly share your custom unit? Head to the Authoring Tool, select your unit, go to the Unit
+      Info page, and click Publish!
     </p>
     <p class="mat-caption" i18n>
       *Please note: While WISE staff have reviewed these units, we cannot specifically vouch for

--- a/src/app/modules/library/public-unit-type-selector/community-library-details.html
+++ b/src/app/modules/library/public-unit-type-selector/community-library-details.html
@@ -3,8 +3,8 @@
   <div class="info-block">
     <p i18n>
       "Community Built" units are designed and contributed by WISE community members. Want to
-      publicly share your custom unit? Head to the Authoring Tool, select your unit, go to the Unit
-      Info page, and click Publish!
+      publicly share your custom unit? Select the Publish option in the unit details pop-up. Or open
+      your unit in the Authoring Tool, go to Unit Info, and tap Publish!
     </p>
     <p class="mat-caption" i18n>
       *Please note: While WISE staff have reviewed these units, we cannot specifically vouch for

--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html
@@ -1,3 +1,10 @@
+@if (isMyUnit) {
+  <a href="{{ shareUnitUrl }}" class="share-button">
+    <button mat-flat-button color="success">
+      <mat-icon>upload</mat-icon>&nbsp;<ng-container i18n>Share with Community</ng-container>
+    </button>
+  </a>
+}
 <div class="project-icon-label" fxLayoutGap="20px">
   <span i18n>Unit Icon</span>
   <button mat-raised-button color="primary" (click)="toggleEditProjectIconMode()" i18n>Edit</button>

--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html
@@ -1,7 +1,7 @@
 @if (isMyUnit) {
   <a href="{{ shareUnitUrl }}" class="share-button">
-    <button mat-flat-button color="success">
-      <mat-icon>upload</mat-icon>&nbsp;<ng-container i18n>Share with Community</ng-container>
+    <button mat-flat-button color="primary">
+      <mat-icon>public</mat-icon>&nbsp;<ng-container i18n>Publish</ng-container>
     </button>
   </a>
 }

--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html
@@ -1,5 +1,5 @@
 @if (isMyUnit) {
-  <a href="{{ shareUnitUrl }}" class="share-button">
+  <a href="{{ publishUnitUrl }}" class="share-button">
     <button mat-flat-button color="primary">
       <mat-icon>public</mat-icon>&nbsp;<ng-container i18n>Publish</ng-container>
     </button>

--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.scss
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.scss
@@ -46,3 +46,7 @@
 .input {
   width: 50%;
 }
+
+.share-button {
+  float: right;
+}

--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.spec.ts
@@ -7,8 +7,10 @@ import { ConfigService } from '../../services/configService';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { EditUnitResourcesComponent } from '../edit-unit-resources/edit-unit-resources.component';
 import { EditUnitTypeComponent } from '../edit-unit-type/edit-unit-type.component';
+import { MockProvider } from 'ng-mocks';
+import { UserService } from '../../../../app/services/user.service';
 
-describe('ProjectInfoAuthoringComponent', () => {
+fdescribe('ProjectInfoAuthoringComponent', () => {
   let component: ProjectInfoAuthoringComponent;
   let fixture: ComponentFixture<ProjectInfoAuthoringComponent>;
 
@@ -21,13 +23,17 @@ describe('ProjectInfoAuthoringComponent', () => {
         StudentTeacherCommonServicesModule
       ],
       providers: [
+        MockProvider(UserService),
         TeacherProjectService,
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting()
       ]
     }).compileComponents();
-    spyOn(TestBed.inject(TeacherProjectService), 'getProjectMetadata').and.returnValue({});
+    spyOn(TestBed.inject(TeacherProjectService), 'getProjectMetadata').and.returnValue({
+      authors: []
+    });
     spyOn(TestBed.inject(ConfigService), 'getConfigParam').and.returnValue('{ "fields": [] }');
+    spyOn(TestBed.inject(UserService), 'getUserId').and.returnValue(1);
     fixture = TestBed.createComponent(ProjectInfoAuthoringComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.spec.ts
@@ -10,7 +10,7 @@ import { EditUnitTypeComponent } from '../edit-unit-type/edit-unit-type.componen
 import { MockProvider } from 'ng-mocks';
 import { UserService } from '../../../../app/services/user.service';
 
-fdescribe('ProjectInfoAuthoringComponent', () => {
+describe('ProjectInfoAuthoringComponent', () => {
   let component: ProjectInfoAuthoringComponent;
   let fixture: ComponentFixture<ProjectInfoAuthoringComponent>;
 

--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.ts
@@ -47,7 +47,7 @@ export class ProjectInfoAuthoringComponent {
       (author) => author.id === this.userService.getUserId()
     );
     this.isMyUnit = userAuthor !== undefined;
-    this.publishUnitUrl = `${this.configService.getContextPath()}/contact?projectId=${this.configService.getRunId()}&publish=true`;
+    this.publishUnitUrl = `${this.configService.getContextPath()}/contact?projectId=${this.configService.getProjectId()}&publish=true`;
     this.loadProjectIcon();
     this.processMetadata();
     this.metadataChanged.pipe(debounceTime(1000)).subscribe(() => {

--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.ts
@@ -43,10 +43,9 @@ export class ProjectInfoAuthoringComponent {
     this.metadataAuthoring = JSON.parse(
       this.configService.getConfigParam('projectMetadataSettings')
     );
-    const userAuthor = this.metadata.authors.find(
+    this.isMyUnit = this.metadata.authors.some(
       (author) => author.id === this.userService.getUserId()
     );
-    this.isMyUnit = userAuthor !== undefined;
     this.publishUnitUrl = `${this.configService.getContextPath()}/contact?projectId=${this.configService.getProjectId()}&publish=true`;
     this.loadProjectIcon();
     this.processMetadata();

--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.ts
@@ -23,7 +23,7 @@ export class ProjectInfoAuthoringComponent {
   metadataChanged: Subject<void> = new Subject<void>();
   projectIcon: string = '';
   projectIcons: any = [];
-  protected shareUnitUrl;
+  protected publishUnitUrl;
 
   constructor(
     private configService: ConfigService,
@@ -47,7 +47,7 @@ export class ProjectInfoAuthoringComponent {
       (author) => author.id === this.userService.getUserId()
     );
     this.isMyUnit = userAuthor !== undefined;
-    this.shareUnitUrl = `${this.configService.getContextPath()}/contact?projectId=${this.configService.getRunId()}&share=true`;
+    this.publishUnitUrl = `${this.configService.getContextPath()}/contact?projectId=${this.configService.getRunId()}&publish=true`;
     this.loadProjectIcon();
     this.processMetadata();
     this.metadataChanged.pipe(debounceTime(1000)).subscribe(() => {

--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.ts
@@ -4,6 +4,7 @@ import { TeacherProjectService } from '../../services/teacherProjectService';
 import { MatDialog } from '@angular/material/dialog';
 import { Subject, debounceTime } from 'rxjs';
 import { AssetChooser } from '../project-asset-authoring/asset-chooser';
+import { UserService } from '../../../../app/services/user.service';
 
 @Component({
   selector: 'project-info-authoring',
@@ -13,6 +14,7 @@ import { AssetChooser } from '../project-asset-authoring/asset-chooser';
 })
 export class ProjectInfoAuthoringComponent {
   isEditingProjectIcon: boolean = false;
+  protected isMyUnit: boolean;
   isShowProjectIcon: boolean = false;
   isShowProjectIconError: boolean = false;
   isShowProjectIconLoading: boolean = false;
@@ -21,11 +23,13 @@ export class ProjectInfoAuthoringComponent {
   metadataChanged: Subject<void> = new Subject<void>();
   projectIcon: string = '';
   projectIcons: any = [];
+  protected shareUnitUrl;
 
   constructor(
     private configService: ConfigService,
     private dialog: MatDialog,
-    private projectService: TeacherProjectService
+    private projectService: TeacherProjectService,
+    private userService: UserService
   ) {}
 
   ngOnInit(): void {
@@ -39,6 +43,11 @@ export class ProjectInfoAuthoringComponent {
     this.metadataAuthoring = JSON.parse(
       this.configService.getConfigParam('projectMetadataSettings')
     );
+    const userAuthor = this.metadata.authors.find(
+      (author) => author.id === this.userService.getUserId()
+    );
+    this.isMyUnit = userAuthor !== undefined;
+    this.shareUnitUrl = `${this.configService.getContextPath()}/contact?projectId=${this.configService.getRunId()}&share=true`;
     this.loadProjectIcon();
     this.processMetadata();
     this.metadataChanged.pipe(debounceTime(1000)).subscribe(() => {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1577,7 +1577,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">158,162</context>
+          <context context-type="linenumber">157,161</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.html</context>
@@ -2225,21 +2225,35 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source> Recaptcha failed. Please reload the page and try again! </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">128,131</context>
+          <context context-type="linenumber">126,129</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2030256990555278300" datatype="html">
         <source> Sorry, there was a problem submitting the form. Please try again. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">132,136</context>
+          <context context-type="linenumber">130,134</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7898998821450935640" datatype="html">
+        <source> By submitting, you will be sending your unit to be reviewed. If approved, it will be added to the Community Built library. Make sure you have filled out all appropriate fields in the Unit Info page in the authoring tool. We will be in touch if we require any more information. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
+          <context context-type="linenumber">136,141</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3357031660050032232" datatype="html">
+        <source>Thank you!</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
+          <context context-type="linenumber">141,145</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7330209395505773206" datatype="html">
         <source>Submit for Review</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">156,158</context>
+          <context context-type="linenumber">155,157</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6178733511992894634" datatype="html">
@@ -2323,8 +2337,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">141</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4331388718968090017" datatype="html">
-        <source>Publish Unit to the WISE Community</source>
+      <trans-unit id="6193846139411583890" datatype="html">
+        <source>Publish Unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
           <context context-type="linenumber">142</context>
@@ -6320,8 +6334,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">12,14</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6028237129237746121" datatype="html">
-        <source> &quot;Community Built&quot; units are designed and contributed by WISE community members. Want to publicly share your custom unit? Head to the Authoring Tool, select your unit, go to the Unit Info page, and click Publish! </source>
+      <trans-unit id="7175062744029329865" datatype="html">
+        <source> &quot;Community Built&quot; units are designed and contributed by WISE community members. Want to publicly share your custom unit? Select the Publish option in the unit details pop-up. Or open your unit in the Authoring Tool, go to Unit Info, and tap Publish! </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/public-unit-type-selector/community-library-details.html</context>
           <context context-type="linenumber">5,10</context>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -6320,11 +6320,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">12,14</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4008237488978704162" datatype="html">
-        <source> &quot;Community Built&quot; units are designed and contributed by WISE community members. Want to publicly share your custom unit? <x id="START_LINK" ctype="x-a" equiv-text="&lt;a routerLink=&quot;/contact&quot; target=&quot;_blank&quot;&gt;"/>Contact Us<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>! </source>
+      <trans-unit id="6028237129237746121" datatype="html">
+        <source> &quot;Community Built&quot; units are designed and contributed by WISE community members. Want to publicly share your custom unit? Head to the Authoring Tool, select your unit, go to the Unit Info page, and click Publish! </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/public-unit-type-selector/community-library-details.html</context>
-          <context context-type="linenumber">5,9</context>
+          <context context-type="linenumber">5,10</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3753369387408426398" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -283,7 +283,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">208,211</context>
+          <context context-type="linenumber">208,212</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/public-unit-type-selector/community-library-details.html</context>
@@ -1576,6 +1576,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">73,77</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
+          <context context-type="linenumber">158,162</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.html</context>
           <context context-type="linenumber">16,20</context>
         </context-group>
@@ -2126,7 +2130,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Summary</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">88,91</context>
+          <context context-type="linenumber">87,88</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/SummaryInfo.ts</context>
@@ -2145,14 +2149,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Summary required</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">97,100</context>
+          <context context-type="linenumber">90,94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4902817035128594900" datatype="html">
         <source>Description</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">104,107</context>
+          <context context-type="linenumber">96,99</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/milestones-authoring/milestones-authoring.component.html</context>
@@ -2187,14 +2191,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Description required</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">120,124</context>
+          <context context-type="linenumber">112,116</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1818615214955413398" datatype="html">
         <source> This site is protected by reCAPTCHA and the Google <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://policies.google.com/privacy&quot;&gt;"/>Privacy Policy<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> and <x id="START_LINK_1" equiv-text="&lt;a href=&quot;https://policies.google.com/terms&quot;&gt;"/>Terms of Service<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> apply. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">126,129</context>
+          <context context-type="linenumber">118,121</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-security/forgot-student-password-security.component.html</context>
@@ -2221,21 +2225,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source> Recaptcha failed. Please reload the page and try again! </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">136,139</context>
+          <context context-type="linenumber">128,131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2030256990555278300" datatype="html">
         <source> Sorry, there was a problem submitting the form. Please try again. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">140,144</context>
+          <context context-type="linenumber">132,136</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8777496545744200068" datatype="html">
-        <source>Submit<x id="INTERPOLATION" equiv-text="{{ isShareIssueType() ? &apos; for Review&apos; : &apos;&apos; }}"/></source>
+      <trans-unit id="7330209395505773206" datatype="html">
+        <source>Submit for Review</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">155,156</context>
+          <context context-type="linenumber">156,158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6178733511992894634" datatype="html">
@@ -2319,15 +2323,18 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">142</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="5330638366927680633" datatype="html">
-        <source>Share Unit</source>
+      <trans-unit id="4331388718968090017" datatype="html">
+        <source>Publish Unit to the WISE Community</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
           <context context-type="linenumber">143</context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="1936787644032074292" datatype="html">
+        <source>Publish my unit to the WISE Community Built library</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
-          <context context-type="linenumber">1,3</context>
+          <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
+          <context context-type="linenumber">154</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4340256332658641886" datatype="html">
@@ -5859,7 +5866,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.ts</context>
-          <context context-type="linenumber">54</context>
+          <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3785094524839933600" datatype="html">
@@ -5870,7 +5877,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.ts</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9120263586696781927" datatype="html">
@@ -5881,7 +5888,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.ts</context>
-          <context context-type="linenumber">53</context>
+          <context context-type="linenumber">52</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7722179973203037469" datatype="html">
@@ -6032,22 +6039,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">201,207</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6515244744534979276" datatype="html">
-        <source>Share with Community</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">212,218</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
-          <context context-type="linenumber">4,8</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="5537658691712388681" datatype="html">
         <source>Use with Class</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">224,229</context>
+          <context context-type="linenumber">217,222</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/create-run-dialog/create-run-dialog.component.html</context>
@@ -6058,7 +6054,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Preview</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">232,234</context>
+          <context context-type="linenumber">225,227</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-menu/run-menu.component.html</context>
@@ -6093,7 +6089,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Unit Resources</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">234,239</context>
+          <context context-type="linenumber">227,232</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3563179927132287246" datatype="html">
@@ -6144,11 +6140,22 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">20,24</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="7430416142942514215" datatype="html">
+        <source>Publish</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/library/library-project-menu/library-project-menu.component.html</context>
+          <context context-type="linenumber">25,29</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
+          <context context-type="linenumber">4,8</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="6770769801335635194" datatype="html">
         <source>Restore</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-menu/library-project-menu.component.html</context>
-          <context context-type="linenumber">26,29</context>
+          <context context-type="linenumber">31,34</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/notebook/notebook-report/notebook-report.component.html</context>
@@ -6167,7 +6174,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Archive</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-menu/library-project-menu.component.html</context>
-          <context context-type="linenumber">31,36</context>
+          <context context-type="linenumber">36,41</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/archive-projects-button/archive-projects-button.component.html</context>
@@ -6395,6 +6402,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/share-item-dialog/share-item-dialog.component.ts</context>
           <context context-type="linenumber">153</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5330638366927680633" datatype="html">
+        <source>Share Unit</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
+          <context context-type="linenumber">1,3</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6144460604168701739" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -283,7 +283,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">198,202</context>
+          <context context-type="linenumber">198,201</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/public-unit-type-selector/community-library-details.html</context>
@@ -1576,10 +1576,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">73,77</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">135,139</context>
-        </context-group>
-        <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.html</context>
           <context context-type="linenumber">16,20</context>
         </context-group>
@@ -1944,28 +1940,28 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Thank you for contacting WISE!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">10,11</context>
+          <context context-type="linenumber">11,12</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4103120565906069522" datatype="html">
         <source>Your message has been sent. We will get back to you as soon as possible.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">11,14</context>
+          <context context-type="linenumber">12,15</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8864930425454064488" datatype="html">
         <source>Return to WISE Home</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">14,19</context>
+          <context context-type="linenumber">15,19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7533853265286649557" datatype="html">
         <source>Contact WISE</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">24,26</context>
+          <context context-type="linenumber">20,22</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-change/forgot-student-password-change.component.html</context>
@@ -2004,7 +2000,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Name</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">27,28</context>
+          <context context-type="linenumber">23,24</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
@@ -2027,14 +2023,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Name required</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">30,34</context>
+          <context context-type="linenumber">26,30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4768749765465246664" datatype="html">
         <source>Email</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">36,37</context>
+          <context context-type="linenumber">33,34</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-username/forgot-teacher-username.component.html</context>
@@ -2057,7 +2053,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Email required</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">39,41</context>
+          <context context-type="linenumber">36,38</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/teacher/forgot-teacher-username/forgot-teacher-username.component.html</context>
@@ -2076,14 +2072,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Invalid Email</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">42,46</context>
+          <context context-type="linenumber">39,42</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4250948520990652627" datatype="html">
         <source>Teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">48,50</context>
+          <context context-type="linenumber">47,49</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/forgot-home/forgot-home.component.html</context>
@@ -2102,35 +2098,35 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Teacher required</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">55,59</context>
+          <context context-type="linenumber">56,59</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3187063371811307868" datatype="html">
         <source>Issue Type</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">61,63</context>
+          <context context-type="linenumber">64,66</context>
         </context-group>
       </trans-unit>
       <trans-unit id="305786410811878097" datatype="html">
         <source>Issue Type required</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">68,72</context>
+          <context context-type="linenumber">73,76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4157564596155275219" datatype="html">
         <source>Project Name</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">74,75</context>
+          <context context-type="linenumber">80,81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4739818603756173797" datatype="html">
         <source>Summary</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">80,81</context>
+          <context context-type="linenumber">88,91</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/SummaryInfo.ts</context>
@@ -2149,14 +2145,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Summary required</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">83,87</context>
+          <context context-type="linenumber">97,100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4902817035128594900" datatype="html">
         <source>Description</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">89,92</context>
+          <context context-type="linenumber">104,107</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/milestones-authoring/milestones-authoring.component.html</context>
@@ -2191,14 +2187,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Description required</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">100,104</context>
+          <context context-type="linenumber">120,124</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1818615214955413398" datatype="html">
         <source> This site is protected by reCAPTCHA and the Google <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;https://policies.google.com/privacy&quot;&gt;"/>Privacy Policy<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> and <x id="START_LINK_1" equiv-text="&lt;a href=&quot;https://policies.google.com/terms&quot;&gt;"/>Terms of Service<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> apply. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">105,109</context>
+          <context context-type="linenumber">126,129</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/forgot/student/forgot-student-password-security/forgot-student-password-security.component.html</context>
@@ -2225,69 +2221,76 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source> Recaptcha failed. Please reload the page and try again! </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">118,121</context>
+          <context context-type="linenumber">136,139</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2030256990555278300" datatype="html">
         <source> Sorry, there was a problem submitting the form. Please try again. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
-          <context context-type="linenumber">123,127</context>
+          <context context-type="linenumber">140,144</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8777496545744200068" datatype="html">
+        <source>Submit<x id="INTERPOLATION" equiv-text="{{ isShareIssueType() ? &apos; for Review&apos; : &apos;&apos; }}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
+          <context context-type="linenumber">155,156</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6178733511992894634" datatype="html">
         <source>Trouble Signing In</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">127</context>
+          <context context-type="linenumber">130</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">135</context>
+          <context context-type="linenumber">138</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6892681827231609313" datatype="html">
         <source>Need Help Using WISE</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">128</context>
+          <context context-type="linenumber">131</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">136</context>
+          <context context-type="linenumber">139</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2072690839988671006" datatype="html">
         <source>Problems with a WISE Unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">129</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">137</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2959002981630304422" datatype="html">
-        <source>Feedback to WISE</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">130</context>
+          <context context-type="linenumber">132</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
           <context context-type="linenumber">140</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="2959002981630304422" datatype="html">
+        <source>Feedback to WISE</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
+          <context context-type="linenumber">133</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
+          <context context-type="linenumber">144</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="8693603235657020323" datatype="html">
         <source>Other</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">131</context>
+          <context context-type="linenumber">134</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">141</context>
+          <context context-type="linenumber">145</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/domain/profile.constants.ts</context>
@@ -2298,7 +2301,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Student Management</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">138</context>
+          <context context-type="linenumber">141</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/help/faq/teacher-faq/teacher-faq.component.html</context>
@@ -2313,7 +2316,18 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Need Help with Authoring</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">139</context>
+          <context context-type="linenumber">142</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5330638366927680633" datatype="html">
+        <source>Share Unit</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
+          <context context-type="linenumber">143</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
+          <context context-type="linenumber">1,3</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4340256332658641886" datatype="html">
@@ -5838,7 +5852,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.ts</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">54</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3785094524839933600" datatype="html">
@@ -5849,7 +5863,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.ts</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">52</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9120263586696781927" datatype="html">
@@ -5860,7 +5874,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.ts</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2247270192251966992" datatype="html">
@@ -5983,11 +5997,22 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">191,197</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="6515244744534979276" datatype="html">
+        <source>Share with Community</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
+          <context context-type="linenumber">202,208</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
+          <context context-type="linenumber">4,8</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="5537658691712388681" datatype="html">
         <source>Use with Class</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">207,212</context>
+          <context context-type="linenumber">214,219</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/create-run-dialog/create-run-dialog.component.html</context>
@@ -5998,7 +6023,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Preview</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">213,217</context>
+          <context context-type="linenumber">220,224</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-menu/run-menu.component.html</context>
@@ -6033,7 +6058,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>License pertains to original content created by the author(s). Authors are responsible for the usage and attribution of any third-party content linked to or included in this work.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.ts</context>
-          <context context-type="linenumber">44</context>
+          <context context-type="linenumber">45</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3538004306368214541" datatype="html">
@@ -6059,7 +6084,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
-          <context context-type="linenumber">3,6</context>
+          <context context-type="linenumber">10,13</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-annotations/edit-component-annotations.component.html</context>
@@ -6328,13 +6353,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/share-item-dialog/share-item-dialog.component.ts</context>
           <context context-type="linenumber">153</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="5330638366927680633" datatype="html">
-        <source>Share Unit</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/library/share-project-dialog/share-project-dialog.component.html</context>
-          <context context-type="linenumber">1,3</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6144460604168701739" datatype="html">
@@ -12956,35 +12974,35 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>Unit Icon</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
-          <context context-type="linenumber">2,3</context>
+          <context context-type="linenumber">9,10</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6612727015582273891" datatype="html">
         <source>This unit does not have a unit icon.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
-          <context context-type="linenumber">10,12</context>
+          <context context-type="linenumber">17,19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8401624672824530115" datatype="html">
         <source>Click the edit button to set one.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
-          <context context-type="linenumber">11,14</context>
+          <context context-type="linenumber">18,21</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8945986900727189150" datatype="html">
         <source>Choose a new Unit Icon by clicking on one below or upload your own custom icon.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
-          <context context-type="linenumber">20,22</context>
+          <context context-type="linenumber">27,29</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4842432534148275616" datatype="html">
         <source> Upload </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
-          <context context-type="linenumber">23,28</context>
+          <context context-type="linenumber">30,35</context>
         </context-group>
       </trans-unit>
       <trans-unit id="955279821105592607" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -2246,6 +2246,17 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Trouble Signing In</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
+          <context context-type="linenumber">129</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
+          <context context-type="linenumber">137</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6892681827231609313" datatype="html">
+        <source>Need Help Using WISE</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
           <context context-type="linenumber">130</context>
         </context-group>
         <context-group purpose="location">
@@ -2253,8 +2264,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">138</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6892681827231609313" datatype="html">
-        <source>Need Help Using WISE</source>
+      <trans-unit id="2072690839988671006" datatype="html">
+        <source>Problems with a WISE Unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
           <context context-type="linenumber">131</context>
@@ -2264,19 +2275,19 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">139</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2072690839988671006" datatype="html">
-        <source>Problems with a WISE Unit</source>
+      <trans-unit id="2959002981630304422" datatype="html">
+        <source>Feedback to WISE</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
           <context context-type="linenumber">132</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">140</context>
+          <context context-type="linenumber">143</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2959002981630304422" datatype="html">
-        <source>Feedback to WISE</source>
+      <trans-unit id="8693603235657020323" datatype="html">
+        <source>Other</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
           <context context-type="linenumber">133</context>
@@ -2284,17 +2295,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
           <context context-type="linenumber">144</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8693603235657020323" datatype="html">
-        <source>Other</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">134</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">145</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/domain/profile.constants.ts</context>
@@ -2305,7 +2305,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Student Management</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">141</context>
+          <context context-type="linenumber">140</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/help/faq/teacher-faq/teacher-faq.component.html</context>
@@ -2320,21 +2320,21 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Need Help with Authoring</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">142</context>
+          <context context-type="linenumber">141</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4331388718968090017" datatype="html">
         <source>Publish Unit to the WISE Community</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">143</context>
+          <context context-type="linenumber">142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1936787644032074292" datatype="html">
         <source>Publish my unit to the WISE Community Built library</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.ts</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">153</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4340256332658641886" datatype="html">


### PR DESCRIPTION
## Changes
- Added buttons to library project details and project info that link to the contact form. 
- Added a new issue type for sharing units.

## Test w/ [API](https://github.com/WISE-Community/WISE-API/pull/305)
- You should only see the share unit button for units that you are an author on.
- When you click the share unit button from unit info or library project details, the contact form should automatically have sharing set as the issue type and the project set as the project.
- When the issue type is unit sharing, the summary section should be automatically filled in, and the description section should have placeholder text telling the user what kind of thing to write.

Closes #2175 
