### PR TITLE
feat(Match): Filter out detected ideas from pre-authored choices #2184

### DIFF
--- a/src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts
+++ b/src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts
@@ -613,11 +613,17 @@ export class MatchStudentDefaultComponent extends ComponentStudent {
   }
 
   private addIdeasToSourceBucket(responses: any[], rubric: CRaterRubric): void {
-    getUniqueIdeas(responses, rubric).forEach((idea) => {
-      const choice = new Choice(idea.name, idea.text);
-      this.choices.push(choice);
-      this.getBucketById(this.sourceBucketId).items.push(choice);
-    });
+    getUniqueIdeas(responses, rubric)
+      .filter((idea) => !this.isInSourceBucket(idea.name))
+      .forEach((idea) => {
+        const choice = new Choice(idea.name, idea.text);
+        this.choices.push(choice);
+        this.getBucketById(this.sourceBucketId).items.push(choice);
+      });
+  }
+
+  private isInSourceBucket(choiceId: string): boolean {
+    return this.sourceBucket.items.some((item) => item.id === choiceId);
   }
 
   protected addChoice(): void {

--- a/src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts
+++ b/src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts
@@ -614,7 +614,7 @@ export class MatchStudentDefaultComponent extends ComponentStudent {
 
   private addIdeasToSourceBucket(responses: any[], rubric: CRaterRubric): void {
     getUniqueIdeas(responses, rubric)
-      .filter((idea) => !this.isInSourceBucket(idea.name))
+      .filter((idea) => !this.isInSourceBucket(idea.text))
       .forEach((idea) => {
         const choice = new Choice(idea.name, idea.text);
         this.choices.push(choice);
@@ -623,7 +623,7 @@ export class MatchStudentDefaultComponent extends ComponentStudent {
   }
 
   private isInSourceBucket(choiceId: string): boolean {
-    return this.sourceBucket.items.some((item) => item.id === choiceId);
+    return this.sourceBucket.items.some((item) => item.value === choiceId);
   }
 
   protected addChoice(): void {

--- a/src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts
+++ b/src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts
@@ -38,6 +38,7 @@ import { NotebookService } from '../../../../services/notebookService';
 import { ProjectService } from '../../../../services/projectService';
 import { StudentAssetService } from '../../../../services/studentAssetService';
 import { StudentDataService } from '../../../../services/studentDataService';
+import { CRaterIdea } from '../../../common/cRater/CRaterIdea';
 
 @Component({
   imports: [
@@ -614,7 +615,7 @@ export class MatchStudentDefaultComponent extends ComponentStudent {
 
   private addIdeasToSourceBucket(responses: any[], rubric: CRaterRubric): void {
     getUniqueIdeas(responses, rubric)
-      .filter((idea) => !this.isInSourceBucket(idea.text))
+      .filter((idea) => !this.isInSourceBucket(idea))
       .forEach((idea) => {
         const choice = new Choice(idea.name, idea.text);
         this.choices.push(choice);
@@ -622,8 +623,8 @@ export class MatchStudentDefaultComponent extends ComponentStudent {
       });
   }
 
-  private isInSourceBucket(choiceId: string): boolean {
-    return this.sourceBucket.items.some((item) => item.value === choiceId);
+  private isInSourceBucket(idea: CRaterIdea): boolean {
+    return this.sourceBucket.items.some((item) => item.value === idea.text);
   }
 
   protected addChoice(): void {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10945,7 +10945,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts</context>
-          <context context-type="linenumber">125</context>
+          <context context-type="linenumber">126</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html</context>
@@ -19584,7 +19584,7 @@ Warning: This will delete all existing choices and buckets in this component.</s
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts</context>
-          <context context-type="linenumber">470</context>
+          <context context-type="linenumber">471</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-show-work/multiple-choice-show-work.component.html</context>
@@ -19615,7 +19615,7 @@ Warning: This will delete all existing choices and buckets in this component.</s
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts</context>
-          <context context-type="linenumber">470</context>
+          <context context-type="linenumber">471</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-show-work/multiple-choice-show-work.component.html</context>
@@ -19680,7 +19680,7 @@ Warning: This will delete all existing choices and buckets in this component.</s
         <source>Correct bucket but wrong position</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts</context>
-          <context context-type="linenumber">463</context>
+          <context context-type="linenumber">464</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3309404570196522710" datatype="html">


### PR DESCRIPTION
## Changes
If the student has an idea that is authored as one of the choices, remove it from the choices to avoid duplication. We consider it a duplication if choice.id (authored choice) and idea.name (detected student idea) are the same.

## Test Prep
For a unit with DG connected to a Match component, author choices in the match component. Using the advanced JSON editing, give the choices the same ids as the choice names in the CRaterRubric.ideas.name.

## Test
Ensure that choices with the same id do not appear more than once in the choices array. 

Closes #2184
