### PR TITLE
fix(Library): Remove archive option for public units

### DIFF
--- a/src/app/modules/library/library-project-menu/library-project-menu.component.html
+++ b/src/app/modules/library/library-project-menu/library-project-menu.component.html
@@ -25,16 +25,18 @@
         <mat-icon>public</mat-icon> <ng-container i18n>Publish</ng-container>
       </a>
     }
-    @if (archived) {
-      <a mat-menu-item (click)="archive(false)">
-        <mat-icon>unarchive</mat-icon>
-        <span i18n>Restore</span>
-      </a>
-    } @else {
-      <a mat-menu-item (click)="archive(true)">
-        <mat-icon>archive</mat-icon>
-        <span i18n>Archive</span>
-      </a>
+    @if (!project.metadata.publicUnitType) {
+      @if (archived) {
+        <a mat-menu-item (click)="archive(false)">
+          <mat-icon>unarchive</mat-icon>
+          <span i18n>Restore</span>
+        </a>
+      } @else {
+        <a mat-menu-item (click)="archive(true)">
+          <mat-icon>archive</mat-icon>
+          <span i18n>Archive</span>
+        </a>
+      }
     }
   </div>
 </mat-menu>

--- a/src/app/modules/library/library-project-menu/library-project-menu.component.spec.ts
+++ b/src/app/modules/library/library-project-menu/library-project-menu.component.spec.ts
@@ -38,6 +38,7 @@ describe('LibraryProjectMenuComponent', () => {
     user.displayName = 'Spongebob Squarepants';
     project.owner = user;
     project.tags = [];
+    project.metadata = { publicUnitType: null };
     component.project = project;
     fixture.detectChanges();
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, LibraryProjectMenuHarness);
@@ -45,6 +46,7 @@ describe('LibraryProjectMenuComponent', () => {
 
   showsArchiveButton();
   showsRestoreButton();
+  hideArchiveAndRestoreButtons();
 });
 
 function showsArchiveButton() {
@@ -63,6 +65,19 @@ function showsRestoreButton() {
     });
     it('shows restore button', async () => {
       expect(await harness.hasRestoreMenuButton()).toBe(true);
+    });
+  });
+}
+
+function hideArchiveAndRestoreButtons() {
+  describe('project is public', () => {
+    beforeEach(() => {
+      component.project.metadata.publicUnitType = 'wiseTested';
+      component.ngOnInit();
+    });
+    it('does not show archive or restore buttons', async () => {
+      expect(await harness.hasRestoreMenuButton()).toBe(false);
+      expect(await harness.hasArchiveMenuButton()).toBe(false);
     });
   });
 }

--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.spec.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.spec.ts
@@ -8,7 +8,7 @@ import { SummaryService } from '../../../components/summary/summaryService';
 import { TeacherDataService } from '../../../services/teacherDataService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 
-fdescribe('MatchSummaryDisplayComponent', () => {
+describe('MatchSummaryDisplayComponent', () => {
   let component: MatchSummaryDisplayComponent;
   let fixture: ComponentFixture<MatchSummaryDisplayComponent>;
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -6158,7 +6158,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Publish</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-menu/library-project-menu.component.html</context>
-          <context context-type="linenumber">25,29</context>
+          <context context-type="linenumber">25,28</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
@@ -6169,7 +6169,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Restore</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-menu/library-project-menu.component.html</context>
-          <context context-type="linenumber">31,34</context>
+          <context context-type="linenumber">32,35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/notebook/notebook-report/notebook-report.component.html</context>
@@ -6188,7 +6188,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Archive</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-menu/library-project-menu.component.html</context>
-          <context context-type="linenumber">36,41</context>
+          <context context-type="linenumber">37,43</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/archive-projects-button/archive-projects-button.component.html</context>


### PR DESCRIPTION
## Changes
- Removes "Archive" option for Public library units.

## Test
1. Go to homepage, scroll down to Curriculum Offerings.
2. Click on units in the library.
3. In the unit details pop-up, click on the three dot menu. Make sure the "Archive" option is not shown.
4. Sign in as a teacher and go to /curriculum and complete step 3 for Public units.
5. Select the My Units tab.
6. Click on any of the units in My Units, click on the three dot menu, and make sure that the "Archive" option is shown.

Closes #2187.
