### PR TITLE
feat(Unit Library): Order units WISETested -> CommunityBuilt

### DIFF
--- a/src/app/modules/library/library/library.component.ts
+++ b/src/app/modules/library/library/library.component.ts
@@ -64,7 +64,7 @@ export abstract class LibraryComponent implements OnInit {
         return project;
       })
       .filter((project) => project.visible)
-      .sort((a, b) => b.id - a.id);
+      .sort(this.sortUnits);
     this.emitNumberOfProjectsVisible(this.countVisibleProjects(this.filteredProjects));
     this.pageIndex = 0;
     this.setPagination();
@@ -82,5 +82,19 @@ export abstract class LibraryComponent implements OnInit {
 
   protected countVisibleProjects(projects: LibraryProject[]): number {
     return projects.filter((project) => project.visible).length;
+  }
+
+  // Sort units from newest -> oldest in each of these categories
+  // WISE Tested (Platform) -> WISE Tested (Other) -> Community (Platform) -> Community (Other)
+  private sortUnits(a: LibraryProject, b: LibraryProject): number {
+    const unitTypes = [
+      'wiseTestedPlatform',
+      'wiseTestedOther',
+      'communityBuiltPlatform',
+      'communityBuiltOther'
+    ];
+    const unitTypeIndexA = unitTypes.indexOf(a.metadata.publicUnitType + a.metadata.unitType);
+    const unitTypeIndexB = unitTypes.indexOf(b.metadata.publicUnitType + b.metadata.unitType);
+    return unitTypeIndexA === unitTypeIndexB ? b.id - a.id : unitTypeIndexA - unitTypeIndexB;
   }
 }

--- a/src/app/modules/library/public-library/public-library.component.spec.ts
+++ b/src/app/modules/library/public-library/public-library.component.spec.ts
@@ -16,12 +16,12 @@ describe('PublicLibraryComponent', () => {
       providers: [
         MockProvider(LibraryService, {
           communityLibraryProjectsSource$: of([
-            { id: 1, name: 'P1' },
-            { id: 2, name: 'P2' }
+            { id: 1, metadata: { publicUnitType: 'wiseTested', unitType: 'Platform' } },
+            { id: 2, metadata: { publicUnitType: 'wiseTested', unitType: 'Platform' } }
           ] as LibraryProject[]),
           officialLibraryProjectsSource$: of([
-            { id: 1, name: 'P1' },
-            { id: 3, name: 'P3' }
+            { id: 1, metadata: { publicUnitType: 'wiseTested', unitType: 'Platform' } },
+            { id: 3, metadata: { publicUnitType: 'communityBuilt', unitType: 'Platform' } }
           ] as LibraryProject[])
         }),
         ProjectFilterValues
@@ -33,7 +33,7 @@ describe('PublicLibraryComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should remove duplicate units', () => {
-    expect(component['projects'].length).toBe(3);
+  it('should remove duplicates and order units', () => {
+    expect(component['filteredProjects'].map((p) => p.id)).toEqual([2, 1, 3]);
   });
 });


### PR DESCRIPTION
## Changes
Right now, the units in the Unit Library are order by newest -> oldest across all unit types.

This PR changes this to show the units in this order:
1. WISE Tested (Platform) newest -> oldest
2. WISE Tested (Other) newest -> oldest
3. Community (Platform) newest -> oldest
4. Community (Other) newest -> oldest

## Test
- Unit library sorts the units in order as described above

Closes #2213
