### PR TITLE
feat(Unit Library): Filter units by location

### DIFF
--- a/src/app/domain/projectFilterValues.ts
+++ b/src/app/domain/projectFilterValues.ts
@@ -105,7 +105,7 @@ export class ProjectFilterValues {
         ?.map((location) => Object.assign(new Location(), location))
         .map((location) => location.getLocationOptions())
         .flat()
-        .some((locationOption) => this.locationValue.includes(locationOption.id))
+        .some((locationOption) => this.locationValue.includes(locationOption.name))
     );
   }
 

--- a/src/app/domain/projectFilterValues.ts
+++ b/src/app/domain/projectFilterValues.ts
@@ -1,10 +1,12 @@
 import { Subject } from 'rxjs';
 import { LibraryProject } from '../modules/library/libraryProject';
+import { Location } from '../modules/library/Location';
 
 export class ProjectFilterValues {
   disciplineValue: string[] = [];
   featureValue: string[] = [];
   gradeLevelValue: number[] = [];
+  locationValue: string[] = [];
   publicUnitType?: ('wiseTested' | 'communityBuilt')[] = [];
   publicUnitTypeValue?: ('wiseTested' | 'communityBuilt')[] = [];
   searchValue: string = '';
@@ -21,7 +23,8 @@ export class ProjectFilterValues {
       this.matchesDiscipline(project) &&
       this.matchesUnitType(project) &&
       this.matchesFeature(project) &&
-      this.matchesGradeLevel(project)
+      this.matchesGradeLevel(project) &&
+      this.matchesLocation(project)
     );
   }
 
@@ -92,6 +95,17 @@ export class ProjectFilterValues {
       [...commonCore, ...ngss, ...learningForJustice].some((val) =>
         this.standardValue.includes(val.id)
       )
+    );
+  }
+
+  private matchesLocation(project: LibraryProject): boolean {
+    return (
+      this.locationValue.length === 0 ||
+      project.metadata.locations
+        ?.map((location) => Object.assign(new Location(), location))
+        .map((location) => location.getLocationOptions())
+        .flat()
+        .some((locationOption) => this.locationValue.includes(locationOption.id))
     );
   }
 

--- a/src/app/domain/projectFilterValues.ts
+++ b/src/app/domain/projectFilterValues.ts
@@ -57,7 +57,8 @@ export class ProjectFilterValues {
         this.disciplineValue.length +
         this.unitTypeValue.length +
         this.gradeLevelValue.length +
-        this.featureValue.length >
+        this.featureValue.length +
+        this.locationValue.length >
       0
     );
   }
@@ -70,6 +71,7 @@ export class ProjectFilterValues {
     this.searchValue = '';
     this.standardValue = [];
     this.unitTypeValue = [];
+    this.locationValue = [];
   }
 
   private matchesUnitType(project: LibraryProject): boolean {

--- a/src/app/modules/library/Location.ts
+++ b/src/app/modules/library/Location.ts
@@ -7,13 +7,11 @@ export const locationTypeToLabel: { [key in LocationType]: string } = {
 };
 
 export class LocationOption {
-  id: string;
   name: string;
   type: LocationType;
   constructor(type: LocationType, name: string) {
     this.type = type;
     this.name = name;
-    this.id = `${locationTypeToLabel[type]}:${name}`;
   }
 }
 

--- a/src/app/modules/library/Location.ts
+++ b/src/app/modules/library/Location.ts
@@ -1,0 +1,40 @@
+export type LocationType = 'level1' | 'level2' | 'level3';
+
+export const locationTypeToLabel: { [key in LocationType]: string } = {
+  level3: $localize`Locale`,
+  level2: $localize`State`,
+  level1: $localize`Country`
+};
+
+export class LocationOption {
+  id: string;
+  name: string;
+  type: LocationType;
+  constructor(type: LocationType, name: string) {
+    this.type = type;
+    this.name = name;
+    this.id = `${locationTypeToLabel[type]}:${name}`;
+  }
+}
+
+// Represents a geographical location associated with a project
+export class Location {
+  id: string = '';
+  level1: string = ''; // country
+  level2: string = ''; // state
+  level3: string = ''; // city, county, or other locale
+
+  getLocationOptions(): LocationOption[] {
+    const options = [];
+    if (this.level1) {
+      options.push(new LocationOption('level1', this.level1));
+    }
+    if (this.level2) {
+      options.push(new LocationOption('level2', `${this.level2}, ${this.level1}`));
+    }
+    if (this.level3) {
+      options.push(new LocationOption('level3', `${this.level3}, ${this.level2}, ${this.level1}`));
+    }
+    return options;
+  }
+}

--- a/src/app/modules/library/library-filters/library-filters.component.html
+++ b/src/app/modules/library/library-filters/library-filters.component.html
@@ -138,7 +138,7 @@
           placeholderText="Locations"
           [value]="filterValues.locationValue"
           (update)="filterUpdated($event, 'location')"
-          [valueProp]="'id'"
+          [valueProp]="'name'"
           [viewValueProp]="'name'"
           [multiple]="true"
         />

--- a/src/app/modules/library/library-filters/library-filters.component.html
+++ b/src/app/modules/library/library-filters/library-filters.component.html
@@ -127,5 +127,22 @@
         />
       </div>
     }
+    @if (locationOptions.length > 0) {
+      <div
+        class="library-filter"
+        [ngClass]="{ 'md:w-full': isSplitScreen, 'md:w-1/4': !isSplitScreen }"
+      >
+        <location-select-menu
+          [options]="locationOptions"
+          i18n-placeholderText
+          placeholderText="Locations"
+          [value]="filterValues.locationValue"
+          (update)="filterUpdated($event, 'location')"
+          [valueProp]="'id'"
+          [viewValueProp]="'name'"
+          [multiple]="true"
+        />
+      </div>
+    }
   </div>
 </div>

--- a/src/app/modules/library/library-filters/library-filters.component.ts
+++ b/src/app/modules/library/library-filters/library-filters.component.ts
@@ -16,6 +16,8 @@ import { Feature } from '../Feature';
 import { Grade, GradeLevel } from '../GradeLevel';
 import { MatDialog } from '@angular/material/dialog';
 import { DialogWithCloseComponent } from '../../../../assets/wise5/directives/dialog-with-close/dialog-with-close.component';
+import { Location } from '../Location';
+import { LocationSelectMenuComponent } from '../../shared/location-select-menu/location-select-menu.component';
 
 @Component({
   imports: [
@@ -23,6 +25,7 @@ import { DialogWithCloseComponent } from '../../../../assets/wise5/directives/di
     MatBadgeModule,
     MatButtonModule,
     MatIconModule,
+    LocationSelectMenuComponent,
     SearchBarComponent,
     SelectMenuComponent,
     StandardsSelectMenuComponent
@@ -44,6 +47,7 @@ export class LibraryFiltersComponent {
   private sharedProjects: LibraryProject[] = [];
   protected showFilters: boolean = false;
   protected standardOptions: Standard[] = [];
+  protected locationOptions: Location[] = [];
   protected unitTypeOptions: { id: string; name: string }[] = [
     { id: 'WISE Platform', name: $localize`WISE Platform` },
     { id: 'Other Platform', name: $localize`Other Platform` }
@@ -97,6 +101,7 @@ export class LibraryFiltersComponent {
     );
     this.populateGradeLevels(project);
     this.populateStandards(project);
+    this.populateLocations(project);
   }
 
   private populateGradeLevels(project: LibraryProject): void {
@@ -123,12 +128,23 @@ export class LibraryFiltersComponent {
     });
   }
 
+  private populateLocations(project: LibraryProject): void {
+    project.metadata.locations?.forEach((location: Location) =>
+      this.locationOptions.push(Object.assign(new Location(), location))
+    );
+  }
+
   private removeDuplicatesAndSortAlphabetically(): void {
     this.standardOptions = this.utilService.removeObjectArrayDuplicatesByProperty(
       this.standardOptions,
       'id'
     );
     this.utilService.sortObjectArrayByProperty(this.standardOptions, 'id');
+    this.locationOptions = this.utilService.removeObjectArrayDuplicatesByProperty(
+      this.locationOptions,
+      'id'
+    );
+    this.utilService.sortObjectArrayByProperty(this.locationOptions, 'id');
     this.disciplineOptions = this.utilService.removeObjectArrayDuplicatesByProperty(
       this.disciplineOptions,
       'id'
@@ -168,6 +184,9 @@ export class LibraryFiltersComponent {
       case 'unitType':
         this.filterValues.unitTypeValue = value;
         break;
+      case 'location':
+        this.filterValues.locationValue = value;
+        break;
     }
     this.emitFilterValues();
   }
@@ -182,9 +201,9 @@ export class LibraryFiltersComponent {
   }
 
   protected showTypeInfo(): void {
-    const message = $localize`"Type" indicates the platform on which a unit runs. "WISE Platform" units are created 
-      using the WISE authoring tool. Students use WISE accounts to complete lessons and teachers can review and grade 
-      work on the WISE platform. "Other" units are created using different platforms. Resources for these units 
+    const message = $localize`"Type" indicates the platform on which a unit runs. "WISE Platform" units are created
+      using the WISE authoring tool. Students use WISE accounts to complete lessons and teachers can review and grade
+      work on the WISE platform. "Other" units are created using different platforms. Resources for these units
       are linked in the unit details.`;
     this.dialog.open(DialogWithCloseComponent, {
       data: {

--- a/src/app/modules/library/library-project-details/library-project-details.component.html
+++ b/src/app/modules/library/library-project-details/library-project-details.component.html
@@ -148,6 +148,16 @@
           }
         </p>
       }
+      @if (project.metadata.locations?.length > 0) {
+        <p>
+          <strong i18n>Locations:</strong>
+          @for (location of project.metadata.locations; track location.id; let last = $last) {
+            {{ location.level3 ? location.level3 + ', ' : ''
+            }}{{ location.level2 ? location.level2 + ', ' : '' }}{{ location.level1 }}
+            {{ last ? '' : ' • ' }}
+          }
+        </p>
+      }
       @if (project.tags) {
         <unit-tags [tags]="project.tags" />
       }

--- a/src/app/modules/shared/location-select-menu/location-select-menu.component.html
+++ b/src/app/modules/shared/location-select-menu/location-select-menu.component.html
@@ -1,0 +1,25 @@
+<mat-form-field class="select-menu" appearance="fill" [subscriptSizing]="'dynamic'">
+  <mat-label>{{ placeholderText }}</mat-label>
+  <mat-select
+    [formControl]="selectField"
+    [placeholder]="placeholderText"
+    [(value)]="value"
+    [multiple]="multiple"
+  >
+    @if (multiple) {
+      <mat-select-trigger>
+        {{ selectField.value ? selectField.value[0] : '' }}
+        @if (selectField.value?.length > 1) {
+          <span>(+{{ selectField.value.length - 1 }} <ng-container i18n>more</ng-container>)</span>
+        }
+      </mat-select-trigger>
+    }
+    @for (label of labels; track label) {
+      <mat-optgroup [label]="locationTypeToLabel[label]">
+        @for (option of locationOptions[label]; track option.id) {
+          <mat-option [value]="option[valueProp]">{{ option[viewValueProp] }}</mat-option>
+        }
+      </mat-optgroup>
+    }
+  </mat-select>
+</mat-form-field>

--- a/src/app/modules/shared/location-select-menu/location-select-menu.component.ts
+++ b/src/app/modules/shared/location-select-menu/location-select-menu.component.ts
@@ -24,7 +24,7 @@ export class LocationSelectMenuComponent extends SelectMenuComponent {
     this.options
       .flatMap((option: Location) => option.getLocationOptions())
       .forEach((option: LocationOption) => {
-        if (!this.locationOptions[option.type].some((opt) => opt.id === option.id)) {
+        if (!this.locationOptions[option.type].some((opt) => opt.name === option.name)) {
           this.locationOptions[option.type].push(option);
         }
       });

--- a/src/app/modules/shared/location-select-menu/location-select-menu.component.ts
+++ b/src/app/modules/shared/location-select-menu/location-select-menu.component.ts
@@ -1,0 +1,35 @@
+import { Component } from '@angular/core';
+import { SelectMenuComponent } from '../select-menu/select-menu.component';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatSelectModule } from '@angular/material/select';
+import {
+  Location,
+  LocationOption,
+  LocationType,
+  locationTypeToLabel
+} from '../../library/Location';
+
+@Component({
+  imports: [FormsModule, MatSelectModule, ReactiveFormsModule],
+  selector: 'location-select-menu',
+  templateUrl: './location-select-menu.component.html'
+})
+export class LocationSelectMenuComponent extends SelectMenuComponent {
+  protected labels: LocationType[];
+  protected locationOptions = { level3: [], level2: [], level1: [] };
+  protected locationTypeToLabel = locationTypeToLabel;
+
+  ngOnInit(): void {
+    super.ngOnInit();
+    this.options
+      .flatMap((option: Location) => option.getLocationOptions())
+      .forEach((option: LocationOption) => {
+        if (!this.locationOptions[option.type].some((opt) => opt.id === option.id)) {
+          this.locationOptions[option.type].push(option);
+        }
+      });
+    this.labels = Object.keys(this.locationOptions).filter(
+      (key: LocationType) => this.locationOptions[key].length > 0
+    ) as LocationType[];
+  }
+}

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -283,7 +283,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">208,212</context>
+          <context context-type="linenumber">218,222</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/public-unit-type-selector/community-library-details.html</context>
@@ -6065,53 +6065,60 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">121,123</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="6644602411705618484" datatype="html">
+        <source>Locations:</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
+          <context context-type="linenumber">153,154</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="8316240444829030702" datatype="html">
         <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;{{ project.uri }}&quot; target=&quot;_blank&quot;&gt;"/>This unit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> is a copy of <x id="START_LINK_1" equiv-text="&lt;a href=&quot;{{ parentProject.uri }}&quot; target=&quot;_blank&quot;&gt;"/><x id="INTERPOLATION" equiv-text="{{ parentProject.title }}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> (used under <x id="START_LINK_2" equiv-text="&lt;a href=&quot;{{ licenseUrl }}&quot; target=&quot;_blank&quot;&gt;"/>CC BY-SA<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">164,166</context>
+          <context context-type="linenumber">174,176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1086545303898503399" datatype="html">
         <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;{{ project.uri }}&quot; target=&quot;_blank&quot;&gt;"/>This unit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> is a copy of <x id="START_LINK_1" equiv-text="&lt;a href=&quot;{{ parentProject.uri }}&quot; target=&quot;_blank&quot;&gt;"/><x id="INTERPOLATION" equiv-text="{{ parentProject.title }}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> by <x id="INTERPOLATION_1" equiv-text="{{ parentAuthorsString }}"/> (used under <x id="START_LINK_2" equiv-text="&lt;a href=&quot;{{ licenseUrl }}&quot; target=&quot;_blank&quot;&gt;"/>CC BY-SA<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">170,173</context>
+          <context context-type="linenumber">180,183</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6204036064480384422" datatype="html">
         <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;{{ project.uri }}&quot; target=&quot;_blank&quot;&gt;"/>This unit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> is licensed under <x id="START_LINK_1" equiv-text="&lt;a href=&quot;{{ licenseUrl }}&quot; target=&quot;_blank&quot;&gt;"/>CC BY-SA<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">181,183</context>
+          <context context-type="linenumber">191,193</context>
         </context-group>
       </trans-unit>
       <trans-unit id="322569619342487074" datatype="html">
         <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;{{ project.uri }}&quot; target=&quot;_blank&quot;&gt;"/>This unit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> is licensed under <x id="START_LINK_1" equiv-text="&lt;a href=&quot;{{ licenseUrl }}&quot; target=&quot;_blank&quot;&gt;"/>CC BY-SA<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> by <x id="INTERPOLATION" equiv-text="{{ authorsString }}"/>. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">186,188</context>
+          <context context-type="linenumber">196,198</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7138375215763430051" datatype="html">
         <source>View License</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">193,197</context>
+          <context context-type="linenumber">203,207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5937251202465808296" datatype="html">
         <source>More</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">201,207</context>
+          <context context-type="linenumber">211,217</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5537658691712388681" datatype="html">
         <source>Use with Class</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">217,222</context>
+          <context context-type="linenumber">227,232</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/create-run-dialog/create-run-dialog.component.html</context>
@@ -6122,7 +6129,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Preview</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">225,227</context>
+          <context context-type="linenumber">235,237</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/run-menu/run-menu.component.html</context>
@@ -6157,7 +6164,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Unit Resources</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.html</context>
-          <context context-type="linenumber">227,232</context>
+          <context context-type="linenumber">237,242</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3563179927132287246" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -5753,6 +5753,43 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">27,30</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="6780407325174304229" datatype="html">
+        <source>Locale</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/library/Location.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5911214550882917183" datatype="html">
+        <source>State</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/library/Location.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/register/register-teacher-form/register-teacher-form.component.html</context>
+          <context context-type="linenumber">69,70</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.html</context>
+          <context context-type="linenumber">63,64</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="516176798986294299" datatype="html">
+        <source>Country</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/library/Location.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/register/register-teacher-form/register-teacher-form.component.html</context>
+          <context context-type="linenumber">78,79</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.html</context>
+          <context context-type="linenumber">72,73</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1111779696786090540" datatype="html">
         <source>Copy Unit</source>
         <context-group purpose="location">
@@ -5868,25 +5905,32 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">104,106</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="4022066031214545422" datatype="html">
+        <source>Locations</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/library/library-filters/library-filters.component.html</context>
+          <context context-type="linenumber">138,140</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="6394457198241790363" datatype="html">
         <source>WISE Platform</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-filters/library-filters.component.ts</context>
-          <context context-type="linenumber">48</context>
+          <context context-type="linenumber">52</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8239294784362097209" datatype="html">
         <source>Other Platform</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-filters/library-filters.component.ts</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3437559734835046374" datatype="html">
         <source>NGSS</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-filters/library-filters.component.ts</context>
-          <context context-type="linenumber">114</context>
+          <context context-type="linenumber">119</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.ts</context>
@@ -5897,7 +5941,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Common Core</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-filters/library-filters.component.ts</context>
-          <context context-type="linenumber">115</context>
+          <context context-type="linenumber">120</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.ts</context>
@@ -5908,28 +5952,28 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Learning For Justice</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-filters/library-filters.component.ts</context>
-          <context context-type="linenumber">116</context>
+          <context context-type="linenumber">121</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-details/library-project-details.component.ts</context>
           <context context-type="linenumber">52</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7722179973203037469" datatype="html">
-        <source>&quot;Type&quot; indicates the platform on which a unit runs. &quot;WISE Platform&quot; units are created 
-      using the WISE authoring tool. Students use WISE accounts to complete lessons and teachers can review and grade 
-      work on the WISE platform. &quot;Other&quot; units are created using different platforms. Resources for these units 
+      <trans-unit id="3410262322826131465" datatype="html">
+        <source>&quot;Type&quot; indicates the platform on which a unit runs. &quot;WISE Platform&quot; units are created
+      using the WISE authoring tool. Students use WISE accounts to complete lessons and teachers can review and grade
+      work on the WISE platform. &quot;Other&quot; units are created using different platforms. Resources for these units
       are linked in the unit details.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-filters/library-filters.component.ts</context>
-          <context context-type="linenumber">185,188</context>
+          <context context-type="linenumber">204,207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3323880774610969171" datatype="html">
         <source>Unit Type</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-filters/library-filters.component.ts</context>
-          <context context-type="linenumber">192</context>
+          <context context-type="linenumber">211</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/edit-unit-type/edit-unit-type.component.html</context>
@@ -6685,6 +6729,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
       </trans-unit>
       <trans-unit id="7011425206383801543" datatype="html">
         <source>more</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/shared/location-select-menu/location-select-menu.component.html</context>
+          <context context-type="linenumber">13,17</context>
+        </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/shared/select-menu/select-menu.component.html</context>
           <context context-type="linenumber">14,18</context>
@@ -7761,17 +7809,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">57,62</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="5911214550882917183" datatype="html">
-        <source>State</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/register/register-teacher-form/register-teacher-form.component.html</context>
-          <context context-type="linenumber">69,70</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.html</context>
-          <context context-type="linenumber">63,64</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="4756382175496941028" datatype="html">
         <source>State required</source>
         <context-group purpose="location">
@@ -7781,17 +7818,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.html</context>
           <context context-type="linenumber">66,71</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="516176798986294299" datatype="html">
-        <source>Country</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/register/register-teacher-form/register-teacher-form.component.html</context>
-          <context context-type="linenumber">78,79</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/teacher/account/edit-profile/edit-profile.component.html</context>
-          <context context-type="linenumber">72,73</context>
         </context-group>
       </trans-unit>
       <trans-unit id="935361298840141106" datatype="html">


### PR DESCRIPTION
## Changes
- Add location filter that looks at project.metadata.locations

## Test prep
- Test with https://github.com/WISE-Community/WISE-API/pull/307

- For library unit(s), add locations array to its metadata using Advanced JSON editing. Authoring support will be implemented in a future PR.

Sample project JSON:
```
{
...
  "metadata": {
        ...
        "locations": [
            {
                "id": "123",
                "level3": "Berkeley",
                "level2": "California",
                "level1": "USA"
            },
            {
                "id": "124",
                "level3": "Pinole",
                "level2": "California",
                "level1": "USA"
            },
            {
                "id": "125",
                "level2": "Kanagawa",
                "level1": "Japan"
            }
            {
                "id": "126",
                "level1": "Brazil"
            }
        ],
...
}
```

## Test
- Options appear in the locations filter in both the homepage unit listing and in the curriculum page
- Selecting the options correctly filters the units
- Location info appears in the unit info dialog

