### PR TITLE
feat(GraphComponent): Conditionally disable decimals for yAxis based on authored content

### DIFF
--- a/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
+++ b/src/assets/wise5/components/graph/graph-student/graph-student.component.ts
@@ -602,7 +602,9 @@ export class GraphStudent extends ComponentStudent {
    */
   drawGraphHelper(resolve) {
     this.turnOffXAxisDecimals();
-    this.turnOffYAxisDecimals();
+    if (!this.isAllowDecimalsForYAxis()) {
+      this.turnOffYAxisDecimals();
+    }
     this.copyXAxisPlotBandsFromComponentContent();
     this.setupXAxisLimitSpacerWidth();
     let series = null;
@@ -653,6 +655,12 @@ export class GraphStudent extends ComponentStudent {
 
   turnOffXAxisDecimals() {
     this.xAxis.allowDecimals = false;
+  }
+
+  private isAllowDecimalsForYAxis(): boolean {
+    return isSingleYAxis(this.yAxis)
+      ? this.yAxis.allowDecimals
+      : this.yAxis.some((yAxis) => yAxis.allowDecimals);
   }
 
   turnOffYAxisDecimals() {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -19189,39 +19189,39 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>The series you are trying to add a point to is currently hidden. Please show the series by clicking the series name in the legend and try adding the point again.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">853</context>
+          <context context-type="linenumber">861</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2852989551014711458" datatype="html">
         <source>You can not edit this series. Please choose a series that can be edited.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">867</context>
+          <context context-type="linenumber">875</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7053114367342967943" datatype="html">
         <source>Are you sure you want to reset the series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1100</context>
+          <context context-type="linenumber">1108</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7889560203726829643" datatype="html">
         <source>Are you sure you want to reset the &quot;<x id="PH" equiv-text="seriesName"/>&quot; series?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1102</context>
+          <context context-type="linenumber">1110</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6999515396807067782" datatype="html">
         <source>Trial</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">1519</context>
+          <context context-type="linenumber">1527</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-student/graph-student.component.ts</context>
-          <context context-type="linenumber">2351</context>
+          <context context-type="linenumber">2359</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7500488806315952979" datatype="html">


### PR DESCRIPTION
## Changes
- Conditionally disable decimal labels for y-axis. Previously, we were always disabling decimal labels. This was leading to strange behavior when the data points and max values were decimal values, as reported by Kelly.

## Test prep
- Download unit 44494 and import it locally. Steps 3.7 and 3.8 have the data explorer with decimal values.
- Enable decimals for y-axis for the graph component. 
   - Open JSON authoring for the graph components on steps 3.7 and 3.8 and set ```allowDecimals``` to true for yAxis. Note that there are multiple yAxis in this component, and they are all set to false. You’ll need to set it to true for all of them.

## Test
- Preview the steps. Make sure that the y-axis shows the correct labels as you choose different options to graph.