### PR TITLE
fix(Discussion): Replying to posts doesn't save reply

### DIFF
--- a/src/assets/wise5/components/discussion/discussion-common.module.ts
+++ b/src/assets/wise5/components/discussion/discussion-common.module.ts
@@ -10,12 +10,15 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDividerModule } from '@angular/material/divider';
 import { RouterModule } from '@angular/router';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { TextFieldModule } from '@angular/cdk/text-field';
+import { CdkTextareaAutosize, TextFieldModule } from '@angular/cdk/text-field';
+import { FormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [ClassResponse],
   imports: [
+    CdkTextareaAutosize,
     CommonModule,
+    FormsModule,
     FlexLayoutModule,
     MatButtonModule,
     MatCardModule,


### PR DESCRIPTION
## Changes
- Fixes issue where typing a reply and hitting enter did not result in the reply being saved and displayed.

We forgot to import some modules during recent changes.

## Test
- Above works