### PR TITLE
fix(Unit Library): Show filters on wide screens

### DIFF
--- a/src/app/modules/library/library-filters/library-filters.component.scss
+++ b/src/app/modules/library/library-filters/library-filters.component.scss
@@ -10,7 +10,7 @@
   }
 
   &.isSplitScreen {
-    @screen md {
+    @variant md {
       @apply max-h-[1000px];
     }
   }


### PR DESCRIPTION
## Changes
- Fixes a bug that caused curriculum library filters to be hidden on wider screens.

## Test
- Library filters are visible on wide screens.
