### PR TITLE
fix(Teacher Tools): Switch from AT step view

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/filter-components/filter-components.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/filter-components/filter-components.component.html
@@ -16,5 +16,7 @@
         </mat-option>
       }
     </mat-select>
+  } @else {
+    <mat-select [(ngModel)]="selectedComponents" (selectionChange)="updateSelectedComponents()" />
   }
 </mat-form-field>


### PR DESCRIPTION
## Changes
- Fixes issue where switching from a specific step view in AT to the Teacher Tools was throwing a js error and causing the display to not render properly. The issue seem to have stemmed from not having a default mat-select block. This happens when there are no components to grade in the step- e.g., only HTML components.

## Test
- Above issue is fixed.

Closes #2230 
