### PR TITLE
fix(Milestones): Resize milestone report graphs on load

### DIFF
--- a/src/app/teacher/milestone/milestone-report-graph/milestone-report-graph.component.ts
+++ b/src/app/teacher/milestone/milestone-report-graph/milestone-report-graph.component.ts
@@ -4,10 +4,11 @@ import { rgbToHex } from '../../../../assets/wise5/common/color/color';
 import { trimToLength } from '../../../../assets/wise5/common/string/string';
 
 @Component({
-    selector: 'milestone-report-graph',
-    styleUrls: ['./milestone-report-graph.component.scss'],
-    template: '<highcharts-chart [Highcharts]="Highcharts" [options]="chartConfig"></highcharts-chart>',
-    standalone: false
+  selector: 'milestone-report-graph',
+  styleUrls: ['./milestone-report-graph.component.scss'],
+  template:
+    '<highcharts-chart [Highcharts]="Highcharts" [options]="chartConfig" (chartInstance)="onLoad($event)"></highcharts-chart>',
+  standalone: false
 })
 export class MilestoneReportGraphComponent implements OnInit {
   DEFAULT_COLOR = 'rgb(194, 24, 91)';
@@ -135,5 +136,11 @@ export class MilestoneReportGraphComponent implements OnInit {
       seriesData.push(scoreData);
     }
     return seriesData;
+  }
+
+  protected onLoad(chart: Highcharts.Chart): void {
+    setTimeout(() => {
+      chart.reflow();
+    }, 0);
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9178,7 +9178,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Teams</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/teacher/milestone/milestone-report-graph/milestone-report-graph.component.ts</context>
-          <context context-type="linenumber">71</context>
+          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="819750642673322683" datatype="html">


### PR DESCRIPTION
## Changes
Redraw milestone report graphs when milestone report is loaded. This fixes a bug where some milestone report graphs would not size properly and would overflow their containers.

## Test
- Make sure milestone report graphs work as before and are sized properly so that full graph content is visible.
