### PR TITLE
feat(CRater): Ping endpoint when component is rendered

### DIFF
--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.html
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.html
@@ -14,7 +14,6 @@
       />
       @if (studentCanRespond) {
         <chat-input
-          (focusEvent)="startPinging()"
           [submitDisabled]="isWaitingForComputerResponse"
           (submitEvent)="submitStudentResponse($event)"
         />

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-student/dialog-guidance-student.component.ts
@@ -108,9 +108,10 @@ export class DialogGuidanceStudentComponent extends ComponentStudent {
       this.constraintService
     );
     this.initializeComputerAvatar();
+    this.pingCRaterEndpoint();
   }
 
-  protected startPinging(): void {
+  private pingCRaterEndpoint(): void {
     this.cRaterPingService.startPinging(this.getItemId());
   }
 

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.html
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.html
@@ -34,7 +34,6 @@
       (ngModelChange)="studentDataChanged()"
       [disabled]="isDisabled"
       cdkTextareaAutosize
-      (focus)="onFocus()"
     >
     </textarea>
   </mat-form-field>

--- a/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
+++ b/src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts
@@ -107,10 +107,11 @@ export class OpenResponseStudent extends ComponentStudent {
       });
     }
     this.updateAudioAttachments();
+    this.pingCRaterEndpoint();
     this.broadcastDoneRenderingComponent();
   }
 
-  protected onFocus() {
+  private pingCRaterEndpoint(): void {
     if (this.isCRaterEnabled()) {
       this.cRaterPingService.startPinging(this.getItemId());
     }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -16531,7 +16531,7 @@ Are you sure you want to proceed?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.html</context>
-          <context context-type="linenumber">58,60</context>
+          <context context-type="linenumber">57,59</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7589669206989444799" datatype="html">
@@ -16542,11 +16542,11 @@ Are you sure you want to proceed?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">179</context>
+          <context context-type="linenumber">180</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">195</context>
+          <context context-type="linenumber">196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4965414112249568013" datatype="html">
@@ -17483,7 +17483,7 @@ Are you ready to receive feedback on this answer?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">182</context>
+          <context context-type="linenumber">183</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2353574516166744013" datatype="html">
@@ -20480,7 +20480,7 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">186</context>
+          <context context-type="linenumber">187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7482125205220618294" datatype="html">
@@ -20489,7 +20489,7 @@ Are you ready to receive feedback on this answer?</source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">199</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6316287012266891697" datatype="html">
@@ -20498,21 +20498,21 @@ Are you ready to receive feedback on this answer?</source>
 Are you ready to submit this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">202</context>
+          <context context-type="linenumber">203</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8936495196157450285" datatype="html">
         <source>We are scoring your work...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">321</context>
+          <context context-type="linenumber">322</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2283191014272031538" datatype="html">
         <source>Please Wait</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">322</context>
+          <context context-type="linenumber">323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8785209093929133444" datatype="html">
@@ -20520,7 +20520,7 @@ Are you ready to submit this answer?</source>
 If this problem continues, let your teacher know and move on to the next activity. Your work will still be saved.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
-          <context context-type="linenumber">344</context>
+          <context context-type="linenumber">345</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1703970408358128709" datatype="html">


### PR DESCRIPTION
## Changes
Right, now ping the c-rater endpoint when the user focuses on the textarea in OpenResponse and DialogGuidance components. Sometimes this is not enough time for the model to be ready.

This PR changes this behavior so that we start pinging when the component is rendered.

## Test
- Pinging the model endpoint starts when the step containing the c-rater item is rendered

Closes #2235 
