### PR TITLE
feat(CRater authoring): Populate rubric automatically

### DIFF
--- a/src/app/services/cRaterService.spec.ts
+++ b/src/app/services/cRaterService.spec.ts
@@ -5,7 +5,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { CRaterIdea } from '../../assets/wise5/components/common/cRater/CRaterIdea';
 import { CRaterScore } from '../../assets/wise5/components/common/cRater/CRaterScore';
 import { RawCRaterResponse } from '../../assets/wise5/components/common/cRater/RawCRaterResponse';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideHttpClient } from '@angular/common/http';
 import { ProjectService } from '../../assets/wise5/services/projectService';
 import { ComponentContent } from '../../assets/wise5/common/ComponentContent';
 let service: CRaterService;
@@ -24,7 +24,7 @@ describe('CRaterService', () => {
         ConfigService,
         CRaterService,
         { provide: ProjectService, useClass: MockProjectService },
-        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClient(),
         provideHttpClientTesting()
       ]
     });
@@ -182,7 +182,7 @@ function makeCRaterVerifyRequest() {
     it('should make a CRater verify request', () => {
       spyOn(configService, 'getCRaterRequestURL').and.returnValue('/c-rater');
       const itemId = 'ColdBeverage1Sub';
-      service.makeCRaterVerifyRequest(itemId);
+      service.makeCRaterVerifyRequest(itemId).subscribe();
       http.expectOne({
         url: `/c-rater/verify?itemId=${itemId}`,
         method: 'GET'

--- a/src/assets/wise5/components/common/cRater/crater-item-select/crater-item-select.component.html
+++ b/src/assets/wise5/components/common/cRater/crater-item-select/crater-item-select.component.html
@@ -1,0 +1,8 @@
+<mat-form-field>
+  <mat-label i18n>Item ID</mat-label>
+  <mat-select [(ngModel)]="selectedItemId" (selectionChange)="getItemRubric()">
+    @for (itemId of itemIds; track itemId) {
+      <mat-option [value]="itemId">{{ itemId }}</mat-option>
+    }
+  </mat-select>
+</mat-form-field>

--- a/src/assets/wise5/components/common/cRater/crater-item-select/crater-item-select.component.html
+++ b/src/assets/wise5/components/common/cRater/crater-item-select/crater-item-select.component.html
@@ -1,5 +1,5 @@
 <mat-form-field>
-  <mat-label i18n>Item ID</mat-label>
+  <mat-label i18n>AI Model ID</mat-label>
   <mat-select [(ngModel)]="selectedItemId" (selectionChange)="getItemRubric()">
     @for (itemId of itemIds; track itemId) {
       <mat-option [value]="itemId">{{ itemId }}</mat-option>

--- a/src/assets/wise5/components/common/cRater/crater-item-select/crater-item-select.component.spec.ts
+++ b/src/assets/wise5/components/common/cRater/crater-item-select/crater-item-select.component.spec.ts
@@ -1,0 +1,66 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CRaterItemSelectComponent } from './crater-item-select.component';
+import { MockProviders } from 'ng-mocks';
+import { CRaterService } from '../../../../services/cRaterService';
+import { TeacherProjectService } from '../../../../services/teacherProjectService';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatSelectHarness } from '@angular/material/select/testing';
+import { Observable } from 'rxjs';
+
+let loader: HarnessLoader;
+describe('CRaterItemSelectComponent', () => {
+  let component: CRaterItemSelectComponent;
+  let fixture: ComponentFixture<CRaterItemSelectComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CRaterItemSelectComponent],
+      providers: [MockProviders(CRaterService, TeacherProjectService)]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CRaterItemSelectComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    component = fixture.componentInstance;
+    component.componentContent = { itemId: 'berkeley_HeLa', type: 'DialogGuidance' };
+    fixture.detectChanges();
+  });
+
+  it('should show selected item id', async () => {
+    const select = await loader.getHarness(MatSelectHarness);
+    expect(await select.getValueText()).toBe('berkeley_HeLa');
+  });
+
+  it('should get rubric and update component when item id is changed', async () => {
+    const cRaterService = TestBed.inject(CRaterService);
+    const rubricSpy = spyOn(cRaterService, 'makeCRaterVerifyRequest').and.returnValue(
+      new Observable<any>((observer) => {
+        observer.next({
+          rubric: {
+            description: 'Test description',
+            ideas: [
+              { name: '1', text: 'Idea 1 text' },
+              { name: '2', text: 'Idea 2 text' }
+            ]
+          }
+        });
+        observer.complete();
+      })
+    );
+    const saveSpy = spyOn(TestBed.inject(TeacherProjectService), 'saveProject');
+    const select = await loader.getHarness(MatSelectHarness);
+    await select.open();
+    const options = await select.getOptions();
+    await options[0].click(); // Select the first item (berkeley_BowlsInAFridge)
+    expect(rubricSpy).toHaveBeenCalled();
+    expect(saveSpy).toHaveBeenCalled();
+    expect(component.componentContent.itemId).toEqual('berkeley_BowlsInAFridge');
+    expect(component.componentContent.cRaterRubric).toEqual({
+      description: 'Test description',
+      ideas: [
+        { name: '1', text: 'Idea 1 text' },
+        { name: '2', text: 'Idea 2 text' }
+      ]
+    });
+  });
+});

--- a/src/assets/wise5/components/common/cRater/crater-item-select/crater-item-select.component.ts
+++ b/src/assets/wise5/components/common/cRater/crater-item-select/crater-item-select.component.ts
@@ -1,0 +1,59 @@
+import { Component, Input } from '@angular/core';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatOption, MatSelect } from '@angular/material/select';
+import { CRaterService } from '../../../../services/cRaterService';
+import { TeacherProjectService } from '../../../../services/teacherProjectService';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  imports: [FormsModule, MatFormFieldModule, MatSelect, MatOption],
+  selector: 'c-rater-item-select',
+  templateUrl: './crater-item-select.component.html'
+})
+export class CRaterItemSelectComponent {
+  @Input() componentContent: any;
+  protected itemIds = [
+    'berkeley_BowlsInAFridge',
+    'berkeley_CarOnAColdDay',
+    'berkeley_COAL-II',
+    'berkeley_CovidImpacts',
+    'berkeley_FoodJustice',
+    'berkeley_FoodJusticeShortLabelIdeaKI',
+    'berkeley_GenEx-Siblings',
+    'berkeley_HeLa',
+    'berkeley_Impacts',
+    'berkeley_Lizards',
+    'berkeley_MusicalInstruments-Speed',
+    'berkeley_PhotoEnergyStory',
+    'berkeley_PlateTectonics_MtHood',
+    'berkeley_SPOON-II'
+  ];
+  protected selectedItemId: string;
+
+  constructor(
+    private cRaterService: CRaterService,
+    private projectService: TeacherProjectService
+  ) {}
+
+  ngOnInit(): void {
+    if (this.componentContent.type === 'OpenResponse') {
+      this.selectedItemId = this.componentContent.cRater.itemId;
+    } else if (this.componentContent.type === 'DialogGuidance') {
+      this.selectedItemId = this.componentContent.itemId;
+    }
+  }
+
+  protected getItemRubric(): void {
+    this.cRaterService.makeCRaterVerifyRequest(this.selectedItemId).subscribe((response) => {
+      const cRaterRubric = response.rubric ?? { description: '', ideas: [] };
+      if (this.componentContent.type === 'OpenResponse') {
+        this.componentContent.cRater.rubric = cRaterRubric;
+        this.componentContent.cRater.itemId = this.selectedItemId;
+      } else if (this.componentContent.type === 'DialogGuidance') {
+        this.componentContent.cRaterRubric = cRaterRubric;
+        this.componentContent.itemId = this.selectedItemId;
+      }
+      this.projectService.saveProject();
+    });
+  }
+}

--- a/src/assets/wise5/components/common/cRater/edit-crater-description/edit-crater-description.component.html
+++ b/src/assets/wise5/components/common/cRater/edit-crater-description/edit-crater-description.component.html
@@ -1,16 +1,9 @@
-<div class="description notice-bg-bg">
-  <h5 class="flex flex-row items-center gap-1 !text-xl">
-    <span i18n>Model Description</span>
-  </h5>
-  <mat-card appearance="outlined" class="description-content">
-    <mat-form-field class="description-input form-field-no-hint" appearance="fill">
-      <mat-label i18n>User-Friendly Description</mat-label>
-      <textarea
-        matInput
-        [(ngModel)]="cRaterRubric.description"
-        (ngModelChange)="inputChanged.next($event)"
-        cdkTextareaAutosize
-      ></textarea>
-    </mat-form-field>
-  </mat-card>
-</div>
+<mat-form-field class="description-input" appearance="fill">
+  <mat-label i18n>User-Friendly Description</mat-label>
+  <textarea
+    matInput
+    [(ngModel)]="cRaterRubric.description"
+    (ngModelChange)="inputChanged.next($event)"
+    cdkTextareaAutosize
+  ></textarea>
+</mat-form-field>

--- a/src/assets/wise5/components/common/cRater/edit-crater-description/edit-crater-description.component.ts
+++ b/src/assets/wise5/components/common/cRater/edit-crater-description/edit-crater-description.component.ts
@@ -3,7 +3,6 @@ import { Component, Input } from '@angular/core';
 import { CRaterRubric } from '../CRaterRubric';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { FormsModule } from '@angular/forms';
-import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { Subject, Subscription } from 'rxjs';
@@ -11,7 +10,7 @@ import { TeacherProjectService } from '../../../../services/teacherProjectServic
 
 @Component({
   selector: 'edit-crater-description',
-  imports: [CdkTextareaAutosize, FormsModule, MatCardModule, MatFormFieldModule, MatInputModule],
+  imports: [CdkTextareaAutosize, FormsModule, MatFormFieldModule, MatInputModule],
   templateUrl: './edit-crater-description.component.html',
   styleUrl: './edit-crater-description.component.scss'
 })

--- a/src/assets/wise5/components/common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component.scss
+++ b/src/assets/wise5/components/common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component.scss
@@ -12,6 +12,8 @@ h5 {
 ul {
   margin: 16px 0 0 0;
   padding: 0 0 16px;
+  max-height: 60vh;
+  overflow: auto;
 }
 
 li {

--- a/src/assets/wise5/components/common/cRater/edit-crater-info/edit-crater-info.component.ts
+++ b/src/assets/wise5/components/common/cRater/edit-crater-info/edit-crater-info.component.ts
@@ -2,19 +2,13 @@ import { Component, Input } from '@angular/core';
 import { CRaterRubric } from '../CRaterRubric';
 import { EditCRaterDescriptionComponent } from '../edit-crater-description/edit-crater-description.component';
 import { EditCRaterIdeaDescriptionsComponent } from '../edit-crater-idea-descriptions/edit-crater-idea-descriptions.component';
-import { MatCardModule } from '@angular/material/card';
 
 @Component({
   selector: 'edit-crater-info',
-  imports: [EditCRaterDescriptionComponent, EditCRaterIdeaDescriptionsComponent, MatCardModule],
-  styles: ['.wrapper { padding: 16px; }'],
-  template: `<mat-card appearance="outlined" class="wrapper">
-    <h5 class="gap-1 !text-xl">
-      <span i18n>Edit CRater Information</span>
-    </h5>
+  imports: [EditCRaterDescriptionComponent, EditCRaterIdeaDescriptionsComponent],
+  template: `<h5 class="!text-xl" i18n>AI Model Details</h5>
     <edit-crater-description [cRaterRubric]="cRaterRubric" />
-    <edit-crater-idea-descriptions [ideaDescriptions]="cRaterRubric.ideas" />
-  </mat-card>`
+    <edit-crater-idea-descriptions [ideaDescriptions]="cRaterRubric.ideas" />`
 })
 export class EditCRaterInfoComponent {
   @Input() cRaterRubric: CRaterRubric;

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.html
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.html
@@ -21,4 +21,5 @@
     [feedbackRules]="componentContent.feedbackRules"
     [version]="componentContent.version"
   />
+  <edit-crater-info [cRaterRubric]="componentContent.cRaterRubric" />
 </div>

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.html
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.html
@@ -3,15 +3,7 @@
     [componentContent]="componentContent"
     (promptChangedEvent)="promptChanged($event)"
   />
-  <mat-form-field>
-    <mat-label i18n>Item ID</mat-label>
-    <input
-      matInput
-      [(ngModel)]="componentContent.itemId"
-      (ngModelChange)="inputChange.next($event)"
-      type="text"
-    />
-  </mat-form-field>
+  <c-rater-item-select [componentContent]="componentContent" />
   <edit-component-max-submit [componentContent]="componentContent" />
   <mat-checkbox
     color="primary"

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.spec.ts
@@ -1,4 +1,4 @@
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProjectLocale } from '../../../../../app/domain/projectLocale';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
@@ -8,6 +8,8 @@ import { TeacherNodeService } from '../../../services/teacherNodeService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { TeacherProjectTranslationService } from '../../../services/teacherProjectTranslationService';
 import { DialogGuidanceAuthoringComponent } from './dialog-guidance-authoring.component';
+import { MockComponent } from 'ng-mocks';
+import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-component-prompt/edit-component-prompt.component';
 
 const componentContent = {
   id: 'i64ex48j1z',
@@ -18,31 +20,31 @@ const componentContent = {
   showSubmitButton: false,
   isComputerAvatarEnabled: false
 };
-
 describe('DialogGuidanceAuthoringComponent', () => {
   let component: DialogGuidanceAuthoringComponent;
   let fixture: ComponentFixture<DialogGuidanceAuthoringComponent>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [DialogGuidanceAuthoringComponent, StudentTeacherCommonServicesModule],
+      imports: [
+        DialogGuidanceAuthoringComponent,
+        MockComponent(EditComponentPrompt),
+        StudentTeacherCommonServicesModule
+      ],
       providers: [
         ProjectAssetService,
         TeacherNodeService,
         TeacherProjectService,
         TeacherProjectTranslationService,
-        provideHttpClient(withInterceptorsFromDi())
+        provideHttpClient()
       ]
     });
-    spyOn(TestBed.inject(TeacherProjectService), 'getLocale').and.returnValue(
-      new ProjectLocale({ default: 'en-US' })
-    );
     fixture = TestBed.createComponent(DialogGuidanceAuthoringComponent);
     component = fixture.componentInstance;
-    spyOn(TestBed.inject(TeacherProjectService), 'isDefaultLocale').and.returnValue(true);
-    spyOn(TestBed.inject(TeacherProjectService), 'getComponent').and.returnValue(
-      copy(componentContent)
-    );
+    const projectService = TestBed.inject(TeacherProjectService);
+    spyOn(projectService, 'getLocale').and.returnValue(new ProjectLocale({ default: 'en-US' }));
+    spyOn(projectService, 'isDefaultLocale').and.returnValue(true);
+    spyOn(projectService, 'getComponent').and.returnValue(copy(componentContent));
     component.componentContent = copy(componentContent);
     fixture.detectChanges();
   });

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInput } from '@angular/material/input';
 import { EditComponentMaxSubmitComponent } from '../../../../../app/authoring-tool/edit-component-max-submit/edit-component-max-submit.component';
 import { EditComponentPrompt } from '../../../../../app/authoring-tool/edit-component-prompt/edit-component-prompt.component';
 import { ProjectAssetService } from '../../../../../app/services/projectAssetService';
@@ -14,21 +13,22 @@ import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { CRaterRubric } from '../../common/cRater/CRaterRubric';
 import { EditFeedbackRulesComponent } from '../../common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component';
 import { EditDialogGuidanceComputerAvatarComponent } from '../edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component';
+import { CRaterItemSelectComponent } from '../../common/cRater/crater-item-select/crater-item-select.component';
 
 @Component({
-  selector: 'dialog-guidance-authoring',
-  templateUrl: './dialog-guidance-authoring.component.html',
-  styles: ['edit-feedback-rules { margin-bottom: 16px; } '],
   imports: [
-    EditComponentPrompt,
-    MatFormFieldModule,
-    MatInput,
-    FormsModule,
+    CRaterItemSelectComponent,
     EditComponentMaxSubmitComponent,
-    MatCheckbox,
+    EditComponentPrompt,
     EditDialogGuidanceComputerAvatarComponent,
-    EditFeedbackRulesComponent
-  ]
+    EditFeedbackRulesComponent,
+    FormsModule,
+    MatCheckbox,
+    MatFormFieldModule
+  ],
+  selector: 'dialog-guidance-authoring',
+  styles: ['edit-feedback-rules { margin-bottom: 16px; } '],
+  templateUrl: './dialog-guidance-authoring.component.html'
 })
 export class DialogGuidanceAuthoringComponent extends AbstractComponentAuthoring {
   constructor(
@@ -41,7 +41,7 @@ export class DialogGuidanceAuthoringComponent extends AbstractComponentAuthoring
     super(configService, nodeService, projectAssetService, projectService);
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     super.ngOnInit();
     if (this.componentContent.computerAvatarSettings == null) {
       this.componentContent.computerAvatarSettings =

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.ts
@@ -29,7 +29,6 @@ import { EditCRaterInfoComponent } from '../../common/cRater/edit-crater-info/ed
     MatFormFieldModule
   ],
   selector: 'dialog-guidance-authoring',
-  styles: ['edit-feedback-rules { margin-bottom: 16px; } '],
   templateUrl: './dialog-guidance-authoring.component.html'
 })
 export class DialogGuidanceAuthoringComponent extends AbstractComponentAuthoring {

--- a/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.ts
@@ -14,12 +14,14 @@ import { CRaterRubric } from '../../common/cRater/CRaterRubric';
 import { EditFeedbackRulesComponent } from '../../common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component';
 import { EditDialogGuidanceComputerAvatarComponent } from '../edit-dialog-guidance-computer-avatar/edit-dialog-guidance-computer-avatar.component';
 import { CRaterItemSelectComponent } from '../../common/cRater/crater-item-select/crater-item-select.component';
+import { EditCRaterInfoComponent } from '../../common/cRater/edit-crater-info/edit-crater-info.component';
 
 @Component({
   imports: [
     CRaterItemSelectComponent,
     EditComponentMaxSubmitComponent,
     EditComponentPrompt,
+    EditCRaterInfoComponent,
     EditDialogGuidanceComputerAvatarComponent,
     EditFeedbackRulesComponent,
     FormsModule,

--- a/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-advanced/edit-dialog-guidance-advanced.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-advanced/edit-dialog-guidance-advanced.component.ts
@@ -2,14 +2,12 @@ import { Component } from '@angular/core';
 import { EditAdvancedComponentComponent } from '../../../../../app/authoring-tool/edit-advanced-component/edit-advanced-component.component';
 import { EditComponentConstraintsComponent } from '../../../../../app/authoring-tool/edit-component-constraints/edit-component-constraints.component';
 import { EditComponentJsonComponent } from '../../../../../app/authoring-tool/edit-component-json/edit-component-json.component';
-import { EditCRaterInfoComponent } from '../../common/cRater/edit-crater-info/edit-crater-info.component';
 
 @Component({
-  imports: [EditComponentConstraintsComponent, EditComponentJsonComponent, EditCRaterInfoComponent],
+  imports: [EditComponentConstraintsComponent, EditComponentJsonComponent],
   template: `
     <edit-component-constraints [componentContent]="component.content" />
     <edit-component-json [component]="component" />
-    <edit-crater-info [cRaterRubric]="component.content.cRaterRubric" />
   `
 })
 export class EditDialogGuidanceAdvancedComponent extends EditAdvancedComponentComponent {}

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
@@ -538,14 +538,11 @@
     }
   </div>
   <div class="section-container">
-    @if (showIdeaDescriptions) {
-      <edit-crater-idea-descriptions
-        [ideaDescriptions]="componentContent.cRater.rubric.ideas"
-        [enableAutoscrolling]="false"
-      />
-      <a (click)="toggleShowIdeaDescriptions()" i18n>Hide</a>
+    @if (showCRaterInfo) {
+      <a (click)="toggleShowCRaterInfo()" i18n>Hide CRater Information</a>
+      <edit-crater-info [cRaterRubric]="componentContent.cRater.rubric" />
     } @else {
-      <a (click)="toggleShowIdeaDescriptions()" i18n>Show Idea Descriptions</a>
+      <a (click)="toggleShowCRaterInfo()" i18n>Show CRater Information</a>
     }
   </div>
 }

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
@@ -28,34 +28,7 @@
   </mat-checkbox>
 </div>
 @if (componentContent.enableCRater) {
-  <div class="flex flex-row items-center justify-start gap-4">
-    <mat-form-field>
-      <mat-label i18n>Item Id</mat-label>
-      <input
-        matInput
-        [(ngModel)]="componentContent.cRater.itemId"
-        (ngModelChange)="componentChanged()"
-      />
-    </mat-form-field>
-    <div>
-      <button
-        mat-raised-button
-        color="primary"
-        (click)="verifyCRaterItemId(componentContent.cRater.itemId)"
-        i18n
-      >
-        Verify
-      </button>
-    </div>
-    @if (isVerifyingCRaterItemId) {
-      <span i18n>Verifying...</span>
-    }
-    @if (cRaterItemIdIsValid) {
-      <span class="valid" i18n>Valid</span>
-    } @else {
-      <span class="invalid" i18n>Invalid</span>
-    }
-  </div>
+  <c-rater-item-select [componentContent]="componentContent" />
   <div>
     <mat-form-field>
       <mat-label i18n>Score On</mat-label>

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
@@ -24,7 +24,7 @@
     (ngModelChange)="enableCRaterClicked()"
     i18n
   >
-    Enable CRater
+    Enable AI Model
   </mat-checkbox>
 </div>
 @if (componentContent.enableCRater) {
@@ -538,11 +538,8 @@
     }
   </div>
   <div class="section-container">
-    @if (showCRaterInfo) {
-      <a (click)="toggleShowCRaterInfo()" i18n>Hide CRater Information</a>
+    @if (componentContent.enableCRater) {
       <edit-crater-info [cRaterRubric]="componentContent.cRater.rubric" />
-    } @else {
-      <a (click)="toggleShowCRaterInfo()" i18n>Show CRater Information</a>
     }
   </div>
 }

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
@@ -12,17 +12,12 @@ import { EditCommonAdvancedComponent } from '../../../../../app/authoring-tool/e
 import { EditComponentAddToNotebookButtonComponent } from '../../../../../app/authoring-tool/edit-component-add-to-notebook-button/edit-component-add-to-notebook-button.component';
 import { TranslatableTextareaComponent } from '../../../authoringTool/components/translatable-textarea/translatable-textarea.component';
 import { ComponentContent } from '../../../common/ComponentContent';
-import { CRaterService } from '../../../services/cRaterService';
-import { NotebookService } from '../../../services/notebookService';
-import { TeacherNodeService } from '../../../services/teacherNodeService';
-import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { EditCRaterIdeaDescriptionsComponent } from '../../common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component';
 import { EditFeedbackRulesComponent } from '../../common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component';
 import { OpenResponseContent } from '../OpenResponseContent';
+import { CRaterItemSelectComponent } from '../../common/cRater/crater-item-select/crater-item-select.component';
 
 @Component({
-  styleUrl: 'edit-open-response-advanced.component.scss',
-  templateUrl: 'edit-open-response-advanced.component.html',
   imports: [
     TranslatableTextareaComponent,
     MatCheckbox,
@@ -36,13 +31,15 @@ import { OpenResponseContent } from '../OpenResponseContent';
     MatIcon,
     EditCRaterIdeaDescriptionsComponent,
     EditComponentAddToNotebookButtonComponent,
-    EditCommonAdvancedComponent
-  ]
+    EditCommonAdvancedComponent,
+    CRaterItemSelectComponent
+  ],
+  styleUrl: 'edit-open-response-advanced.component.scss',
+  templateUrl: 'edit-open-response-advanced.component.html'
 })
 export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComponent {
   protected allowedConnectedComponentTypes = ['OpenResponse'];
   componentContent: OpenResponseContent;
-  protected cRaterItemIdIsValid: boolean = null;
   private initialFeedbackRules = [
     {
       id: 'isDefault',
@@ -50,19 +47,9 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
       feedback: [$localize`Default feedback`]
     }
   ];
-  protected isVerifyingCRaterItemId: boolean;
   protected nodeIds: string[] = [];
   useCustomCompletionCriteria: boolean;
   protected showIdeaDescriptions = true;
-
-  constructor(
-    protected cRaterService: CRaterService,
-    protected nodeService: TeacherNodeService,
-    protected notebookService: NotebookService,
-    protected teacherProjectService: TeacherProjectService
-  ) {
-    super(nodeService, notebookService, teacherProjectService);
-  }
 
   ngOnInit(): void {
     super.ngOnInit();
@@ -139,15 +126,6 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
       this.componentContent.cRater.scoringRules.splice(index, 1);
       this.componentChanged();
     }
-  }
-
-  verifyCRaterItemId(itemId: string): void {
-    this.cRaterItemIdIsValid = null;
-    this.isVerifyingCRaterItemId = true;
-    this.cRaterService.makeCRaterVerifyRequest(itemId).then((response: any) => {
-      this.isVerifyingCRaterItemId = false;
-      this.cRaterItemIdIsValid = response.available;
-    });
   }
 
   addMultipleAttemptScoringRule(): void {

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
@@ -48,7 +48,6 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
     }
   ];
   protected nodeIds: string[] = [];
-  protected showCRaterInfo: boolean;
   useCustomCompletionCriteria: boolean;
 
   ngOnInit(): void {
@@ -59,7 +58,6 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
     this.nodeIds = this.teacherProjectService.getFlattenedProjectAsNodeIds();
     if (this.componentContent.enableCRater) {
       this.createCRaterAndRubricIfNull();
-      this.showCRaterInfo = true;
     }
   }
 
@@ -278,10 +276,6 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
       this.componentContent.completionCriteria.criteria.splice(index, 1);
       this.componentChanged();
     }
-  }
-
-  protected toggleShowCRaterInfo(): void {
-    this.showCRaterInfo = !this.showCRaterInfo;
   }
 
   getComponents(nodeId: string): ComponentContent[] {

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
@@ -12,10 +12,10 @@ import { EditCommonAdvancedComponent } from '../../../../../app/authoring-tool/e
 import { EditComponentAddToNotebookButtonComponent } from '../../../../../app/authoring-tool/edit-component-add-to-notebook-button/edit-component-add-to-notebook-button.component';
 import { TranslatableTextareaComponent } from '../../../authoringTool/components/translatable-textarea/translatable-textarea.component';
 import { ComponentContent } from '../../../common/ComponentContent';
-import { EditCRaterIdeaDescriptionsComponent } from '../../common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component';
 import { EditFeedbackRulesComponent } from '../../common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component';
 import { OpenResponseContent } from '../OpenResponseContent';
 import { CRaterItemSelectComponent } from '../../common/cRater/crater-item-select/crater-item-select.component';
+import { EditCRaterInfoComponent } from '../../common/cRater/edit-crater-info/edit-crater-info.component';
 
 @Component({
   imports: [
@@ -29,9 +29,9 @@ import { CRaterItemSelectComponent } from '../../common/cRater/crater-item-selec
     EditFeedbackRulesComponent,
     MatTooltip,
     MatIcon,
-    EditCRaterIdeaDescriptionsComponent,
     EditComponentAddToNotebookButtonComponent,
     EditCommonAdvancedComponent,
+    EditCRaterInfoComponent,
     CRaterItemSelectComponent
   ],
   styleUrl: 'edit-open-response-advanced.component.scss',
@@ -48,8 +48,8 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
     }
   ];
   protected nodeIds: string[] = [];
+  protected showCRaterInfo: boolean;
   useCustomCompletionCriteria: boolean;
-  protected showIdeaDescriptions = true;
 
   ngOnInit(): void {
     super.ngOnInit();
@@ -59,6 +59,7 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
     this.nodeIds = this.teacherProjectService.getFlattenedProjectAsNodeIds();
     if (this.componentContent.enableCRater) {
       this.createCRaterAndRubricIfNull();
+      this.showCRaterInfo = true;
     }
   }
 
@@ -279,8 +280,8 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
     }
   }
 
-  protected toggleShowIdeaDescriptions(): void {
-    this.showIdeaDescriptions = !this.showIdeaDescriptions;
+  protected toggleShowCRaterInfo(): void {
+    this.showCRaterInfo = !this.showCRaterInfo;
   }
 
   getComponents(nodeId: string): ComponentContent[] {

--- a/src/assets/wise5/services/cRaterService.ts
+++ b/src/assets/wise5/services/cRaterService.ts
@@ -208,18 +208,10 @@ export class CRaterService {
    * @param itemId A string.
    * @return A promise that returns whether the item id is valid.
    */
-  makeCRaterVerifyRequest(itemId: string): any {
-    const url = this.configService.getCRaterRequestURL() + '/verify';
-    const params = new HttpParams().set('itemId', itemId);
-    const options = {
-      params: params
-    };
-    return this.http
-      .get(url, options)
-      .toPromise()
-      .then((isAvailable: boolean) => {
-        return isAvailable;
-      });
+  makeCRaterVerifyRequest(itemId: string): Observable<any> {
+    return this.http.get(this.configService.getCRaterRequestURL() + '/verify', {
+      params: new HttpParams().set('itemId', itemId)
+    });
   }
 
   getCRaterResponse(responses: RawCRaterResponse, submitCounter: number): CRaterResponse {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1663,11 +1663,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">66,68</context>
+          <context context-type="linenumber">39,41</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">524,525</context>
+          <context context-type="linenumber">497,498</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/node/node.component.html</context>
@@ -1729,7 +1729,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">505,506</context>
+          <context context-type="linenumber">478,479</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html</context>
@@ -1744,7 +1744,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">515,519</context>
+          <context context-type="linenumber">488,492</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.html</context>
@@ -1783,7 +1783,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">493,494</context>
+          <context context-type="linenumber">466,467</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html</context>
@@ -2461,7 +2461,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">132,135</context>
+          <context context-type="linenumber">105,108</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8352660755693654653" datatype="html">
@@ -9008,11 +9008,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">67,69</context>
+          <context context-type="linenumber">40,42</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">525,528</context>
+          <context context-type="linenumber">498,501</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/node/node.component.html</context>
@@ -14486,7 +14486,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">574,575</context>
+          <context context-type="linenumber">547,548</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8461842260159597706" datatype="html">
@@ -15999,7 +15999,7 @@ Are you sure you want to proceed?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.html</context>
-          <context context-type="linenumber">21,24</context>
+          <context context-type="linenumber">13,16</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1724462837246542874" datatype="html">
@@ -16849,6 +16849,13 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">285</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="194067946846246769" datatype="html">
+        <source>Item ID</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/common/cRater/crater-item-select/crater-item-select.component.html</context>
+          <context context-type="linenumber">2,3</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="864633004805861509" datatype="html">
         <source>Idea detection rubric</source>
         <context-group purpose="location">
@@ -17533,7 +17540,7 @@ Are you ready to receive feedback on this answer?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">318,320</context>
+          <context context-type="linenumber">291,293</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8185078869695276161" datatype="html">
@@ -17741,13 +17748,6 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/detected-ideas/detected-ideas.component.html</context>
           <context context-type="linenumber">7,9</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="194067946846246769" datatype="html">
-        <source>Item ID</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-guidance-authoring/dialog-guidance-authoring.component.html</context>
-          <context context-type="linenumber">7,10</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7920283242192845616" datatype="html">
@@ -19916,7 +19916,7 @@ Warning: This will delete all existing choices and buckets in this component.</s
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">90,94</context>
+          <context context-type="linenumber">63,67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7065715943846466006" datatype="html">
@@ -20080,233 +20080,198 @@ Warning: This will delete all existing choices in this component.</source>
           <context context-type="linenumber">27,31</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8299940778443852460" datatype="html">
-        <source>Item Id</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">33,36</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1812429098722823159" datatype="html">
-        <source> Verify </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">47,51</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4371485180715105780" datatype="html">
-        <source>Verifying...</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">51,54</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2831497907036176442" datatype="html">
-        <source>Valid</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">54,57</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4136129438009397007" datatype="html">
-        <source>Invalid</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">56,61</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="9153897398545804453" datatype="html">
         <source>Score On</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">61,63</context>
+          <context context-type="linenumber">34,36</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1230154438678955604" datatype="html">
         <source>Change</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">68,73</context>
+          <context context-type="linenumber">41,46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7401107549258505528" datatype="html">
         <source> Show Score </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">80,85</context>
+          <context context-type="linenumber">53,58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6706329976663713413" datatype="html">
         <source> Enable Feedback Rules </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">100,102</context>
+          <context context-type="linenumber">73,75</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5056621402071854825" datatype="html">
         <source>Scoring Rule</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">111,114</context>
+          <context context-type="linenumber">84,87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2840439048375115947" datatype="html">
         <source>Add Scoring Rule</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">116,119</context>
+          <context context-type="linenumber">89,92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1749702431264125217" datatype="html">
         <source>Feedback Text</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">144,146</context>
+          <context context-type="linenumber">117,119</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6318060955337736972" datatype="html">
         <source>Move Scoring Rule Up</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">155,158</context>
+          <context context-type="linenumber">128,131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8741073904951621119" datatype="html">
         <source>Move Scoring Rule Down</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">166,169</context>
+          <context context-type="linenumber">139,142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8481143767365565734" datatype="html">
         <source>Delete Scoring Rule</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">176,179</context>
+          <context context-type="linenumber">149,152</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4753983371217895606" datatype="html">
         <source> Enable Multiple Attempt Feedback </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">196,199</context>
+          <context context-type="linenumber">169,172</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6924674031457346140" datatype="html">
         <source>Multiple Attempt Scoring Rules</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">201,204</context>
+          <context context-type="linenumber">174,177</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2707777420645958826" datatype="html">
         <source>Add Multiple Attempt Scoring Rule</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">206,209</context>
+          <context context-type="linenumber">179,182</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2885623017281914681" datatype="html">
         <source>Previous Score</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">222,225</context>
+          <context context-type="linenumber">195,198</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">331,334</context>
+          <context context-type="linenumber">304,307</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2466216299740593982" datatype="html">
         <source>Current Score</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">231,234</context>
+          <context context-type="linenumber">204,207</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">341,344</context>
+          <context context-type="linenumber">314,317</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8219288603984689566" datatype="html">
         <source>Feedback to Student</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">242,244</context>
+          <context context-type="linenumber">215,217</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">429,431</context>
+          <context context-type="linenumber">402,404</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1237543279965214424" datatype="html">
         <source>Move Multiple Attempt Scoring Rule Up</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">258,261</context>
+          <context context-type="linenumber">231,234</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5646689888494364443" datatype="html">
         <source>Move Multiple Attempt Scoring Rule Down</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">274,277</context>
+          <context context-type="linenumber">247,250</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8247485612014750779" datatype="html">
         <source>Delet Multiple Attempt Scoring</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">284,287</context>
+          <context context-type="linenumber">257,260</context>
         </context-group>
       </trans-unit>
       <trans-unit id="681347196878226021" datatype="html">
         <source> Enable Notifications </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">304,307</context>
+          <context context-type="linenumber">277,280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5851560788527570644" datatype="html">
         <source>Notifications</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">309,312</context>
+          <context context-type="linenumber">282,285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="370200567263525921" datatype="html">
         <source>Move Notification Up</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">362,364</context>
+          <context context-type="linenumber">335,337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2769177863929534863" datatype="html">
         <source>Move Notification Down</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">378,380</context>
+          <context context-type="linenumber">351,353</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1807548935384776633" datatype="html">
         <source>Delete Notification</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">388,390</context>
+          <context context-type="linenumber">361,363</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6336206965755061198" datatype="html">
         <source> Enable Ambient Display Dismiss Mode </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">403,405</context>
+          <context context-type="linenumber">376,378</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4441143426637747672" datatype="html">
         <source>Dismiss Code</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">407,410</context>
+          <context context-type="linenumber">380,383</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/dismiss-ambient-notification-dialog/dismiss-ambient-notification-dialog.component.html</context>
@@ -20317,77 +20282,77 @@ Warning: This will delete all existing choices in this component.</source>
         <source> Notify Student </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">423,425</context>
+          <context context-type="linenumber">396,398</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6137238378032253613" datatype="html">
         <source> Notify Teacher </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">443,445</context>
+          <context context-type="linenumber">416,418</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6470995886890122968" datatype="html">
         <source>Feedback to Teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">449,451</context>
+          <context context-type="linenumber">422,424</context>
         </context-group>
       </trans-unit>
       <trans-unit id="853281253580647095" datatype="html">
         <source> Use Custom Completion Criteria </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">468,470</context>
+          <context context-type="linenumber">441,443</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6321190757824576813" datatype="html">
         <source>Custom Completion Criteria</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">472,475</context>
+          <context context-type="linenumber">445,448</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3954026354727494376" datatype="html">
         <source>Add Completion Criteria</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">477,480</context>
+          <context context-type="linenumber">450,453</context>
         </context-group>
       </trans-unit>
       <trans-unit id="376261460573165321" datatype="html">
         <source>Move Completion Criteria Up</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">535,538</context>
+          <context context-type="linenumber">508,511</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2584224885214103035" datatype="html">
         <source>Move Completion Criteria Down</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">546,549</context>
+          <context context-type="linenumber">519,522</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4117701430807776885" datatype="html">
         <source>Delete Completion Criteria</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">556,559</context>
+          <context context-type="linenumber">529,532</context>
         </context-group>
       </trans-unit>
       <trans-unit id="493950846706766768" datatype="html">
         <source>Show Idea Descriptions</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">575,580</context>
+          <context context-type="linenumber">548,553</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8705933649296793690" datatype="html">
         <source>Default feedback</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">47</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2839735751687486837" datatype="html">
@@ -20398,7 +20363,7 @@ Score: <x id="PH" equiv-text="score"/>
 Feedback Text: <x id="PH_1" equiv-text="feedbackText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">136</context>
+          <context context-type="linenumber">123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1461861786609911168" datatype="html">
@@ -20411,28 +20376,28 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/>
 Feedback Text: <x id="PH_2" equiv-text="feedbackText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">184</context>
+          <context context-type="linenumber">162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846244999760672149" datatype="html">
         <source>you got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">214</context>
+          <context context-type="linenumber">192</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7599226289089492371" datatype="html">
         <source>Please talk to your teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">216</context>
+          <context context-type="linenumber">194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5580639382077453513" datatype="html">
         <source>got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">218</context>
+          <context context-type="linenumber">196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="867656616658826137" datatype="html">
@@ -20443,21 +20408,21 @@ Previous Score: <x id="PH" equiv-text="previousScore"/>
 Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">232</context>
+          <context context-type="linenumber">210</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3689003016353565518" datatype="html">
         <source>Are you sure you want to delete the custom completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">266</context>
+          <context context-type="linenumber">244</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2986030604058491184" datatype="html">
         <source>Are you sure you want to delete this completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">298</context>
+          <context context-type="linenumber">276</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8648892006027324370" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -16845,8 +16845,8 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">285</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="194067946846246769" datatype="html">
-        <source>Item ID</source>
+      <trans-unit id="463092785656273861" datatype="html">
+        <source>AI Model ID</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/crater-item-select/crater-item-select.component.html</context>
           <context context-type="linenumber">2,3</context>
@@ -16873,18 +16873,11 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">17,20</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1859914769947265531" datatype="html">
-        <source>Model Description</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/common/cRater/edit-crater-description/edit-crater-description.component.html</context>
-          <context context-type="linenumber">3,5</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="5849203454479447363" datatype="html">
         <source>User-Friendly Description</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/edit-crater-description/edit-crater-description.component.html</context>
-          <context context-type="linenumber">7,10</context>
+          <context context-type="linenumber">2,5</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/edit-crater-idea-descriptions/edit-crater-idea-descriptions.component.html</context>
@@ -16930,11 +16923,11 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">83</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6899004768129159617" datatype="html">
-        <source>Edit CRater Information</source>
+      <trans-unit id="668752428708284985" datatype="html">
+        <source>AI Model Details</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/edit-crater-info/edit-crater-info.component.ts</context>
-          <context context-type="linenumber">13,15</context>
+          <context context-type="linenumber">9,11</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5596810972110629301" datatype="html">
@@ -20069,8 +20062,8 @@ Warning: This will delete all existing choices in this component.</source>
           <context context-type="linenumber">16,22</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4878057874769185358" datatype="html">
-        <source> Enable CRater </source>
+      <trans-unit id="1759795162772199785" datatype="html">
+        <source> Enable AI Model </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
           <context context-type="linenumber">27,31</context>
@@ -20337,20 +20330,6 @@ Warning: This will delete all existing choices in this component.</source>
           <context context-type="linenumber">529,532</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8111325095864712479" datatype="html">
-        <source>Hide CRater Information</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">542,543</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7858412626108584485" datatype="html">
-        <source>Show CRater Information</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">545,550</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="8705933649296793690" datatype="html">
         <source>Default feedback</source>
         <context-group purpose="location">
@@ -20366,7 +20345,7 @@ Score: <x id="PH" equiv-text="score"/>
 Feedback Text: <x id="PH_1" equiv-text="feedbackText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">124</context>
+          <context context-type="linenumber">122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1461861786609911168" datatype="html">
@@ -20379,28 +20358,28 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/>
 Feedback Text: <x id="PH_2" equiv-text="feedbackText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">163</context>
+          <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846244999760672149" datatype="html">
         <source>you got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">193</context>
+          <context context-type="linenumber">191</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7599226289089492371" datatype="html">
         <source>Please talk to your teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">195</context>
+          <context context-type="linenumber">193</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5580639382077453513" datatype="html">
         <source>got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">195</context>
         </context-group>
       </trans-unit>
       <trans-unit id="867656616658826137" datatype="html">
@@ -20411,21 +20390,21 @@ Previous Score: <x id="PH" equiv-text="previousScore"/>
 Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">211</context>
+          <context context-type="linenumber">209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3689003016353565518" datatype="html">
         <source>Are you sure you want to delete the custom completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">245</context>
+          <context context-type="linenumber">243</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2986030604058491184" datatype="html">
         <source>Are you sure you want to delete this completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">277</context>
+          <context context-type="linenumber">275</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8648892006027324370" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -14484,10 +14484,6 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading/node-grading.component.html</context>
           <context context-type="linenumber">32,33</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">547,548</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="8461842260159597706" datatype="html">
         <source>Show</source>
@@ -20341,11 +20337,18 @@ Warning: This will delete all existing choices in this component.</source>
           <context context-type="linenumber">529,532</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="493950846706766768" datatype="html">
-        <source>Show Idea Descriptions</source>
+      <trans-unit id="8111325095864712479" datatype="html">
+        <source>Hide CRater Information</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">548,553</context>
+          <context context-type="linenumber">542,543</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7858412626108584485" datatype="html">
+        <source>Show CRater Information</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
+          <context context-type="linenumber">545,550</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8705933649296793690" datatype="html">
@@ -20363,7 +20366,7 @@ Score: <x id="PH" equiv-text="score"/>
 Feedback Text: <x id="PH_1" equiv-text="feedbackText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">123</context>
+          <context context-type="linenumber">124</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1461861786609911168" datatype="html">
@@ -20376,28 +20379,28 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/>
 Feedback Text: <x id="PH_2" equiv-text="feedbackText"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">162</context>
+          <context context-type="linenumber">163</context>
         </context-group>
       </trans-unit>
       <trans-unit id="846244999760672149" datatype="html">
         <source>you got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">192</context>
+          <context context-type="linenumber">193</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7599226289089492371" datatype="html">
         <source>Please talk to your teacher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">194</context>
+          <context context-type="linenumber">195</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5580639382077453513" datatype="html">
         <source>got a score of</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">196</context>
+          <context context-type="linenumber">197</context>
         </context-group>
       </trans-unit>
       <trans-unit id="867656616658826137" datatype="html">
@@ -20408,21 +20411,21 @@ Previous Score: <x id="PH" equiv-text="previousScore"/>
 Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">210</context>
+          <context context-type="linenumber">211</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3689003016353565518" datatype="html">
         <source>Are you sure you want to delete the custom completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">244</context>
+          <context context-type="linenumber">245</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2986030604058491184" datatype="html">
         <source>Are you sure you want to delete this completion criteria?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts</context>
-          <context context-type="linenumber">276</context>
+          <context context-type="linenumber">277</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8648892006027324370" datatype="html">


### PR DESCRIPTION
## Changes
- For both OpenResponse and DialogGuidance components:
   - Update the CRater item id field so that it is a drop-down option of all available CRater items. Before, this was an input field.
   - The CRater item verification endpoint now returns a rubric for CRater items, if it exists. This PR changes the authoring tool to use the returned rubric to populate the content's rubric field when the author updates the component's item id.
      - The newly-selected item's rubric will always overwrite any existing rubric 
- Just for DialogGuidance:
   - Move the CRater info editing (item description and idea rubric editing) from advanced editing view to the main editing view 

## Test
- Verify that the CRater editing changes above work as described
   - "berkeley_CovidImpacts" and "berkeley_HeLa" items have sample rubrics

Closes #2238 
