### PR TITLE
fix(Grade by Team): Score and max-score does not immediate update in StepItem

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts
@@ -49,7 +49,7 @@ export class StepItemComponent {
   @Input() maxScore: number;
   @Input() nodeId: string;
   @Output() onUpdateExpand: any = new EventEmitter();
-  protected score: any;
+  @Input() score: any;
   @Input() showScore: boolean;
   private status: any;
   protected statusClass: string;
@@ -67,12 +67,14 @@ export class StepItemComponent {
       this.maxScore =
         typeof changesObj.maxScore.currentValue === 'number' ? changesObj.maxScore.currentValue : 0;
     }
+    if (changesObj.score) {
+      this.score = changesObj.score.currentValue >= 0 ? changesObj.score.currentValue : '-';
+    }
     if (changesObj.stepData) {
       const stepData = copy(changesObj.stepData.currentValue);
       this.hasAlert = stepData.hasAlert;
       this.hasNewAlert = stepData.hasNewAlert;
       this.status = stepData.completionStatus;
-      this.score = stepData.score >= 0 ? stepData.score : '-';
       this.components = this.projectService.getComponents(this.nodeId);
       this.componentIdToIsVisible = calculateComponentVisibility(
         this.projectService.calculateComponentIdToHasWork(this.components),

--- a/src/assets/wise5/classroomMonitor/student-grading/student-grading.component.html
+++ b/src/assets/wise5/classroomMonitor/student-grading/student-grading.component.html
@@ -106,6 +106,7 @@
               [maxScore]="node.maxScore"
               [showScore]="node.hasWork"
               [nodeId]="node.id"
+              [score]="node.score"
               [stepData]="node"
               [workgroupId]="workgroupId"
               (onUpdateExpand)="onUpdateExpand($event)"

--- a/src/assets/wise5/classroomMonitor/student-grading/student-grading.component.ts
+++ b/src/assets/wise5/classroomMonitor/student-grading/student-grading.component.ts
@@ -227,6 +227,7 @@ export class StudentGradingComponent implements OnInit {
       node.nodeStatus = this.classroomStatusService.getStudentStatusForWorkgroupId(
         this.workgroupId
       )?.nodeStatuses[nodeId];
+      this.sortedNodes = Object.values(this.nodesById);
     }
   }
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -9528,7 +9528,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts</context>
-          <context context-type="linenumber">94</context>
+          <context context-type="linenumber">96</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/themes/default/themeComponents/nodeStatusIcon/node-status-icon.component.html</context>
@@ -14382,7 +14382,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts</context>
-          <context context-type="linenumber">89</context>
+          <context context-type="linenumber">91</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5725893165169390019" datatype="html">
@@ -14397,7 +14397,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts</context>
-          <context context-type="linenumber">101</context>
+          <context context-type="linenumber">103</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2981239280931729191" datatype="html">
@@ -14412,7 +14412,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts</context>
-          <context context-type="linenumber">106</context>
+          <context context-type="linenumber">108</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4729134067352333395" datatype="html">
@@ -14514,7 +14514,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">98</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6699405178343319429" datatype="html">
@@ -14525,7 +14525,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/studentGrading/step-item/step-item.component.ts</context>
-          <context context-type="linenumber">108</context>
+          <context context-type="linenumber">110</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2488512407151757745" datatype="html">


### PR DESCRIPTION
This PR fixes the issue where updating the component score/max score in grade by team page did not immediately update those figures in StepItem. This was happening after we switched to the new for template syntax, which was not causing the StepItem element to be re-rendered.