### PR TITLE
feat(NodeAuthoring): Show component preview in current language

### DIFF
--- a/src/assets/wise5/authoringTool/components/component-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/components/component-authoring.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, effect, EventEmitter, Input, Output } from '@angular/core';
 import { ComponentContent } from '../../common/ComponentContent';
 import { PreviewComponentComponent } from './preview-component/preview-component.component';
 import { EditComponentComponent } from './edit-component/edit-component.component';
@@ -6,6 +6,8 @@ import { ComponentFactory } from '../../common/ComponentFactory';
 import { Component as WISEComponent } from '../../common/Component';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { TeacherProjectTranslationService } from '../../services/teacherProjectTranslationService';
+import { copy } from '../../common/object/object';
 
 @Component({
   imports: [PreviewComponentComponent, EditComponentComponent, MatTooltipModule],
@@ -53,12 +55,22 @@ export class ComponentAuthoringComponent {
   @Output() editComponentEvent: EventEmitter<void> = new EventEmitter<void>();
   @Input() nodeId: string;
 
-  constructor(private projectService: TeacherProjectService) {}
-
-  ngOnChanges(): void {
-    this.component = new ComponentFactory().getComponent(
-      this.projectService.injectAssetPaths(this.componentContent),
-      this.nodeId
-    );
+  constructor(
+    private projectService: TeacherProjectService,
+    private projectTranslationService: TeacherProjectTranslationService
+  ) {
+    effect(() => {
+      // apply translations to a copy of the component content so the original component content
+      // is not modified for subsequent use.
+      const componentContent = copy(this.componentContent);
+      this.projectTranslationService.applyTranslations(
+        componentContent,
+        this.projectTranslationService.currentTranslations()
+      );
+      this.component = new ComponentFactory().getComponent(
+        this.projectService.injectAssetPaths(componentContent),
+        this.nodeId
+      );
+    });
   }
 }

--- a/src/assets/wise5/services/projectTranslationService.ts
+++ b/src/assets/wise5/services/projectTranslationService.ts
@@ -1,9 +1,10 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { catchError, Observable, of } from 'rxjs';
+import { catchError, lastValueFrom, Observable, of, switchMap } from 'rxjs';
 import { ConfigService } from './configService';
 import { ProjectService } from './projectService';
 import { Translations } from '../../../app/domain/translations';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 
 @Injectable()
 export class ProjectTranslationService {
@@ -12,6 +13,17 @@ export class ProjectTranslationService {
     protected http: HttpClient,
     protected projectService: ProjectService
   ) {}
+
+  currentTranslations = toSignal(
+    toObservable(this.projectService.currentLanguage).pipe(
+      switchMap((language) =>
+        this.projectService.getLocale().isDefaultLocale(language.locale)
+          ? of({})
+          : lastValueFrom(this.fetchTranslations(language.locale))
+      )
+    ),
+    { initialValue: {} }
+  );
 
   protected fetchTranslations(locale: string): Observable<Translations> {
     return this.http
@@ -25,5 +37,24 @@ export class ProjectTranslationService {
     return this.configService
       .getConfigParam('projectURL')
       .replace('project.json', `translations.${locale}.json`);
+  }
+
+  applyTranslations(projectElement: object, translations: Translations): void {
+    Object.keys(projectElement)
+      .filter((key) => key.endsWith('.i18n'))
+      .forEach((key) => {
+        const translationKey = projectElement[key].id;
+        if (translations[translationKey]) {
+          const keyWithoutI18NId = key.substring(0, key.lastIndexOf('.i18n'));
+          projectElement[keyWithoutI18NId] = translations[translationKey].value;
+        }
+      });
+    Object.values(projectElement).forEach((value) => {
+      if (Array.isArray(value)) {
+        value.forEach((val) => this.applyTranslations(val, translations));
+      } else if (typeof value === 'object' && value != null) {
+        this.applyTranslations(value, translations);
+      }
+    });
   }
 }

--- a/src/assets/wise5/services/studentProjectTranslationService.ts
+++ b/src/assets/wise5/services/studentProjectTranslationService.ts
@@ -1,9 +1,8 @@
 import { Injectable } from '@angular/core';
-import { lastValueFrom, of, switchMap, tap } from 'rxjs';
+import { lastValueFrom, of, tap } from 'rxjs';
 import { copy } from '../common/object/object';
 import { Translations } from '../../../app/domain/translations';
 import { ProjectTranslationService } from './projectTranslationService';
-import { toSignal, toObservable } from '@angular/core/rxjs-interop';
 import { Language } from '../../../app/domain/language';
 import { HttpClient } from '@angular/common/http';
 import { ConfigService } from './configService';
@@ -20,17 +19,6 @@ export class StudentProjectTranslationService extends ProjectTranslationService 
   ) {
     super(configService, http, projectService);
   }
-
-  currentTranslations = toSignal(
-    toObservable(this.projectService.currentLanguage).pipe(
-      switchMap((language) =>
-        this.projectService.getLocale().isDefaultLocale(language.locale)
-          ? of({})
-          : lastValueFrom(this.fetchTranslations(language.locale))
-      )
-    ),
-    { initialValue: {} }
-  );
 
   async switchLanguage(language: Language, requester: 'student' | 'system'): Promise<void> {
     this.projectService.setCurrentLanguage(language);
@@ -63,24 +51,5 @@ export class StudentProjectTranslationService extends ProjectTranslationService 
     const project = copy(this.projectService.getOriginalProject());
     this.projectService.setProject(project);
     return project;
-  }
-
-  private applyTranslations(projectElement: object, translations: Translations): void {
-    Object.keys(projectElement)
-      .filter((key) => key.endsWith('.i18n'))
-      .forEach((key) => {
-        const translationKey = projectElement[key].id;
-        if (translations[translationKey]) {
-          const keyWithoutI18NId = key.substring(0, key.lastIndexOf('.i18n'));
-          projectElement[keyWithoutI18NId] = translations[translationKey].value;
-        }
-      });
-    Object.values(projectElement).forEach((value) => {
-      if (Array.isArray(value)) {
-        value.forEach((val) => this.applyTranslations(val, translations));
-      } else if (typeof value === 'object' && value != null) {
-        this.applyTranslations(value, translations);
-      }
-    });
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10649,7 +10649,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>Edit content</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/component-authoring.component.ts</context>
-          <context context-type="linenumber">44,49</context>
+          <context context-type="linenumber">46,51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4602079498884979331" datatype="html">


### PR DESCRIPTION
## Changes
- In node authoring, show the component preview in the currently-selected language. Before, it was always showing the preview in default language.

## Test
- For units with translations
   - Component previews in node authoring view are displayed in the currently-selected language
   - Try switching languages and ensure that component previews update to display that language
- For units without translations: AT loads and works as before
