### PR TITLE
fix(Layout): Revert display property for media elements

### DIFF
--- a/src/style/base/_base.scss
+++ b/src/style/base/_base.scss
@@ -12,6 +12,10 @@ ol, ul {
   padding-inline-start: 1em;
 }
 
+img, svg, video, canvas, audio, iframe, embed, object {
+  display: revert;
+}
+
 figure {
   &.image {
     display: inline-block;


### PR DESCRIPTION
## Changes
Tailwind adds `display: block` to media elements (img, svg, video, canvas, audio, iframe, embed, object). This PR reverts media elements to browser defaults. Adding `display: block` to images and other elements was causing visual problems for existing unit content.

## Test
Check that images can display inline by default (see the open response in this step, for example: https://wise.berkeley.edu/preview/unit/40050/node23.)
