### PR TITLE
fix(Match Summary): Don't wrap choices bucket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24329,7 +24329,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -24347,7 +24346,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -24359,15 +24357,13 @@
       "version": "9.2.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -24385,7 +24381,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -24401,7 +24396,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "minipass": "^7.0.4"
       },
@@ -24413,15 +24407,13 @@
       "version": "1.1.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "http-proxy-agent": "^7.0.0",
@@ -24438,7 +24430,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/fs": "^4.0.0",
@@ -24488,7 +24479,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@npmcli/map-workspaces": "^4.0.1",
         "@npmcli/package-json": "^6.0.1",
@@ -24508,7 +24498,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -24521,7 +24510,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@npmcli/promise-spawn": "^8.0.0",
         "ini": "^5.0.0",
@@ -24541,7 +24529,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "npm-bundled": "^4.0.0",
         "npm-normalize-package-bin": "^4.0.0"
@@ -24558,7 +24545,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@npmcli/name-from-folder": "^3.0.0",
         "@npmcli/package-json": "^6.0.0",
@@ -24574,7 +24560,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "cacache": "^19.0.0",
         "json-parse-even-better-errors": "^4.0.0",
@@ -24591,7 +24576,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@npmcli/git": "^6.0.0",
         "@npmcli/installed-package-contents": "^3.0.0",
@@ -24623,7 +24607,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -24633,7 +24616,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -24643,7 +24625,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@npmcli/git": "^6.0.0",
         "glob": "^10.2.2",
@@ -24662,7 +24643,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "which": "^5.0.0"
       },
@@ -24675,7 +24655,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "postcss-selector-parser": "^7.0.0"
       },
@@ -24688,7 +24667,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -24698,7 +24676,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@npmcli/node-gyp": "^4.0.0",
         "@npmcli/package-json": "^6.0.0",
@@ -24717,7 +24694,6 @@
       "inBundle": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -24727,7 +24703,6 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -24737,7 +24712,6 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.4.1",
         "tuf-js": "^3.0.1"
@@ -24751,7 +24725,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
@@ -24761,7 +24734,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -24771,7 +24743,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -24781,7 +24752,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -24791,7 +24761,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -24803,29 +24772,25 @@
       "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "cmd-shim": "^7.0.0",
         "npm-normalize-package-bin": "^4.0.0",
@@ -24842,7 +24807,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -24855,7 +24819,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -24865,7 +24828,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@npmcli/fs": "^4.0.0",
         "fs-minipass": "^3.0.0",
@@ -24889,7 +24851,6 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -24899,7 +24860,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
       },
@@ -24915,7 +24875,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -24933,7 +24892,6 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -24943,7 +24901,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -24956,7 +24913,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -24972,7 +24928,6 @@
       ],
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -24982,7 +24937,6 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "ip-regex": "^5.0.0"
       },
@@ -24995,7 +24949,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1"
@@ -25009,7 +24962,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -25019,7 +24971,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -25031,22 +24982,19 @@
       "version": "1.1.4",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/cross-spawn": {
       "version": "7.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -25061,7 +25009,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -25077,7 +25024,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -25090,7 +25036,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -25108,7 +25053,6 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -25117,15 +25061,13 @@
       "version": "0.2.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
@@ -25133,7 +25075,6 @@
       "inBundle": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -25143,7 +25084,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -25152,22 +25092,19 @@
       "version": "2.0.3",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.2",
       "dev": true,
       "inBundle": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.9.1"
       }
@@ -25177,7 +25114,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
@@ -25194,7 +25130,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -25207,7 +25142,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -25227,15 +25161,13 @@
       "version": "4.2.11",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "8.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "lru-cache": "^10.0.1"
       },
@@ -25247,15 +25179,13 @@
       "version": "4.2.0",
       "dev": true,
       "inBundle": true,
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -25269,7 +25199,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -25284,7 +25213,6 @@
       "inBundle": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -25297,7 +25225,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "minimatch": "^9.0.0"
       },
@@ -25310,7 +25237,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -25320,7 +25246,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -25330,7 +25255,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@npmcli/package-json": "^6.0.0",
         "npm-package-arg": "^12.0.0",
@@ -25349,7 +25273,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -25363,7 +25286,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -25376,7 +25298,6 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "cidr-regex": "^4.1.1"
       },
@@ -25389,7 +25310,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -25398,15 +25318,13 @@
       "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/jackspeak": {
       "version": "3.4.3",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -25421,15 +25339,13 @@
       "version": "1.1.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -25439,7 +25355,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
@@ -25451,29 +25366,25 @@
         "node >= 0.2.0"
       ],
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "9.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "npm-package-arg": "^12.0.0",
         "npm-registry-fetch": "^18.0.1"
@@ -25487,7 +25398,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^8.0.1",
         "@npmcli/installed-package-contents": "^3.0.0",
@@ -25507,7 +25417,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^8.0.1",
         "@npmcli/run-script": "^9.0.1",
@@ -25529,7 +25438,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^8.0.1"
       },
@@ -25542,7 +25450,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "aproba": "^2.0.0",
         "npm-registry-fetch": "^18.0.1"
@@ -25556,7 +25463,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "aproba": "^2.0.0",
         "npm-registry-fetch": "^18.0.1"
@@ -25570,7 +25476,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^8.0.1",
         "@npmcli/run-script": "^9.0.1",
@@ -25586,7 +25491,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "ci-info": "^4.0.0",
         "normalize-package-data": "^7.0.0",
@@ -25606,7 +25510,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "npm-registry-fetch": "^18.0.1"
       },
@@ -25619,7 +25522,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "aproba": "^2.0.0",
         "npm-registry-fetch": "^18.0.1"
@@ -25633,7 +25535,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@npmcli/git": "^6.0.1",
         "@npmcli/run-script": "^9.0.1",
@@ -25649,15 +25550,13 @@
       "version": "10.4.3",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "14.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@npmcli/agent": "^3.0.0",
         "cacache": "^19.0.1",
@@ -25680,7 +25579,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -25690,7 +25588,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -25706,7 +25603,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -25716,7 +25612,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -25729,7 +25624,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3",
         "minipass-sized": "^1.0.3",
@@ -25747,7 +25641,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -25760,7 +25653,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -25773,7 +25665,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -25786,7 +25677,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -25799,7 +25689,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -25812,7 +25701,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -25825,7 +25713,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minipass": "^7.1.2"
       },
@@ -25838,7 +25725,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -25850,15 +25736,13 @@
       "version": "2.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -25868,7 +25752,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
@@ -25893,7 +25776,6 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25903,7 +25785,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
       },
@@ -25919,7 +25800,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -25937,7 +25817,6 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25947,7 +25826,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "abbrev": "^3.0.0"
       },
@@ -25963,7 +25841,6 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "hosted-git-info": "^8.0.0",
         "semver": "^7.3.5",
@@ -25978,7 +25855,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -25988,7 +25864,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "npm-normalize-package-bin": "^4.0.0"
       },
@@ -26001,7 +25876,6 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "semver": "^7.1.1"
       },
@@ -26014,7 +25888,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -26024,7 +25897,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "hosted-git-info": "^8.0.0",
         "proc-log": "^5.0.0",
@@ -26040,7 +25912,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "ignore-walk": "^7.0.0"
       },
@@ -26053,7 +25924,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "npm-install-checks": "^7.1.0",
         "npm-normalize-package-bin": "^4.0.0",
@@ -26069,7 +25939,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "npm-registry-fetch": "^18.0.0",
         "proc-log": "^5.0.0"
@@ -26083,7 +25952,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@npmcli/redact": "^3.0.0",
         "jsonparse": "^1.3.1",
@@ -26103,7 +25971,6 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -26113,7 +25980,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -26125,15 +25991,13 @@
       "version": "1.0.1",
       "dev": true,
       "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "peer": true
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "19.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@npmcli/git": "^6.0.0",
         "@npmcli/installed-package-contents": "^3.0.0",
@@ -26165,7 +26029,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "json-parse-even-better-errors": "^4.0.0",
         "just-diff": "^6.0.0",
@@ -26180,7 +26043,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -26190,7 +26052,6 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -26207,7 +26068,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -26221,7 +26081,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -26231,7 +26090,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -26241,7 +26099,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
@@ -26251,7 +26108,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
@@ -26261,7 +26117,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -26275,7 +26130,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "read": "^4.0.0"
       },
@@ -26287,7 +26141,6 @@
       "version": "0.12.0",
       "dev": true,
       "inBundle": true,
-      "peer": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
@@ -26297,7 +26150,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "mute-stream": "^2.0.0"
       },
@@ -26310,7 +26162,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -26320,7 +26171,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "json-parse-even-better-errors": "^4.0.0",
         "npm-normalize-package-bin": "^4.0.0"
@@ -26334,7 +26184,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -26344,15 +26193,13 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.7.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -26365,7 +26212,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -26378,7 +26224,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -26388,7 +26233,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -26401,7 +26245,6 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@sigstore/bundle": "^3.1.0",
         "@sigstore/core": "^2.0.0",
@@ -26419,7 +26262,6 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.4.0"
       },
@@ -26432,7 +26274,6 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -26442,7 +26283,6 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@sigstore/bundle": "^3.1.0",
         "@sigstore/core": "^2.0.0",
@@ -26460,7 +26300,6 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@sigstore/bundle": "^3.1.0",
         "@sigstore/core": "^2.0.0",
@@ -26475,7 +26314,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -26486,7 +26324,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -26501,7 +26338,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -26516,7 +26352,6 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -26527,7 +26362,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -26537,15 +26371,13 @@
       "version": "2.5.0",
       "dev": true,
       "inBundle": true,
-      "license": "CC-BY-3.0",
-      "peer": true
+      "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -26555,22 +26387,19 @@
       "version": "3.0.21",
       "dev": true,
       "inBundle": true,
-      "license": "CC0-1.0",
-      "peer": true
+      "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/sprintf-js": {
       "version": "1.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "12.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -26583,7 +26412,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -26599,7 +26427,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -26614,7 +26441,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -26628,7 +26454,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -26641,7 +26466,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -26654,7 +26478,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -26672,7 +26495,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -26685,7 +26507,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -26698,7 +26519,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -26708,7 +26528,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -26722,7 +26541,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -26734,22 +26552,19 @@
       "version": "0.2.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
       "version": "0.2.14",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fdir": "^6.4.4",
         "picomatch": "^4.0.2"
@@ -26766,7 +26581,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -26781,7 +26595,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -26794,7 +26607,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -26804,7 +26616,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tufjs/models": "3.0.1",
         "debug": "^4.3.6",
@@ -26819,7 +26630,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tufjs/canonical-json": "2.0.0",
         "minimatch": "^9.0.5"
@@ -26833,7 +26643,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "unique-slug": "^5.0.0"
       },
@@ -26846,7 +26655,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
       },
@@ -26858,15 +26666,13 @@
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -26877,7 +26683,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -26888,7 +26693,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -26897,15 +26701,13 @@
       "version": "3.0.1",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/which": {
       "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -26921,7 +26723,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -26931,7 +26732,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -26950,7 +26750,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -26968,7 +26767,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -26984,7 +26782,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -26996,15 +26793,13 @@
       "version": "9.2.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -27022,7 +26817,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -27038,7 +26832,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -27051,8 +26844,7 @@
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/nth-check": {
       "version": "2.1.1",

--- a/src/app/chatbot/awsBedRock.service.ts
+++ b/src/app/chatbot/awsBedRock.service.ts
@@ -4,7 +4,7 @@ import { ChatService } from './chat.service';
 @Injectable({ providedIn: 'root' })
 export class AwsBedRockService extends ChatService {
   protected chatEndpoint = '/api/aws-bedrock/chat';
-  protected model: string = 'google.gemma-3-27b-it';
+  protected model: string = 'openai.gpt-oss-20b-1:0';
 
   processResponse(response: string): string {
     return response.replace(/<reasoning>.*?<\/reasoning>/gs, '');

--- a/src/app/chatbot/awsBedRock.service.ts
+++ b/src/app/chatbot/awsBedRock.service.ts
@@ -4,7 +4,7 @@ import { ChatService } from './chat.service';
 @Injectable({ providedIn: 'root' })
 export class AwsBedRockService extends ChatService {
   protected chatEndpoint = '/api/aws-bedrock/chat';
-  protected model: string = 'openai.gpt-oss-20b-1:0';
+  protected model: string = 'google.gemma-3-27b-it';
 
   processResponse(response: string): string {
     return response.replace(/<reasoning>.*?<\/reasoning>/gs, '');

--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html
@@ -8,7 +8,7 @@
     </h3>
     <ul>
       @for (choice of bucket.choices; track $index) {
-        @if ($index < 3 || getBucketShowMore(bucket.value) || first) {
+        @if ($index < 3 || getBucketShowMore(bucket.value)) {
           <li>
             <div class="choice">
               <div [innerHTML]="choice.getId()"></div>
@@ -21,7 +21,7 @@
           </li>
         }
       }
-      @if (bucket.choices.length > 3 && !first) {
+      @if (bucket.choices.length > 3) {
         <a href="#" class="text-sm px-1" (click)="toggleBucketShowMore(bucket.value, $event)">
           @if (getBucketShowMore(bucket.value)) {
             <span i18n>Show less</span>
@@ -38,10 +38,12 @@
 @if (bucketData.length > 0) {
   <p i18n>Number of teams that moved each item (choice) into the different buckets (categories).</p>
   <div class="columns-3xs gap-2">
-    <ng-container
-      [ngTemplateOutlet]="bucketTemplate"
-      [ngTemplateOutletContext]="{ bucket: bucketData[0], first: true }"
-    />
+    <div class="break-inside-avoid">
+      <ng-container
+        [ngTemplateOutlet]="bucketTemplate"
+        [ngTemplateOutletContext]="{ bucket: bucketData[0], first: true }"
+      />
+    </div>
     @for (bucket of bucketData; track $index) {
       @if ($index > 0) {
         <div class="break-inside-avoid">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -21920,14 +21920,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Number of teams that moved each item (choice) into the different buckets (categories).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">39,42</context>
+          <context context-type="linenumber">39,41</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2004123481203797507" datatype="html">
         <source> Your students&apos; choices will show up here when they complete the activity. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">58,61</context>
+          <context context-type="linenumber">60,63</context>
         </context-group>
       </trans-unit>
       <trans-unit id="866753876041645935" datatype="html">

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -1,0 +1,2 @@
+/* Support Tailwind integration in VS Code */
+@import "tailwindcss";


### PR DESCRIPTION
## Changes
- Don't allow Choices bucket in Match summary display to break across columns. Wrapping to multiple columns was making the display difficult to read.
- Limit Choices bucket to 3 visible items by default and add a "Show more" link, like we do with the other buckets.

Before:
<img width="1281" height="512" alt="Screenshot 2026-01-28 at 3 32 27 PM" src="https://github.com/user-attachments/assets/a0bc1823-91e9-4e39-98e1-af1ce1ead1f1" />

After:
<img width="1280" height="465" alt="Screenshot 2026-01-28 at 3 34 39 PM" src="https://github.com/user-attachments/assets/9802dfc0-8364-46bf-9f53-cb447fe88b2a" />


## Test
- Make sure Match summary displays still in the grading tool.
- Make sure Choices bucket limits to 3 visible items and that "Show more" and "Show less" links toggle the rest of the items.

fixes #2261 