### PR TITLE
feat(Grade by Student): Visual location display

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/testing/ClassroomMonitorTestHelper.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/shared/testing/ClassroomMonitorTestHelper.ts
@@ -1,4 +1,4 @@
-import { StudentProgress } from '../../../student-progress/student-progress.component';
+import { StudentProgress } from '../../../student-progress/StudentProgress';
 
 export class ClassroomMonitorTestHelper {
   workgroupId1: number = 1;

--- a/src/assets/wise5/classroomMonitor/project-location/project-location.component.html
+++ b/src/assets/wise5/classroomMonitor/project-location/project-location.component.html
@@ -1,0 +1,15 @@
+<div class="container" matTooltip="{{ studentProgress.positionAndTitle }}">
+  @for (segment of segments; track segment.id) {
+    @if (segment.id === currentSegment?.id) {
+      <div class="segment">
+        {{ studentProgress.nodePosition }}
+        <mat-icon>place</mat-icon>
+        <div class="segment-bar active"></div>
+      </div>
+    } @else {
+      <div class="segment">
+        <div class="segment-bar"></div>
+      </div>
+    }
+  }
+</div>

--- a/src/assets/wise5/classroomMonitor/project-location/project-location.component.html
+++ b/src/assets/wise5/classroomMonitor/project-location/project-location.component.html
@@ -1,15 +1,21 @@
-<div class="container" matTooltip="{{ studentProgress.positionAndTitle }}">
+<div
+  class="flex justify-between w-full"
+  matTooltip="{{ studentProgress.positionAndTitle }}"
+  matTooltipPosition="above"
+>
   @for (segment of segments; track segment.id) {
-    @if (segment.id === currentSegment?.id) {
-      <div class="segment">
-        {{ studentProgress.nodePosition }}
-        <mat-icon>place</mat-icon>
-        <div class="segment-bar active"></div>
-      </div>
-    } @else {
-      <div class="segment">
-        <div class="segment-bar"></div>
-      </div>
-    }
+    <div class="segment flex-1 h-8 relative mx-0.25">
+      @if (segment.id === currentSegment?.id) {
+        <span
+          class="mat-caption absolute top-0 left-1/2 -translate-x-1/2 flex min-w-full items-center justify-center @container"
+        >
+          <mat-icon class="mat-18 @max-[2.5rem]:!hidden">place</mat-icon>
+          <span>{{ studentProgress.nodePosition }}</span>
+        </span>
+        <div class="segment-bar primary-bg"></div>
+      } @else {
+        <div class="segment-bar bg-neutral-200"></div>
+      }
+    </div>
   }
 </div>

--- a/src/assets/wise5/classroomMonitor/project-location/project-location.component.scss
+++ b/src/assets/wise5/classroomMonitor/project-location/project-location.component.scss
@@ -1,21 +1,5 @@
-.container {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  width: 100%;
-  height: 40px;
-}
-
-.segment {
-  flex: 1;
-  flex-direction: column;
-}
+@import "tailwindcss";
 
 .segment-bar {
-  height: 15px;
-  border: 1px solid black;
-}
-
-.active {
-  background-color: orange;
+  @apply h-3 absolute bottom-0 w-full;
 }

--- a/src/assets/wise5/classroomMonitor/project-location/project-location.component.scss
+++ b/src/assets/wise5/classroomMonitor/project-location/project-location.component.scss
@@ -1,0 +1,21 @@
+.container {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  width: 100%;
+  height: 40px;
+}
+
+.segment {
+  flex: 1;
+  flex-direction: column;
+}
+
+.segment-bar {
+  height: 15px;
+  border: 1px solid black;
+}
+
+.active {
+  background-color: orange;
+}

--- a/src/assets/wise5/classroomMonitor/project-location/project-location.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/project-location/project-location.component.spec.ts
@@ -186,7 +186,7 @@ describe('ProjectLocationComponent', () => {
       expect(activeSegment.querySelector('mat-icon').textContent).toBe('place');
     });
 
-    it('should apply active class to current segment bar', () => {
+    it('should apply active style to current segment bar', () => {
       component.studentProgress = new StudentProgress({
         currentNodeId: 'node2',
         nodePosition: '2.1',
@@ -196,7 +196,7 @@ describe('ProjectLocationComponent', () => {
       fixture.detectChanges();
       const segments = fixture.nativeElement.querySelectorAll('.segment');
       const activeSegmentBar = segments[1].querySelector('.segment-bar');
-      expect(activeSegmentBar.classList.contains('active')).toBeTrue();
+      expect(activeSegmentBar.classList.contains('primary-bg')).toBeTrue();
     });
 
     it('should not display node position or icon for non-current segments', () => {
@@ -213,7 +213,7 @@ describe('ProjectLocationComponent', () => {
       expect(inactiveSegment.textContent.trim()).not.toContain('2.1');
     });
 
-    it('should not apply active class to non-current segment bars', () => {
+    it('should not apply active style to non-current segment bars', () => {
       component.studentProgress = new StudentProgress({
         currentNodeId: 'node2',
         nodePosition: '2.1',
@@ -223,7 +223,7 @@ describe('ProjectLocationComponent', () => {
       fixture.detectChanges();
       const segments = fixture.nativeElement.querySelectorAll('.segment');
       const inactiveSegmentBar = segments[0].querySelector('.segment-bar');
-      expect(inactiveSegmentBar.classList.contains('active')).toBeFalse();
+      expect(inactiveSegmentBar.classList.contains('primary-bg')).toBeFalse();
     });
   });
 });

--- a/src/assets/wise5/classroomMonitor/project-location/project-location.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/project-location/project-location.component.spec.ts
@@ -1,0 +1,229 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ProjectLocationComponent } from './project-location.component';
+import { ProjectService } from '../../services/projectService';
+import { StudentProgress } from '../student-progress/StudentProgress';
+import { ClassroomMonitorTestingModule } from '../classroom-monitor-testing.module';
+import { Node } from '../../common/Node';
+
+describe('ProjectLocationComponent', () => {
+  let component: ProjectLocationComponent;
+  let fixture: ComponentFixture<ProjectLocationComponent>;
+  let projectService: ProjectService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ClassroomMonitorTestingModule, ProjectLocationComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProjectLocationComponent);
+    component = fixture.componentInstance;
+    projectService = TestBed.inject(ProjectService);
+  });
+
+  describe('ngOnChanges()', () => {
+    describe('when project has multiple group nodes', () => {
+      beforeEach(() => {
+        spyOn(projectService, 'getOrderedGroupNodes').and.returnValue([
+          { id: 'group1', title: 'Segment 1' },
+          { id: 'group2', title: 'Segment 2' },
+          { id: 'group3', title: 'Segment 3' }
+        ]);
+        spyOn(projectService, 'getParentGroup').and.returnValue({
+          id: 'group2',
+          title: 'Segment 2'
+        });
+      });
+
+      it('should set segments to group nodes', () => {
+        component.studentProgress = new StudentProgress({
+          currentNodeId: 'node2',
+          nodePosition: '2.1',
+          positionAndTitle: '2.1: Step Title'
+        });
+        component.ngOnChanges();
+        expect(component['segments'].length).toBe(3);
+        expect(component['segments'][0].id).toBe('group1');
+      });
+
+      it('should set current segment to parent group of current node', () => {
+        component.studentProgress = new StudentProgress({
+          currentNodeId: 'node2',
+          nodePosition: '2.1',
+          positionAndTitle: '2.1: Step Title'
+        });
+        component.ngOnChanges();
+        expect(component['currentSegment'].id).toBe('group2');
+        expect(projectService.getParentGroup).toHaveBeenCalledWith('node2');
+      });
+    });
+
+    describe('when project has single or no group nodes', () => {
+      beforeEach(() => {
+        spyOn(projectService, 'getOrderedGroupNodes').and.returnValue([
+          { id: 'group1', title: 'Main Group' }
+        ]);
+        spyOn(projectService, 'getNode').and.returnValue({
+          id: 'node2',
+          title: 'Step 2',
+          type: 'node'
+        } as Node);
+        projectService.idToOrder = {
+          node1: { order: 1 },
+          node2: { order: 2 },
+          node3: { order: 3 },
+          group1: { order: 0 }
+        };
+        spyOn(projectService, 'getNodes').and.returnValue([
+          { id: 'group1', type: 'group' },
+          { id: 'node1', type: 'node' },
+          { id: 'node2', type: 'node' },
+          { id: 'node3', type: 'node' }
+        ]);
+      });
+
+      it('should set segments to ordered step nodes', () => {
+        component.studentProgress = new StudentProgress({
+          currentNodeId: 'node2',
+          nodePosition: '2',
+          positionAndTitle: '2: Step Title'
+        });
+        component.ngOnChanges();
+        expect(component['segments'].length).toBe(3);
+        expect(component['segments'][0].id).toBe('node1');
+        expect(component['segments'][1].id).toBe('node2');
+        expect(component['segments'][2].id).toBe('node3');
+      });
+
+      it('should set current segment to current node', () => {
+        component.studentProgress = new StudentProgress({
+          currentNodeId: 'node2',
+          nodePosition: '2',
+          positionAndTitle: '2: Step Title'
+        });
+        component.ngOnChanges();
+        expect(component['currentSegment'].id).toBe('node2');
+        expect(projectService.getNode).toHaveBeenCalledWith('node2');
+      });
+
+      it('should filter out group nodes from segments', () => {
+        component.studentProgress = new StudentProgress({
+          currentNodeId: 'node1',
+          nodePosition: '1',
+          positionAndTitle: '1: First Step'
+        });
+        component.ngOnChanges();
+        const hasGroupNode = component['segments'].some((segment) => segment.type === 'group');
+        expect(hasGroupNode).toBeFalse();
+      });
+
+      it('should sort nodes by order', () => {
+        projectService.idToOrder = {
+          node1: { order: 3 },
+          node2: { order: 1 },
+          node3: { order: 2 },
+          group1: { order: 0 }
+        };
+        component.studentProgress = new StudentProgress({
+          currentNodeId: 'node2',
+          nodePosition: '1',
+          positionAndTitle: '1: Step Title'
+        });
+        component.ngOnChanges();
+        expect(component['segments'][0].id).toBe('node2');
+        expect(component['segments'][1].id).toBe('node3');
+        expect(component['segments'][2].id).toBe('node1');
+      });
+    });
+  });
+
+  describe('template rendering', () => {
+    beforeEach(() => {
+      spyOn(projectService, 'getOrderedGroupNodes').and.returnValue([
+        { id: 'group1', title: 'Segment 1' },
+        { id: 'group2', title: 'Segment 2' },
+        { id: 'group3', title: 'Segment 3' }
+      ]);
+      spyOn(projectService, 'getParentGroup').and.returnValue({ id: 'group2', title: 'Segment 2' });
+    });
+
+    it('should display tooltip with position and title', () => {
+      component.studentProgress = new StudentProgress({
+        currentNodeId: 'node2',
+        nodePosition: '2.1',
+        positionAndTitle: '2.1: Step Title'
+      });
+      component.ngOnChanges();
+      fixture.detectChanges();
+      expect(component.studentProgress.positionAndTitle).toBe('2.1: Step Title');
+    });
+
+    it('should render all segments', () => {
+      component.studentProgress = new StudentProgress({
+        currentNodeId: 'node2',
+        nodePosition: '2.1',
+        positionAndTitle: '2.1: Step Title'
+      });
+      component.ngOnChanges();
+      fixture.detectChanges();
+      const segments = fixture.nativeElement.querySelectorAll('.segment');
+      expect(segments.length).toBe(3);
+    });
+
+    it('should display node position and icon for current segment', () => {
+      component.studentProgress = new StudentProgress({
+        currentNodeId: 'node2',
+        nodePosition: '2.1',
+        positionAndTitle: '2.1: Step Title'
+      });
+      component.ngOnChanges();
+      fixture.detectChanges();
+      const segments = fixture.nativeElement.querySelectorAll('.segment');
+      const activeSegment = segments[1]; // group2 is the second segment
+      expect(activeSegment.textContent.trim()).toContain('2.1');
+      expect(activeSegment.querySelector('mat-icon')).toBeTruthy();
+      expect(activeSegment.querySelector('mat-icon').textContent).toBe('place');
+    });
+
+    it('should apply active class to current segment bar', () => {
+      component.studentProgress = new StudentProgress({
+        currentNodeId: 'node2',
+        nodePosition: '2.1',
+        positionAndTitle: '2.1: Step Title'
+      });
+      component.ngOnChanges();
+      fixture.detectChanges();
+      const segments = fixture.nativeElement.querySelectorAll('.segment');
+      const activeSegmentBar = segments[1].querySelector('.segment-bar');
+      expect(activeSegmentBar.classList.contains('active')).toBeTrue();
+    });
+
+    it('should not display node position or icon for non-current segments', () => {
+      component.studentProgress = new StudentProgress({
+        currentNodeId: 'node2',
+        nodePosition: '2.1',
+        positionAndTitle: '2.1: Step Title'
+      });
+      component.ngOnChanges();
+      fixture.detectChanges();
+      const segments = fixture.nativeElement.querySelectorAll('.segment');
+      const inactiveSegment = segments[0]; // group1 is the first segment
+      expect(inactiveSegment.querySelector('mat-icon')).toBeFalsy();
+      expect(inactiveSegment.textContent.trim()).not.toContain('2.1');
+    });
+
+    it('should not apply active class to non-current segment bars', () => {
+      component.studentProgress = new StudentProgress({
+        currentNodeId: 'node2',
+        nodePosition: '2.1',
+        positionAndTitle: '2.1: Step Title'
+      });
+      component.ngOnChanges();
+      fixture.detectChanges();
+      const segments = fixture.nativeElement.querySelectorAll('.segment');
+      const inactiveSegmentBar = segments[0].querySelector('.segment-bar');
+      expect(inactiveSegmentBar.classList.contains('active')).toBeFalse();
+    });
+  });
+});

--- a/src/assets/wise5/classroomMonitor/project-location/project-location.component.ts
+++ b/src/assets/wise5/classroomMonitor/project-location/project-location.component.ts
@@ -1,0 +1,38 @@
+import { Component, inject, Input } from '@angular/core';
+import { MatTooltip } from '@angular/material/tooltip';
+import { ProjectService } from '../../services/projectService';
+import { MatIcon } from '@angular/material/icon';
+import { StudentProgress } from '../student-progress/StudentProgress';
+
+@Component({
+  imports: [MatIcon, MatTooltip],
+  selector: 'project-location',
+  styleUrl: './project-location.component.scss',
+  templateUrl: './project-location.component.html'
+})
+export class ProjectLocationComponent {
+  private projectService: ProjectService = inject(ProjectService);
+
+  protected currentSegment: any;
+  protected segments: any[];
+  @Input() studentProgress: StudentProgress;
+
+  ngOnChanges(): void {
+    const groupNodes = this.projectService.getOrderedGroupNodes();
+    if (groupNodes.length > 1) {
+      this.segments = groupNodes;
+      this.currentSegment = this.projectService.getParentGroup(this.studentProgress.currentNodeId);
+    } else {
+      this.segments = this.getOrderedNodes();
+      this.currentSegment = this.projectService.getNode(this.studentProgress.currentNodeId);
+    }
+  }
+
+  private getOrderedNodes(): any[] {
+    const idToOrder = this.projectService.idToOrder;
+    return this.projectService
+      .getNodes()
+      .filter((node) => node.type !== 'group')
+      .sort((a, b) => idToOrder[a.id].order - idToOrder[b.id].order);
+  }
+}

--- a/src/assets/wise5/classroomMonitor/student-progress/StudentProgress.ts
+++ b/src/assets/wise5/classroomMonitor/student-progress/StudentProgress.ts
@@ -1,0 +1,25 @@
+import { ProjectCompletion } from '../../common/ProjectCompletion';
+
+export class StudentProgress {
+  currentNodeId: string;
+  periodId: string;
+  periodName: string;
+  workgroupId: number;
+  username: string;
+  firstName: string;
+  lastName: string;
+  nodePosition: string;
+  positionAndTitle: string;
+  order: number;
+  completion: ProjectCompletion;
+  completionPct: number;
+  score: number;
+  maxScore: number;
+  scorePct: number;
+
+  constructor(jsonObject: any = {}) {
+    for (const key of Object.keys(jsonObject)) {
+      this[key] = jsonObject[key];
+    }
+  }
+}

--- a/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html
+++ b/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.html
@@ -54,7 +54,9 @@
                 } @else {
                   <td class="heavy td--wrap">{{ student.username }}</td>
                 }
-                <td class="center td--wrap td--max-width">{{ student.position }}</td>
+                <td class="center td--wrap td--max-width">
+                  <project-location [studentProgress]="student" />
+                </td>
                 <td class="flex justify-center items-center">
                   <project-progress
                     [completed]="student.completion.completedItems"

--- a/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.spec.ts
+++ b/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.spec.ts
@@ -5,6 +5,8 @@ import { ClassroomMonitorTestingModule } from '../classroom-monitor-testing.modu
 import { ClassroomMonitorTestHelper } from '../classroomMonitorComponents/shared/testing/ClassroomMonitorTestHelper';
 import { StudentProgressComponent } from './student-progress.component';
 import { provideRouter } from '@angular/router';
+import { MockComponent } from 'ng-mocks';
+import { ProjectLocationComponent } from '../project-location/project-location.component';
 
 class SortTestParams {
   constructor(
@@ -22,7 +24,11 @@ const { workgroupId1, workgroupId2, workgroupId3, workgroupId4, workgroupId5 } =
 describe('StudentProgressComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ClassroomMonitorTestingModule, StudentProgressComponent],
+      imports: [
+        ClassroomMonitorTestingModule,
+        MockComponent(ProjectLocationComponent),
+        StudentProgressComponent
+      ],
       providers: [provideRouter([])]
     }).compileComponents();
   });

--- a/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts
+++ b/src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts
@@ -4,7 +4,6 @@ import { ConfigService } from '../../services/configService';
 import { ClassroomStatusService } from '../../services/classroomStatusService';
 import { TeacherDataService } from '../../services/teacherDataService';
 import { ActivatedRoute, Router } from '@angular/router';
-import { ProjectCompletion } from '../../common/ProjectCompletion';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
@@ -12,6 +11,8 @@ import { MatTableModule } from '@angular/material/table';
 import { CommonModule } from '@angular/common';
 import { WorkgroupSelectAutocompleteComponent } from '../../../../app/classroom-monitor/workgroup-select/workgroup-select-autocomplete/workgroup-select-autocomplete.component';
 import { ProjectProgressComponent } from '../classroomMonitorComponents/studentProgress/project-progress/project-progress.component';
+import { ProjectLocationComponent } from '../project-location/project-location.component';
+import { StudentProgress } from './StudentProgress';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -21,6 +22,7 @@ import { ProjectProgressComponent } from '../classroomMonitorComponents/studentP
     MatIconModule,
     MatListModule,
     MatTableModule,
+    ProjectLocationComponent,
     ProjectProgressComponent,
     WorkgroupSelectAutocompleteComponent
   ],
@@ -129,7 +131,9 @@ export class StudentProgressComponent implements OnInit {
     this.students
       .filter((student) => student.workgroupId === workgroupId)
       .forEach((student) => {
-        student.position = location?.position || '';
+        student.currentNodeId = location?.nodeId || '';
+        student.nodePosition = location?.nodePosition || '';
+        student.positionAndTitle = location?.positionAndTitle || '';
         student.order = location?.order || 0;
         student.completion = completion;
         student.completionPct = completion.completionPct || 0;
@@ -198,27 +202,5 @@ export class StudentProgressComponent implements OnInit {
     this.sort = this.sort === value ? `-${value}` : value;
     this.dataService.studentProgressSort = this.sort;
     this.sortWorkgroups();
-  }
-}
-
-export class StudentProgress {
-  periodId: string;
-  periodName: string;
-  workgroupId: number;
-  username: string;
-  firstName: string;
-  lastName: string;
-  position: string;
-  order: number;
-  completion: ProjectCompletion;
-  completionPct: number;
-  score: number;
-  maxScore: number;
-  scorePct: number;
-
-  constructor(jsonObject: any = {}) {
-    for (const key of Object.keys(jsonObject)) {
-      this[key] = jsonObject[key];
-    }
   }
 }

--- a/src/assets/wise5/services/classroomStatusService.ts
+++ b/src/assets/wise5/services/classroomStatusService.ts
@@ -56,7 +56,9 @@ export class ClassroomStatusService {
     if (studentStatus != null) {
       const currentNodeId = studentStatus.currentNodeId;
       return {
-        position: this.projectService.getNodePositionAndTitle(currentNodeId),
+        nodeId: currentNodeId,
+        nodePosition: this.projectService.getNodePositionById(currentNodeId),
+        positionAndTitle: this.projectService.getNodePositionAndTitle(currentNodeId),
         order: this.projectService.getNodeOrderById(currentNodeId)
       };
     }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -2701,7 +2701,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts</context>
-          <context context-type="linenumber">68</context>
+          <context context-type="linenumber">70</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
@@ -3201,7 +3201,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts</context>
-          <context context-type="linenumber">43</context>
+          <context context-type="linenumber">45</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7105610884619319408" datatype="html">
@@ -3444,7 +3444,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts</context>
-          <context context-type="linenumber">48</context>
+          <context context-type="linenumber">50</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8002081175565655432" datatype="html">
@@ -3498,7 +3498,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts</context>
-          <context context-type="linenumber">53</context>
+          <context context-type="linenumber">55</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5469305124226201713" datatype="html">
@@ -14359,7 +14359,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts</context>
-          <context context-type="linenumber">38</context>
+          <context context-type="linenumber">40</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7086571803149209594" datatype="html">
@@ -15851,7 +15851,7 @@ Are you sure you want to proceed?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts</context>
-          <context context-type="linenumber">63</context>
+          <context context-type="linenumber">65</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5263690784228037855" datatype="html">
@@ -15897,7 +15897,7 @@ Are you sure you want to proceed?</source>
         <source>Location</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts</context>
-          <context context-type="linenumber">58</context>
+          <context context-type="linenumber">60</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4385250158870992242" datatype="html">


### PR DESCRIPTION
## Notes
Please style as you see fit! I had trouble with these, as you can see in the image below:
- The highlighted segment is not the same size as the non-highlighted segments. This seems to happen for only units with multiple lessons. It looks like the width of the segment is matching the width of the step position ("1.2")
- Text overlaps with the display above. 

## Changes 
<img width="1279" height="440" alt="Screenshot 2026-02-02 at 11 01 18 PM" src="https://github.com/user-attachments/assets/361e2ccd-d552-4471-ad57-1b47df028b0b" />

In Grade by Student view, add a visual display (see above) to show where students are in the unit. Before, this was text-only, like "1.2: Let's Discuss". The visual should be more useful because it will give a quick overview of where the students are.
- If the unit has just 1 lesson, the segments are the steps in that lesson.
- If the unit has more than 1 lesson, the segments are the lessons in the unit.
- The segment that the student is on has a fill-color, a location marker, and the step number (e.g., "1.2")
- Hovering over the component shows step position text (e.g., "1.2: Let's Discuss")
- If the student hasn't done any work, it still shows the segments, but none of the segments are highlighted

## Test
- Above works as described
- Sorting by columns (location, completion, etc.) works as before