### PR TITLE
feat(Teacher Tools): Show detected ideas for Open Response grading view

### DIFF
--- a/src/app/classroom-monitor/show-crater-rubric/show-crater-rubric.component.html
+++ b/src/app/classroom-monitor/show-crater-rubric/show-crater-rubric.component.html
@@ -1,0 +1,11 @@
+@if (hasRubricData) {
+  <span class="flex items-center">
+    <mat-icon class="mat-18" color="primary">auto_awesome</mat-icon>&nbsp;<a
+      tabindex="0"
+      (click)="openIdeasRubric()"
+      (keyup.enter)="openIdeasRubric()"
+      i18n
+      >Detectable ideas</a
+    >
+  </span>
+}

--- a/src/app/classroom-monitor/show-crater-rubric/show-crater-rubric.component.scss
+++ b/src/app/classroom-monitor/show-crater-rubric/show-crater-rubric.component.scss
@@ -1,1 +1,0 @@
-// Styles for ShowCRaterRubricComponent

--- a/src/app/classroom-monitor/show-crater-rubric/show-crater-rubric.component.scss
+++ b/src/app/classroom-monitor/show-crater-rubric/show-crater-rubric.component.scss
@@ -1,0 +1,1 @@
+// Styles for ShowCRaterRubricComponent

--- a/src/app/classroom-monitor/show-crater-rubric/show-crater-rubric.component.ts
+++ b/src/app/classroom-monitor/show-crater-rubric/show-crater-rubric.component.ts
@@ -8,7 +8,6 @@ import { RubricEventService } from '../../../assets/wise5/components/common/cRat
 @Component({
   imports: [MatIconModule],
   selector: 'show-crater-rubric',
-  styleUrl: './show-crater-rubric.component.scss',
   templateUrl: './show-crater-rubric.component.html'
 })
 export class ShowCRaterRubricComponent {

--- a/src/app/classroom-monitor/show-crater-rubric/show-crater-rubric.component.ts
+++ b/src/app/classroom-monitor/show-crater-rubric/show-crater-rubric.component.ts
@@ -1,0 +1,45 @@
+import { Component, Input } from '@angular/core';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { CRaterRubric } from '../../../assets/wise5/components/common/cRater/CRaterRubric';
+import { CRaterRubricComponent } from '../../../assets/wise5/components/common/cRater/crater-rubric/crater-rubric.component';
+import { RubricEventService } from '../../../assets/wise5/components/common/cRater/crater-rubric/RubricEventService';
+
+@Component({
+  imports: [MatIconModule],
+  selector: 'show-crater-rubric',
+  styleUrl: './show-crater-rubric.component.scss',
+  templateUrl: './show-crater-rubric.component.html'
+})
+export class ShowCRaterRubricComponent {
+  @Input() cRaterRubric: CRaterRubric;
+  protected hasRubricData: boolean;
+  private rubricDialog: MatDialogRef<CRaterRubricComponent>;
+
+  constructor(
+    protected dialog: MatDialog,
+    protected rubricEventService: RubricEventService
+  ) {}
+
+  ngOnInit(): void {
+    this.hasRubricData = this.cRaterRubric?.hasRubricData() ?? false;
+  }
+
+  ngOnDestroy(): void {
+    if (this.rubricEventService.getIsRubricOpen()) {
+      this.rubricDialog.close();
+    }
+  }
+
+  protected openIdeasRubric(): void {
+    if (!this.rubricEventService.getIsRubricOpen()) {
+      this.rubricDialog = this.dialog.open(CRaterRubricComponent, {
+        panelClass: 'dialog-sm',
+        position: { right: '0', bottom: '0' },
+        hasBackdrop: false,
+        data: this.cRaterRubric,
+        autoFocus: false
+      });
+    }
+  }
+}

--- a/src/assets/wise5/components/dialogGuidance/detected-ideas/detected-ideas.component.html
+++ b/src/assets/wise5/components/dialogGuidance/detected-ideas/detected-ideas.component.html
@@ -1,5 +1,5 @@
 @if (ideas.length > 0) {
-  <div class="flex flex-row-reverse gap-1 items-start">
+  <div class="flex gap-1 items-start" [ngClass]="{ 'flex-row-reverse': alignEnd }">
     <div class="avatar highlighted-bg border border-gray-300">
       <mat-icon class="mat-18" aria-label="AI analysis" aria-label-i18n>auto_awesome</mat-icon>
     </div>

--- a/src/assets/wise5/components/dialogGuidance/detected-ideas/detected-ideas.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/detected-ideas/detected-ideas.component.ts
@@ -10,6 +10,7 @@ import { MatIconModule } from '@angular/material/icon';
   templateUrl: './detected-ideas.component.html'
 })
 export class DetectedIdeasComponent {
+  @Input() alignEnd: boolean = false;
   @Input() cRaterRubric: CRaterRubric;
   protected ideas: CRaterIdea[];
   @Input() responses: any;

--- a/src/assets/wise5/components/dialogGuidance/detected-ideas/detected-ideas.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/detected-ideas/detected-ideas.component.ts
@@ -1,10 +1,11 @@
 import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { CRaterRubric, getUniqueIdeas } from '../../common/cRater/CRaterRubric';
 import { CRaterIdea } from '../../common/cRater/CRaterIdea';
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
-  imports: [MatIconModule],
+  imports: [CommonModule, MatIconModule],
   selector: 'detected-ideas',
   styleUrl: './detected-ideas.component.scss',
   templateUrl: './detected-ideas.component.html'

--- a/src/assets/wise5/components/dialogGuidance/dialog-responses/dialog-responses.component.html
+++ b/src/assets/wise5/components/dialogGuidance/dialog-responses/dialog-responses.component.html
@@ -1,17 +1,11 @@
-@if (showDetectedIdeas && hasRubricData) {
-  <div class="flex items-center justify-end">
-    <mat-icon class="mat-18" color="primary">auto_awesome</mat-icon>&nbsp;<a
-      tabindex="0"
-      (click)="openIdeasRubric()"
-      (keyup.enter)="openIdeasRubric()"
-      i18n
-      >Detectable ideas</a
-    >
+@if (showDetectedIdeas) {
+  <div class="flex justify-end">
+    <show-crater-rubric [cRaterRubric]="cRaterRubric" />
   </div>
 }
 @for (response of responses; track response.timestamp) {
   @if (response.user === 'Computer' && showDetectedIdeas && cRaterRubric.ideas.length) {
-    <detected-ideas [cRaterRubric]="cRaterRubric" [responses]="[response]" />
+    <detected-ideas [cRaterRubric]="cRaterRubric" [responses]="[response]" [alignEnd]="true" />
   }
   <dialog-response [response]="response" [computerAvatar]="computerAvatar" />
 }

--- a/src/assets/wise5/components/dialogGuidance/dialog-responses/dialog-responses.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialog-responses/dialog-responses.component.ts
@@ -1,16 +1,19 @@
 import { Component, Input } from '@angular/core';
 import { ComputerAvatar } from '../../../common/computer-avatar/ComputerAvatar';
 import { CRaterRubric } from '../../common/cRater/CRaterRubric';
-import { CRaterRubricComponent } from '../../common/cRater/crater-rubric/crater-rubric.component';
 import { DetectedIdeasComponent } from '../detected-ideas/detected-ideas.component';
 import { DialogResponse } from '../DialogResponse';
 import { DialogResponseComponent } from '../dialog-response/dialog-response.component';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
-import { RubricEventService } from '../../common/cRater/crater-rubric/RubricEventService';
+import { ShowCRaterRubricComponent } from '../../../../../app/classroom-monitor/show-crater-rubric/show-crater-rubric.component';
 
 @Component({
-  imports: [DetectedIdeasComponent, DialogResponseComponent, MatIconModule],
+  imports: [
+    DetectedIdeasComponent,
+    DialogResponseComponent,
+    MatIconModule,
+    ShowCRaterRubricComponent
+  ],
   selector: 'dialog-responses',
   styleUrl: './dialog-responses.component.scss',
   templateUrl: './dialog-responses.component.html'
@@ -18,36 +21,7 @@ import { RubricEventService } from '../../common/cRater/crater-rubric/RubricEven
 export class DialogResponsesComponent {
   @Input() computerAvatar: ComputerAvatar;
   @Input() cRaterRubric: CRaterRubric;
-  protected hasRubricData: boolean;
   @Input() isWaitingForComputerResponse: boolean;
   @Input() responses: DialogResponse[] = [];
-  private rubricDialog: MatDialogRef<CRaterRubricComponent>;
   @Input() showDetectedIdeas: boolean = false;
-
-  constructor(
-    protected dialog: MatDialog,
-    protected rubricEventService: RubricEventService
-  ) {}
-
-  ngOnInit(): void {
-    this.hasRubricData = this.cRaterRubric?.hasRubricData() ?? false;
-  }
-
-  ngOnDestroy(): void {
-    if (this.rubricEventService.getIsRubricOpen()) {
-      this.rubricDialog.close();
-    }
-  }
-
-  protected openIdeasRubric(): void {
-    if (!this.rubricEventService.getIsRubricOpen()) {
-      this.rubricDialog = this.dialog.open(CRaterRubricComponent, {
-        panelClass: 'dialog-sm',
-        position: { right: '0', bottom: '0' },
-        hasBackdrop: false,
-        data: this.cRaterRubric,
-        autoFocus: false
-      });
-    }
-  }
 }

--- a/src/assets/wise5/components/openResponse/open-response-show-work/open-response-show-work.component.html
+++ b/src/assets/wise5/components/openResponse/open-response-show-work/open-response-show-work.component.html
@@ -1,3 +1,8 @@
+@if (showDetectedIdeas) {
+  <div class="flex justify-end mb-4">
+    <show-crater-rubric [cRaterRubric]="cRaterRubric" />
+  </div>
+}
 <div class="component--grading__response__content" [innerHTML]="studentResponse"></div>
 @for (audioAttachment of audioAttachments; track audioAttachment) {
   <div class="component__attachment flex items-center justify-start">
@@ -10,4 +15,11 @@
   <div class="component__attachment">
     <img [src]="otherAttachment.iconURL" class="component__attachment__content" />
   </div>
+}
+@if (showDetectedIdeas) {
+  <detected-ideas
+    [cRaterRubric]="cRaterRubric"
+    [responses]="[cRaterAnnotation.data]"
+    class="block mt-4"
+  />
 }

--- a/src/assets/wise5/components/openResponse/open-response-show-work/open-response-show-work.component.spec.ts
+++ b/src/assets/wise5/components/openResponse/open-response-show-work/open-response-show-work.component.spec.ts
@@ -1,0 +1,106 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StudentTeacherCommonServicesModule } from '../../../../../app/student-teacher-common-services.module';
+import { OpenResponseShowWorkComponent } from './open-response-show-work.component';
+import { AnnotationService } from '../../../services/annotationService';
+import { UserService } from '../../../../../app/services/user.service';
+import { ProjectService } from '../../../services/projectService';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+
+describe('OpenResponseShowWorkComponent', () => {
+  let component: OpenResponseShowWorkComponent;
+  let fixture: ComponentFixture<OpenResponseShowWorkComponent>;
+  let annotationService: AnnotationService;
+  let userService: UserService;
+  let projectService: ProjectService;
+  const mockComponentState = {
+    id: 1,
+    studentData: {
+      response: 'Student answer',
+      attachments: [
+        { type: 'audio', url: 'audio1.mp3' },
+        { type: 'audio', url: 'audio2.mp3' },
+        { type: 'image', url: 'image1.png' },
+        { type: 'file', url: 'document.pdf' }
+      ]
+    }
+  };
+  const mockCRaterAnnotation = {
+    id: 1,
+    type: 'autoScore',
+    data: {
+      ideas: [{ name: 'idea1', detected: true }]
+    },
+    studentWorkId: 1
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [OpenResponseShowWorkComponent, StudentTeacherCommonServicesModule],
+      providers: [
+        { provide: UserService, useValue: { isTeacher() {} } },
+        provideHttpClient(withInterceptorsFromDi())
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OpenResponseShowWorkComponent);
+    component = fixture.componentInstance;
+    annotationService = TestBed.inject(AnnotationService);
+    userService = TestBed.inject(UserService);
+    projectService = TestBed.inject(ProjectService);
+    component.componentState = mockComponentState;
+    component.nodeId = 'node1';
+    component.componentId = 'component1';
+    spyOn(projectService, 'getComponent').and.returnValue({
+      id: 'component1',
+      type: 'OpenResponse',
+      cRater: {
+        rubric: {
+          ideas: [{ name: 'idea1' }]
+        }
+      }
+    } as any);
+    spyOn(projectService, 'injectAssetPaths').and.callFake((arg) => arg);
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  describe('ngOnInit', () => {
+    it('should initialize student response and process attachments', () => {
+      spyOn(annotationService, 'getAnnotationsByStudentWorkId').and.returnValue([]);
+      fixture.detectChanges();
+      expect(component['studentResponse']).toBe('Student answer');
+      expect(component['audioAttachments'].length).toBe(2);
+      expect(component['otherAttachments'].length).toBe(2);
+    });
+
+    it('should set up CRater rubric and annotations when CRater is configured', () => {
+      spyOn(annotationService, 'getAnnotationsByStudentWorkId').and.returnValue([
+        mockCRaterAnnotation
+      ] as any);
+      spyOn(userService, 'isTeacher').and.returnValue(true);
+      fixture.detectChanges();
+      expect(annotationService.getAnnotationsByStudentWorkId).toHaveBeenCalledWith(1);
+    });
+
+    it('should show detected ideas when user is teacher and CRater annotation exists', () => {
+      spyOn(annotationService, 'getAnnotationsByStudentWorkId').and.returnValue([
+        mockCRaterAnnotation
+      ] as any);
+      spyOn(userService, 'isTeacher').and.returnValue(true);
+      fixture.detectChanges();
+      expect(component['showDetectedIdeas']).toBe(true);
+    });
+
+    it('should not show detected ideas when user is not a teacher', () => {
+      spyOn(annotationService, 'getAnnotationsByStudentWorkId').and.returnValue([]);
+      spyOn(userService, 'isTeacher').and.returnValue(false);
+      fixture.detectChanges();
+      expect(component['showDetectedIdeas']).toBe(false);
+    });
+  });
+});

--- a/src/assets/wise5/components/openResponse/open-response-show-work/open-response-show-work.component.ts
+++ b/src/assets/wise5/components/openResponse/open-response-show-work/open-response-show-work.component.ts
@@ -42,9 +42,7 @@ export class OpenResponseShowWorkComponent extends ComponentShowWorkDirective {
         this.annotations = this.annotationService.getAnnotationsByStudentWorkId(
           this.componentState.id
         );
-        this.cRaterAnnotation = this.annotations.find((annotation) => {
-          return annotation.type === 'autoScore' && annotation.data.ideas;
-        });
+        this.cRaterAnnotation = this.annotations.find((annotation) => annotation.type === 'autoScore' && annotation.data.ideas);
       }
       this.showDetectedIdeas =
         this.userService.isTeacher() &&

--- a/src/assets/wise5/components/openResponse/open-response-show-work/open-response-show-work.component.ts
+++ b/src/assets/wise5/components/openResponse/open-response-show-work/open-response-show-work.component.ts
@@ -1,20 +1,55 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { ComponentShowWorkDirective } from '../../component-show-work.directive';
 import { CommonModule } from '@angular/common';
+import { CRaterRubric } from '../../common/cRater/CRaterRubric';
+import { DetectedIdeasComponent } from '../../dialogGuidance/detected-ideas/detected-ideas.component';
+import { NodeService } from '../../../services/nodeService';
+import { ProjectService } from '../../../services/projectService';
+import { AnnotationService } from '../../../services/annotationService';
+import { Annotation } from '../../../common/Annotation';
+import { ShowCRaterRubricComponent } from '../../../../../app/classroom-monitor/show-crater-rubric/show-crater-rubric.component';
+import { UserService } from '../../../../../app/services/user.service';
 
 @Component({
-  imports: [CommonModule],
+  imports: [CommonModule, DetectedIdeasComponent, ShowCRaterRubricComponent],
   selector: 'open-response-show-work',
   templateUrl: 'open-response-show-work.component.html'
 })
 export class OpenResponseShowWorkComponent extends ComponentShowWorkDirective {
+  private annotations: Annotation[] = [];
   protected audioAttachments: any[] = [];
+  private cRaterAnnotation: Annotation;
+  protected cRaterRubric: CRaterRubric;
   protected otherAttachments: any[] = [];
+  protected showDetectedIdeas: boolean = false;
   protected studentResponse: string = '';
+
+  constructor(
+    private annotationService: AnnotationService,
+    nodeService: NodeService,
+    projectService: ProjectService,
+    protected userService: UserService
+  ) {
+    super(nodeService, projectService);
+  }
 
   ngOnInit(): void {
     if (this.componentState != null && this.componentState !== '') {
       this.studentResponse = this.componentState.studentData.response;
+      this.componentContent = this.projectService.getComponent(this.nodeId, this.componentId);
+      if (this.componentContent.cRater) {
+        this.cRaterRubric = new CRaterRubric(this.componentContent.cRater.rubric);
+        this.annotations = this.annotationService.getAnnotationsByStudentWorkId(
+          this.componentState.id
+        );
+        this.cRaterAnnotation = this.annotations.find((annotation) => {
+          return annotation.type === 'autoScore' && annotation.data.ideas;
+        });
+      }
+      this.showDetectedIdeas =
+        this.userService.isTeacher() &&
+        this.cRaterRubric?.ideas.length &&
+        this.cRaterAnnotation != null;
       this.processAttachments();
     }
   }

--- a/src/assets/wise5/components/showMyWork/show-my-work-grading/show-my-work-grading.component.spec.ts
+++ b/src/assets/wise5/components/showMyWork/show-my-work-grading/show-my-work-grading.component.spec.ts
@@ -5,6 +5,8 @@ import { ProjectService } from '../../../services/projectService';
 import { MockComponent, MockProviders } from 'ng-mocks';
 import { OpenResponseShowWorkComponent } from '../../openResponse/open-response-show-work/open-response-show-work.component';
 import { NodeService } from '../../../services/nodeService';
+import { AnnotationService } from '../../../services/annotationService';
+import { UserService } from '../../../../../app/services/user.service';
 
 let component: ShowMyWorkGradingComponent;
 const componentId: string = 'component1';
@@ -17,7 +19,15 @@ describe('ShowMyWorkGradingComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [ShowMyWorkGradingComponent, MockComponent(OpenResponseShowWorkComponent)],
-      providers: [MockProviders(TeacherDataService, ProjectService, NodeService)]
+      providers: [
+        MockProviders(
+          AnnotationService,
+          NodeService,
+          ProjectService,
+          TeacherDataService,
+          UserService
+        )
+      ]
     });
     projectService = TestBed.inject(ProjectService);
     spyOn(projectService, 'getComponent').and.returnValue({

--- a/src/assets/wise5/components/showWork/show-work-student/show-work-student.component.spec.ts
+++ b/src/assets/wise5/components/showWork/show-work-student/show-work-student.component.spec.ts
@@ -4,6 +4,9 @@ import { MockComponent, MockProviders } from 'ng-mocks';
 import { OpenResponseShowWorkComponent } from '../../openResponse/open-response-show-work/open-response-show-work.component';
 import { NodeService } from '../../../services/nodeService';
 import { ProjectService } from '../../../services/projectService';
+import { AnnotationService } from '../../../services/annotationService';
+import { ConfigService } from '../../../../../app/services/config.service';
+import { UserService } from '../../../../../app/services/user.service';
 
 describe('ShowWorkStudentComponent', () => {
   let component: ShowWorkStudentComponent;
@@ -12,7 +15,9 @@ describe('ShowWorkStudentComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MockComponent(OpenResponseShowWorkComponent), ShowWorkStudentComponent],
-      providers: [MockProviders(NodeService, ProjectService)]
+      providers: [
+        MockProviders(AnnotationService, ConfigService, NodeService, ProjectService, UserService)
+      ]
     }).compileComponents();
   });
 

--- a/src/assets/wise5/directives/teacher-summary-display/ideas-summary-display/ideas-summary.component.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/ideas-summary-display/ideas-summary.component.ts
@@ -66,11 +66,7 @@ export class IdeasSummaryComponent extends TeacherSummaryDisplayComponent {
   }
 
   ngOnInit(): void {
-    this.ideaDescriptions = this.cRaterService.getCRaterRubric(
-      this.nodeId,
-      this.componentId,
-      this.componentType
-    );
+    this.ideaDescriptions = this.cRaterService.getCRaterRubric(this.nodeId, this.componentId);
     this.generateIdeasSummary();
   }
 

--- a/src/assets/wise5/services/cRaterService.ts
+++ b/src/assets/wise5/services/cRaterService.ts
@@ -260,10 +260,10 @@ export class CRaterService {
     return ideas;
   }
 
-  getCRaterRubric(nodeId: string, componentId: string, componentType?: string): CRaterRubric {
+  getCRaterRubric(nodeId: string, componentId: string): CRaterRubric {
     const componentContent = this.projectService.getComponent(nodeId, componentId);
     let rubricContent;
-    if (componentType === 'OpenResponse') {
+    if (componentContent.type === 'OpenResponse') {
       rubricContent = (componentContent as OpenResponseContent).cRater?.rubric;
     } else {
       rubricContent = componentContent.cRaterRubric;

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -2050,6 +2050,13 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">54,55</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="7920283242192845616" datatype="html">
+        <source>Detectable ideas</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/classroom-monitor/show-crater-rubric/show-crater-rubric.component.html</context>
+          <context context-type="linenumber">8,12</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="3662593190562390972" datatype="html">
         <source>Has new alert(s)</source>
         <context-group purpose="location">
@@ -17943,13 +17950,6 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/detected-ideas/detected-ideas.component.html</context>
           <context context-type="linenumber">7,9</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7920283242192845616" datatype="html">
-        <source>Detectable ideas</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/dialog-responses/dialog-responses.component.html</context>
-          <context context-type="linenumber">8,12</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4100639410288917446" datatype="html">


### PR DESCRIPTION
## Changes
- In the Teacher Tools, show detected ideas in grading view for each workgroup for idea detection enabled open response components.
- Also display a link to view the idea detection rubric.

<img width="1291" height="494" alt="Screenshot 2026-02-06 at 1 25 39 PM" src="https://github.com/user-attachments/assets/06724215-d574-48c2-ba25-646f768d0189" />


- Re-enable the idea detection summary view for OR components:
<img width="1294" height="466" alt="Screenshot 2026-02-06 at 1 29 58 PM" src="https://github.com/user-attachments/assets/ed1d63f3-3f28-4b88-9772-b46af90dfb79" />

## Test
- For Open Response components that have idea detection enabled, student work display in grading view for each workgroup shows the ideas detected and "Detectable ideas" link that shows the rubric.
- OR components that don't have idea detection enabled don't show the link to view idea detection rubric.
- Idea summary view displays for OR components with idea detection enabled.
- Grading view works as before.
