### PR TITLE
feat(IdeasDetected): Hide ideas that are not in the rubric

### DIFF
--- a/src/assets/wise5/components/common/cRater/CRaterRubric.spec.ts
+++ b/src/assets/wise5/components/common/cRater/CRaterRubric.spec.ts
@@ -20,18 +20,20 @@ const responses = [
 ];
 const rubric = new CRaterRubric({
   ideas: [
-    { name: 'idea1' },
-    { name: 'idea2' },
-    { name: 'idea3' },
-    { name: 'idea4' },
-    { name: 'idea5' }
+    { name: 'idea1', text: 'idea1 description' },
+    { name: 'idea2', text: 'idea2 description' },
+    { name: 'idea3', text: 'idea3 description' },
+    { name: 'idea5', text: 'idea5 description' }
   ]
 });
 
 describe('CRaterRubric', () => {
   describe('getUniqueIdeas', () => {
-    it('should return unique ideas', () => {
-      expect(getUniqueIdeas(responses, rubric).length).toEqual(3);
+    it('should return unique ideas that are in the rubric', () => {
+      // idea 4 is detected but not in the rubric, so should be omitted
+      const ideas = getUniqueIdeas(responses, rubric);
+      expect(ideas.length).toEqual(2);
+      expect(ideas.map((idea) => idea.name)).toEqual(['idea1', 'idea2']);
     });
   });
 });

--- a/src/assets/wise5/components/common/cRater/CRaterRubric.spec.ts
+++ b/src/assets/wise5/components/common/cRater/CRaterRubric.spec.ts
@@ -1,4 +1,4 @@
-import { CRaterRubric, getUniqueIdeas } from './CRaterRubric';
+import { CRaterRubric } from './CRaterRubric';
 
 const responses = [
   {
@@ -31,7 +31,7 @@ describe('CRaterRubric', () => {
   describe('getUniqueIdeas', () => {
     it('should return unique ideas that are in the rubric', () => {
       // idea 4 is detected but not in the rubric, so should be omitted
-      const ideas = getUniqueIdeas(responses, rubric);
+      const ideas = rubric.getUniqueIdeas(responses);
       expect(ideas.length).toEqual(2);
       expect(ideas.map((idea) => idea.name)).toEqual(['idea1', 'idea2']);
     });

--- a/src/assets/wise5/components/common/cRater/CRaterRubric.ts
+++ b/src/assets/wise5/components/common/cRater/CRaterRubric.ts
@@ -22,6 +22,10 @@ export class CRaterRubric {
     return this.getIdea(ideaId)?.tags ?? [];
   }
 
+  hasIdeaDescriptionText(ideaId: string): boolean {
+    return this.getIdea(ideaId)?.text != null;
+  }
+
   getIdeaDescriptionText(ideaId: string): string {
     return this.getIdea(ideaId)?.text ?? 'idea ' + ideaId;
   }

--- a/src/assets/wise5/components/common/cRater/CRaterRubric.ts
+++ b/src/assets/wise5/components/common/cRater/CRaterRubric.ts
@@ -49,26 +49,26 @@ export class CRaterRubric {
   getAdditionalIdeasSummaryGroups(): any[] {
     return this.ideasSummaryGroups.additional;
   }
-}
 
-export function getUniqueIdeas(responses: any[], rubric: CRaterRubric): CRaterIdea[] {
-  const uniqueIdeas: CRaterIdea[] = [];
-  responses.forEach((response) =>
-    response.ideas
-      ?.filter(
-        (idea) =>
-          idea.detected &&
-          rubric.hasIdeaDescriptionText(idea.name) &&
-          !uniqueIdeas.some((uniqueIdea) => uniqueIdea.name === idea.name)
-      )
-      .forEach((idea) => {
-        const cRaterIdea = new CRaterIdea(idea.name, true);
-        const cRaterRubricIdea = rubric.getIdea(idea.name);
-        cRaterIdea.text = cRaterRubricIdea?.text ?? idea.name;
-        uniqueIdeas.push(cRaterIdea);
-      })
-  );
-  return uniqueIdeas;
+  getUniqueIdeas(responses: any[]): CRaterIdea[] {
+    const uniqueIdeas: CRaterIdea[] = [];
+    responses.forEach((response) =>
+      response.ideas
+        ?.filter(
+          (idea) =>
+            idea.detected &&
+            this.hasIdeaDescriptionText(idea.name) &&
+            !uniqueIdeas.some((uniqueIdea) => uniqueIdea.name === idea.name)
+        )
+        .forEach((idea) => {
+          const cRaterIdea = new CRaterIdea(idea.name, true);
+          const cRaterRubricIdea = this.getIdea(idea.name);
+          cRaterIdea.text = cRaterRubricIdea?.text ?? idea.name;
+          uniqueIdeas.push(cRaterIdea);
+        })
+    );
+    return uniqueIdeas;
+  }
 }
 
 export const DEFAULT_IDEAS_SUMMARY_GROUPS = {

--- a/src/assets/wise5/components/common/cRater/CRaterRubric.ts
+++ b/src/assets/wise5/components/common/cRater/CRaterRubric.ts
@@ -1,3 +1,4 @@
+import { arrayContainsAll } from '../../../common/array/array';
 import { CRaterIdea } from './CRaterIdea';
 
 export class CRaterRubric {
@@ -15,6 +16,22 @@ export class CRaterRubric {
 
   getIdea(ideaId: string): CRaterIdea {
     return this.ideas.find((idea) => idea.name === ideaId);
+  }
+
+  getIdeaTags(ideaId: string): string[] {
+    return this.getIdea(ideaId)?.tags ?? [];
+  }
+
+  getIdeaDescriptionText(ideaId: string): string {
+    return this.getIdea(ideaId)?.text ?? 'idea ' + ideaId;
+  }
+
+  getIdeaColor(ideaId: string): string {
+    const ideaTags = this.getIdeaTags(ideaId);
+    return (
+      this.ideaColors?.find((ideaColor) => arrayContainsAll(ideaTags, ideaColor.tags))
+        ?.colorValue ?? ''
+    );
   }
 
   hasRubricData(): boolean {

--- a/src/assets/wise5/components/common/cRater/CRaterRubric.ts
+++ b/src/assets/wise5/components/common/cRater/CRaterRubric.ts
@@ -56,7 +56,10 @@ export function getUniqueIdeas(responses: any[], rubric: CRaterRubric): CRaterId
   responses.forEach((response) =>
     response.ideas
       ?.filter(
-        (idea) => idea.detected && !uniqueIdeas.some((uniqueIdea) => uniqueIdea.name === idea.name)
+        (idea) =>
+          idea.detected &&
+          rubric.hasIdeaDescriptionText(idea.name) &&
+          !uniqueIdeas.some((uniqueIdea) => uniqueIdea.name === idea.name)
       )
       .forEach((idea) => {
         const cRaterIdea = new CRaterIdea(idea.name, true);

--- a/src/assets/wise5/components/dialogGuidance/detected-ideas/detected-ideas.component.spec.ts
+++ b/src/assets/wise5/components/dialogGuidance/detected-ideas/detected-ideas.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DetectedIdeasComponent } from './detected-ideas.component';
 import { By } from '@angular/platform-browser';
+import { CRaterRubric } from '../../common/cRater/CRaterRubric';
 
 describe('DetectedIdeasComponent', () => {
   let component: DetectedIdeasComponent;
@@ -14,6 +15,7 @@ describe('DetectedIdeasComponent', () => {
     fixture = TestBed.createComponent(DetectedIdeasComponent);
     component = fixture.componentInstance;
     component.responses = [];
+    component.cRaterRubric = new CRaterRubric({ ideas: [] });
     fixture.detectChanges();
   });
 

--- a/src/assets/wise5/components/dialogGuidance/detected-ideas/detected-ideas.component.ts
+++ b/src/assets/wise5/components/dialogGuidance/detected-ideas/detected-ideas.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { CRaterRubric, getUniqueIdeas } from '../../common/cRater/CRaterRubric';
+import { CRaterRubric } from '../../common/cRater/CRaterRubric';
 import { CRaterIdea } from '../../common/cRater/CRaterIdea';
 import { MatIconModule } from '@angular/material/icon';
 
@@ -17,6 +17,6 @@ export class DetectedIdeasComponent {
   @Input() responses: any;
 
   ngOnInit(): void {
-    this.ideas = getUniqueIdeas(this.responses, this.cRaterRubric);
+    this.ideas = this.cRaterRubric.getUniqueIdeas(this.responses);
   }
 }

--- a/src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.spec.ts
+++ b/src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.spec.ts
@@ -7,6 +7,8 @@ import { ClickToSnipImageService } from '../../../../services/clickToSnipImageSe
 import { ProjectService } from '../../../../services/projectService';
 import { MatchStudentDefaultComponent } from './match-student-default.component';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { CRaterService } from '../../../../services/cRaterService';
+import { CRaterRubric } from '../../../common/cRater/CRaterRubric';
 
 let component: MatchStudentDefaultComponent;
 let fixture: ComponentFixture<MatchStudentDefaultComponent>;
@@ -463,10 +465,16 @@ function createMergedComponentState() {
         }
       };
       expect(component.buckets[0].items.length).toEqual(3);
+      spyOn(TestBed.inject(CRaterService), 'getCRaterRubric').and.returnValue(
+        new CRaterRubric({
+          ideas: [{ name: '1', text: '1 description' }]
+        })
+      );
       component.createMergedComponentState([componentState]);
-      expect(component.buckets[0].items.length).toEqual(5);
-      expect(component.buckets[0].items[3].value).toEqual('1');
-      expect(component.buckets[0].items[4].value).toEqual('3');
+      // even though 1 and 3 were detected, only idea 1 should be added to the source bucket
+      // because 3 is not in the rubric
+      expect(component.buckets[0].items.length).toEqual(4);
+      expect(component.buckets[0].items[3].value).toEqual('1 description');
     });
   });
 }

--- a/src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts
+++ b/src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts
@@ -20,7 +20,6 @@ import { ConfigService } from '../../../../services/configService';
 import { Container } from '../container';
 import { copy } from '../../../../common/object/object';
 import { CRaterService } from '../../../../services/cRaterService';
-import { CRaterRubric, getUniqueIdeas } from '../../../common/cRater/CRaterRubric';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { filter } from 'rxjs';
 import { generateRandomKey } from '../../../../common/string/string';
@@ -598,10 +597,7 @@ export class MatchStudentDefaultComponent extends ComponentStudent {
       if (componentState.componentType === 'Match') {
         componentState.studentData.buckets.forEach((bucket) => mergeBucket(mergedBuckets, bucket));
       } else if (componentState.componentType === 'DialogGuidance') {
-        this.addIdeasToSourceBucket(
-          componentState.studentData.responses,
-          this.craterService.getCRaterRubric(componentState.nodeId, componentState.componentId)
-        );
+        this.addIdeasToSourceBucket(componentState);
       }
     });
     const mergedComponentState: any = this.createNewComponentState();
@@ -611,8 +607,10 @@ export class MatchStudentDefaultComponent extends ComponentStudent {
     return mergedComponentState;
   }
 
-  private addIdeasToSourceBucket(responses: any[], rubric: CRaterRubric): void {
-    getUniqueIdeas(responses, rubric)
+  private addIdeasToSourceBucket(componentState: any): void {
+    this.craterService
+      .getCRaterRubric(componentState.nodeId, componentState.componentId)
+      .getUniqueIdeas(componentState.studentData.responses)
       .filter((idea) => !this.isInSourceBucket(idea))
       .forEach((idea) => {
         const choice = new Choice(idea.name, idea.text);

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.ts
@@ -98,7 +98,7 @@ export class EditOpenResponseAdvancedComponent extends EditAdvancedComponentComp
       rubric: {
         ideas: [],
         ideaColors: [],
-        ideaSummaryGroups: DEFAULT_IDEAS_SUMMARY_GROUPS
+        ideasSummaryGroups: DEFAULT_IDEAS_SUMMARY_GROUPS
       }
     };
   }

--- a/src/assets/wise5/directives/teacher-summary-display/summary-data/DialogGuidanceSummaryData.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/summary-data/DialogGuidanceSummaryData.ts
@@ -6,9 +6,7 @@ import { IdeasSummaryData } from './IdeasSummaryData';
 export class DialogGuidanceSummaryData extends IdeasSummaryData {
   constructor(componentStates: ComponentState[], rubric: CRaterRubric) {
     super(rubric);
-    componentStates.forEach((componentState) =>
-      this.dataPoints.push(new DialogGuidanceSummaryDataPoint(componentState))
-    );
+    this.dataPoints = componentStates.map((state) => new DialogGuidanceSummaryDataPoint(state));
     this.setIdeaDataArray();
   }
 }

--- a/src/assets/wise5/directives/teacher-summary-display/summary-data/IdeasSummaryData.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/summary-data/IdeasSummaryData.ts
@@ -68,6 +68,7 @@ export abstract class IdeasSummaryData {
     if (!group.showUndetectedIdeas) {
       ideas = ideas.filter((idea) => idea.count > 0);
     }
+    ideas = ideas.filter((idea) => this.rubric.hasIdeaDescriptionText(idea.id));
     sortIdeasByCount(ideas, group.sort.order ?? 'desc');
     return ideas.slice(0, group.maxIdeas ?? ideas.length);
   }

--- a/src/assets/wise5/directives/teacher-summary-display/summary-data/IdeasSummaryData.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/summary-data/IdeasSummaryData.ts
@@ -26,10 +26,10 @@ export abstract class IdeasSummaryData {
     this.getIdeaCountMap().forEach((count, ideaId) => {
       this.ideaDataArray.push({
         id: ideaId,
-        text: this.getIdeaDescriptionText(ideaId),
-        tags: this.getIdeaTags(ideaId),
         count: count,
-        color: this.getIdeaColor(ideaId)
+        color: this.rubric.getIdeaColor(ideaId),
+        tags: this.rubric.getIdeaTags(ideaId),
+        text: this.rubric.getIdeaDescriptionText(ideaId)
       });
     });
   }
@@ -47,25 +47,6 @@ export abstract class IdeasSummaryData {
       });
     });
     return ideaCountMap;
-  }
-
-  private getIdeaDescriptionText(ideaId: string): string {
-    return (
-      this.rubric.ideas.find((ideaDescription) => ideaDescription.name === ideaId)?.text ??
-      'idea ' + ideaId
-    );
-  }
-
-  private getIdeaTags(ideaId: string): string[] {
-    return this.rubric.ideas.find((ideaDescription) => ideaDescription.name === ideaId)?.tags ?? [];
-  }
-
-  private getIdeaColor(ideaId: string): string {
-    const ideaTags = this.getIdeaTags(ideaId);
-    return (
-      this.rubric.ideaColors?.find((ideaColor) => arrayContainsAll(ideaTags, ideaColor.tags))
-        ?.colorValue ?? ''
-    );
   }
 
   getIdeasSummaryGroups(): [IdeaGroup[], IdeaGroup[]] {

--- a/src/assets/wise5/directives/teacher-summary-display/summary-data/OpenResponseSummaryData.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/summary-data/OpenResponseSummaryData.ts
@@ -6,9 +6,7 @@ import { OpenResponseSummaryDataPoint } from './OpenResponseSummaryDataPoint';
 export class OpenResponseSummaryData extends IdeasSummaryData {
   constructor(annotations: Annotation[], rubric: CRaterRubric) {
     super(rubric);
-    annotations.forEach((annotation) =>
-      this.dataPoints.push(new OpenResponseSummaryDataPoint(annotation))
-    );
+    this.dataPoints = annotations.map((annotation) => new OpenResponseSummaryDataPoint(annotation));
     this.setIdeaDataArray();
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -17074,21 +17074,21 @@ Are you ready to receive feedback on this answer?</source>
         <source>Most Common</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/CRaterRubric.ts</context>
-          <context context-type="linenumber">75</context>
+          <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
       <trans-unit id="419421250444615914" datatype="html">
         <source>Unique Ideas</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/CRaterRubric.ts</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="786337790284911605" datatype="html">
         <source>All Ideas</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/CRaterRubric.ts</context>
-          <context context-type="linenumber">94</context>
+          <context context-type="linenumber">97</context>
         </context-group>
       </trans-unit>
       <trans-unit id="463092785656273861" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -17074,21 +17074,21 @@ Are you ready to receive feedback on this answer?</source>
         <source>Most Common</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/CRaterRubric.ts</context>
-          <context context-type="linenumber">71</context>
+          <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
       <trans-unit id="419421250444615914" datatype="html">
         <source>Unique Ideas</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/CRaterRubric.ts</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="786337790284911605" datatype="html">
         <source>All Ideas</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/CRaterRubric.ts</context>
-          <context context-type="linenumber">90</context>
+          <context context-type="linenumber">94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="463092785656273861" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -17074,21 +17074,21 @@ Are you ready to receive feedback on this answer?</source>
         <source>Most Common</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/CRaterRubric.ts</context>
-          <context context-type="linenumber">54</context>
+          <context context-type="linenumber">71</context>
         </context-group>
       </trans-unit>
       <trans-unit id="419421250444615914" datatype="html">
         <source>Unique Ideas</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/CRaterRubric.ts</context>
-          <context context-type="linenumber">63</context>
+          <context context-type="linenumber">80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="786337790284911605" datatype="html">
         <source>All Ideas</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/CRaterRubric.ts</context>
-          <context context-type="linenumber">73</context>
+          <context context-type="linenumber">90</context>
         </context-group>
       </trans-unit>
       <trans-unit id="463092785656273861" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -11334,7 +11334,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts</context>
-          <context context-type="linenumber">124</context>
+          <context context-type="linenumber">123</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-authoring/multiple-choice-authoring.component.html</context>
@@ -19997,7 +19997,7 @@ Warning: This will delete all existing choices and buckets in this component.</s
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts</context>
-          <context context-type="linenumber">469</context>
+          <context context-type="linenumber">468</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-show-work/multiple-choice-show-work.component.html</context>
@@ -20028,7 +20028,7 @@ Warning: This will delete all existing choices and buckets in this component.</s
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts</context>
-          <context context-type="linenumber">469</context>
+          <context context-type="linenumber">468</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/multiple-choice-show-work/multiple-choice-show-work.component.html</context>
@@ -20093,7 +20093,7 @@ Warning: This will delete all existing choices and buckets in this component.</s
         <source>Correct bucket but wrong position</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-student/match-student-default/match-student-default.component.ts</context>
-          <context context-type="linenumber">462</context>
+          <context context-type="linenumber">461</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3309404570196522710" datatype="html">


### PR DESCRIPTION
## Changes
- Don't show ideas that are not in the rubric from the following places:
   - Match imported ideas from Dialog Guidance (student vle)
   - Idea summary display (teacher tools)
   - Detected ideas for student responses (teacher tools)
- Refactor surrounding code for clarity
- Fix typo: ideaSummaryGroups -> ideasSummaryGroups

## Test
- Ideas that are not in the rubric should not appear in:
   - Match imported ideas from Dialog Guidance (student vle)
   - Idea summary display (teacher tools)
   - Detected ideas for student responses (teacher tools)
- Idea summary display (teacher tools) still works and looks as before. I refactored code that the feature is using
