### PR TITLE
fix(ConceptMap): Cannot open editing view

### DIFF
--- a/src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts
+++ b/src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts
@@ -123,8 +123,10 @@ export class ConceptMapStudent extends ComponentStudent {
   ngOnDestroy(): void {
     super.ngOnDestroy();
     const svg = this.getElementById(this.svgId, true);
-    svg.removeEventListener('dragover', this.dragOverListenerFunction);
-    svg.removeEventListener('drop', this.dropListenerFunction);
+    if (svg) {
+      svg.removeEventListener('dragover', this.dragOverListenerFunction);
+      svg.removeEventListener('drop', this.dropListenerFunction);
+    }
   }
 
   initialize(): void {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -2712,7 +2712,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">416</context>
+          <context context-type="linenumber">418</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
@@ -10541,11 +10541,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">425</context>
+          <context context-type="linenumber">427</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">434</context>
+          <context context-type="linenumber">436</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/match-authoring/match-authoring.component.html</context>
@@ -16800,7 +16800,7 @@ Are you ready to receive feedback on this answer?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">350</context>
+          <context context-type="linenumber">352</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3308736994783976865" datatype="html">
@@ -17723,7 +17723,7 @@ Label: <x id="PH" equiv-text="linkLabel"/></source>
         <source>You have no more chances to receive feedback on your answer.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">344</context>
+          <context context-type="linenumber">346</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1088900768760788337" datatype="html">
@@ -17732,7 +17732,7 @@ Label: <x id="PH" equiv-text="linkLabel"/></source>
 Are you ready to receive feedback on this answer?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">347</context>
+          <context context-type="linenumber">349</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-student/open-response-student.component.ts</context>
@@ -17743,7 +17743,7 @@ Are you ready to receive feedback on this answer?</source>
         <source>Are you sure you want to reset your work?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/conceptMap/concept-map-student/concept-map-student.component.ts</context>
-          <context context-type="linenumber">1433</context>
+          <context context-type="linenumber">1435</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4145474018067473865" datatype="html">


### PR DESCRIPTION
It looks like this was introduced when this component was converted to standalone. A NPE was thrown, which prevented the editing view from being displayed

## Changes
- Add null check in case svg element isn't on the page when ngOnDestroy() is called

## Test
- Concept map editing view is rendered and works as before

Closes #2273 
