### PR TITLE
fix(Idea Summary): Only show ideas and sample responses for the current period

### DIFF
--- a/src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.spec.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.spec.ts
@@ -71,25 +71,6 @@ describe('IdeaSummaryComponent', () => {
     });
   });
 
-  describe('when expanding for the first time', () => {
-    beforeEach(() => {
-      component['expanded'] = false;
-      component['responses'] = [];
-    });
-
-    it('should not fetch responses again when already loaded', async () => {
-      component['responses'] = [{ text: 'Existing response', timestamp: 123456 }];
-
-      const getComponentSpy = spyOn(projectService, 'getComponent');
-      const getLatestWorkSpy = spyOn<any>(component, 'getLatestWork');
-
-      await component['toggleDetails']();
-
-      expect(getComponentSpy).not.toHaveBeenCalled();
-      expect(getLatestWorkSpy).not.toHaveBeenCalled();
-    });
-  });
-
   describe('getDGResponsesWithIdea()', () => {
     it('should return responses with the specified idea', () => {
       const states = [

--- a/src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.ts
@@ -32,19 +32,28 @@ export class IdeaSummaryComponent extends TeacherSummaryDisplayComponent {
   protected expanded: boolean = false;
   protected responses: Response[] = [];
 
+  protected renderDisplay(): void {
+    super.renderDisplay();
+    this.getResponses();
+  }
+
   protected async toggleDetails(): Promise<void> {
     this.expanded = !this.expanded;
-    if (this.responses.length === 0) {
-      const component = this.projectService.getComponent(this.nodeId, this.componentId);
-      const states = await firstValueFrom(this.getLatestWork());
-      if (component.type === 'DialogGuidance') {
-        this.responses = this.getDGResponsesWithIdea(states, this.idea.id);
-      } else if (component.type === 'OpenResponse') {
-        this.responses = this.getORResponsesWithIdea(states, this.idea.id);
-      }
-      if (this.responses.length > 2) {
-        this.responses = this.responses.slice(0, 2); // only show 2 responses max
-      }
+    if (this.expanded) {
+      await this.getResponses();
+    }
+  }
+
+  private async getResponses(): Promise<void> {
+    const component = this.projectService.getComponent(this.nodeId, this.componentId);
+    const states = await firstValueFrom(this.getLatestWork());
+    if (component.type === 'DialogGuidance') {
+      this.responses = this.getDGResponsesWithIdea(states, this.idea.id);
+    } else if (component.type === 'OpenResponse') {
+      this.responses = this.getORResponsesWithIdea(states, this.idea.id);
+    }
+    if (this.responses.length > 2) {
+      this.responses = this.responses.slice(0, 2); // only show 2 responses max
     }
   }
 

--- a/src/assets/wise5/directives/teacher-summary-display/ideas-summary-display/ideas-summary.component.spec.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/ideas-summary-display/ideas-summary.component.spec.ts
@@ -87,6 +87,7 @@ describe('IdeasSummaryComponent for Open Response component', () => {
     ngInit_OR_NoIdeasDetected_ShowMessage();
     ngInit_OR_IdeasDetected_ShowSummary();
     ngInit_OR_ManyIdeasDetected_ShowTopAndBottomThree();
+    ngInit_OR_FilterByPeriod();
   });
 });
 
@@ -217,4 +218,35 @@ function generateIdeas(numIdeas: number) {
     ideas.push({ name: 'idea ' + (i + 1), detected: true });
   }
   return ideas;
+}
+
+function ngInit_OR_FilterByPeriod() {
+  describe('filtering by period', () => {
+    beforeEach(() => {
+      generateMockRubric(1, 1);
+      const ideas = generateIdeas(1);
+      spyOn(TestBed.inject(AnnotationService), 'getAnnotationsByNodeIdComponentId').and.returnValue(
+        [
+          new Annotation({ periodId: 1, data: { ideas: ideas } } as any),
+          new Annotation({ periodId: 2, data: { ideas: ideas } } as any)
+        ]
+      );
+    });
+
+    it('includes all annotations when period is "All Periods" (-1)', () => {
+      component.periodId = -1;
+      spyOn<any>(component, 'groupIdeas');
+      component.ngOnInit();
+      const summaryData = (component as any).groupIdeas.calls.mostRecent().args[0];
+      expect(summaryData.dataPoints.length).toEqual(2);
+    });
+
+    it('includes only annotations for the selected period', () => {
+      component.periodId = 1;
+      spyOn<any>(component, 'groupIdeas');
+      component.ngOnInit();
+      const summaryData = (component as any).groupIdeas.calls.mostRecent().args[0];
+      expect(summaryData.dataPoints.length).toEqual(1);
+    });
+  });
 }

--- a/src/assets/wise5/directives/teacher-summary-display/ideas-summary-display/ideas-summary.component.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/ideas-summary-display/ideas-summary.component.ts
@@ -72,12 +72,10 @@ export class IdeasSummaryComponent extends TeacherSummaryDisplayComponent {
         this.groupIdeas(new DialogGuidanceSummaryData(componentStates, this.rubric))
       );
     } else if (this.componentType === 'OpenResponse') {
-      this.groupIdeas(
-        new OpenResponseSummaryData(
-          this.annotationService.getAnnotationsByNodeIdComponentId(this.nodeId, this.componentId),
-          this.rubric
-        )
-      );
+      const annotations = this.annotationService
+        .getAnnotationsByNodeIdComponentId(this.nodeId, this.componentId)
+        .filter((annotation) => this.periodId === -1 || annotation.periodId === this.periodId);
+      this.groupIdeas(new OpenResponseSummaryData(annotations, this.rubric));
     }
   }
 


### PR DESCRIPTION
## Changes
- Only show sample responses for the currently-selected period for Open Response items with idea detection
- Only show ideas for the currently-selected period

## Test
- Changes above work as described