### PR TITLE
feat(Application): Change "component" to "activity"

### DIFF
--- a/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html
+++ b/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html
@@ -1,7 +1,7 @@
-<h2 mat-dialog-title i18n>Add New Component</h2>
+<h2 mat-dialog-title i18n>Add New Activity</h2>
 <mat-dialog-content>
   <p class="flex flex-wrap justify-start items-center gap-2">
-    <span i18n>Select the component type you want to add or</span>
+    <span i18n>Select the activity you want to add or</span>
     <button mat-raised-button color="primary" (click)="goToImportComponent()" i18n>
       import from another unit
     </button>

--- a/src/app/authoring-tool/edit-component-json/edit-component-json.component.html
+++ b/src/app/authoring-tool/edit-component-json/edit-component-json.component.html
@@ -16,7 +16,7 @@
   <div class="flex flex-col gap-2">
     <span i18n style="color: red">Close the JSON view to save the changes</span>
     <mat-form-field class="w-full">
-      <mat-label i18n>Edit Component JSON</mat-label>
+      <mat-label i18n>Edit Activity JSON</mat-label>
       <textarea
         matInput
         cdkTextareaAutosize

--- a/src/app/authoring-tool/edit-component-rubric/edit-component-rubric.component.html
+++ b/src/app/authoring-tool/edit-component-rubric/edit-component-rubric.component.html
@@ -5,7 +5,7 @@
     color="primary"
     class="topButton enable-in-translation"
     (click)="showRubricAuthoring = !showRubricAuthoring"
-    matTooltip="Edit Component Rubric"
+    matTooltip="Edit activity rubric"
     i18n-matTooltip
     matTooltipPosition="above"
   >

--- a/src/app/authoring-tool/edit-component-width/edit-component-width.component.ts
+++ b/src/app/authoring-tool/edit-component-width/edit-component-width.component.ts
@@ -8,7 +8,7 @@ import { FormsModule } from '@angular/forms';
   imports: [FormsModule, MatFormFieldModule, MatInputModule],
   selector: 'edit-component-width',
   template: `<mat-form-field>
-    <mat-label i18n>Component Width</mat-label>
+    <mat-label i18n>Activity Width</mat-label>
     <input
       matInput
       type="number"

--- a/src/app/authoring-tool/edit-connected-component-component-select/edit-connected-component-component-select.component.html
+++ b/src/app/authoring-tool/edit-connected-component-component-select/edit-connected-component-component-select.component.html
@@ -1,5 +1,5 @@
 <mat-form-field>
-  <mat-label i18n>Component</mat-label>
+  <mat-label i18n>Activity</mat-label>
   <mat-select
     [(ngModel)]="connectedComponent.componentId"
     (ngModelChange)="connectedComponentComponentIdChanged()"
@@ -17,7 +17,7 @@
       >
         <span>{{ componentIndex + 1 }}. {{ component.type }} </span>
         @if (component.id === componentId) {
-          <span i18n>(This Component)</span>
+          <span i18n>(This activity)</span>
         }
       </mat-option>
     }

--- a/src/app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component.ts
+++ b/src/app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component.ts
@@ -10,13 +10,12 @@ import { MatTooltipModule } from '@angular/material/tooltip';
   template: `<div
     class="connected-components-label-div flex flex-row justify-start items-center gap-5"
   >
-    <label i18n>Connected Components</label>
+    <label i18n>Connected Activities</label>
     <button
       mat-raised-button
       color="primary"
       (click)="addConnectedComponent()"
-      matTooltip="Add Connected Component"
-      matTooltip
+      matTooltip="Add connected activity"
       i18n-matTooltipPosition="above"
     >
       <mat-icon>add</mat-icon>

--- a/src/app/authoring-tool/edit-connected-components/edit-connected-components.component.ts
+++ b/src/app/authoring-tool/edit-connected-components/edit-connected-components.component.ts
@@ -74,7 +74,7 @@ export class EditConnectedComponentsComponent implements OnInit {
   automaticallySetConnectedComponentFieldsIfPossible(connectedComponent: any): void {}
 
   deleteConnectedComponent(index: number): void {
-    if (confirm($localize`Are you sure you want to delete this connected component?`)) {
+    if (confirm($localize`Are you sure you want to delete this connected activity?`)) {
       this.connectedComponents.splice(index, 1);
       this.connectedComponentChanged();
     }

--- a/src/app/authoring-tool/edit-dynamic-prompt/edit-dynamic-prompt.component.html
+++ b/src/app/authoring-tool/edit-dynamic-prompt/edit-dynamic-prompt.component.html
@@ -12,7 +12,7 @@
   @if (componentContent.dynamicPrompt?.enabled) {
     <div>
       <div class="reference-component-div flex flex-row flex-wrap justify-start items-center gap-5">
-        <mat-label class="bold" i18n>Reference Component:</mat-label>
+        <mat-label class="bold" i18n>Reference Activity:</mat-label>
         <select-step-and-component
           [referenceComponent]="componentContent.dynamicPrompt.referenceComponent"
           [thisComponentId]="componentId"

--- a/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html
+++ b/src/app/authoring-tool/edit-question-bank/edit-question-bank.component.html
@@ -44,7 +44,7 @@
         </mat-form-field>
       </div>
       <div class="reference-component flex flex-row flex-wrap justify-start items-center gap-5">
-        <mat-label class="bold" i18n>Reference Component:</mat-label>
+        <mat-label class="bold" i18n>Reference Activity:</mat-label>
         <select-step-and-component
           [referenceComponent]="componentContent.questionBank.referenceComponent"
           [thisComponentId]="componentId"

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html
@@ -13,7 +13,7 @@
 @if (importType === 'step') {
   <h5 i18n>Choose a unit from which to import step(s).</h5>
 } @else {
-  <h5 i18n>Choose a unit from which to import component(s).</h5>
+  <h5 i18n>Choose a unit from which to import activities.</h5>
 }
 <mat-tab-group mat-stretch-tabs="false">
   <mat-tab label="My Units" i18n-label>

--- a/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.ts
+++ b/src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.ts
@@ -30,7 +30,7 @@ export class ChooseImportUnitComponent {
   ) {}
 
   ngOnInit(): void {
-    this.importType = history.state.importType;
+    this.importType = history.state.importType ?? 'step';
     this.target = history.state;
     this.myProjects = this.configService.getAuthorableProjects();
     this.subscriptions.add(

--- a/src/app/authoring-tool/select-component/select-component.component.html
+++ b/src/app/authoring-tool/select-component/select-component.component.html
@@ -1,5 +1,5 @@
 <mat-form-field>
-  <mat-label i18n>Component</mat-label>
+  <mat-label i18n>Activity</mat-label>
   <mat-select [(ngModel)]="componentId" (ngModelChange)="componentChanged()">
     @for (component of components; track component; let componentIndex = $index) {
       <mat-option
@@ -8,7 +8,7 @@
       >
         <span>{{ componentIndex + 1 }}. {{ component.type }}</span>
         @if (component.id === thisComponentId) {
-          <span i18n>(This Component)</span>
+          <span i18n>(This activity)</span>
         }
       </mat-option>
     }

--- a/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html
+++ b/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html
@@ -6,11 +6,11 @@
       <mat-error i18n> Step Title is required </mat-error>
     }
   </mat-form-field>
-  <h5 i18n>Select components to add to your new step (optional):</h5>
+  <h5 i18n>Select activities to add to your new step (optional):</h5>
   <div class="flex flex-col md:flex-row">
     <div class="initial-components notice-bg-bg flex items-start md:w-1/3 lg:w-1/4">
       @if (initialComponents.length == 0) {
-        <div class="mat-small" i18n>No components added</div>
+        <div class="mat-small" i18n>No activities added</div>
       }
       @if (initialComponents.length > 0) {
         <div class="component-list w-full" cdkDropList (cdkDropListDropped)="drop($event)">
@@ -23,7 +23,7 @@
                 mat-icon-button
                 (click)="deleteComponent(i)"
                 i18n-aria-label
-                aria-label="Delete component"
+                aria-label="Delete activity"
               >
                 <mat-icon class="secondary-text">close</mat-icon>
               </button>

--- a/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html
+++ b/src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html
@@ -1,5 +1,5 @@
 <div class="flex justify-start items-center">
-  <h2 mat-dialog-title i18n>Component Info</h2>
+  <h2 mat-dialog-title i18n>Activity Info</h2>
   <div class="flex grow"></div>
   <component-type-selector
     [componentType]="componentType"

--- a/src/assets/wise5/authoringTool/components/preview-component-dialog/preview-component-dialog.component.html
+++ b/src/assets/wise5/authoringTool/components/preview-component-dialog/preview-component-dialog.component.html
@@ -1,11 +1,7 @@
-<h2 mat-dialog-title i18n>Preview Component</h2>
+<h2 mat-dialog-title i18n>Preview Activity</h2>
 @if (canSaveStarterState) {
   <mat-divider />
-  <save-starter-state
-    class="notice-bg-bg"
-    [component]="component"
-    [starterState]="starterState"
-  />
+  <save-starter-state class="notice-bg-bg" [component]="component" [starterState]="starterState" />
 }
 <mat-divider />
 <mat-dialog-content>

--- a/src/assets/wise5/authoringTool/constraint/component-constraint-authoring/component-constraint-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/constraint/component-constraint-authoring/component-constraint-authoring.component.ts
@@ -28,6 +28,6 @@ import { EditConstraintRemovalCriteriaComponent } from '../edit-constraint-remov
 export class ComponentConstraintAuthoringComponent extends ConstraintAuthoringComponent {
   constraintActions = [
     new ConstraintAction('', $localize`Please Choose an Action`),
-    new ConstraintAction('makeThisComponentNotVisible', $localize`Make This Component Not Visible`)
+    new ConstraintAction('makeThisComponentNotVisible', $localize`Make This Activity Not Visible`)
   ];
 }

--- a/src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.html
+++ b/src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.html
@@ -60,7 +60,7 @@
           <mat-label>{{ param.text }}</mat-label>
           <mat-select [(ngModel)]="criteria.params.componentId" (ngModelChange)="saveProject()">
             <mat-option [value]="''">
-              <span class="red" i18n>Please Choose a Component</span>
+              <span class="red" i18n>Please Choose an Activity</span>
             </mat-option>
             @for (
               component of getComponents(criteria.params.nodeId);

--- a/src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts
+++ b/src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.ts
@@ -38,7 +38,7 @@ export class EditConstraintRemovalCriteriaComponent implements OnInit {
   protected componentIdToIsSelectable: { [componentId: string]: boolean } = {};
   private componentParam: RemovalCriteriaParam = new RemovalCriteriaParam(
     'componentId',
-    $localize`Component`
+    $localize`Activity`
   );
   @Input() constraint: any;
   @Input() criteria: any;

--- a/src/assets/wise5/authoringTool/create-branch/create-branch.component.html
+++ b/src/assets/wise5/authoringTool/create-branch/create-branch.component.html
@@ -16,7 +16,7 @@
     formGroup.controls['criteria'].value === SCORE_VALUE ||
     formGroup.controls['criteria'].value === CHOICE_CHOSEN_VALUE
   ) {
-    <p class="strong" i18n>Reference component:</p>
+    <p class="strong" i18n>Reference activity:</p>
     <div class="flex flex-wrap gap-2">
       <select-step
         [nodeId]="formGroup.controls['nodeId'].value"

--- a/src/assets/wise5/authoringTool/edit-branch/edit-branch.component.html
+++ b/src/assets/wise5/authoringTool/edit-branch/edit-branch.component.html
@@ -15,7 +15,7 @@
     formGroup.controls['criteria'].value === SCORE_VALUE ||
     formGroup.controls['criteria'].value === CHOICE_CHOSEN_VALUE
   ) {
-    <p class="strong" i18n>Reference component:</p>
+    <p class="strong" i18n>Reference activity:</p>
     <div class="flex flex-wrap gap-2">
       <select-step
         [nodeId]="formGroup.controls['nodeId'].value"

--- a/src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html
+++ b/src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html
@@ -1,4 +1,4 @@
-<h5 i18n>Choose the component(s) that you want to import, then select Submit.</h5>
+<h5 i18n>Choose the activities that you want to import, then select Submit.</h5>
 <p class="flex flex-wrap justify-start items-center gap-2">
   <strong i18n>Selected unit: {{ project?.metadata.title }}</strong>
   <button
@@ -50,7 +50,7 @@
                 mat-raised-button
                 color="primary"
                 (click)="previewNode(item.node)"
-                matTooltip="Preview component"
+                matTooltip="Preview activity"
                 matTooltipPosition="above"
                 i18n-matTooltip
               >

--- a/src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.spec.ts
+++ b/src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.spec.ts
@@ -83,7 +83,7 @@ function ngOnInit() {
       );
       expect(previewStepButton).toBeTruthy();
       const previewComponentButton = await loader.getHarness(
-        MatButtonHarness.with({ selector: '[mattooltip="Preview component"]' })
+        MatButtonHarness.with({ selector: '[mattooltip="Preview activity"]' })
       );
       expect(previewComponentButton).toBeTruthy();
     }));

--- a/src/assets/wise5/authoringTool/milestones-authoring/milestones-authoring.component.html
+++ b/src/assets/wise5/authoringTool/milestones-authoring/milestones-authoring.component.html
@@ -158,7 +158,7 @@
                           </mat-select>
                         </mat-form-field>
                         <mat-form-field class="width-200">
-                          <mat-label i18n>Component ID</mat-label>
+                          <mat-label i18n>Activity ID</mat-label>
                           <mat-select
                             [(ngModel)]="satisfyCriteria.componentId"
                             (ngModelChange)="save()"
@@ -205,7 +205,7 @@
                               satisfyCriteria.componentId
                             )
                           "
-                          matTooltip="Copy Node ID and Component ID to Milestone"
+                          matTooltip="Copy Node ID and Activity ID to Milestone"
                           i18n-matTooltip
                         >
                           <mat-icon>content_copy</mat-icon>
@@ -253,7 +253,7 @@
                           </mat-select>
                         </mat-form-field>
                         <mat-form-field class="width-200">
-                          <mat-label i18n>Component ID</mat-label>
+                          <mat-label i18n>Activity ID</mat-label>
                           <mat-select [(ngModel)]="location.componentId" (ngModelChange)="save()">
                             @for (
                               component of getComponents(location.nodeId);
@@ -455,7 +455,7 @@
                                       </mat-select>
                                     </mat-form-field>
                                     <mat-form-field class="width-300">
-                                      <mat-label i18n>Component ID</mat-label>
+                                      <mat-label i18n>Activity ID</mat-label>
                                       <mat-select
                                         [(ngModel)]="satisfyCriteria.componentId"
                                         (ngModelChange)="save()"

--- a/src/assets/wise5/authoringTool/milestones-authoring/milestones-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/milestones-authoring/milestones-authoring.component.ts
@@ -247,7 +247,7 @@ export class MilestonesAuthoringComponent {
     nodeId: string,
     componentId: string
   ): void {
-    const message = $localize`Are you sure you want to copy the Node ID and Component ID to the rest of this Milestone?`;
+    const message = $localize`Are you sure you want to copy the Node ID and Activity ID to the rest of this Milestone?`;
     if (confirm(message)) {
       this.setNodeIdAndComponentIdToAllSatisfyCriteria(milestone, nodeId, componentId);
       this.setNodeIdAndComponentIdToAllLocations(milestone, nodeId, componentId);

--- a/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.html
+++ b/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.html
@@ -1,7 +1,7 @@
 <button
   mat-icon-button
   color="primary"
-  matTooltip="Add component"
+  matTooltip="Add activity"
   matTooltipPosition="after"
   (click)="addComponent()"
 >

--- a/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.ts
+++ b/src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.ts
@@ -31,7 +31,7 @@ export class AddComponentButtonComponent {
   @Input() insertAfterComponentId: string = null;
   @Output() newComponentsEvent: EventEmitter<any> = new EventEmitter<any>();
   @Input() node: Node;
-  protected tooltipText = $localize`Add component`;
+  protected tooltipText = $localize`Add activity`;
 
   constructor(
     private createComponentService: CreateComponentService,
@@ -48,7 +48,7 @@ export class AddComponentButtonComponent {
   private updateUI(): void {
     this.firstComponent = this.node.getComponentPosition(this.insertAfterComponentId) === 0;
     if (this.node.components.length > 0 && !this.firstComponent) {
-      this.tooltipText = $localize`Add component after`;
+      this.tooltipText = $localize`Add activity after`;
     }
   }
 

--- a/src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts
@@ -42,20 +42,20 @@ export class NodeAdvancedPathAuthoringComponent implements OnInit {
   protected transitionCriterias = [
     {
       value: 'score',
-      text: $localize`Get a specific score on a component`,
+      text: $localize`Get a specific score on an activity`,
       params: [
         { value: 'nodeId', text: $localize`Node ID` },
-        { value: 'componentId', text: $localize`Component ID` },
+        { value: 'componentId', text: $localize`Activity ID` },
         { value: 'scores', text: $localize`Scores(s)` },
         { value: 'scoreId', text: $localize`Score ID (Optional)` }
       ]
     },
     {
       value: 'choiceChosen',
-      text: $localize`Choose a specific choice on a component`,
+      text: $localize`Choose a specific choice on an activity`,
       params: [
         { value: 'nodeId', text: $localize`Node ID` },
-        { value: 'componentId', text: $localize`Component ID` },
+        { value: 'componentId', text: $localize`Activity ID` },
         { value: 'choiceIds', text: $localize`Choices` }
       ]
     },

--- a/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.html
+++ b/src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.html
@@ -2,7 +2,7 @@
   mat-icon-button
   (click)="$event.stopPropagation(); copy()"
   (keydown)="$event.stopPropagation()"
-  matTooltip="Copy component"
+  matTooltip="Copy activity"
   matTooltipPosition="above"
   i18n-matTooltip
 >

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html
@@ -14,7 +14,7 @@
   </button>
 </div>
 @if (components.length === 0 && !isGroupNode) {
-  <p i18n>This step does not have any components.</p>
+  <p i18n>This step does not have any activities.</p>
   <add-component [node]="node" (newComponentsEvent)="highlightComponents($event)" />
 }
 <div
@@ -62,7 +62,7 @@
                 mat-icon-button
                 (click)="$event.stopPropagation(); deleteComponent($event, i + 1, component)"
                 (keydown)="$event.stopPropagation()"
-                matTooltip="Delete Component"
+                matTooltip="Delete activity"
                 matTooltipPosition="above"
                 i18n-matTooltip
               >

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.spec.ts
@@ -138,7 +138,7 @@ function deleteComponent() {
       confirmSpy.and.returnValue(true);
       clickComponentDeleteButton(component2.id);
       expect(confirmSpy).toHaveBeenCalledWith(
-        `Are you sure you want to delete this component?\n\n2. MultipleChoice`
+        `Are you sure you want to delete this activity?\n\n2. MultipleChoice`
       );
       expect(saveProjectSpy).toHaveBeenCalled();
       expect(teacherProjectService.idToNode[nodeId1].components).toEqual([component1, component3]);

--- a/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.ts
@@ -163,7 +163,7 @@ export class NodeAuthoringComponent implements OnInit {
     event.stopPropagation();
     if (
       confirm(
-        $localize`Are you sure you want to delete this component?\n\n${componentNumber}. ${component.type}`
+        $localize`Are you sure you want to delete this activity?\n\n${componentNumber}. ${component.type}`
       )
     ) {
       this.deleteComponentsOnServer([this.node.deleteComponent(component.id)]);

--- a/src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-dialog/select-peer-grouping-dialog.component.html
+++ b/src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-dialog/select-peer-grouping-dialog.component.html
@@ -1,6 +1,6 @@
 <h2 mat-dialog-title i18n>Select Peer Grouping</h2>
 <mat-dialog-content class="dialog-content-scroll">
-  <p i18n>Choose a Peer Grouping to use for this component:</p>
+  <p i18n>Choose a Peer Grouping to use for this activity:</p>
   @if (peerGroupings.length === 0) {
     <p i18n>(There are no Peer Groupings. Please create a new one.)</p>
   }

--- a/src/assets/wise5/authoringTool/wise-link-authoring-dialog/wise-link-authoring-dialog.component.html
+++ b/src/assets/wise5/authoringTool/wise-link-authoring-dialog/wise-link-authoring-dialog.component.html
@@ -19,10 +19,10 @@
       </mat-select>
     </mat-form-field>
     <mat-form-field class="choose-component">
-      <mat-label i18n>Component (Optional)</mat-label>
+      <mat-label i18n>Activity (optional)</mat-label>
       <mat-select
         [(ngModel)]="wiseLinkComponentId"
-        placeholder="Choose a Component"
+        placeholder="Choose an activity"
         i18n-placeholder
       >
         @for (

--- a/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.html
+++ b/src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.html
@@ -451,7 +451,7 @@
             </mat-select>
           </mat-form-field>
           <mat-form-field class="choose-component">
-            <mat-label i18n>Component</mat-label>
+            <mat-label i18n>Activity</mat-label>
             <mat-select
               [(ngModel)]="object.dataSource.componentId"
               (ngModelChange)="dataSourceComponentChanged(object)"

--- a/src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html
+++ b/src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html
@@ -1,5 +1,5 @@
 <ng-template #accumulatedIdeaCountSupportMessage
-  ><i i18n>Note: this term currently only works in the Dialog Guidance component.</i></ng-template
+  ><i i18n>Note: this term currently only works in the Dialog Guidance activity.</i></ng-template
 >
 <h2 mat-dialog-title i18n>Feedback Rule Authoring</h2>
 <mat-dialog-content class="dialog-content-scroll">

--- a/src/assets/wise5/components/conceptMap/edit-concept-map-connected-components/edit-concept-map-connected-components.component.ts
+++ b/src/assets/wise5/components/conceptMap/edit-concept-map-connected-components/edit-concept-map-connected-components.component.ts
@@ -39,9 +39,9 @@ export class EditConceptMapConnectedComponentsComponent extends EditConnectedCom
   askIfWantToCopyNodesAndLinks({ nodeId, componentId }): void {
     if (
       confirm(
-        $localize`Do you want to copy the nodes and links from the connected component?` +
+        $localize`Do you want to copy the nodes and links from the connected activity?` +
           '\n\n' +
-          $localize`Warning: This will delete all existing nodes and links in this component.`
+          $localize`Warning: This will delete all existing nodes and links in this activity.`
       )
     ) {
       const connectedComponent = this.projectService.getComponent(

--- a/src/assets/wise5/components/match/edit-match-connected-components/edit-match-connected-components.component.ts
+++ b/src/assets/wise5/components/match/edit-match-connected-components/edit-match-connected-components.component.ts
@@ -32,7 +32,7 @@ export class EditMatchConnectedComponentsComponent extends EditConnectedComponen
   askIfWantToCopyChoicesAndBuckets({ nodeId, componentId }): void {
     if (
       confirm(
-        $localize`Do you want to copy the choices and buckets from the connected component?\n\nWarning: This will delete all existing choices and buckets in this component.`
+        $localize`Do you want to copy the choices and buckets from the connected activity?\n\nWarning: This will delete all existing choices and buckets in this activity.`
       )
     ) {
       const connectedComponentContent = copy(this.projectService.getComponent(nodeId, componentId));

--- a/src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.ts
+++ b/src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.ts
@@ -33,7 +33,7 @@ export class EditMultipleChoiceConnectedComponentsComponent extends EditConnecte
   askIfWantToCopyChoices({ nodeId, componentId }): void {
     if (
       confirm(
-        $localize`Do you want to copy the choices from the connected component?\n\nWarning: This will delete all existing choices in this component.`
+        $localize`Do you want to copy the choices from the connected activity?\n\nWarning: This will delete all existing choices in this activity.`
       )
     ) {
       this.copyChoiceTypeFromComponent(nodeId, componentId);

--- a/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
+++ b/src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html
@@ -475,7 +475,7 @@
             </mat-select>
           </mat-form-field>
           <mat-form-field class="custom-completion-criteria-component">
-            <mat-label i18n>Component</mat-label>
+            <mat-label i18n>Activity</mat-label>
             <mat-select [(ngModel)]="criteria.componentId" (ngModelChange)="componentChanged()">
               @for (
                 component of getComponents(criteria.nodeId);
@@ -485,7 +485,7 @@
                 <mat-option [value]="component.id">
                   {{ componentIndex + 1 }}. {{ component.type }}
                   @if (component.id === componentId) {
-                    <span i18n>(This Component)</span>
+                    <span i18n>(This activity)</span>
                   }
                 </mat-option>
               }

--- a/src/assets/wise5/components/openResponse/open-response-authoring/open-response-authoring.component.html
+++ b/src/assets/wise5/components/openResponse/open-response-authoring/open-response-authoring.component.html
@@ -2,8 +2,8 @@
   @if (!componentContent.showPreviousWork) {
     <div>
       <mat-icon
-        matTooltip="If you want to use rich visuals (images, videos, links, bullets, etc.) in your prompt, use an HTML component above this"
-        matTooltipPosition="right"
+        matTooltip="If you want to use rich visuals (images, videos, links, bullets, etc.) in your prompt, use an HTML activity above this"
+        matTooltipPosition="above"
         i18n-matTooltip
         >announcement</mat-icon
       >

--- a/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.html
+++ b/src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.html
@@ -20,7 +20,7 @@
     </mat-select>
   </mat-form-field>
   <mat-form-field>
-    <mat-label i18n>Show Work Component</mat-label>
+    <mat-label i18n>Show Work Activity</mat-label>
     <mat-select
       [(ngModel)]="componentContent.showWorkComponentId"
       (ngModelChange)="componentChanged()"
@@ -39,7 +39,7 @@
         >
           <span>{{ componentIndex + 1 }}. {{ component.type }} </span>
           @if (component.id === componentId) {
-            <span i18n>(This Component)</span>
+            <span i18n>(This activity)</span>
           }
         </mat-option>
       }

--- a/src/assets/wise5/components/showMyWork/show-my-work-authoring/show-my-work-authoring.component.html
+++ b/src/assets/wise5/components/showMyWork/show-my-work-authoring/show-my-work-authoring.component.html
@@ -20,7 +20,7 @@
     </mat-select>
   </mat-form-field>
   <mat-form-field>
-    <mat-label i18n>Show Work Component</mat-label>
+    <mat-label i18n>Show Work Activity</mat-label>
     <mat-select
       [(ngModel)]="componentContent.showWorkComponentId"
       (ngModelChange)="componentChanged()"
@@ -39,7 +39,7 @@
         >
           <span>{{ componentIndex + 1 }}. {{ component.type }} </span>
           @if (component.id === componentId) {
-            <span i18n>(This Component)</span>
+            <span i18n>(This activity)</span>
           }
         </mat-option>
       }

--- a/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html
+++ b/src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html
@@ -2,7 +2,7 @@
   [componentContent]="componentContent"
   (promptChangedEvent)="promptChanged($event)"
 />
-<p i18n>Choose the step and component to show the summary data for:</p>
+<p i18n>Choose the step and activity to show the summary data for:</p>
 <div class="flex flex-row flex-wrap">
   <mat-form-field class="wide-drop-down">
     <mat-label i18n>Step</mat-label>
@@ -19,7 +19,7 @@
     </mat-select>
   </mat-form-field>
   <mat-form-field class="wide-drop-down">
-    <mat-label i18n>Component</mat-label>
+    <mat-label i18n>Activity</mat-label>
     <mat-select
       [(ngModel)]="componentContent.summaryComponentId"
       (ngModelChange)="summaryComponentIdChanged()"
@@ -38,7 +38,7 @@
         >
           {{ componentIndex + 1 }}. {{ component.type }}
           @if (component.id === componentId) {
-            <span i18n>(This Component)</span>
+            <span i18n>(This activity)</span>
           }
         </mat-option>
       }
@@ -83,7 +83,7 @@
       [(ngModel)]="componentContent.requirementToSeeSummary"
       (ngModelChange)="componentChanged()"
     >
-      <mat-option value="completeComponent" i18n> Complete Component </mat-option>
+      <mat-option value="completeComponent" i18n> Complete Activity </mat-option>
       <mat-option value="submitWork" i18n> Submit Work </mat-option>
       <mat-option value="none" i18n> None </mat-option>
     </mat-select>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -380,15 +380,15 @@
           <context context-type="linenumber">26,30</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1394735223918464839" datatype="html">
-        <source>Add New Component</source>
+      <trans-unit id="39198553669202931" datatype="html">
+        <source>Add New Activity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html</context>
           <context context-type="linenumber">1,3</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2287607018465279951" datatype="html">
-        <source>Select the component type you want to add or</source>
+      <trans-unit id="787242500793495382" datatype="html">
+        <source>Select the activity you want to add or</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html</context>
           <context context-type="linenumber">4,5</context>
@@ -930,8 +930,8 @@
           <context context-type="linenumber">17,19</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7349014962687453751" datatype="html">
-        <source>Edit Component JSON</source>
+      <trans-unit id="8880132687084463323" datatype="html">
+        <source>Edit Activity JSON</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-component-json/edit-component-json.component.html</context>
           <context context-type="linenumber">19,23</context>
@@ -1009,8 +1009,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">35</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3347257943543474753" datatype="html">
-        <source>Edit Component Rubric</source>
+      <trans-unit id="8741193813895692751" datatype="html">
+        <source>Edit activity rubric</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-component-rubric/edit-component-rubric.component.html</context>
           <context context-type="linenumber">8,12</context>
@@ -1062,8 +1062,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">85</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1930747845651698993" datatype="html">
-        <source>Component Width</source>
+      <trans-unit id="2810375050239191789" datatype="html">
+        <source>Activity Width</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-component-width/edit-component-width.component.ts</context>
           <context context-type="linenumber">11,15</context>
@@ -1114,15 +1114,15 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">23,24</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="5469582288677140959" datatype="html">
-        <source>Connected Components</source>
+      <trans-unit id="2139297247455088646" datatype="html">
+        <source>Connected Activities</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-connected-components-add-button/edit-connected-components-add-button.component.ts</context>
           <context context-type="linenumber">13,17</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8885984788303127081" datatype="html">
-        <source>Are you sure you want to delete this connected component?</source>
+      <trans-unit id="2346934958152395597" datatype="html">
+        <source>Are you sure you want to delete this connected activity?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-connected-components/edit-connected-components.component.ts</context>
           <context context-type="linenumber">77</context>
@@ -1321,8 +1321,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">9,12</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1717192557803901792" datatype="html">
-        <source>Reference Component:</source>
+      <trans-unit id="514264802422485519" datatype="html">
+        <source>Reference Activity:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-dynamic-prompt/edit-dynamic-prompt.component.html</context>
           <context context-type="linenumber">15,17</context>
@@ -1700,8 +1700,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">14,16</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2601245297771715218" datatype="html">
-        <source>Choose a unit from which to import component(s).</source>
+      <trans-unit id="8094381161211658587" datatype="html">
+        <source>Choose a unit from which to import activities.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-unit/choose-import-unit.component.html</context>
           <context context-type="linenumber">16,19</context>
@@ -1725,8 +1725,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">27,30</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="5847302460276630595" datatype="html">
-        <source>Component</source>
+      <trans-unit id="5306473977542913614" datatype="html">
+        <source>Activity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/select-component/select-component.component.html</context>
           <context context-type="linenumber">2,3</context>
@@ -1748,8 +1748,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">22,24</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3441536572634125088" datatype="html">
-        <source>(This Component)</source>
+      <trans-unit id="5995283214427196521" datatype="html">
+        <source>(This activity)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/select-component/select-component.component.html</context>
           <context context-type="linenumber">11,16</context>
@@ -10363,25 +10363,29 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">6,9</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1567315535994082287" datatype="html">
-        <source>Select components to add to your new step (optional):</source>
+      <trans-unit id="7691000626720208901" datatype="html">
+        <source>Select activities to add to your new step (optional):</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
           <context context-type="linenumber">9,11</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1481803350013682273" datatype="html">
-        <source>No components added</source>
+      <trans-unit id="287136474033183481" datatype="html">
+        <source>No activities added</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
           <context context-type="linenumber">13,16</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2995584297025117986" datatype="html">
-        <source>Delete component</source>
+      <trans-unit id="1057829402524211130" datatype="html">
+        <source>Delete activity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
           <context context-type="linenumber">26,28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
+          <context context-type="linenumber">65,67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4365227337792214829" datatype="html">
@@ -10873,8 +10877,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">46,51</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4602079498884979331" datatype="html">
-        <source>Component Info</source>
+      <trans-unit id="6290720414265350279" datatype="html">
+        <source>Activity Info</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/component-info-dialog/component-info-dialog.component.html</context>
           <context context-type="linenumber">2,5</context>
@@ -11071,8 +11075,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="5542693800123465162" datatype="html">
-        <source>Make This Component Not Visible</source>
+      <trans-unit id="6246530767125926453" datatype="html">
+        <source>Make This Activity Not Visible</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/component-constraint-authoring/component-constraint-authoring.component.ts</context>
           <context context-type="linenumber">31</context>
@@ -11198,8 +11202,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">45,48</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7139551500615655479" datatype="html">
-        <source>Please Choose a Component</source>
+      <trans-unit id="6119789013700511616" datatype="html">
+        <source>Please Choose an Activity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/constraint/edit-constraint-removal-criteria/edit-constraint-removal-criteria.component.html</context>
           <context context-type="linenumber">63,66</context>
@@ -11532,8 +11536,8 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="linenumber">7,8</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7680383127278188009" datatype="html">
-        <source>Reference component:</source>
+      <trans-unit id="8378432943903351878" datatype="html">
+        <source>Reference activity:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/create-branch/create-branch.component.html</context>
           <context context-type="linenumber">19,22</context>
@@ -11690,8 +11694,8 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">7,11</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3548317051881233027" datatype="html">
-        <source>Choose the component(s) that you want to import, then select Submit.</source>
+      <trans-unit id="6526204345613381873" datatype="html">
+        <source>Choose the activities that you want to import, then select Submit.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
           <context context-type="linenumber">1,3</context>
@@ -11711,8 +11715,8 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">33,36</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1389439426367341194" datatype="html">
-        <source>Preview component</source>
+      <trans-unit id="4853312017560609228" datatype="html">
+        <source>Preview activity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/importComponent/choose-import-component/choose-import-component.component.html</context>
           <context context-type="linenumber">53,55</context>
@@ -11880,8 +11884,8 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6666903681821403514" datatype="html">
-        <source>Component ID</source>
+      <trans-unit id="6443328348885175541" datatype="html">
+        <source>Activity ID</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/milestones-authoring/milestones-authoring.component.html</context>
           <context context-type="linenumber">161,163</context>
@@ -11903,8 +11907,8 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4128783014966097137" datatype="html">
-        <source>Copy Node ID and Component ID to Milestone</source>
+      <trans-unit id="5098305517091967664" datatype="html">
+        <source>Copy Node ID and Activity ID to Milestone</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/milestones-authoring/milestones-authoring.component.html</context>
           <context context-type="linenumber">208,211</context>
@@ -12134,8 +12138,8 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">231,233</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3843742807165983746" datatype="html">
-        <source>Are you sure you want to copy the Node ID and Component ID to the rest of this Milestone?</source>
+      <trans-unit id="550310164494800905" datatype="html">
+        <source>Are you sure you want to copy the Node ID and Activity ID to the rest of this Milestone?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/milestones-authoring/milestones-authoring.component.ts</context>
           <context context-type="linenumber">250</context>
@@ -12361,15 +12365,15 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">132</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3307198501674154798" datatype="html">
-        <source>Add component</source>
+      <trans-unit id="6005640251215534178" datatype="html">
+        <source>Add activity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.ts</context>
           <context context-type="linenumber">34</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7570310837284973582" datatype="html">
-        <source>Add component after</source>
+      <trans-unit id="4970978330013358284" datatype="html">
+        <source>Add activity after</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/add-component-button/add-component-button.component.ts</context>
           <context context-type="linenumber">51</context>
@@ -12590,8 +12594,8 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">35</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2240347155507306942" datatype="html">
-        <source>Get a specific score on a component</source>
+      <trans-unit id="7152509567296715925" datatype="html">
+        <source>Get a specific score on an activity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
           <context context-type="linenumber">45</context>
@@ -12611,8 +12615,8 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">50</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4259244002485463451" datatype="html">
-        <source>Choose a specific choice on a component</source>
+      <trans-unit id="1399601407334255100" datatype="html">
+        <source>Choose a specific choice on an activity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/advanced/path/node-advanced-path-authoring.component.ts</context>
           <context context-type="linenumber">55</context>
@@ -12667,29 +12671,22 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">221</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7088161748012321453" datatype="html">
-        <source>Copy component</source>
+      <trans-unit id="7916798927548288771" datatype="html">
+        <source>Copy activity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/copy-component-button/copy-component-button.component.html</context>
           <context context-type="linenumber">5,9</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7529107736747118202" datatype="html">
-        <source>This step does not have any components.</source>
+      <trans-unit id="6007148783088748338" datatype="html">
+        <source>This step does not have any activities.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
           <context context-type="linenumber">17,18</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6819692194334126635" datatype="html">
-        <source>Delete Component</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
-          <context context-type="linenumber">65,67</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3122407218727181695" datatype="html">
-        <source>Are you sure you want to delete this component?
+      <trans-unit id="8750433175440754789" datatype="html">
+        <source>Are you sure you want to delete this activity?
 
 <x id="PH" equiv-text="componentNumber"/>. <x id="PH_1" equiv-text="component.type"/></source>
         <context-group purpose="location">
@@ -13019,8 +13016,8 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">1,3</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6672767207836946071" datatype="html">
-        <source>Choose a Peer Grouping to use for this component:</source>
+      <trans-unit id="6080450091840666246" datatype="html">
+        <source>Choose a Peer Grouping to use for this activity:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/peer-grouping/select-peer-grouping-dialog/select-peer-grouping-dialog.component.html</context>
           <context context-type="linenumber">3,5</context>
@@ -13728,15 +13725,15 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">8,10</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="5264909596461534988" datatype="html">
-        <source>Component (Optional)</source>
+      <trans-unit id="8008754613513650645" datatype="html">
+        <source>Activity (optional)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/wise-link-authoring-dialog/wise-link-authoring-dialog.component.html</context>
           <context context-type="linenumber">22,25</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1437565577227375336" datatype="html">
-        <source>Choose a Component</source>
+      <trans-unit id="4737253247919643571" datatype="html">
+        <source>Choose an activity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/wise-link-authoring-dialog/wise-link-authoring-dialog.component.html</context>
           <context context-type="linenumber">25,29</context>
@@ -17225,8 +17222,8 @@ Are you ready to receive feedback on this answer?</source>
           <context context-type="linenumber">104</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="368815297929378084" datatype="html">
-        <source>Note: this term currently only works in the Dialog Guidance component.</source>
+      <trans-unit id="658186677327876605" datatype="html">
+        <source>Note: this term currently only works in the Dialog Guidance activity.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/feedback-rule-help/feedback-rule-help.component.html</context>
           <context context-type="linenumber">2,4</context>
@@ -19810,10 +19807,10 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">8,13</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2145150118792012851" datatype="html">
-        <source>Do you want to copy the choices and buckets from the connected component?
+      <trans-unit id="2424938650602658133" datatype="html">
+        <source>Do you want to copy the choices and buckets from the connected activity?
 
-Warning: This will delete all existing choices and buckets in this component.</source>
+Warning: This will delete all existing choices and buckets in this activity.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/edit-match-connected-components/edit-match-connected-components.component.ts</context>
           <context context-type="linenumber">35</context>
@@ -20147,10 +20144,10 @@ Warning: This will delete all existing choices and buckets in this component.</s
           <context context-type="linenumber">63,67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7065715943846466006" datatype="html">
-        <source>Do you want to copy the choices from the connected component?
+      <trans-unit id="3824537844289284943" datatype="html">
+        <source>Do you want to copy the choices from the connected activity?
 
-Warning: This will delete all existing choices in this component.</source>
+Warning: This will delete all existing choices in this activity.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/edit-multiple-choice-connected-components/edit-multiple-choice-connected-components.component.ts</context>
           <context context-type="linenumber">36</context>
@@ -20646,8 +20643,8 @@ Current Score: <x id="PH_1" equiv-text="currentScore"/></source>
           <context context-type="linenumber">278</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8648892006027324370" datatype="html">
-        <source>If you want to use rich visuals (images, videos, links, bullets, etc.) in your prompt, use an HTML component above this</source>
+      <trans-unit id="2481731999593972877" datatype="html">
+        <source>If you want to use rich visuals (images, videos, links, bullets, etc.) in your prompt, use an HTML activity above this</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/openResponse/open-response-authoring/open-response-authoring.component.html</context>
           <context context-type="linenumber">5,8</context>
@@ -21043,8 +21040,8 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">87,88</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7820322921034051164" datatype="html">
-        <source>Show Work Component</source>
+      <trans-unit id="8641853795765435400" datatype="html">
+        <source>Show Work Activity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/showGroupWork/show-group-work-authoring/show-group-work-authoring.component.html</context>
           <context context-type="linenumber">23,25</context>
@@ -21135,8 +21132,8 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3927338573004362816" datatype="html">
-        <source>Choose the step and component to show the summary data for:</source>
+      <trans-unit id="5609998247039115265" datatype="html">
+        <source>Choose the step and activity to show the summary data for:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html</context>
           <context context-type="linenumber">5,7</context>
@@ -21219,8 +21216,8 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">81,83</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4138191398907594032" datatype="html">
-        <source> Complete Component </source>
+      <trans-unit id="4130179133520653126" datatype="html">
+        <source> Complete Activity </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/summary-authoring/summary-authoring.component.html</context>
           <context context-type="linenumber">86,87</context>


### PR DESCRIPTION
To make our UI more user-friendly, we're moving away from using the term "component", and replacing it with "activity". These changes are mostly in the authoring tool.

Examples of changes:
- "add component" -> "add activity"
- "component width" -> "activity width"
- "connected components" -> "connected activities"

## Changes
- Change instances of "component" to "activity" and "components" to "activities", while keeping the letter-casing (e.g., Component -> Activity)
- Note that the code still uses the term "component" everywhere (e.g. ```node.addComponent()```)

## Test
- Make sure that you don't see the term "component" anywhere as a teacher and student. Test the authoring tool in particular, because this was where it was heavily used.