### PR TITLE
feat(NodeGrading): Add show/hide toggle for class responses

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading/node-grading.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading/node-grading.component.html
@@ -60,8 +60,6 @@
           [selectedComponents]="visibleComponents"
           (componentsChange)="setVisibleComponents($event)"
         />
-      }
-      @if (classResponsesVisible) {
         <a href="#" class="mat-caption" (click)="toggleClassResponses($event)" i18n>Hide</a>
       } @else {
         <a href="#" class="mat-caption" (click)="toggleClassResponses($event)" i18n>Show</a>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading/node-grading.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading/node-grading.component.html
@@ -54,12 +54,21 @@
     </div>
     <div class="flex gap-2 items-center flex-wrap mt-4 mb-2 mx-2">
       <h3 class="mat-body-1" i18n>Class Responses</h3>
-      <filter-components
-        [components]="components"
-        [selectedComponents]="visibleComponents"
-        (componentsChange)="setVisibleComponents($event)"
-      />
+      @if (classResponsesVisible) {
+        <filter-components
+          [components]="components"
+          [selectedComponents]="visibleComponents"
+          (componentsChange)="setVisibleComponents($event)"
+        />
+      }
+      @if (classResponsesVisible) {
+        <a href="#" class="mat-caption" (click)="toggleClassResponses($event)" i18n>Hide</a>
+      } @else {
+        <a href="#" class="mat-caption" (click)="toggleClassResponses($event)" i18n>Show</a>
+      }
     </div>
-    <node-class-responses [node]="node" [components]="visibleComponents" />
+    @if (classResponsesVisible) {
+      <node-class-responses [node]="node" [components]="visibleComponents" />
+    }
   </div>
 </div>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading/node-grading.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading/node-grading.component.ts
@@ -44,6 +44,7 @@ import { AnnotationService } from '../../../../services/annotationService';
   templateUrl: './node-grading.component.html'
 })
 export class NodeGradingComponent implements OnInit, OnDestroy, OnChanges {
+  protected classResponsesVisible: boolean = true;
   protected components: ComponentContent[];
   protected hasWork: boolean;
   protected node: Node;
@@ -148,5 +149,10 @@ export class NodeGradingComponent implements OnInit, OnDestroy, OnChanges {
   protected selectSummary(componentIndex: number): void {
     this.selectedComponent.setValue(componentIndex);
     this.visibleComponents = [this.components[componentIndex]];
+  }
+
+  protected toggleClassResponses(event: Event): void {
+    event.preventDefault();
+    this.classResponsesVisible = !this.classResponsesVisible;
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -14696,12 +14696,20 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading/node-grading.component.html</context>
           <context context-type="linenumber">32,33</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading/node-grading.component.html</context>
+          <context context-type="linenumber">66,67</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="8461842260159597706" datatype="html">
         <source>Show</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading/node-grading.component.html</context>
           <context context-type="linenumber">34,37</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading/node-grading.component.html</context>
+          <context context-type="linenumber">68,71</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2142002953999044695" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -14698,7 +14698,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading/node-grading.component.html</context>
-          <context context-type="linenumber">66,67</context>
+          <context context-type="linenumber">64,65</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8461842260159597706" datatype="html">
@@ -14709,7 +14709,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading/node-grading.component.html</context>
-          <context context-type="linenumber">68,71</context>
+          <context context-type="linenumber">66,69</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2142002953999044695" datatype="html">


### PR DESCRIPTION
## Changes
- Add an option to show and hide Class Responses display in the NodeGradingComponent of the Classroom Monitor.
<img width="1320" height="791" alt="Screenshot 2026-03-09 at 1 15 24 PM" src="https://github.com/user-attachments/assets/2d229dc2-d805-4e90-a513-b1a2135cecf7" />
<img width="1306" height="624" alt="Screenshot 2026-03-09 at 1 15 04 PM" src="https://github.com/user-attachments/assets/8bf33082-c0ce-495f-9628-de9ea5015f1b" />


## Test
- Make sure toggling visibility for Class Responses works and grading tools work as before.
