### PR TITLE
feat(NodeGrading): Add option to expand summaries

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.html
@@ -30,7 +30,7 @@
     <peer-group-button [node]="node" [component]="component" />
   </div>
   @if (hasSummaryData) {
-    <div class="flex flex-col sm:flex-row mt-3 gap-3">
+    <div class="flex flex-col md:flex-row mt-3 gap-3">
       @if (hasScoresSummary && hasScoreAnnotation) {
         <div class="summary-graph">
           <teacher-summary-display

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.html
@@ -1,5 +1,16 @@
-<div class="component-summary mat-elevation-z1 app-background flex flex-col p-3">
-  <div class="notice !text-start flex justify-between gap-4">
+<ng-template #expandSummaryTpl let-type="type">
+  <button
+    matIconButton
+    class="!absolute top-0 end-0"
+    title="Expand summary"
+    i18n-title
+    (click)="expandSummary(type)"
+  >
+    <mat-icon>fullscreen</mat-icon>
+  </button>
+</ng-template>
+<div class="component-summary notice flex flex-col p-3">
+  <div class="flex justify-between gap-4">
     <div>
       <div i18n>Prompt</div>
       @if (component.prompt) {
@@ -21,57 +32,67 @@
   @if (hasSummaryData) {
     <div class="flex flex-col sm:flex-row mt-3 gap-3">
       @if (hasScoresSummary && hasScoreAnnotation) {
-        <teacher-summary-display
-          [nodeId]="node.id"
-          [componentId]="component.id"
-          [periodId]="periodId"
-          [studentDataType]="'scores'"
-          [source]="source"
-          [chartType]="'column'"
-          [doRender]="true"
-          class="w-full md:w-1/2"
-        />
+        <div class="summary-graph">
+          <teacher-summary-display
+            [nodeId]="node.id"
+            [componentId]="component.id"
+            [periodId]="periodId"
+            [studentDataType]="'scores'"
+            [source]="source"
+            [chartType]="'column'"
+            [doRender]="true"
+            class="summary"
+          />
+        </div>
       }
       @if (component?.type === 'MultipleChoice' && hasStudentWork) {
-        <teacher-summary-display
-          [nodeId]="node.id"
-          [componentId]="component.id"
-          [periodId]="periodId"
-          [studentDataType]="'responses'"
-          [source]="source"
-          [highlightCorrectAnswer]="hasCorrectAnswer"
-          [chartType]="component.choiceType === 'multiple' ? 'columnn' : 'pie'"
-          [doRender]="true"
-          class="w-full md:w-1/2"
-        />
+        <div class="summary-graph">
+          <teacher-summary-display
+            [nodeId]="node.id"
+            [componentId]="component.id"
+            [periodId]="periodId"
+            [studentDataType]="'responses'"
+            [source]="source"
+            [highlightCorrectAnswer]="hasCorrectAnswer"
+            [chartType]="component.choiceType === 'multiple' ? 'columnn' : 'pie'"
+            [doRender]="true"
+            class="summary"
+          />
+        </div>
       }
       @if (hasIdeaRubricData) {
-        <mat-card appearance="outlined" class="w-full">
-          <mat-card-content>
-            <ideas-summary
-              [nodeId]="node.id"
-              [componentId]="component.id"
-              [periodId]="periodId"
-              [studentDataType]="'responses'"
-              [source]="source"
-              [doRender]="true"
-              [componentType]="component.type"
-            />
-          </mat-card-content>
-        </mat-card>
+        <div class="summary-content">
+          <ng-container
+            [ngTemplateOutlet]="expandSummaryTpl"
+            [ngTemplateOutletContext]="{ type: 'ideas' }"
+          />
+          <ideas-summary
+            [nodeId]="node.id"
+            [componentId]="component.id"
+            [periodId]="periodId"
+            [studentDataType]="'responses'"
+            [source]="source"
+            [doRender]="true"
+            [componentType]="component.type"
+            class="summary"
+          />
+        </div>
       }
       @if (component?.type === 'Match') {
-        <mat-card appearance="outlined" class="w-full">
-          <mat-card-content>
-            <match-summary-display
-              [nodeId]="node.id"
-              [componentId]="component.id"
-              [periodId]="periodId"
-              [source]="source"
-              [doRender]="true"
-            />
-          </mat-card-content>
-        </mat-card>
+        <div class="summary-content">
+          <ng-container
+            [ngTemplateOutlet]="expandSummaryTpl"
+            [ngTemplateOutletContext]="{ type: 'match' }"
+          />
+          <match-summary-display
+            [nodeId]="node.id"
+            [componentId]="component.id"
+            [periodId]="periodId"
+            [source]="source"
+            [doRender]="true"
+            class="summary"
+          />
+        </div>
       }
     </div>
   }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.html
@@ -9,7 +9,7 @@
     <mat-icon>fullscreen</mat-icon>
   </button>
 </ng-template>
-<div class="component-summary notice flex flex-col p-3">
+<div class="component-summary notice flex flex-col">
   <div class="flex justify-between gap-4">
     <div>
       <div i18n>Prompt</div>
@@ -85,6 +85,21 @@
             [ngTemplateOutletContext]="{ type: 'match' }"
           />
           <match-summary-display
+            [nodeId]="node.id"
+            [componentId]="component.id"
+            [periodId]="periodId"
+            [source]="source"
+            [doRender]="true"
+            class="summary"
+          />
+        </div>
+      } @else if (component?.type === 'Discussion' && hasStudentWork) {
+        <div class="summary-content">
+          <ng-container
+            [ngTemplateOutlet]="expandSummaryTpl"
+            [ngTemplateOutletContext]="{ type: 'discussion' }"
+          />
+          <discussion-summary
             [nodeId]="node.id"
             [componentId]="component.id"
             [periodId]="periodId"

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.scss
@@ -31,10 +31,10 @@ peer-group-button > * {
 }
 
 .summary-graph {
-  @apply w-full lg:w-1/2 xl:w-1/3;
+  @apply w-full md:w-1/2 lg:w-1/3;
 }
 
 .summary-content {
-  @apply w-full lg:w-1/2 xl:w-2/3 relative;
+  @apply w-full md:w-auto md:grow-2 relative;
 }
 

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.scss
@@ -1,7 +1,7 @@
 @use "tailwindcss";
 
 .notice {
-  @apply m-3 !max-w-none !text-start;
+  @apply m-0 !p-3 !max-w-none !text-start rounded-none;
 }
 
 .mat-body-1 {

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.scss
@@ -1,28 +1,40 @@
-.component-summary {
-  .notice {
-    max-width: none;
-    margin: 0;
-  }
+@use "tailwindcss";
 
-  .mat-body-1 {
-    margin-bottom: 0;
-  }
-
-  .mat-mdc-card-content:last-child {
-    padding-bottom: 12px;
-  }
-
-  .mat-mdc-card-content:first-child {
-    padding-top: 12px;
-  }
-
-  .mat-mdc-card-content {
-    padding: 0 12px;
-  }
-
-  milestone-report-button > *,
-  peer-group-button > * {
-    margin-top: 12px;
-    margin-inline-end: 8px;
-  }
+.notice {
+  @apply m-3 !max-w-none !text-start;
 }
+
+.mat-body-1 {
+  margin-bottom: 0;
+}
+
+.mat-mdc-card-content:last-child {
+  padding-bottom: 12px;
+}
+
+.mat-mdc-card-content:first-child {
+  padding-top: 12px;
+}
+
+.mat-mdc-card-content {
+  padding: 0 12px;
+}
+
+milestone-report-button > *,
+peer-group-button > * {
+  margin-top: 12px;
+  margin-inline-end: 8px;
+}
+
+.summary {
+  @apply rounded-md p-3 overflow-hidden bg-white block;
+}
+
+.summary-graph {
+  @apply w-full lg:w-1/2 xl:w-1/3;
+}
+
+.summary-content {
+  @apply w-full lg:w-1/2 xl:w-2/3 relative;
+}
+

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, ViewEncapsulation } from '@angular/core';
+import { Component, Inject, Input, ViewEncapsulation } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
 import { TeacherSummaryDisplayComponent } from '../../../directives/teacher-summary-display/teacher-summary-display.component';
 import { ComponentServiceLookupService } from '../../../services/componentServiceLookupService';
 import { SummaryService } from '../../../components/summary/summaryService';
@@ -14,21 +15,31 @@ import { IdeasSummaryComponent } from '../../../directives/teacher-summary-displ
 import { MatchSummaryDisplayComponent } from '../../../directives/teacher-summary-display/match-summary-display/match-summary-display.component';
 import { MatCardModule } from '@angular/material/card';
 import { CRaterService } from '../../../services/cRaterService';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialog,
+  MatDialogContent,
+  MatDialogRef
+} from '@angular/material/dialog';
 
 @Component({
   imports: [
     ComponentCompletionComponent,
     IdeasSummaryComponent,
+    MatButtonModule,
     MatCardModule,
+    MatIconModule,
     MatchSummaryDisplayComponent,
     MilestoneReportButtonComponent,
+    NgTemplateOutlet,
     PeerGroupButtonComponent,
     TeacherSummaryDisplayComponent
   ],
   selector: 'component-summary',
   styleUrl: './component-summary.component.scss',
-  templateUrl: './component-summary.component.html',
-  encapsulation: ViewEncapsulation.None
+  templateUrl: './component-summary.component.html'
 })
 export class ComponentSummaryComponent {
   protected avgScore: number;
@@ -48,6 +59,7 @@ export class ComponentSummaryComponent {
     private componentServiceLookupService: ComponentServiceLookupService,
     private cRaterService: CRaterService,
     private dataService: TeacherDataService,
+    private dialog: MatDialog,
     private summaryService: SummaryService
   ) {}
 
@@ -113,4 +125,43 @@ export class ComponentSummaryComponent {
         return soFar;
       }, []);
   }
+
+  protected expandSummary(type: 'ideas' | 'match'): void {
+    this.dialog.open(SummaryDialogComponent, {
+      data: {
+        type: type,
+        node: this.node,
+        component: this.component,
+        periodId: this.periodId,
+        source: this.source,
+        componentType: this.component.type
+      },
+      panelClass: 'summary-dialog'
+    });
+  }
+}
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  imports: [
+    IdeasSummaryComponent,
+    MatchSummaryDisplayComponent,
+    MatButtonModule,
+    MatDialogContent,
+    MatIconModule
+  ],
+  styles: `
+    @import 'tailwindcss';
+
+    .summary-dialog {
+      @apply w-full h-full !max-w-[120rem];
+    }
+  `,
+  templateUrl: './summary-dialog.component.html'
+})
+class SummaryDialogComponent {
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: any,
+    public dialogRef: MatDialogRef<SummaryDialogComponent>
+  ) {}
 }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/summary-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/summary-dialog.component.html
@@ -1,0 +1,25 @@
+<mat-dialog-content>
+  <button matIconButton (click)="dialogRef.close()" class="!absolute top-0 end-0">
+    <mat-icon>fullscreen_exit</mat-icon>
+  </button>
+  @if (data.type === 'ideas') {
+    <ideas-summary
+      [nodeId]="data.node.id"
+      [componentId]="data.component.id"
+      [periodId]="data.periodId"
+      [studentDataType]="'responses'"
+      [source]="data.source"
+      [doRender]="true"
+      [componentType]="data.componentType"
+    />
+  }
+  @if (data.type === 'match') {
+    <match-summary-display
+      [nodeId]="data.node.id"
+      [componentId]="data.component.id"
+      [periodId]="data.periodId"
+      [source]="data.source"
+      [doRender]="true"
+    />
+  }
+</mat-dialog-content>

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/summary-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/summary-dialog.component.html
@@ -12,8 +12,7 @@
       [doRender]="true"
       [componentType]="data.componentType"
     />
-  }
-  @if (data.type === 'match') {
+  } @else if (data.type === 'match') {
     <match-summary-display
       [nodeId]="data.node.id"
       [componentId]="data.component.id"

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/summary-dialog.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/summary-dialog.component.html
@@ -1,5 +1,9 @@
-<mat-dialog-content>
-  <button matIconButton (click)="dialogRef.close()" class="!absolute top-0 end-0">
+<mat-dialog-content class="!max-h-none">
+  <button
+    matIconButton
+    (click)="dialogRef.close()"
+    class="!absolute top-0 end-0 app-background !z-1"
+  >
     <mat-icon>fullscreen_exit</mat-icon>
   </button>
   @if (data.type === 'ideas') {
@@ -11,6 +15,7 @@
       [source]="data.source"
       [doRender]="true"
       [componentType]="data.componentType"
+      [expanded]="true"
     />
   } @else if (data.type === 'match') {
     <match-summary-display
@@ -19,6 +24,16 @@
       [periodId]="data.periodId"
       [source]="data.source"
       [doRender]="true"
+      [expanded]="true"
+    />
+  } @else if (data.type === 'discussion') {
+    <discussion-summary
+      [nodeId]="data.node.id"
+      [componentId]="data.component.id"
+      [periodId]="data.periodId"
+      [source]="data.source"
+      [doRender]="true"
+      [expanded]="true"
     />
   }
 </mat-dialog-content>

--- a/src/assets/wise5/directives/summary-display/summary-display.component.scss
+++ b/src/assets/wise5/directives/summary-display/summary-display.component.scss
@@ -1,5 +1,11 @@
+@use "tailwindcss";
+
 .highcharts-chart {
   display: block;
   height: 300px;
   width: 100%;
+}
+
+.expanded {
+  @apply flex flex-col max-h-full;
 }

--- a/src/assets/wise5/directives/teacher-summary-display/discussion-summary/discussion-summary.component.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/discussion-summary/discussion-summary.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { Component as WISEComponent } from '../../../common/Component';
 import { TeacherSummaryDisplayComponent } from '../teacher-summary-display.component';
 import { ComponentFactory } from '../../../common/ComponentFactory';
@@ -8,19 +8,24 @@ import { DiscussionTeacherComponent } from '../../../components/discussion/discu
 @Component({
   imports: [CommonModule, DiscussionTeacherComponent],
   selector: 'discussion-summary',
+  styleUrl: '../../summary-display/summary-display.component.scss',
   template: `
-    <h2 class="mat-subtitle-1" i18n>Class Discussion</h2>
-    <discussion-teacher
-      class="max-h-160 block overflow-y-auto"
-      [nodeId]="nodeId"
-      [component]="component"
-      [periodId]="periodId"
-      [mode]="'summary'"
-    />
+    <div [class.expanded]="expanded">
+      <h2 class="mat-subtitle-1" i18n>Class Discussion</h2>
+      <discussion-teacher
+        class="max-h-160 block overflow-y-auto"
+        [class.max-h-none]="expanded"
+        [nodeId]="nodeId"
+        [component]="component"
+        [periodId]="periodId"
+        [mode]="'summary'"
+      />
+    </div>
   `
 })
 export class DiscussionSummaryComponent extends TeacherSummaryDisplayComponent implements OnInit {
   protected component: WISEComponent;
+  @Input() expanded: boolean;
 
   ngOnInit(): void {
     let content = this.projectService.getComponent(this.nodeId, this.componentId);

--- a/src/assets/wise5/directives/teacher-summary-display/ideas-summary/ideas-summary.component.html
+++ b/src/assets/wise5/directives/teacher-summary-display/ideas-summary/ideas-summary.component.html
@@ -43,34 +43,38 @@
     }
   </div>
 </ng-template>
-<h2 class="mat-subtitle-1" i18n>Student Ideas Detected</h2>
-@if (hasWarning) {
-  <p class="warn center">{{ warningMessage }}</p>
-}
-@if (doRender) {
-  @if (rubric.ideaColors) {
-    <div class="flex flex-wrap items-center gap-2 mb-4">
-      <span class="text-sm font-medium" i18n>Key:</span>
-      @for (ideaColor of rubric.ideaColors; track ideaColor.colorValue) {
-        <div class="py-0.5 px-1 rounded" [style.background-color]="ideaColor.colorValue">
-          <span class="text-sm">{{ ideaColor.tags.join(', ') }}</span>
+<div [class.expanded]="expanded">
+  <h2 class="mat-subtitle-1" i18n>Student Ideas Detected</h2>
+  @if (hasWarning) {
+    <p class="warn center">{{ warningMessage }}</p>
+  }
+  <div class="overflow-y-auto">
+    @if (doRender) {
+      @if (rubric.ideaColors) {
+        <div class="flex flex-wrap items-center gap-2 mb-4">
+          <span class="text-sm font-medium" i18n>Key:</span>
+          @for (ideaColor of rubric.ideaColors; track ideaColor.colorValue) {
+            <div class="py-0.5 px-1 rounded" [style.background-color]="ideaColor.colorValue">
+              <span class="text-sm">{{ ideaColor.tags.join(', ') }}</span>
+            </div>
+          }
         </div>
       }
-    </div>
-  }
-  <ng-container
-    [ngTemplateOutlet]="ideaGroup"
-    [ngTemplateOutletContext]="{ ideaGroups: initialGroups }"
-  />
-  @if (showMore) {
-    <ng-container
-      [ngTemplateOutlet]="ideaGroup"
-      [ngTemplateOutletContext]="{ ideaGroups: additionalGroups }"
-    />
-    <a tabindex="0" (click)="showMore = false" i18n>Show less</a>
-  } @else if (additionalGroups.length > 0) {
-    <a tabindex="0" (click)="showMore = true" i18n>Show more</a>
-  }
-} @else {
-  <div i18n>Your students' ideas will show up here as they are detected in the activity.</div>
-}
+      <ng-container
+        [ngTemplateOutlet]="ideaGroup"
+        [ngTemplateOutletContext]="{ ideaGroups: initialGroups }"
+      />
+      @if (showMore) {
+        <ng-container
+          [ngTemplateOutlet]="ideaGroup"
+          [ngTemplateOutletContext]="{ ideaGroups: additionalGroups }"
+        />
+        <a tabindex="0" (click)="showMore = false" i18n>Show less</a>
+      } @else if (additionalGroups.length > 0) {
+        <a tabindex="0" (click)="showMore = true" i18n>Show more</a>
+      }
+    } @else {
+      <div i18n>Your students' ideas will show up here as they are detected in the activity.</div>
+    }
+  </div>
+</div>

--- a/src/assets/wise5/directives/teacher-summary-display/ideas-summary/ideas-summary.component.scss
+++ b/src/assets/wise5/directives/teacher-summary-display/ideas-summary/ideas-summary.component.scss
@@ -1,0 +1,16 @@
+h3,
+.mat-subtitle-1,
+.mat-body-1 {
+  margin-bottom: 8px;
+  margin-top: 0;
+}
+
+ul {
+  list-style-type: none;
+  margin-block-start: 0;
+  padding-inline-start: 0;
+}
+
+li:not(:last-child) {
+  margin-bottom: 4px;
+}

--- a/src/assets/wise5/directives/teacher-summary-display/ideas-summary/ideas-summary.component.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/ideas-summary/ideas-summary.component.ts
@@ -17,28 +17,16 @@ import { CRaterRubric } from '../../../components/common/cRater/CRaterRubric';
 @Component({
   imports: [CommonModule, IdeaSummaryComponent],
   selector: 'ideas-summary',
-  styles: `
-    h3,
-    .mat-subtitle-1,
-    .mat-body-1 {
-      margin-bottom: 8px;
-      margin-top: 0;
-    }
-    ul {
-      list-style-type: none;
-      margin-block-start: 0;
-      padding-inline-start: 0;
-    }
-    li:not(:last-child) {
-      margin-bottom: 4px;
-    }
-  `,
+  styleUrls: [
+    './ideas-summary.component.scss',
+    '../../summary-display/summary-display.component.scss'
+  ],
   templateUrl: 'ideas-summary.component.html'
 })
 export class IdeasSummaryComponent extends TeacherSummaryDisplayComponent {
-  @Input() componentType: string;
-
   protected additionalGroups: IdeaGroup[] = [];
+  @Input() componentType: string;
+  @Input() expanded: boolean;
   protected initialGroups: IdeaGroup[] = [];
   protected showMore: boolean;
   protected rubric: CRaterRubric;

--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html
@@ -33,30 +33,35 @@
     </ul>
   </div>
 </ng-template>
-
-<h2 class="mat-subtitle-1" i18n>Choice Frequency</h2>
-@if (bucketData.length > 0) {
-  <p i18n>Number of teams that moved each item (choice) into the different buckets (categories).</p>
-  <div class="columns-3xs gap-2">
-    <div class="break-inside-avoid">
-      <ng-container
-        [ngTemplateOutlet]="bucketTemplate"
-        [ngTemplateOutletContext]="{ bucket: bucketData[0], first: true }"
-      />
-    </div>
-    @for (bucket of bucketData; track $index) {
-      @if ($index > 0) {
+<div [class.expanded]="expanded">
+  <h2 class="mat-subtitle-1" i18n>Choice Frequency</h2>
+  <div class="max-h-160 overflow-y-auto" [class.max-h-none]="expanded">
+    @if (bucketData.length > 0) {
+      <p i18n>
+        Number of teams that moved each item (choice) into the different buckets (categories).
+      </p>
+      <div class="columns-3xs gap-2">
         <div class="break-inside-avoid">
           <ng-container
             [ngTemplateOutlet]="bucketTemplate"
-            [ngTemplateOutletContext]="{ bucket: bucket, first: false }"
+            [ngTemplateOutletContext]="{ bucket: bucketData[0], first: true }"
           />
         </div>
-      }
+        @for (bucket of bucketData; track $index) {
+          @if ($index > 0) {
+            <div class="break-inside-avoid">
+              <ng-container
+                [ngTemplateOutlet]="bucketTemplate"
+                [ngTemplateOutletContext]="{ bucket: bucket, first: false }"
+              />
+            </div>
+          }
+        }
+      </div>
+    } @else {
+      <div class="notice" i18n>
+        Your students' choices will show up here when they complete the activity.
+      </div>
     }
   </div>
-} @else {
-  <div class="notice" i18n>
-    Your students' choices will show up here when they complete the activity.
-  </div>
-}
+</div>

--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.scss
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.scss
@@ -1,0 +1,25 @@
+@use "tailwindcss";
+
+h3,
+.mat-subtitle-1 {
+  margin-bottom: 8px;
+  margin-top: 0;
+}
+
+.bucket {
+  @apply p-2 mb-2 rounded-md;
+}
+
+.choice {
+  @apply flex gap-1 px-2 py-1 mt-1 rounded-md bg-white border border-neutral-200 text-sm;
+}
+
+.mat-icon {
+  vertical-align: middle;
+}
+
+ul {
+  list-style-type: none;
+  margin-block-start: 0;
+  padding-inline-start: 0;
+}

--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { MatchContent } from '../../../components/match/MatchContent';
 import { MatchSummaryData } from '../summary-data/MatchSummaryData';
 import { MatchSummaryDataPoint } from '../summary-data/MatchSummaryDataPoint';
@@ -9,34 +9,17 @@ import { TeacherSummaryDisplayComponent } from '../teacher-summary-display.compo
 @Component({
   imports: [CommonModule, MatIconModule],
   selector: 'match-summary-display',
-  styles: `
-    @reference "tailwindcss";
-    h3,
-    .mat-subtitle-1 {
-      margin-bottom: 8px;
-      margin-top: 0;
-    }
-    .bucket {
-      @apply p-2 mb-2 rounded-md;
-    }
-    .choice {
-      @apply flex gap-1 px-2 py-1 mt-1 rounded-md bg-white border border-neutral-200 text-sm;
-    }
-    .mat-icon {
-      vertical-align: middle;
-    }
-    ul {
-      list-style-type: none;
-      margin-block-start: 0;
-      padding-inline-start: 0;
-    }
-  `,
+  styleUrls: [
+    './match-summary-display.component.scss',
+    '../../summary-display/summary-display.component.scss'
+  ],
   templateUrl: './match-summary-display.component.html'
 })
 export class MatchSummaryDisplayComponent extends TeacherSummaryDisplayComponent implements OnInit {
   protected bucketData: { value: string; choices: MatchSummaryDataPoint[] }[] = [];
   private bucketsShowMore: Map<string, boolean> = new Map<string, boolean>();
   private bucketValues: Set<string> = new Set<string>();
+  @Input() expanded: boolean;
   protected isChoiceReuseMatch: boolean;
   private matchSummaryData: MatchSummaryData;
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15099,7 +15099,7 @@ Are you sure you want to proceed?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ideas-summary/ideas-summary.component.html</context>
-          <context context-type="linenumber">72,75</context>
+          <context context-type="linenumber">74,77</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
@@ -17126,7 +17126,7 @@ Are you ready to receive feedback on this answer?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ideas-summary/ideas-summary.component.html</context>
-          <context context-type="linenumber">53,54</context>
+          <context context-type="linenumber">55,56</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8040881171107393560" datatype="html">
@@ -21941,7 +21941,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Class Discussion</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/discussion-summary/discussion-summary.component.ts</context>
-          <context context-type="linenumber">12,14</context>
+          <context context-type="linenumber">14,16</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3690771652722848805" datatype="html">
@@ -21962,14 +21962,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Student Ideas Detected</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ideas-summary/ideas-summary.component.html</context>
-          <context context-type="linenumber">46,48</context>
+          <context context-type="linenumber">47,49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3517550046701184661" datatype="html">
         <source>Show less</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ideas-summary/ideas-summary.component.html</context>
-          <context context-type="linenumber">70,72</context>
+          <context context-type="linenumber">72,74</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
@@ -21980,7 +21980,7 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Your students&apos; ideas will show up here as they are detected in the activity.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ideas-summary/ideas-summary.component.html</context>
-          <context context-type="linenumber">75,77</context>
+          <context context-type="linenumber">77,81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5353710433603859763" datatype="html">
@@ -21994,21 +21994,21 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Choice Frequency</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">37,39</context>
+          <context context-type="linenumber">37,38</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3546606966003983902" datatype="html">
-        <source>Number of teams that moved each item (choice) into the different buckets (categories).</source>
+      <trans-unit id="7051463422291865328" datatype="html">
+        <source> Number of teams that moved each item (choice) into the different buckets (categories). </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">39,41</context>
+          <context context-type="linenumber">41,44</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2004123481203797507" datatype="html">
         <source> Your students&apos; choices will show up here when they complete the activity. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">60,63</context>
+          <context context-type="linenumber">63,68</context>
         </context-group>
       </trans-unit>
       <trans-unit id="866753876041645935" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -988,7 +988,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.html</context>
-          <context context-type="linenumber">4,6</context>
+          <context context-type="linenumber">15,17</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7561343662252105417" datatype="html">
@@ -13835,6 +13835,13 @@ The branches will be removed but the steps will remain in the unit.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-completion/component-completion.component.html</context>
           <context context-type="linenumber">12,14</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6063735713364961693" datatype="html">
+        <source>Expand summary</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.html</context>
+          <context context-type="linenumber">5,9</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4977425233945972011" datatype="html">


### PR DESCRIPTION
## Changes
- Adds a button to expand Discussion, Match, and Ideas Detected summaries in the NodeGradingComponent of the Classroom Monitor.
- Expanded view opens in a fullscreen dialog.
- Some style and layout updates.

<img width="1281" height="698" alt="Screenshot 2026-03-09 at 2 02 56 PM" src="https://github.com/user-attachments/assets/24569936-493f-4c19-b3e1-d662243b8c1a" />
<img width="1281" height="578" alt="Screenshot 2026-03-09 at 2 03 53 PM" src="https://github.com/user-attachments/assets/b9fa7613-e2c2-43d0-85bd-6c1e3b2454ba" />

## Test
- Make sure you can expand and collapse (close) the Discussion, Match, and Ideas Detected summaries.
- Make sure the summaries display and work properly.
