### PR TITLE
feat(Authoring Tool): Drag and drop lessons and steps

### DIFF
--- a/src/assets/wise5/authoringTool/choose-node-location/node-icon-and-title/node-icon-and-title.component.html
+++ b/src/assets/wise5/authoringTool/choose-node-location/node-icon-and-title/node-icon-and-title.component.html
@@ -1,7 +1,7 @@
 <div class="flex flex-row justify-start items-center gap-1">
   <node-icon [nodeId]="nodeId" size="18" />&nbsp;
   @if (showPosition) {
-    <span class="step-number">{{ getNodePosition(nodeId) }}: </span>
+    <span class="step-number">{{ nodePosition }}: </span>
   }
-  <span class="step-title">{{ getNodeTitle(nodeId) }}</span>
+  <span class="step-title">{{ nodeTitle }}</span>
 </div>

--- a/src/assets/wise5/authoringTool/choose-node-location/node-icon-and-title/node-icon-and-title.component.ts
+++ b/src/assets/wise5/authoringTool/choose-node-location/node-icon-and-title/node-icon-and-title.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from '@angular/core';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { NodeIconComponent } from '../../../vle/node-icon/node-icon.component';
 import { TeacherProjectTranslationService } from '../../../services/teacherProjectTranslationService';
+import { Subscription } from 'rxjs';
 
 @Component({
   imports: [NodeIconComponent],
@@ -11,18 +12,34 @@ import { TeacherProjectTranslationService } from '../../../services/teacherProje
 })
 export class NodeIconAndTitleComponent {
   @Input() protected nodeId: string;
+  protected nodePosition: string;
+  protected nodeTitle: string;
   @Input() protected showPosition: boolean;
+  private subscriptions: Subscription;
 
   constructor(
     private projectService: TeacherProjectService,
     private projectTranslationService: TeacherProjectTranslationService
   ) {}
 
-  protected getNodePosition(nodeId: string): string {
+  ngOnInit(): void {
+    this.nodePosition = this.getNodePosition(this.nodeId);
+    this.nodeTitle = this.getNodeTitle(this.nodeId);
+    this.subscriptions = this.projectService.projectParsed$.subscribe(() => {
+      this.nodePosition = this.getNodePosition(this.nodeId);
+      this.nodeTitle = this.getNodeTitle(this.nodeId);
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+  private getNodePosition(nodeId: string): string {
     return this.projectService.getNodePositionById(nodeId);
   }
 
-  protected getNodeTitle(nodeId: string): string {
+  private getNodeTitle(nodeId: string): string {
     return this.projectService.isDefaultLocale()
       ? this.projectService.getNodeTitle(nodeId)
       : this.translateNodeTitle(nodeId);

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -68,9 +68,10 @@
   <div
     cdkDropList
     [id]="lesson.id"
-    [cdkDropListData]="{ groupId: lesson.id, nodes: lesson.ids }"
+    [cdkDropListData]="{ groupId: lesson.id, nodes: lesson.ids, idToNode: idToNode }"
     cdkDropListLockAxis="y"
     [cdkDropListConnectedTo]="allGroupIds"
+    [cdkDropListSortPredicate]="notAfterBranchingNode"
     (cdkDropListDropped)="dropNode($event)"
   >
     @for (childId of lesson.ids; track childId) {

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -5,6 +5,8 @@
   (closed)="toggleExpanded(false)"
   cdkDrag
   [cdkDragData]="{ type: 'group', id: lesson.id }"
+  (cdkDragStarted)="drag(true)"
+  (cdkDragEnded)="drag(false)"
   [id]="lesson.id"
 >
   <div class="drag-placeholder flex grow" *cdkDragPlaceholder></div>
@@ -82,7 +84,8 @@
           (selectNodeEvent)="selectNodeEvent.emit($event)"
           [showPosition]="showPosition"
           [projectId]="projectId"
-          class="flex grow"
+          (dragStarted)="drag(true)"
+          (dragEnded)="drag(false)"
         />
         <add-step-button [nodeId]="childId" />
       </div>

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -72,7 +72,7 @@
     [cdkDropListData]="{ groupId: lesson.id, nodes: lesson.ids }"
     cdkDropListLockAxis="y"
     [cdkDropListConnectedTo]="allGroupIds"
-    (cdkDropListDropped)="dropStep($event)"
+    (cdkDropListDropped)="dropNode($event)"
   >
     @for (childId of lesson.ids; track childId) {
       <div class="flex flex-row flex-wrap justify-start items-center">

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -9,7 +9,6 @@
   (cdkDragEnded)="drag(false)"
   [id]="lesson.id"
 >
-  <div class="drag-placeholder flex grow" *cdkDragPlaceholder></div>
   <mat-expansion-panel-header aria-label="Expand/collapse lesson" i18n-aria-label>
     <mat-panel-title>
       @if (batchEditMode) {
@@ -25,6 +24,7 @@
       } @else {
         <mat-icon
           cdkDragHandle
+          class="cursor-move me-2"
           (click)="$event.stopPropagation()"
           title="Drag to reorder"
           i18n-title
@@ -68,6 +68,7 @@
     </mat-panel-description>
   </mat-expansion-panel-header>
   <div
+    class="ps-6 flex flex-col gap-1"
     cdkDropList
     [id]="lesson.id"
     [cdkDropListData]="{ groupId: lesson.id, nodes: lesson.ids, idToNode: idToNode }"
@@ -84,14 +85,15 @@
           (selectNodeEvent)="selectNodeEvent.emit($event)"
           [showPosition]="showPosition"
           [projectId]="projectId"
+          class="grow"
           (dragStarted)="drag(true)"
           (dragEnded)="drag(false)"
         />
-        <add-step-button [nodeId]="childId" />
+        <add-step-button [nodeId]="childId" [class.hidden]="isDragging()" />
       </div>
     }
     @if (lesson.ids.length === 0) {
-      <div class="no-steps-message flex justify-start items-center">
+      <div class="px-2 flex justify-start items-center">
         <div i18n>This lesson has no steps</div>
         <button
           mat-icon-button
@@ -106,4 +108,5 @@
       </div>
     }
   </div>
+  <div class="drag-placeholder" *cdkDragPlaceholder></div>
 </mat-expansion-panel>

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -4,8 +4,10 @@
   (opened)="toggleExpanded(true)"
   (closed)="toggleExpanded(false)"
   cdkDrag
-  [cdkDragData]="lesson.id"
+  [cdkDragData]="{ type: 'group', id: lesson.id }"
+  [id]="lesson.id"
 >
+  <div class="drag-placeholder flex grow" *cdkDragPlaceholder></div>
   <mat-expansion-panel-header aria-label="Expand/collapse lesson" i18n-aria-label>
     <mat-panel-title>
       @if (batchEditMode) {
@@ -64,7 +66,14 @@
       </button>
     </mat-panel-description>
   </mat-expansion-panel-header>
-  <div>
+  <div
+    cdkDropList
+    [id]="lesson.id"
+    [cdkDropListData]="{ groupId: lesson.id, nodes: lesson.ids }"
+    cdkDropListLockAxis="y"
+    [cdkDropListConnectedTo]="allGroupIds"
+    (cdkDropListDropped)="dropStep($event)"
+  >
     @for (childId of lesson.ids; track childId) {
       <div class="flex flex-row flex-wrap justify-start items-center">
         <project-authoring-step

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -29,8 +29,7 @@
           >drag_indicator</mat-icon
         >
       }
-      <node-icon-and-title [nodeId]="lesson.id" [showPosition]="showPosition" /> (ID:
-      {{ lesson.id }})
+      <node-icon-and-title [nodeId]="lesson.id" [showPosition]="showPosition" />
     </mat-panel-title>
     <mat-panel-description class="text flex justify-end items-center gap-1">
       <button

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html
@@ -3,19 +3,32 @@
   class="lesson flex grow"
   (opened)="toggleExpanded(true)"
   (closed)="toggleExpanded(false)"
+  cdkDrag
+  [cdkDragData]="lesson.id"
 >
   <mat-expansion-panel-header aria-label="Expand/collapse lesson" i18n-aria-label>
     <mat-panel-title>
-      <mat-checkbox
-        color="primary"
-        (change)="selectNode($event.checked)"
-        (click)="$event.stopPropagation()"
-        (keydown)="$event.stopPropagation()"
-        [disabled]="nodeTypeSelected() === 'step'"
-        aria-label="Select lesson"
-        i18n-aria-label
-      />
-      <node-icon-and-title [nodeId]="lesson.id" [showPosition]="showPosition" />
+      @if (batchEditMode) {
+        <mat-checkbox
+          color="primary"
+          (change)="selectNode($event.checked)"
+          (click)="$event.stopPropagation()"
+          (keydown)="$event.stopPropagation()"
+          [disabled]="nodeTypeSelected() === 'step'"
+          aria-label="Select lesson"
+          i18n-aria-label
+        />
+      } @else {
+        <mat-icon
+          cdkDragHandle
+          (click)="$event.stopPropagation()"
+          title="Drag to reorder"
+          i18n-title
+          >drag_indicator</mat-icon
+        >
+      }
+      <node-icon-and-title [nodeId]="lesson.id" [showPosition]="showPosition" /> (ID:
+      {{ lesson.id }})
     </mat-panel-title>
     <mat-panel-description class="text flex justify-end items-center gap-1">
       <button
@@ -55,6 +68,7 @@
     @for (childId of lesson.ids; track childId) {
       <div class="flex flex-row flex-wrap justify-start items-center">
         <project-authoring-step
+          [batchEditMode]="batchEditMode"
           [step]="idToNode[childId]"
           (selectNodeEvent)="selectNodeEvent.emit($event)"
           [showPosition]="showPosition"

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.scss
@@ -1,3 +1,5 @@
+@reference "tailwindcss";
+
 .lesson {
   .mat-expansion-panel-header {
     padding-inline-start: 8px;
@@ -19,18 +21,18 @@
   .full-width {
     width: 100%;
   }
-
-  .no-steps-message {
-    padding: 0 8px;
-  }
 }
 
 .drag-placeholder {
-  background: #ccc;
-  border: dotted 3px #999;
-  min-height: 60px;
+  @apply rounded border-2 border-dashed border-gray-300 bg-gray-100 flex grow;
+  min-height: 48px;
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }
+
+.branch-path-step {
+  @apply ps-6;
+}
+
 .cdk-drag-preview {
   height: auto !important;
 

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.scss
@@ -31,3 +31,10 @@
   min-height: 60px;
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }
+.cdk-drag-preview {
+  height: auto !important;
+
+  .mat-expansion-panel-content-wrapper {
+    display: none;
+  }
+}

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.scss
@@ -24,3 +24,10 @@
     padding: 0 8px;
   }
 }
+
+.drag-placeholder {
+  background: #ccc;
+  border: dotted 3px #999;
+  min-height: 60px;
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
@@ -47,11 +47,13 @@ describe('ProjectAuthoringLessonComponent', () => {
           CopyTranslationsService,
           DeleteNodeService,
           DeleteTranslationsService,
-          MoveNodesService,
           ProjectService,
           TeacherDataService,
           TeacherProjectTranslationService
         ),
+        MockProvider(MoveNodesService, {
+          getIsDragging: () => signal<boolean>(false)
+        }),
         MockProvider(TeacherProjectService, {
           getNodeTypeSelected: () => signal<NodeTypeSelected>(NodeTypeSelected.lesson),
           projectParsed$: of()

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.spec.ts
@@ -16,6 +16,8 @@ import { CopyTranslationsService } from '../../services/copyTranslationsService'
 import { ConstraintService } from '../../services/constraintService';
 import { Node } from '../../common/Node';
 import { NodeIconAndTitleComponent } from '../choose-node-location/node-icon-and-title/node-icon-and-title.component';
+import { MoveNodesService } from '../../services/moveNodesService';
+import { of } from 'rxjs';
 
 let component: ProjectAuthoringLessonComponent;
 let fixture: ComponentFixture<ProjectAuthoringLessonComponent>;
@@ -45,12 +47,14 @@ describe('ProjectAuthoringLessonComponent', () => {
           CopyTranslationsService,
           DeleteNodeService,
           DeleteTranslationsService,
+          MoveNodesService,
           ProjectService,
           TeacherDataService,
           TeacherProjectTranslationService
         ),
         MockProvider(TeacherProjectService, {
-          getNodeTypeSelected: () => signal<NodeTypeSelected>(NodeTypeSelected.lesson)
+          getNodeTypeSelected: () => signal<NodeTypeSelected>(NodeTypeSelected.lesson),
+          projectParsed$: of()
         }),
         provideRouter([])
       ]

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -66,11 +66,7 @@ export class ProjectAuthoringLessonComponent {
   ) {}
 
   ngOnInit(): void {
-    this.allGroupIds = this.projectService
-      .getGroupNodes()
-      .concat(this.projectService.getInactiveGroupNodes())
-      .map((node) => node.id)
-      .concat('unusedNodes');
+    this.allGroupIds = this.projectService.getAllGroupIds();
     this.idToNode = this.projectService.idToNode;
     this.nodeTypeSelected = this.projectService.getNodeTypeSelected();
   }

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, Output, Signal, ViewEncapsulation } from '@angular/core';
+import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
@@ -17,11 +18,13 @@ import { DeleteNodeService } from '../../services/deleteNodeService';
 import { ActivatedRoute, Router } from '@angular/router';
 import { DeleteTranslationsService } from '../../services/deleteTranslationsService';
 import { AddStepTarget } from '../../../../app/domain/addStepTarget';
+import { MoveNodesService } from '../../services/moveNodesService';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
   imports: [
     FormsModule,
+    DragDropModule,
     MatExpansionModule,
     MatCheckboxModule,
     MatIconModule,
@@ -36,6 +39,7 @@ import { AddStepTarget } from '../../../../app/domain/addStepTarget';
   templateUrl: './project-authoring-lesson.component.html'
 })
 export class ProjectAuthoringLessonComponent {
+  @Input() batchEditMode: boolean;
   @Input() expanded: boolean = true;
   @Output() onExpandedChanged: EventEmitter<ExpandEvent> = new EventEmitter<ExpandEvent>();
   protected idToNode: any = {};
@@ -49,6 +53,7 @@ export class ProjectAuthoringLessonComponent {
     private dataService: TeacherDataService,
     private deleteNodeService: DeleteNodeService,
     private deleteTranslationsService: DeleteTranslationsService,
+    private moveNodesService: MoveNodesService,
     private projectService: TeacherProjectService,
     private route: ActivatedRoute,
     private router: Router
@@ -99,5 +104,9 @@ export class ProjectAuthoringLessonComponent {
   private saveAndRefreshProject(): void {
     this.projectService.saveProject();
     this.projectService.refreshProject();
+  }
+
+  protected dropStep(event: CdkDragDrop<string[]>): void {
+    this.projectService.saveProject();
   }
 }

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, Output, Signal, ViewEncapsulation } from '@angular/core';
-import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
+import { CdkDrag, CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
@@ -123,5 +123,16 @@ export class ProjectAuthoringLessonComponent {
     this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
       this.projectService.refreshProject();
     });
+  }
+
+  // allow a step to drop anywhere except the first step in a first path of a branch activity
+  // otherwise, the step will be placed after a node that has multiple transitions, which is not allowed
+  protected notAfterBranchingNode(index: number, item: CdkDrag<any>): boolean {
+    if (index === 0) return true;
+    const nodesExceptItem = item.dropContainer.data.nodes.filter(
+      (nodeId) => nodeId !== item.data.id
+    );
+    const nodeBefore = item.dropContainer.data.idToNode[nodesExceptItem[index - 1]];
+    return nodeBefore.transitionLogic.transitions.length <= 1;
   }
 }

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -44,6 +44,7 @@ export class ProjectAuthoringLessonComponent {
   @Input() expanded: boolean = true;
   @Output() onExpandedChanged: EventEmitter<ExpandEvent> = new EventEmitter<ExpandEvent>();
   protected idToNode: any = {};
+  protected isDragging: Signal<boolean>;
   @Input() lesson: any;
   protected nodeTypeSelected: Signal<NodeTypeSelected>;
   @Input() projectId: number;
@@ -64,6 +65,7 @@ export class ProjectAuthoringLessonComponent {
     this.allGroupIds = this.projectService.getAllGroupIds();
     this.idToNode = this.projectService.idToNode;
     this.nodeTypeSelected = this.projectService.getNodeTypeSelected();
+    this.isDragging = this.moveNodesService.getIsDragging();
   }
 
   protected selectNode(checked: boolean): void {
@@ -134,5 +136,9 @@ export class ProjectAuthoringLessonComponent {
     );
     const nodeBefore = item.dropContainer.data.idToNode[nodesExceptItem[index - 1]];
     return nodeBefore.transitionLogic.transitions.length <= 1;
+  }
+
+  protected drag(isDragging: boolean): void {
+    this.moveNodesService.setIsDragging(isDragging);
   }
 }

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -1,5 +1,11 @@
 import { Component, EventEmitter, Input, Output, Signal, ViewEncapsulation } from '@angular/core';
-import { CdkDrag, CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
+import {
+  CdkDrag,
+  CdkDragDrop,
+  CdkDropList,
+  DragDropModule,
+  moveItemInArray
+} from '@angular/cdk/drag-drop';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
@@ -129,12 +135,14 @@ export class ProjectAuthoringLessonComponent {
 
   // allow a step to drop anywhere except the first step in a first path of a branch activity
   // otherwise, the step will be placed after a node that has multiple transitions, which is not allowed
-  protected notAfterBranchingNode(index: number, item: CdkDrag<any>): boolean {
+  protected notAfterBranchingNode(
+    index: number,
+    item: CdkDrag<any>,
+    drop: CdkDropList<any>
+  ): boolean {
     if (index === 0) return true;
-    const nodesExceptItem = item.dropContainer.data.nodes.filter(
-      (nodeId) => nodeId !== item.data.id
-    );
-    const nodeBefore = item.dropContainer.data.idToNode[nodesExceptItem[index - 1]];
+    const nodesExceptItem = drop.data.nodes.filter((nodeId) => nodeId !== item.data.id);
+    const nodeBefore = drop.data.idToNode[nodesExceptItem[index - 1]];
     return nodeBefore.transitionLogic.transitions.length <= 1;
   }
 

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -117,24 +117,25 @@ export class ProjectAuthoringLessonComponent {
     this.projectService.refreshProject();
   }
 
-  protected dropStep(event: CdkDragDrop<any>): void {
-    console.log('dropStep', event);
+  protected dropNode(event: CdkDragDrop<any>): void {
+    console.log('dropNode', event);
     if (event.previousContainer === event.container) {
       moveItemInArray(event.container.data.nodes, event.previousIndex, event.currentIndex);
     } else {
-      transferArrayItem(
-        event.previousContainer.data.nodes,
-        event.container.data.nodes,
-        event.previousIndex,
-        event.currentIndex
-      );
+      // the UI will be updated by moveNodesAfter() and refreshProject() calls
     }
     if (event.currentIndex == 0) {
+      console.log('moving inside group', event.item.data.id, event.container.data.groupId);
       this.moveNodesService.moveNodesInsideGroup(
         [event.item.data.id],
         event.container.data.groupId
       );
     } else {
+      console.log(
+        'moving after node',
+        event.item.data.id,
+        event.container.data.nodes[event.currentIndex - 1]
+      );
       this.moveNodesService.moveNodesAfter(
         [event.item.data.id],
         event.container.data.nodes[event.currentIndex - 1]

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -1,5 +1,10 @@
 import { Component, EventEmitter, Input, Output, Signal, ViewEncapsulation } from '@angular/core';
-import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
+import {
+  CdkDragDrop,
+  DragDropModule,
+  moveItemInArray,
+  transferArrayItem
+} from '@angular/cdk/drag-drop';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
@@ -39,6 +44,7 @@ import { MoveNodesService } from '../../services/moveNodesService';
   templateUrl: './project-authoring-lesson.component.html'
 })
 export class ProjectAuthoringLessonComponent {
+  allGroupIds: string[];
   @Input() batchEditMode: boolean;
   @Input() expanded: boolean = true;
   @Output() onExpandedChanged: EventEmitter<ExpandEvent> = new EventEmitter<ExpandEvent>();
@@ -60,6 +66,11 @@ export class ProjectAuthoringLessonComponent {
   ) {}
 
   ngOnInit(): void {
+    this.allGroupIds = this.projectService
+      .getGroupNodes()
+      .concat(this.projectService.getInactiveGroupNodes())
+      .map((node) => node.id)
+      .concat('unusedNodes');
     this.idToNode = this.projectService.idToNode;
     this.nodeTypeSelected = this.projectService.getNodeTypeSelected();
   }
@@ -106,7 +117,31 @@ export class ProjectAuthoringLessonComponent {
     this.projectService.refreshProject();
   }
 
-  protected dropStep(event: CdkDragDrop<string[]>): void {
-    this.projectService.saveProject();
+  protected dropStep(event: CdkDragDrop<any>): void {
+    console.log('dropStep', event);
+    if (event.previousContainer === event.container) {
+      moveItemInArray(event.container.data.nodes, event.previousIndex, event.currentIndex);
+    } else {
+      transferArrayItem(
+        event.previousContainer.data.nodes,
+        event.container.data.nodes,
+        event.previousIndex,
+        event.currentIndex
+      );
+    }
+    if (event.currentIndex == 0) {
+      this.moveNodesService.moveNodesInsideGroup(
+        [event.item.data.id],
+        event.container.data.groupId
+      );
+    } else {
+      this.moveNodesService.moveNodesAfter(
+        [event.item.data.id],
+        event.container.data.nodes[event.currentIndex - 1]
+      );
+    }
+    this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
+      this.projectService.refreshProject();
+    });
   }
 }

--- a/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts
@@ -1,10 +1,5 @@
 import { Component, EventEmitter, Input, Output, Signal, ViewEncapsulation } from '@angular/core';
-import {
-  CdkDragDrop,
-  DragDropModule,
-  moveItemInArray,
-  transferArrayItem
-} from '@angular/cdk/drag-drop';
+import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
@@ -114,28 +109,16 @@ export class ProjectAuthoringLessonComponent {
   }
 
   protected dropNode(event: CdkDragDrop<any>): void {
-    console.log('dropNode', event);
-    if (event.previousContainer === event.container) {
-      moveItemInArray(event.container.data.nodes, event.previousIndex, event.currentIndex);
+    const { container, currentIndex, item, previousContainer, previousIndex } = event;
+    if (previousContainer === container) {
+      moveItemInArray(container.data.nodes, previousIndex, currentIndex);
     } else {
-      // the UI will be updated by moveNodesAfter() and refreshProject() calls
+      // do nothing. the UI will be updated by moveNodesAfter() and refreshProject() calls
     }
-    if (event.currentIndex == 0) {
-      console.log('moving inside group', event.item.data.id, event.container.data.groupId);
-      this.moveNodesService.moveNodesInsideGroup(
-        [event.item.data.id],
-        event.container.data.groupId
-      );
+    if (currentIndex == 0) {
+      this.moveNodesService.moveNodesInsideGroup([item.data.id], container.data.groupId);
     } else {
-      console.log(
-        'moving after node',
-        event.item.data.id,
-        event.container.data.nodes[event.currentIndex - 1]
-      );
-      this.moveNodesService.moveNodesAfter(
-        [event.item.data.id],
-        event.container.data.nodes[event.currentIndex - 1]
-      );
+      this.moveNodesService.moveNodesAfter([item.data.id], container.data.nodes[currentIndex - 1]);
     }
     this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
       this.projectService.refreshProject();

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
@@ -7,6 +7,8 @@
   (keyup.enter)="setCurrentNode(step.id)"
   role="button"
   tabindex="0"
+  cdkDrag
+  [cdkDragData]="{ type: 'step', id: step.id }"
   aria-label="Edit step"
   i18n-aria-label
 >
@@ -20,7 +22,8 @@
       i18n-aria-label
     />
   } @else {
-    <mat-icon (click)="$event.stopPropagation()" title="Drag to reorder" i18n-title
+    <div class="drag-placeholder flex grow" *cdkDragPlaceholder></div>
+    <mat-icon cdkDragHandle(click)="$event.stopPropagation()" title="Drag to reorder" i18n-title
       >drag_indicator</mat-icon
     >
   }

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
@@ -10,16 +10,23 @@
   aria-label="Edit step"
   i18n-aria-label
 >
-  <mat-checkbox
-    color="primary"
-    (change)="selectNode($event.checked)"
-    (click)="$event.stopPropagation()"
-    [disabled]="nodeTypeSelected() === 'lesson'"
-    aria-label="Select step"
-    i18n-aria-label
-  />
+  @if (batchEditMode) {
+    <mat-checkbox
+      color="primary"
+      (change)="selectNode($event.checked)"
+      (click)="$event.stopPropagation()"
+      [disabled]="nodeTypeSelected() === 'lesson'"
+      aria-label="Select step"
+      i18n-aria-label
+    />
+  } @else {
+    <mat-icon (click)="$event.stopPropagation()" title="Drag to reorder" i18n-title
+      >drag_indicator</mat-icon
+    >
+  }
   <strong>
     <node-icon-and-title [nodeId]="step.id" [showPosition]="showPosition" />
+    (ID: {{ step.id }})
   </strong>
   <div class="flex justify-start items-center gap-2">
     @if (isBranchPoint(step.id)) {

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
@@ -8,6 +8,7 @@
   role="button"
   tabindex="0"
   cdkDrag
+  [cdkDragDisabled]="isBranchPoint"
   [cdkDragData]="{ type: 'step', id: step.id }"
   aria-label="Edit step"
   i18n-aria-label
@@ -21,7 +22,7 @@
       aria-label="Select step"
       i18n-aria-label
     />
-  } @else {
+  } @else if (!isBranchPoint) {
     <div class="drag-placeholder flex grow" *cdkDragPlaceholder></div>
     <mat-icon cdkDragHandle(click)="$event.stopPropagation()" title="Drag to reorder" i18n-title
       >drag_indicator</mat-icon
@@ -32,7 +33,7 @@
     (ID: {{ step.id }})
   </strong>
   <div class="flex justify-start items-center gap-2">
-    @if (isBranchPoint(step.id)) {
+    @if (isBranchPoint) {
       <button
         mat-icon-button
         (click)="goToEditBranch(step.id); $event.stopPropagation()"
@@ -76,16 +77,18 @@
   ></div>
   <!-- <div class="dynamic-step-buttons"> -->
   <div class="flex justify-start items-center">
-    <button
-      class="step-action"
-      mat-icon-button
-      (click)="move(); $event.stopPropagation()"
-      matTooltip="Move step"
-      matTooltipPosition="above"
-      i18n-matTooltip
-    >
-      <mat-icon>redo</mat-icon>
-    </button>
+    @if (!isBranchPoint) {
+      <button
+        class="step-action"
+        mat-icon-button
+        (click)="move(); $event.stopPropagation()"
+        matTooltip="Move step"
+        matTooltipPosition="above"
+        i18n-matTooltip
+      >
+        <mat-icon>redo</mat-icon>
+      </button>
+    }
     <button
       class="step-action"
       mat-icon-button

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
@@ -10,6 +10,8 @@
   cdkDrag
   [cdkDragDisabled]="branchPoint"
   [cdkDragData]="{ type: 'step', id: step.id }"
+  (cdkDragStarted)="drag(true)"
+  (cdkDragEnded)="drag(false)"
   aria-label="Edit step"
   i18n-aria-label
 >

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
@@ -30,7 +30,6 @@
   }
   <strong>
     <node-icon-and-title [nodeId]="step.id" [showPosition]="showPosition" />
-    (ID: {{ step.id }})
   </strong>
   <div class="flex justify-start items-center gap-2">
     @if (isBranchPoint) {

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
@@ -24,7 +24,7 @@
     />
   } @else if (!branchPoint) {
     <div class="drag-placeholder flex grow" *cdkDragPlaceholder></div>
-    <mat-icon cdkDragHandle(click)="$event.stopPropagation()" title="Drag to reorder" i18n-title
+    <mat-icon cdkDragHandle (click)="$event.stopPropagation()" title="Drag to reorder" i18n-title
       >drag_indicator</mat-icon
     >
   }

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
@@ -1,7 +1,6 @@
 <div
   id="{{ step.id }}"
   class="step flex justify-start items-center gap-2 grow"
-  [ngClass]="{ 'branch-path-step': isNodeInAnyBranchPath(step.id) }"
   [ngStyle]="{ 'background-color': getStepBackgroundColor(step.id) }"
   (click)="setCurrentNode(step.id)"
   (keyup.enter)="setCurrentNode(step.id)"
@@ -25,8 +24,12 @@
       i18n-aria-label
     />
   } @else if (!branchPoint) {
-    <div class="drag-placeholder flex grow" *cdkDragPlaceholder></div>
-    <mat-icon cdkDragHandle (click)="$event.stopPropagation()" title="Drag to reorder" i18n-title
+    <mat-icon
+      cdkDragHandle
+      class="cursor-move"
+      (click)="$event.stopPropagation()"
+      title="Drag to reorder"
+      i18n-title
       >drag_indicator</mat-icon
     >
   }
@@ -76,7 +79,6 @@
     matTooltipPosition="above"
     i18n-matTooltip
   ></div>
-  <!-- <div class="dynamic-step-buttons"> -->
   <div class="flex justify-start items-center">
     @if (!branchPoint) {
       <button
@@ -111,5 +113,5 @@
       <mat-icon>delete</mat-icon>
     </button>
   </div>
-  <!-- </div> -->
+  <div class="drag-placeholder" *cdkDragPlaceholder></div>
 </div>

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html
@@ -8,7 +8,7 @@
   role="button"
   tabindex="0"
   cdkDrag
-  [cdkDragDisabled]="isBranchPoint"
+  [cdkDragDisabled]="branchPoint"
   [cdkDragData]="{ type: 'step', id: step.id }"
   aria-label="Edit step"
   i18n-aria-label
@@ -22,7 +22,7 @@
       aria-label="Select step"
       i18n-aria-label
     />
-  } @else if (!isBranchPoint) {
+  } @else if (!branchPoint) {
     <div class="drag-placeholder flex grow" *cdkDragPlaceholder></div>
     <mat-icon cdkDragHandle(click)="$event.stopPropagation()" title="Drag to reorder" i18n-title
       >drag_indicator</mat-icon
@@ -32,7 +32,7 @@
     <node-icon-and-title [nodeId]="step.id" [showPosition]="showPosition" />
   </strong>
   <div class="flex justify-start items-center gap-2">
-    @if (isBranchPoint) {
+    @if (branchPoint) {
       <button
         mat-icon-button
         (click)="goToEditBranch(step.id); $event.stopPropagation()"
@@ -76,7 +76,7 @@
   ></div>
   <!-- <div class="dynamic-step-buttons"> -->
   <div class="flex justify-start items-center">
-    @if (!isBranchPoint) {
+    @if (!branchPoint) {
       <button
         class="step-action"
         mat-icon-button

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.scss
@@ -1,19 +1,15 @@
 .step {
   height: 50px;
   padding: 4px;
-  margin: 4px 4px 4px 30px;
   border: 2px solid #dddddd;
   border-radius: 6px;
   position: relative;
   cursor: pointer;
+  background-color: white;
 }
 
 .step:hover {
   background-color: #add8e6 !important;
-}
-
-.branch-path-step {
-  margin-left: 55px !important;
 }
 
 .step-action {
@@ -32,11 +28,4 @@
 
 .tooltip-helper {
   height: 100%;
-}
-
-.drag-placeholder {
-  background: #ccc;
-  border: dotted 3px #999;
-  min-height: 60px;
-  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.scss
@@ -33,3 +33,10 @@
 .tooltip-helper {
   height: 100%;
 }
+
+.drag-placeholder {
+  background: #ccc;
+  border: dotted 3px #999;
+  min-height: 60px;
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
@@ -35,7 +35,7 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
 })
 export class ProjectAuthoringStepComponent {
   @Input() batchEditMode: boolean;
-  protected isBranchPoint: boolean;
+  protected branchPoint: boolean;
   protected nodeTypeSelected: Signal<NodeTypeSelected>;
   @Input() projectId: number;
   @Output() selectNodeEvent: EventEmitter<SelectNodeEvent> = new EventEmitter<SelectNodeEvent>();
@@ -55,7 +55,7 @@ export class ProjectAuthoringStepComponent {
   ) {}
 
   ngOnInit(): void {
-    this.isBranchPoint = this.projectService.isBranchPoint(this.step.id);
+    this.branchPoint = this.projectService.isBranchPoint(this.step.id);
     this.nodeTypeSelected = this.projectService.getNodeTypeSelected();
   }
 

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
@@ -36,6 +36,8 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
 export class ProjectAuthoringStepComponent {
   @Input() batchEditMode: boolean;
   protected branchPoint: boolean;
+  @Output() dragStarted: EventEmitter<void> = new EventEmitter<void>();
+  @Output() dragEnded: EventEmitter<void> = new EventEmitter<void>();
   protected nodeTypeSelected: Signal<NodeTypeSelected>;
   @Input() projectId: number;
   @Output() selectNodeEvent: EventEmitter<SelectNodeEvent> = new EventEmitter<SelectNodeEvent>();
@@ -172,5 +174,13 @@ export class ProjectAuthoringStepComponent {
   private saveAndRefreshProject(): void {
     this.projectService.saveProject();
     this.projectService.refreshProject();
+  }
+
+  protected drag(isDragging: boolean): void {
+    if (isDragging) {
+      this.dragStarted.emit();
+    } else {
+      this.dragEnded.emit();
+    }
   }
 }

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
@@ -16,10 +16,12 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { NodeIconAndTitleComponent } from '../choose-node-location/node-icon-and-title/node-icon-and-title.component';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 
 @Component({
   imports: [
     CommonModule,
+    DragDropModule,
     MatButtonModule,
     MatCheckboxModule,
     MatIconModule,
@@ -32,6 +34,7 @@ import { NodeIconAndTitleComponent } from '../choose-node-location/node-icon-and
   templateUrl: './project-authoring-step.component.html'
 })
 export class ProjectAuthoringStepComponent {
+  @Input() batchEditMode: boolean;
   protected nodeTypeSelected: Signal<NodeTypeSelected>;
   @Input() projectId: number;
   @Output() selectNodeEvent: EventEmitter<SelectNodeEvent> = new EventEmitter<SelectNodeEvent>();

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
@@ -35,6 +35,7 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
 })
 export class ProjectAuthoringStepComponent {
   @Input() batchEditMode: boolean;
+  protected isBranchPoint: boolean;
   protected nodeTypeSelected: Signal<NodeTypeSelected>;
   @Input() projectId: number;
   @Output() selectNodeEvent: EventEmitter<SelectNodeEvent> = new EventEmitter<SelectNodeEvent>();
@@ -54,6 +55,7 @@ export class ProjectAuthoringStepComponent {
   ) {}
 
   ngOnInit(): void {
+    this.isBranchPoint = this.projectService.isBranchPoint(this.step.id);
     this.nodeTypeSelected = this.projectService.getNodeTypeSelected();
   }
 
@@ -108,10 +110,6 @@ export class ProjectAuthoringStepComponent {
 
   protected setCurrentNode(nodeId: string): void {
     this.dataService.setCurrentNodeByNodeId(nodeId);
-  }
-
-  protected isBranchPoint(nodeId: string): boolean {
-    return this.projectService.isBranchPoint(nodeId);
   }
 
   protected nodeHasConstraint(nodeId: string): boolean {

--- a/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts
@@ -19,6 +19,9 @@ import { NodeIconAndTitleComponent } from '../choose-node-location/node-icon-and
 import { DragDropModule } from '@angular/cdk/drag-drop';
 
 @Component({
+  host: {
+    '[class.branch-path-step]': 'isNodeInAnyBranchPath(step.id)'
+  },
   imports: [
     CommonModule,
     DragDropModule,

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -1,37 +1,42 @@
 <div class="project-content flex flex-row flex-wrap gap-4">
-  <button
-    mat-raised-button
-    color="primary"
-    (click)="chooseLocation(false)"
-    [disabled]="!hasSelectedNodes()"
-    matTooltip="Move"
-    matTooltipPosition="above"
-    i18n-matTooltip
-  >
-    <mat-icon>redo</mat-icon>
-  </button>
-  <button
-    mat-raised-button
-    color="primary"
-    (click)="chooseLocation(true)"
-    [disabled]="!hasSelectedStepsOnly()"
-    matTooltip="Copy"
-    matTooltipPosition="above"
-    i18n-matTooltip
-  >
-    <mat-icon>content_copy</mat-icon>
-  </button>
-  <button
-    mat-raised-button
-    color="primary"
-    (click)="deleteSelectedNodes()"
-    [disabled]="!hasSelectedNodes()"
-    matTooltip="Delete"
-    matTooltipPosition="above"
-    i18n-matTooltip
-  >
-    <mat-icon>delete</mat-icon>
-  </button>
+  <p>
+    <mat-slide-toggle [(ngModel)]="batchEditMode" i18n>Batch edit mode</mat-slide-toggle>
+  </p>
+  @if (batchEditMode) {
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="chooseLocation(false)"
+      [disabled]="!hasSelectedNodes()"
+      matTooltip="Move"
+      matTooltipPosition="above"
+      i18n-matTooltip
+    >
+      <mat-icon>redo</mat-icon>
+    </button>
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="chooseLocation(true)"
+      [disabled]="!hasSelectedStepsOnly()"
+      matTooltip="Copy"
+      matTooltipPosition="above"
+      i18n-matTooltip
+    >
+      <mat-icon>content_copy</mat-icon>
+    </button>
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="deleteSelectedNodes()"
+      [disabled]="!hasSelectedNodes()"
+      matTooltip="Delete"
+      matTooltipPosition="above"
+      i18n-matTooltip
+    >
+      <mat-icon>delete</mat-icon>
+    </button>
+  }
   <div class="flex grow"></div>
   <button
     class="enable-in-translation"
@@ -54,7 +59,14 @@
     - Collapse All
   </button>
 </div>
-<div class="all-nodes-div flex flex-col gap-2">
+<div
+  class="all-nodes-div flex flex-col gap-2"
+  cdkDropList
+  [cdkDropListData]="lessons"
+  cdkDropListLockAxis="y"
+  cdkDropListAutoScrollStep="10"
+  (cdkDropListDropped)="dropLesson($event)"
+>
   @if (lessons.length === 0) {
     <div class="flex flex-row justify-start items-center">
       <div i18n>There are no lessons</div>
@@ -64,6 +76,7 @@
     @for (lesson of lessons; track lesson.id; let first = $first) {
       <div class="flex flex-row gap-1">
         <project-authoring-lesson
+          [batchEditMode]="batchEditMode"
           [lesson]="lesson"
           (selectNodeEvent)="selectNode($event)"
           [showPosition]="true"
@@ -77,31 +90,41 @@
     }
   }
   <div>
-    <h6 class="unused-header" i18n>Unused Lessons</h6>
-    @if (inactiveGroupNodes.length === 0) {
-      <div class="flex flex-row justify-start items-center">
-        <div i18n>There are no unused lessons</div>
-        <add-lesson-button />
-      </div>
-    } @else {
-      <div class="flex flex-col gap-2">
-        @for (groupNode of inactiveGroupNodes; track groupNode.id; let first = $first) {
-          <div class="flex flex-row gap-1">
-            <project-authoring-lesson
-              [lesson]="groupNode"
-              (selectNodeEvent)="selectNode($event)"
-              [showPosition]="false"
-              [projectId]="projectId"
-              [expanded]="lessonIdToExpanded()[groupNode.id]"
-              (onExpandedChanged)="onExpandedChanged($event)"
-              class="flex grow"
-            />
-            <add-lesson-button [first]="first" [lessonId]="groupNode.id" />
-          </div>
-        }
-      </div>
-    }
-    <div>
+    <div
+      style="border: 1px solid red"
+      cdkDropList
+      [cdkDropListData]="inactiveGroupNodes"
+      cdkDropListLockAxis="y"
+      cdkDropListAutoScrollStep="10"
+      (cdkDropListDropped)="dropLesson($event)"
+    >
+      <h6 class="unused-header" i18n>Unused Lessons</h6>
+      @if (inactiveGroupNodes.length === 0) {
+        <div class="flex flex-row justify-start items-center">
+          <div i18n>There are no unused lessons</div>
+          <add-lesson-button />
+        </div>
+      } @else {
+        <div class="flex flex-col gap-2">
+          @for (groupNode of inactiveGroupNodes; track groupNode.id; let first = $first) {
+            <div class="flex flex-row gap-1">
+              <project-authoring-lesson
+                [batchEditMode]="batchEditMode"
+                [lesson]="groupNode"
+                (selectNodeEvent)="selectNode($event)"
+                [showPosition]="false"
+                [projectId]="projectId"
+                [expanded]="lessonIdToExpanded()[groupNode.id]"
+                (onExpandedChanged)="onExpandedChanged($event)"
+                class="flex grow"
+              />
+              <add-lesson-button [first]="first" [lessonId]="groupNode.id" />
+            </div>
+          }
+        </div>
+      }
+    </div>
+    <div style="border: 1px solid red">
       <h6 class="unused-header" i18n>Unused Steps</h6>
       @if (inactiveStepNodes.length === 0) {
         <div i18n>There are no unused steps</div>
@@ -109,6 +132,7 @@
         @for (inactiveStepNode of inactiveStepNodes; track inactiveStepNode.id) {
           @if (getParentGroup(inactiveStepNode.id) == null) {
             <project-authoring-step
+              [batchEditMode]="batchEditMode"
               [step]="inactiveStepNode"
               (selectNodeEvent)="selectNode($event)"
               [showPosition]="false"

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -1,5 +1,5 @@
 <div cdkDropListGroup>
-  <div class="project-content flex flex-row flex-wrap gap-4">
+  <div class="sticky top-0 z-2 bg-white p-3 -mx-2 flex flex-row flex-wrap gap-2">
     <p>
       <mat-slide-toggle [(ngModel)]="batchEditMode" i18n>Batch edit mode</mat-slide-toggle>
     </p>
@@ -67,6 +67,7 @@
       cdkDropListLockAxis="y"
       cdkDropListAutoScrollStep="10"
       (cdkDropListDropped)="dropGroup($event)"
+      class="flex flex-col gap-2"
     >
       @if (lessons.length === 0) {
         <div class="flex flex-row justify-start items-center">
@@ -107,32 +108,27 @@
       >
         <h6 class="unused-header" i18n>Unused Lessons</h6>
         @if (inactiveGroupNodes.length === 0) {
-          <div class="flex flex-row justify-start items-center">
-            <div i18n>There are no unused lessons</div>
-            <add-lesson-button />
-          </div>
+          <p i18n>There are no unused lessons</p>
         } @else {
           <div class="flex flex-col gap-2">
             @for (groupNode of inactiveGroupNodes; track groupNode.id; let first = $first) {
-              <div class="flex flex-row gap-1">
-                <project-authoring-lesson
-                  [batchEditMode]="batchEditMode"
-                  [lesson]="groupNode"
-                  (selectNodeEvent)="selectNode($event)"
-                  [showPosition]="false"
-                  [projectId]="projectId"
-                  [expanded]="lessonIdToExpanded()[groupNode.id]"
-                  (onExpandedChanged)="onExpandedChanged($event)"
-                  class="flex grow"
-                />
-                <add-lesson-button [first]="first" [lessonId]="groupNode.id" />
-              </div>
+              <project-authoring-lesson
+                [batchEditMode]="batchEditMode"
+                [lesson]="groupNode"
+                (selectNodeEvent)="selectNode($event)"
+                [showPosition]="false"
+                [projectId]="projectId"
+                [expanded]="lessonIdToExpanded()[groupNode.id]"
+                (onExpandedChanged)="onExpandedChanged($event)"
+                class="flex grow"
+              />
             }
           </div>
         }
       </div>
       <div
         cdkDropList
+        class="flex flex-col gap-1"
         id="inactiveSteps"
         [cdkDropListData]="{ type: 'inactiveSteps', nodes: inactiveStepNodes }"
         cdkDropListLockAxis="y"
@@ -143,7 +139,7 @@
       >
         <h6 class="unused-header" i18n>Unused Steps</h6>
         @if (inactiveStepNodes.length === 0) {
-          <div i18n>There are no unused steps</div>
+          <p i18n>There are no unused steps</p>
         } @else {
           @for (inactiveStepNode of inactiveStepNodes; track inactiveStepNode.id) {
             @if (getParentGroup(inactiveStepNode.id) == null) {

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -128,7 +128,7 @@
       </div>
       <div
         cdkDropList
-        id="unusedNodes"
+        id="inactiveSteps"
         [cdkDropListData]="{ type: 'inactiveSteps', nodes: inactiveStepNodes }"
         cdkDropListLockAxis="y"
         cdkDropListAutoScrollStep="10"

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -61,19 +61,19 @@
     </button>
   </div>
   <div class="all-nodes-div flex flex-col gap-2">
-    @if (lessons.length === 0) {
-      <div class="flex flex-row justify-start items-center">
-        <div i18n>There are no lessons</div>
-        <add-lesson-button [active]="true" />
-      </div>
-    } @else {
-      <div
-        cdkDropList
-        [cdkDropListData]="{ type: 'active', nodes: lessons }"
-        cdkDropListLockAxis="y"
-        cdkDropListAutoScrollStep="10"
-        (cdkDropListDropped)="dropGroup($event)"
-      >
+    <div
+      cdkDropList
+      [cdkDropListData]="{ type: 'active', nodes: lessons }"
+      cdkDropListLockAxis="y"
+      cdkDropListAutoScrollStep="10"
+      (cdkDropListDropped)="dropGroup($event)"
+    >
+      @if (lessons.length === 0) {
+        <div class="flex flex-row justify-start items-center">
+          <div i18n>There are no lessons</div>
+          <add-lesson-button [active]="true" />
+        </div>
+      } @else {
         @for (lesson of lessons; track lesson.id; let first = $first) {
           <div class="flex flex-row gap-1">
             <project-authoring-lesson
@@ -89,8 +89,8 @@
             <add-lesson-button [active]="true" [first]="first" [lessonId]="lesson.id" />
           </div>
         }
-      </div>
-    }
+      }
+    </div>
     <div>
       <div
         style="border: 1px solid red"

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -98,6 +98,7 @@
         [cdkDropListData]="{ type: 'inactive', nodes: inactiveGroupNodes }"
         cdkDropListLockAxis="y"
         cdkDropListAutoScrollStep="10"
+        [cdkDropListEnterPredicate]="groupPredicate"
         (cdkDropListDropped)="dropGroup($event)"
       >
         <h6 class="unused-header" i18n>Unused Lessons</h6>
@@ -134,6 +135,7 @@
         cdkDropListLockAxis="y"
         cdkDropListAutoScrollStep="10"
         [cdkDropListConnectedTo]="allGroupIds"
+        [cdkDropListEnterPredicate]="stepPredicate"
         (cdkDropListDropped)="dropInactiveStep($event)"
       >
         <h6 class="unused-header" i18n>Unused Steps</h6>

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -71,7 +71,7 @@
       @if (lessons.length === 0) {
         <div class="flex flex-row justify-start items-center">
           <div i18n>There are no lessons</div>
-          <add-lesson-button [active]="true" />
+          <add-lesson-button [active]="true" [class.hidden]="isDragging()" />
         </div>
       } @else {
         @for (lesson of lessons; track lesson.id; let first = $first) {
@@ -86,7 +86,12 @@
               (onExpandedChanged)="onExpandedChanged($event)"
               class="flex grow"
             />
-            <add-lesson-button [active]="true" [first]="first" [lessonId]="lesson.id" />
+            <add-lesson-button
+              [active]="true"
+              [first]="first"
+              [lessonId]="lesson.id"
+              [class.hidden]="isDragging()"
+            />
           </div>
         }
       }
@@ -144,6 +149,8 @@
             @if (getParentGroup(inactiveStepNode.id) == null) {
               <project-authoring-step
                 [batchEditMode]="batchEditMode"
+                (dragStarted)="drag(true)"
+                (dragEnded)="drag(false)"
                 [step]="inactiveStepNode"
                 (selectNodeEvent)="selectNode($event)"
                 [showPosition]="false"

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -134,7 +134,7 @@
         cdkDropListAutoScrollStep="10"
         [cdkDropListConnectedTo]="allGroupIds"
         [cdkDropListEnterPredicate]="stepPredicate"
-        (cdkDropListDropped)="dropInactiveStep($event)"
+        (cdkDropListDropped)="dropInactiveNode($event)"
       >
         <h6 class="unused-header" i18n>Unused Steps</h6>
         @if (inactiveStepNodes.length === 0) {

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -93,7 +93,6 @@
     </div>
     <div>
       <div
-        style="border: 1px solid red"
         cdkDropList
         [cdkDropListData]="{ type: 'inactive', nodes: inactiveGroupNodes }"
         cdkDropListLockAxis="y"
@@ -128,7 +127,6 @@
         }
       </div>
       <div
-        style="border: 1px solid red"
         cdkDropList
         id="unusedNodes"
         [cdkDropListData]="{ type: 'inactiveSteps', nodes: inactiveStepNodes }"

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -1,146 +1,158 @@
-<div class="project-content flex flex-row flex-wrap gap-4">
-  <p>
-    <mat-slide-toggle [(ngModel)]="batchEditMode" i18n>Batch edit mode</mat-slide-toggle>
-  </p>
-  @if (batchEditMode) {
+<div cdkDropListGroup>
+  <div class="project-content flex flex-row flex-wrap gap-4">
+    <p>
+      <mat-slide-toggle [(ngModel)]="batchEditMode" i18n>Batch edit mode</mat-slide-toggle>
+    </p>
+    @if (batchEditMode) {
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="chooseLocation(false)"
+        [disabled]="!hasSelectedNodes()"
+        matTooltip="Move"
+        matTooltipPosition="above"
+        i18n-matTooltip
+      >
+        <mat-icon>redo</mat-icon>
+      </button>
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="chooseLocation(true)"
+        [disabled]="!hasSelectedStepsOnly()"
+        matTooltip="Copy"
+        matTooltipPosition="above"
+        i18n-matTooltip
+      >
+        <mat-icon>content_copy</mat-icon>
+      </button>
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="deleteSelectedNodes()"
+        [disabled]="!hasSelectedNodes()"
+        matTooltip="Delete"
+        matTooltipPosition="above"
+        i18n-matTooltip
+      >
+        <mat-icon>delete</mat-icon>
+      </button>
+    }
+    <div class="flex grow"></div>
     <button
+      class="enable-in-translation"
+      (click)="expandAllLessons()"
+      [disabled]="allLessonsExpanded()"
       mat-raised-button
       color="primary"
-      (click)="chooseLocation(false)"
-      [disabled]="!hasSelectedNodes()"
-      matTooltip="Move"
-      matTooltipPosition="above"
-      i18n-matTooltip
+      i18n
     >
-      <mat-icon>redo</mat-icon>
+      + Expand All
     </button>
     <button
+      class="enable-in-translation"
+      (click)="collapseAllLessons()"
+      [disabled]="allLessonsCollapsed()"
       mat-raised-button
       color="primary"
-      (click)="chooseLocation(true)"
-      [disabled]="!hasSelectedStepsOnly()"
-      matTooltip="Copy"
-      matTooltipPosition="above"
-      i18n-matTooltip
+      i18n
     >
-      <mat-icon>content_copy</mat-icon>
+      - Collapse All
     </button>
-    <button
-      mat-raised-button
-      color="primary"
-      (click)="deleteSelectedNodes()"
-      [disabled]="!hasSelectedNodes()"
-      matTooltip="Delete"
-      matTooltipPosition="above"
-      i18n-matTooltip
-    >
-      <mat-icon>delete</mat-icon>
-    </button>
-  }
-  <div class="flex grow"></div>
-  <button
-    class="enable-in-translation"
-    (click)="expandAllLessons()"
-    [disabled]="allLessonsExpanded()"
-    mat-raised-button
-    color="primary"
-    i18n
-  >
-    + Expand All
-  </button>
-  <button
-    class="enable-in-translation"
-    (click)="collapseAllLessons()"
-    [disabled]="allLessonsCollapsed()"
-    mat-raised-button
-    color="primary"
-    i18n
-  >
-    - Collapse All
-  </button>
-</div>
-<div
-  class="all-nodes-div flex flex-col gap-2"
-  cdkDropList
-  [cdkDropListData]="lessons"
-  cdkDropListLockAxis="y"
-  cdkDropListAutoScrollStep="10"
-  (cdkDropListDropped)="dropLesson($event)"
->
-  @if (lessons.length === 0) {
-    <div class="flex flex-row justify-start items-center">
-      <div i18n>There are no lessons</div>
-      <add-lesson-button [active]="true" />
-    </div>
-  } @else {
-    @for (lesson of lessons; track lesson.id; let first = $first) {
-      <div class="flex flex-row gap-1">
-        <project-authoring-lesson
-          [batchEditMode]="batchEditMode"
-          [lesson]="lesson"
-          (selectNodeEvent)="selectNode($event)"
-          [showPosition]="true"
-          [projectId]="projectId"
-          [expanded]="lessonIdToExpanded()[lesson.id]"
-          (onExpandedChanged)="onExpandedChanged($event)"
-          class="flex grow"
-        />
-        <add-lesson-button [active]="true" [first]="first" [lessonId]="lesson.id" />
+  </div>
+  <div class="all-nodes-div flex flex-col gap-2">
+    @if (lessons.length === 0) {
+      <div class="flex flex-row justify-start items-center">
+        <div i18n>There are no lessons</div>
+        <add-lesson-button [active]="true" />
+      </div>
+    } @else {
+      <div
+        cdkDropList
+        [cdkDropListData]="{ type: 'active', nodes: lessons }"
+        cdkDropListLockAxis="y"
+        cdkDropListAutoScrollStep="10"
+        (cdkDropListDropped)="dropGroup($event)"
+      >
+        @for (lesson of lessons; track lesson.id; let first = $first) {
+          <div class="flex flex-row gap-1">
+            <project-authoring-lesson
+              [batchEditMode]="batchEditMode"
+              [lesson]="lesson"
+              (selectNodeEvent)="selectNode($event)"
+              [showPosition]="true"
+              [projectId]="projectId"
+              [expanded]="lessonIdToExpanded()[lesson.id]"
+              (onExpandedChanged)="onExpandedChanged($event)"
+              class="flex grow"
+            />
+            <add-lesson-button [active]="true" [first]="first" [lessonId]="lesson.id" />
+          </div>
+        }
       </div>
     }
-  }
-  <div>
-    <div
-      style="border: 1px solid red"
-      cdkDropList
-      [cdkDropListData]="inactiveGroupNodes"
-      cdkDropListLockAxis="y"
-      cdkDropListAutoScrollStep="10"
-      (cdkDropListDropped)="dropLesson($event)"
-    >
-      <h6 class="unused-header" i18n>Unused Lessons</h6>
-      @if (inactiveGroupNodes.length === 0) {
-        <div class="flex flex-row justify-start items-center">
-          <div i18n>There are no unused lessons</div>
-          <add-lesson-button />
-        </div>
-      } @else {
-        <div class="flex flex-col gap-2">
-          @for (groupNode of inactiveGroupNodes; track groupNode.id; let first = $first) {
-            <div class="flex flex-row gap-1">
-              <project-authoring-lesson
+    <div>
+      <div
+        style="border: 1px solid red"
+        cdkDropList
+        [cdkDropListData]="{ type: 'inactive', nodes: inactiveGroupNodes }"
+        cdkDropListLockAxis="y"
+        cdkDropListAutoScrollStep="10"
+        (cdkDropListDropped)="dropGroup($event)"
+      >
+        <h6 class="unused-header" i18n>Unused Lessons</h6>
+        @if (inactiveGroupNodes.length === 0) {
+          <div class="flex flex-row justify-start items-center">
+            <div i18n>There are no unused lessons</div>
+            <add-lesson-button />
+          </div>
+        } @else {
+          <div class="flex flex-col gap-2">
+            @for (groupNode of inactiveGroupNodes; track groupNode.id; let first = $first) {
+              <div class="flex flex-row gap-1">
+                <project-authoring-lesson
+                  [batchEditMode]="batchEditMode"
+                  [lesson]="groupNode"
+                  (selectNodeEvent)="selectNode($event)"
+                  [showPosition]="false"
+                  [projectId]="projectId"
+                  [expanded]="lessonIdToExpanded()[groupNode.id]"
+                  (onExpandedChanged)="onExpandedChanged($event)"
+                  class="flex grow"
+                />
+                <add-lesson-button [first]="first" [lessonId]="groupNode.id" />
+              </div>
+            }
+          </div>
+        }
+      </div>
+      <div
+        style="border: 1px solid red"
+        cdkDropList
+        id="unusedNodes"
+        [cdkDropListData]="{ name: 'unusedNodes' }"
+        cdkDropListLockAxis="y"
+        cdkDropListAutoScrollStep="10"
+        [cdkDropListConnectedTo]="allGroupIds"
+        (cdkDropListDropped)="dropInactiveStep($event)"
+      >
+        <h6 class="unused-header" i18n>Unused Steps</h6>
+        @if (inactiveStepNodes.length === 0) {
+          <div i18n>There are no unused steps</div>
+        } @else {
+          @for (inactiveStepNode of inactiveStepNodes; track inactiveStepNode.id) {
+            @if (getParentGroup(inactiveStepNode.id) == null) {
+              <project-authoring-step
                 [batchEditMode]="batchEditMode"
-                [lesson]="groupNode"
+                [step]="inactiveStepNode"
                 (selectNodeEvent)="selectNode($event)"
                 [showPosition]="false"
                 [projectId]="projectId"
-                [expanded]="lessonIdToExpanded()[groupNode.id]"
-                (onExpandedChanged)="onExpandedChanged($event)"
-                class="flex grow"
               />
-              <add-lesson-button [first]="first" [lessonId]="groupNode.id" />
-            </div>
-          }
-        </div>
-      }
-    </div>
-    <div style="border: 1px solid red">
-      <h6 class="unused-header" i18n>Unused Steps</h6>
-      @if (inactiveStepNodes.length === 0) {
-        <div i18n>There are no unused steps</div>
-      } @else {
-        @for (inactiveStepNode of inactiveStepNodes; track inactiveStepNode.id) {
-          @if (getParentGroup(inactiveStepNode.id) == null) {
-            <project-authoring-step
-              [batchEditMode]="batchEditMode"
-              [step]="inactiveStepNode"
-              (selectNodeEvent)="selectNode($event)"
-              [showPosition]="false"
-              [projectId]="projectId"
-            />
+            }
           }
         }
-      }
+      </div>
     </div>
   </div>
 </div>

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html
@@ -130,7 +130,7 @@
         style="border: 1px solid red"
         cdkDropList
         id="unusedNodes"
-        [cdkDropListData]="{ name: 'unusedNodes' }"
+        [cdkDropListData]="{ type: 'inactiveSteps', nodes: inactiveStepNodes }"
         cdkDropListLockAxis="y"
         cdkDropListAutoScrollStep="10"
         [cdkDropListConnectedTo]="allGroupIds"

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.scss
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.scss
@@ -1,11 +1,3 @@
-.project-content {
-  background-color: white;
-  margin-bottom: 15px;
-  position: sticky;
-  top: 26px;
-  z-index: 2;
-}
-
 .all-nodes-div {
   margin-top: 20px;
 }

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -19,12 +19,18 @@ import { DeleteTranslationsService } from '../../services/deleteTranslationsServ
 import { ComponentContent } from '../../common/ComponentContent';
 import { copy } from '../../common/object/object';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
-import { CdkDragDrop, CdkDropListGroup, DragDropModule } from '@angular/cdk/drag-drop';
+import {
+  CdkDrag,
+  CdkDragDrop,
+  CdkDropList,
+  DragDropModule,
+  moveItemInArray,
+  transferArrayItem
+} from '@angular/cdk/drag-drop';
 import { MoveNodesService } from '../../services/moveNodesService';
 
 @Component({
   imports: [
-    CdkDropListGroup,
     DragDropModule,
     FormsModule,
     MatButtonModule,
@@ -39,6 +45,7 @@ import { MoveNodesService } from '../../services/moveNodesService';
   templateUrl: './project-authoring.component.html'
 })
 export class ProjectAuthoringComponent implements OnInit {
+  protected allGroupIds: string[];
   protected allLessonsCollapsed: Signal<boolean> = computed(() =>
     this.isAllLessonsExpandedValue(false)
   );
@@ -68,6 +75,11 @@ export class ProjectAuthoringComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    this.allGroupIds = this.projectService
+      .getGroupNodes()
+      .concat(this.projectService.getInactiveGroupNodes())
+      .map((node) => node.id)
+      .concat('unusedNodes');
     this.projectId = Number(this.projectId);
     this.refreshProject();
     this.dataService.setCurrentNode(null);
@@ -260,23 +272,45 @@ export class ProjectAuthoringComponent implements OnInit {
     this.projectService.setNodeTypeSelected(nodeTypeSelected);
   }
 
-  protected dropLesson(event: CdkDragDrop<string[]>): void {
+  protected dropGroup(event: CdkDragDrop<any>): void {
     const { previousIndex, currentIndex, item } = event;
-    console.log(previousIndex, currentIndex, item.data, this.lessons[currentIndex].id);
-    if (previousIndex === currentIndex) {
-      return;
-    }
-    if (currentIndex === 0) {
-      this.moveNodesService.moveNodesInsideGroup([item.data], 'group0');
+    if (event.previousContainer === event.container) {
+      moveItemInArray(event.container.data.nodes, event.previousIndex, event.currentIndex);
     } else {
-      const moveAfterNodeId =
-        previousIndex > currentIndex
-          ? this.lessons[currentIndex - 1].id
-          : this.lessons[currentIndex].id;
-      this.moveNodesService.moveNodesAfter([item.data], moveAfterNodeId);
+      transferArrayItem(
+        event.previousContainer.data.nodes,
+        event.container.data.nodes,
+        event.previousIndex,
+        event.currentIndex
+      );
+    }
+    if (event.currentIndex == 0) {
+      this.moveNodesService.moveNodesInsideGroup(
+        [event.item.data.id],
+        event.container.data.type === 'active' ? 'group0' : 'inactiveGroups'
+      );
+    } else {
+      this.moveNodesService.moveNodesAfter(
+        [event.item.data.id],
+        event.container.data.nodes[event.currentIndex - 1].id
+      );
     }
     this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
       this.projectService.refreshProject();
     });
+  }
+
+  protected dropInactiveGroup(event: CdkDragDrop<string[]>): void {
+    const { previousIndex, currentIndex, item } = event;
+    console.log('dropInactiveGroup');
+    console.log('prevIndex', previousIndex, 'currentIndex', currentIndex, 'item.data', item.data);
+    console.log('event', event);
+  }
+
+  protected dropInactiveStep(event: CdkDragDrop<string[]>): void {
+    const { previousIndex, currentIndex, item } = event;
+    console.log('dropInactiveStep');
+    console.log('prevIndex', previousIndex, 'currentIndex', currentIndex, 'item.data', item.data);
+    console.log('event', event);
   }
 }

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -74,11 +74,7 @@ export class ProjectAuthoringComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.allGroupIds = this.projectService
-      .getGroupNodes()
-      .concat(this.projectService.getInactiveGroupNodes())
-      .map((node) => node.id)
-      .concat('unusedNodes');
+    this.allGroupIds = this.projectService.getAllGroupIds();
     this.projectId = Number(this.projectId);
     this.refreshProject();
     this.dataService.setCurrentNode(null);

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -18,13 +18,19 @@ import { ExpandEvent } from '../domain/expand-event';
 import { DeleteTranslationsService } from '../../services/deleteTranslationsService';
 import { ComponentContent } from '../../common/ComponentContent';
 import { copy } from '../../common/object/object';
+import { MatSlideToggle } from '@angular/material/slide-toggle';
+import { CdkDragDrop, CdkDropListGroup, DragDropModule } from '@angular/cdk/drag-drop';
+import { MoveNodesService } from '../../services/moveNodesService';
 
 @Component({
   imports: [
+    CdkDropListGroup,
+    DragDropModule,
     FormsModule,
     MatButtonModule,
     MatTooltipModule,
     MatIconModule,
+    MatSlideToggle,
     ProjectAuthoringLessonComponent,
     ProjectAuthoringStepComponent,
     AddLessonButtonComponent
@@ -39,6 +45,7 @@ export class ProjectAuthoringComponent implements OnInit {
   protected allLessonsExpanded: Signal<boolean> = computed(() =>
     this.isAllLessonsExpandedValue(true)
   );
+  protected batchEditMode: boolean = false;
   protected inactiveGroupNodes: any[];
   private inactiveNodes: any[];
   protected inactiveStepNodes: any[];
@@ -54,6 +61,7 @@ export class ProjectAuthoringComponent implements OnInit {
     private dataService: TeacherDataService,
     private deleteNodeService: DeleteNodeService,
     private deleteTranslationsService: DeleteTranslationsService,
+    private moveNodesService: MoveNodesService,
     private projectService: TeacherProjectService,
     private route: ActivatedRoute,
     private router: Router
@@ -250,5 +258,25 @@ export class ProjectAuthoringComponent implements OnInit {
       }
     });
     this.projectService.setNodeTypeSelected(nodeTypeSelected);
+  }
+
+  protected dropLesson(event: CdkDragDrop<string[]>): void {
+    const { previousIndex, currentIndex, item } = event;
+    console.log(previousIndex, currentIndex, item.data, this.lessons[currentIndex].id);
+    if (previousIndex === currentIndex) {
+      return;
+    }
+    if (currentIndex === 0) {
+      this.moveNodesService.moveNodesInsideGroup([item.data], 'group0');
+    } else {
+      const moveAfterNodeId =
+        previousIndex > currentIndex
+          ? this.lessons[currentIndex - 1].id
+          : this.lessons[currentIndex].id;
+      this.moveNodesService.moveNodesAfter([item.data], moveAfterNodeId);
+    }
+    this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
+      this.projectService.refreshProject();
+    });
   }
 }

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -305,10 +305,21 @@ export class ProjectAuthoringComponent implements OnInit {
     console.log('event', event);
   }
 
-  protected dropInactiveStep(event: CdkDragDrop<string[]>): void {
+  protected dropInactiveStep(event: CdkDragDrop<any>): void {
     const { previousIndex, currentIndex, item } = event;
     console.log('dropInactiveStep');
     console.log('prevIndex', previousIndex, 'currentIndex', currentIndex, 'item.data', item.data);
     console.log('event', event);
+    if (event.currentIndex == 0) {
+      this.moveNodesService.moveNodesInsideGroup([event.item.data.id], 'inactiveNodes');
+    } else {
+      this.moveNodesService.moveNodesAfter(
+        [event.item.data.id],
+        event.container.data.nodes[event.currentIndex - 1].id
+      );
+    }
+    this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
+      this.projectService.refreshProject();
+    });
   }
 }

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -20,9 +20,7 @@ import { ComponentContent } from '../../common/ComponentContent';
 import { copy } from '../../common/object/object';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
 import {
-  CdkDrag,
   CdkDragDrop,
-  CdkDropList,
   DragDropModule,
   moveItemInArray,
   transferArrayItem

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -49,6 +49,7 @@ export class ProjectAuthoringComponent implements OnInit {
   protected inactiveGroupNodes: any[];
   private inactiveNodes: any[];
   protected inactiveStepNodes: any[];
+  protected isDragging: Signal<boolean>;
   protected items: any;
   protected lessons: any[] = [];
   protected lessonIdToExpanded: WritableSignal<{ [key: string]: boolean }> = signal({});
@@ -74,6 +75,7 @@ export class ProjectAuthoringComponent implements OnInit {
     this.dataService.setCurrentNode(null);
     this.temporarilyHighlightNewNodes(history.state.newNodes);
     this.nodeTypeSelected = this.projectService.getNodeTypeSelected();
+    this.isDragging = this.moveNodesService.getIsDragging();
     this.subscriptions.add(
       this.projectService.refreshProject$.subscribe(() => {
         this.refreshProject();
@@ -305,5 +307,9 @@ export class ProjectAuthoringComponent implements OnInit {
 
   protected stepPredicate(item: CdkDrag<any>): boolean {
     return item.data.type === 'step';
+  }
+
+  protected drag(isDragging: boolean): void {
+    this.moveNodesService.setIsDragging(isDragging);
   }
 }

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -20,6 +20,7 @@ import { ComponentContent } from '../../common/ComponentContent';
 import { copy } from '../../common/object/object';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
 import {
+  CdkDrag,
   CdkDragDrop,
   DragDropModule,
   moveItemInArray,
@@ -321,5 +322,13 @@ export class ProjectAuthoringComponent implements OnInit {
     this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
       this.projectService.refreshProject();
     });
+  }
+
+  protected groupPredicate(item: CdkDrag<any>): boolean {
+    return item.data.type === 'group';
+  }
+
+  protected stepPredicate(item: CdkDrag<any>): boolean {
+    return item.data.type === 'step';
   }
 }

--- a/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts
@@ -19,13 +19,7 @@ import { DeleteTranslationsService } from '../../services/deleteTranslationsServ
 import { ComponentContent } from '../../common/ComponentContent';
 import { copy } from '../../common/object/object';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
-import {
-  CdkDrag,
-  CdkDragDrop,
-  DragDropModule,
-  moveItemInArray,
-  transferArrayItem
-} from '@angular/cdk/drag-drop';
+import { CdkDrag, CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 import { MoveNodesService } from '../../services/moveNodesService';
 
 @Component({
@@ -268,26 +262,21 @@ export class ProjectAuthoringComponent implements OnInit {
   }
 
   protected dropGroup(event: CdkDragDrop<any>): void {
-    const { previousIndex, currentIndex, item } = event;
-    if (event.previousContainer === event.container) {
-      moveItemInArray(event.container.data.nodes, event.previousIndex, event.currentIndex);
+    const { container, currentIndex, item, previousContainer, previousIndex } = event;
+    if (previousContainer === container) {
+      moveItemInArray(container.data.nodes, previousIndex, currentIndex);
     } else {
-      transferArrayItem(
-        event.previousContainer.data.nodes,
-        event.container.data.nodes,
-        event.previousIndex,
-        event.currentIndex
-      );
+      // do nothing. the UI will be updated by moveNodesAfter() and refreshProject() calls
     }
-    if (event.currentIndex == 0) {
+    if (currentIndex == 0) {
       this.moveNodesService.moveNodesInsideGroup(
-        [event.item.data.id],
-        event.container.data.type === 'active' ? 'group0' : 'inactiveGroups'
+        [item.data.id],
+        container.data.type === 'active' ? 'group0' : 'inactiveGroups'
       );
     } else {
       this.moveNodesService.moveNodesAfter(
-        [event.item.data.id],
-        event.container.data.nodes[event.currentIndex - 1].id
+        [item.data.id],
+        container.data.nodes[currentIndex - 1].id
       );
     }
     this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
@@ -295,24 +284,14 @@ export class ProjectAuthoringComponent implements OnInit {
     });
   }
 
-  protected dropInactiveGroup(event: CdkDragDrop<string[]>): void {
-    const { previousIndex, currentIndex, item } = event;
-    console.log('dropInactiveGroup');
-    console.log('prevIndex', previousIndex, 'currentIndex', currentIndex, 'item.data', item.data);
-    console.log('event', event);
-  }
-
-  protected dropInactiveStep(event: CdkDragDrop<any>): void {
-    const { previousIndex, currentIndex, item } = event;
-    console.log('dropInactiveStep');
-    console.log('prevIndex', previousIndex, 'currentIndex', currentIndex, 'item.data', item.data);
-    console.log('event', event);
-    if (event.currentIndex == 0) {
-      this.moveNodesService.moveNodesInsideGroup([event.item.data.id], 'inactiveNodes');
+  protected dropInactiveNode(event: CdkDragDrop<any>): void {
+    const { container, currentIndex, item } = event;
+    if (currentIndex == 0) {
+      this.moveNodesService.moveNodesInsideGroup([item.data.id], 'inactiveNodes');
     } else {
       this.moveNodesService.moveNodesAfter(
-        [event.item.data.id],
-        event.container.data.nodes[event.currentIndex - 1].id
+        [item.data.id],
+        container.data.nodes[currentIndex - 1].id
       );
     }
     this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {

--- a/src/assets/wise5/services/moveNodesService.ts
+++ b/src/assets/wise5/services/moveNodesService.ts
@@ -1,13 +1,23 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Signal, WritableSignal, signal } from '@angular/core';
 import { TeacherProjectService } from './teacherProjectService';
 import { RemoveNodeIdFromTransitionsService } from './removeNodeIdFromTransitionsService';
 
 @Injectable()
 export class MoveNodesService {
+  private isDragging: WritableSignal<boolean> = signal(false);
+
   constructor(
     protected projectService: TeacherProjectService,
     private removeNodeIdFromTransitionsService: RemoveNodeIdFromTransitionsService
   ) {}
+
+  getIsDragging(): Signal<boolean> {
+    return this.isDragging;
+  }
+
+  setIsDragging(isDragging: boolean): void {
+    this.isDragging.set(isDragging);
+  }
 
   /**
    * Move nodes inside an active/inactive group node

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -1891,6 +1891,13 @@ export class TeacherProjectService extends ProjectService {
     );
   }
 
+  getAllGroupIds(): string[] {
+    return this.getGroupNodes()
+      .concat(this.getInactiveGroupNodes())
+      .map((node) => node.id)
+      .concat('inactiveSteps');
+  }
+
   uiChanged(): void {
     this.uiChangedSource.next();
   }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -723,7 +723,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">30,33</context>
+          <context context-type="linenumber">35,38</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/animation/animation-authoring/animation-authoring.component.html</context>
@@ -1202,6 +1202,14 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
           <context context-type="linenumber">45,47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
+          <context context-type="linenumber">27,31</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
+          <context context-type="linenumber">27,32</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.html</context>
@@ -6061,7 +6069,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">19,22</context>
+          <context context-type="linenumber">24,27</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-list/project-list.component.html</context>
@@ -10207,7 +10215,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">74,77</context>
+          <context context-type="linenumber">97,100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2229114339431741749" datatype="html">
@@ -10784,7 +10792,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">80,82</context>
+          <context context-type="linenumber">103,105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1934853361308081722" datatype="html">
@@ -10810,7 +10818,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">105,107</context>
+          <context context-type="linenumber">139,141</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8605758886613118383" datatype="html">
@@ -13177,67 +13185,67 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>Expand/collapse lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">7,10</context>
+          <context context-type="linenumber">11,14</context>
         </context-group>
       </trans-unit>
       <trans-unit id="718761171336371980" datatype="html">
         <source>Select lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">15,18</context>
+          <context context-type="linenumber">20,25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3990684788047145768" datatype="html">
         <source>Edit lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">26,30</context>
+          <context context-type="linenumber">41,45</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6802950642532163491" datatype="html">
         <source>Move lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">36,40</context>
+          <context context-type="linenumber">51,55</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2385664129371928026" datatype="html">
         <source>Delete lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">46,50</context>
+          <context context-type="linenumber">61,65</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8466479820430643655" datatype="html">
         <source>This lesson has no steps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">69,72</context>
+          <context context-type="linenumber">92,95</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2751426191436053350" datatype="html">
         <source>Are you sure you want to delete this lesson?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8203899744338666712" datatype="html">
         <source>Edit step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">10,15</context>
+          <context context-type="linenumber">13,18</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">63,67</context>
+          <context context-type="linenumber">74,78</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5945303094335274412" datatype="html">
         <source>Select step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">18,22</context>
+          <context context-type="linenumber">22,26</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2586703779914969213" datatype="html">
@@ -13246,7 +13254,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">29,32</context>
+          <context context-type="linenumber">40,43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1566882762026396179" datatype="html">
@@ -13255,56 +13263,63 @@ The branches will be removed but the steps will remain in the unit.</source>
         }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">42,45</context>
+          <context context-type="linenumber">53,56</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2277347790216751711" datatype="html">
         <source>Has rubric/teaching tips</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">54,57</context>
+          <context context-type="linenumber">65,68</context>
         </context-group>
       </trans-unit>
       <trans-unit id="643328772010674978" datatype="html">
         <source>Move step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">73,77</context>
+          <context context-type="linenumber">85,89</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4169620043010477030" datatype="html">
         <source>Copy step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">83,87</context>
+          <context context-type="linenumber">96,100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7892527662707586368" datatype="html">
         <source>Delete step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">93,97</context>
+          <context context-type="linenumber">106,110</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8656136323789683230" datatype="html">
         <source>Are you sure you want to delete this step?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts</context>
-          <context context-type="linenumber">162</context>
+          <context context-type="linenumber">163</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4434932043788640245" datatype="html">
+        <source>Batch edit mode</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
+          <context context-type="linenumber">4,8</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2354817630223808522" datatype="html">
         <source>Move</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">8,11</context>
+          <context context-type="linenumber">13,16</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6892794525260383900" datatype="html">
         <source> + Expand All </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">44,48</context>
+          <context context-type="linenumber">50,54</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestones/milestone-class-responses/milestone-class-responses.component.html</context>
@@ -13323,7 +13338,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source> - Collapse All </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">54,58</context>
+          <context context-type="linenumber">60,63</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/notebook-grading/notebook-grading.component.html</context>
@@ -13338,28 +13353,28 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>There are no lessons</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">60,64</context>
+          <context context-type="linenumber">73,76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1001733534902851872" datatype="html">
         <source>There are no unused lessons</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">83,87</context>
+          <context context-type="linenumber">106,109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6422560368667700251" datatype="html">
         <source>There are no unused steps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">107,109</context>
+          <context context-type="linenumber">141,143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5775641662261420108" datatype="html">
         <source>Are you sure you want to delete the <x id="PH" equiv-text="selectedNodeIds.length"/> selected item(s)?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">105</context>
+          <context context-type="linenumber">123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5051388252985578877" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10215,7 +10215,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">96,99</context>
+          <context context-type="linenumber">97,100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2229114339431741749" datatype="html">
@@ -13220,7 +13220,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>This lesson has no steps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">91,94</context>
+          <context context-type="linenumber">92,95</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2751426191436053350" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10215,7 +10215,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">97,100</context>
+          <context context-type="linenumber">96,99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2229114339431741749" datatype="html">
@@ -10792,7 +10792,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">104,106</context>
+          <context context-type="linenumber">103,105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1934853361308081722" datatype="html">
@@ -10818,7 +10818,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">141,143</context>
+          <context context-type="linenumber">139,141</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8605758886613118383" datatype="html">
@@ -13199,35 +13199,35 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>Edit lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">41,45</context>
+          <context context-type="linenumber">40,44</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6802950642532163491" datatype="html">
         <source>Move lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">51,55</context>
+          <context context-type="linenumber">50,54</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2385664129371928026" datatype="html">
         <source>Delete lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">61,65</context>
+          <context context-type="linenumber">60,64</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8466479820430643655" datatype="html">
         <source>This lesson has no steps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">92,95</context>
+          <context context-type="linenumber">91,94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2751426191436053350" datatype="html">
         <source>Are you sure you want to delete this lesson?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts</context>
-          <context context-type="linenumber">100</context>
+          <context context-type="linenumber">91</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8203899744338666712" datatype="html">
@@ -13238,7 +13238,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">74,78</context>
+          <context context-type="linenumber">73,77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5945303094335274412" datatype="html">
@@ -13254,7 +13254,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">40,43</context>
+          <context context-type="linenumber">39,42</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1566882762026396179" datatype="html">
@@ -13263,35 +13263,35 @@ The branches will be removed but the steps will remain in the unit.</source>
         }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">53,56</context>
+          <context context-type="linenumber">52,55</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2277347790216751711" datatype="html">
         <source>Has rubric/teaching tips</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">65,68</context>
+          <context context-type="linenumber">64,67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="643328772010674978" datatype="html">
         <source>Move step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">85,89</context>
+          <context context-type="linenumber">84,88</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4169620043010477030" datatype="html">
         <source>Copy step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">96,100</context>
+          <context context-type="linenumber">95,99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7892527662707586368" datatype="html">
         <source>Delete step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">106,110</context>
+          <context context-type="linenumber">105,109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8656136323789683230" datatype="html">
@@ -13360,21 +13360,21 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>There are no unused lessons</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">107,110</context>
+          <context context-type="linenumber">106,109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6422560368667700251" datatype="html">
         <source>There are no unused steps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">143,145</context>
+          <context context-type="linenumber">141,143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5775641662261420108" datatype="html">
         <source>Are you sure you want to delete the <x id="PH" equiv-text="selectedNodeIds.length"/> selected item(s)?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">124</context>
+          <context context-type="linenumber">114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5051388252985578877" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -13227,7 +13227,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>Are you sure you want to delete this lesson?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts</context>
-          <context context-type="linenumber">93</context>
+          <context context-type="linenumber">99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8203899744338666712" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1205,11 +1205,11 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">27,31</context>
+          <context context-type="linenumber">29,33</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">27,32</context>
+          <context context-type="linenumber">31,37</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/feedbackRule/edit-feedback-rules/edit-feedback-rules.component.html</context>
@@ -10215,7 +10215,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">97,100</context>
+          <context context-type="linenumber">102,105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2229114339431741749" datatype="html">
@@ -10792,7 +10792,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">103,105</context>
+          <context context-type="linenumber">109,111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1934853361308081722" datatype="html">
@@ -10818,7 +10818,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">139,141</context>
+          <context context-type="linenumber">140,142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8605758886613118383" datatype="html">
@@ -13185,67 +13185,67 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>Expand/collapse lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">11,14</context>
+          <context context-type="linenumber">12,15</context>
         </context-group>
       </trans-unit>
       <trans-unit id="718761171336371980" datatype="html">
         <source>Select lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">20,25</context>
+          <context context-type="linenumber">21,26</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3990684788047145768" datatype="html">
         <source>Edit lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">40,44</context>
+          <context context-type="linenumber">42,46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6802950642532163491" datatype="html">
         <source>Move lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">50,54</context>
+          <context context-type="linenumber">52,56</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2385664129371928026" datatype="html">
         <source>Delete lesson</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">60,64</context>
+          <context context-type="linenumber">62,66</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8466479820430643655" datatype="html">
         <source>This lesson has no steps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.html</context>
-          <context context-type="linenumber">92,95</context>
+          <context context-type="linenumber">97,100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2751426191436053350" datatype="html">
         <source>Are you sure you want to delete this lesson?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-lesson/project-authoring-lesson.component.ts</context>
-          <context context-type="linenumber">91</context>
+          <context context-type="linenumber">93</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8203899744338666712" datatype="html">
         <source>Edit step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">13,18</context>
+          <context context-type="linenumber">14,19</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">73,77</context>
+          <context context-type="linenumber">78,82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5945303094335274412" datatype="html">
         <source>Select step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">22,26</context>
+          <context context-type="linenumber">23,27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2586703779914969213" datatype="html">
@@ -13254,7 +13254,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">39,42</context>
+          <context context-type="linenumber">44,47</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1566882762026396179" datatype="html">
@@ -13263,42 +13263,42 @@ The branches will be removed but the steps will remain in the unit.</source>
         }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">52,55</context>
+          <context context-type="linenumber">57,60</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2277347790216751711" datatype="html">
         <source>Has rubric/teaching tips</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">64,67</context>
+          <context context-type="linenumber">69,72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="643328772010674978" datatype="html">
         <source>Move step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">84,88</context>
+          <context context-type="linenumber">88,92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4169620043010477030" datatype="html">
         <source>Copy step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">95,99</context>
+          <context context-type="linenumber">99,103</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7892527662707586368" datatype="html">
         <source>Delete step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.html</context>
-          <context context-type="linenumber">105,109</context>
+          <context context-type="linenumber">109,113</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8656136323789683230" datatype="html">
         <source>Are you sure you want to delete this step?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring-step/project-authoring-step.component.ts</context>
-          <context context-type="linenumber">163</context>
+          <context context-type="linenumber">168</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4434932043788640245" datatype="html">
@@ -13353,28 +13353,28 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>There are no lessons</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">73,76</context>
+          <context context-type="linenumber">74,75</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1001733534902851872" datatype="html">
         <source>There are no unused lessons</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">106,109</context>
+          <context context-type="linenumber">111,114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6422560368667700251" datatype="html">
         <source>There are no unused steps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">141,143</context>
+          <context context-type="linenumber">142,144</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5775641662261420108" datatype="html">
         <source>Are you sure you want to delete the <x id="PH" equiv-text="selectedNodeIds.length"/> selected item(s)?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">114</context>
+          <context context-type="linenumber">116</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5051388252985578877" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10792,7 +10792,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">103,105</context>
+          <context context-type="linenumber">104,106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1934853361308081722" datatype="html">
@@ -10818,7 +10818,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">139,141</context>
+          <context context-type="linenumber">141,143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8605758886613118383" datatype="html">
@@ -13360,21 +13360,21 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>There are no unused lessons</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">106,109</context>
+          <context context-type="linenumber">107,110</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6422560368667700251" datatype="html">
         <source>There are no unused steps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.html</context>
-          <context context-type="linenumber">141,143</context>
+          <context context-type="linenumber">143,145</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5775641662261420108" datatype="html">
         <source>Are you sure you want to delete the <x id="PH" equiv-text="selectedNodeIds.length"/> selected item(s)?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-authoring/project-authoring.component.ts</context>
-          <context context-type="linenumber">123</context>
+          <context context-type="linenumber">124</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5051388252985578877" datatype="html">


### PR DESCRIPTION
We add a new default mode to the authoring tool unit editing view, which allows the author to move lessons and steps using drag and drop. The existing behavior (choosing lesson(s) or step(s) using the checkbox and then choosing a new location) has been moved to what we now call "batch edit mode".

## Notes
Please style as you see fit. Things we discussed:
- hiding controls (e.g., add step button) while dragging
- indenting drop preview to make it clear that the step will be dragged in a branch path

## Changes (in the unit editing view in the AT)
- Drag and drop lessons and steps in the default view
- Toggle "batch edit mode". This is what the edit unit view used to be 
- Disable moving a branch step. We found a bug https://github.com/WISE-Community/WISE-Client/issues/2287 while working on this PR. We'll disable moving a branching step in default mode and batch edit mode to prevent authors from breaking their units. 

## Test
- The new drag and drop feature works as expected. Test all scenarios (branch, inactive lessons, inactive nodes, etc)
- Existing batch edit mode works as before