### PR TITLE
feat(Discussion): Anonymize responses

### DIFF
--- a/src/assets/wise5/common/ComponentContent.ts
+++ b/src/assets/wise5/common/ComponentContent.ts
@@ -4,6 +4,7 @@ import { DynamicPrompt } from '../directives/dynamic-prompt/DynamicPrompt';
 
 export interface ComponentContent {
   id: string;
+  anonymizeResponses?: boolean;
   connectedComponents?: any[];
   constraints?: any[];
   cRaterRubric?: CRaterRubric;

--- a/src/assets/wise5/components/discussion/Anonymizer.spec.ts
+++ b/src/assets/wise5/components/discussion/Anonymizer.spec.ts
@@ -1,0 +1,55 @@
+import { Anonymizer } from './Anonymizer';
+
+describe('Anonymizer', () => {
+  it('should assign a valid anonymous name based on the index of the provided id', () => {
+    const ids = [100, 200, 300];
+
+    const anonymizer100 = new Anonymizer(100, ids);
+    // Since 100 is at index 0, it should be mapped to the first animal (Tiger)
+    expect(anonymizer100.getName('Student')).toEqual('Student Tiger');
+
+    const anonymizer200 = new Anonymizer(200, ids);
+    // 200 is at index 1 -> Lion
+    expect(anonymizer200.getName('Student')).toEqual('Student Lion');
+
+    const anonymizer300 = new Anonymizer(300, ids);
+    // 300 is at index 2 -> Fox
+    expect(anonymizer300.getName('Student')).toEqual('Student Fox');
+  });
+
+  it('should append numeric suffixes when the number of ids exceeds the available name options (86)', () => {
+    // There are 86 predefined internal names, so we create 87 ids to trigger the suffix logic.
+    const manyIds = Array.from({ length: 87 }, (_, i) => i);
+
+    // The very first user (index 0) will now be "Tiger 1" instead of "Tiger"
+    const firstAnonymizer = new Anonymizer(0, manyIds);
+    expect(firstAnonymizer.getName('Student')).toEqual('Student Tiger 1');
+
+    // The 86th user (index 85, the last of the first batch) will be "Yeti 1"
+    const endOfFirstBatch = new Anonymizer(85, manyIds);
+    expect(endOfFirstBatch.getName('Student')).toEqual('Student Yeti 1');
+
+    // The 87th user (index 86) overflows into the second batch and becomes "Tiger 2"
+    const overflowAnonymizer = new Anonymizer(86, manyIds);
+    expect(overflowAnonymizer.getName('Student')).toEqual('Student Tiger 2');
+  });
+
+  it('should append higher numeric suffixes dynamically if ids continue to increase vastly', () => {
+    // Let's create an array of 200 ids (which will overflow into the 3rd batch since 86 * 2 = 172)
+    const massiveIds = Array.from({ length: 200 }, (_, i) => i);
+
+    // Index 171 is the end of the second batch (Yeti 2)
+    const endOfSecondBatch = new Anonymizer(171, massiveIds);
+    expect(endOfSecondBatch.getName('Student')).toEqual('Student Yeti 2');
+
+    // Index 172 starts the third batch (Tiger 3)
+    const startOfThirdBatch = new Anonymizer(172, massiveIds);
+    expect(startOfThirdBatch.getName('Student')).toEqual('Student Tiger 3');
+  });
+
+  it('should support a custom prefix name', () => {
+    const ids = [10, 20];
+    const anonymizer = new Anonymizer(10, ids);
+    expect(anonymizer.getName('Participant')).toEqual('Participant Tiger');
+  });
+});

--- a/src/assets/wise5/components/discussion/Anonymizer.spec.ts
+++ b/src/assets/wise5/components/discussion/Anonymizer.spec.ts
@@ -6,15 +6,15 @@ describe('Anonymizer', () => {
 
     const anonymizer100 = new Anonymizer(100, ids);
     // Since 100 is at index 0, it should be mapped to the first animal (Tiger)
-    expect(anonymizer100.getName('Student')).toEqual('Student Tiger');
+    expect(anonymizer100.getName()).toEqual('Anonymous Tiger');
 
     const anonymizer200 = new Anonymizer(200, ids);
     // 200 is at index 1 -> Lion
-    expect(anonymizer200.getName('Student')).toEqual('Student Lion');
+    expect(anonymizer200.getName()).toEqual('Anonymous Lion');
 
     const anonymizer300 = new Anonymizer(300, ids);
     // 300 is at index 2 -> Fox
-    expect(anonymizer300.getName('Student')).toEqual('Student Fox');
+    expect(anonymizer300.getName()).toEqual('Anonymous Fox');
   });
 
   it('should append numeric suffixes when the number of ids exceeds the available name options (86)', () => {
@@ -23,15 +23,15 @@ describe('Anonymizer', () => {
 
     // The very first user (index 0) will now be "Tiger 1" instead of "Tiger"
     const firstAnonymizer = new Anonymizer(0, manyIds);
-    expect(firstAnonymizer.getName('Student')).toEqual('Student Tiger 1');
+    expect(firstAnonymizer.getName()).toEqual('Anonymous Tiger 1');
 
     // The 86th user (index 85, the last of the first batch) will be "Yeti 1"
     const endOfFirstBatch = new Anonymizer(85, manyIds);
-    expect(endOfFirstBatch.getName('Student')).toEqual('Student Yeti 1');
+    expect(endOfFirstBatch.getName()).toEqual('Anonymous Yeti 1');
 
     // The 87th user (index 86) overflows into the second batch and becomes "Tiger 2"
     const overflowAnonymizer = new Anonymizer(86, manyIds);
-    expect(overflowAnonymizer.getName('Student')).toEqual('Student Tiger 2');
+    expect(overflowAnonymizer.getName()).toEqual('Anonymous Tiger 2');
   });
 
   it('should append higher numeric suffixes dynamically if ids continue to increase vastly', () => {
@@ -40,11 +40,11 @@ describe('Anonymizer', () => {
 
     // Index 171 is the end of the second batch (Yeti 2)
     const endOfSecondBatch = new Anonymizer(171, massiveIds);
-    expect(endOfSecondBatch.getName('Student')).toEqual('Student Yeti 2');
+    expect(endOfSecondBatch.getName()).toEqual('Anonymous Yeti 2');
 
     // Index 172 starts the third batch (Tiger 3)
     const startOfThirdBatch = new Anonymizer(172, massiveIds);
-    expect(startOfThirdBatch.getName('Student')).toEqual('Student Tiger 3');
+    expect(startOfThirdBatch.getName()).toEqual('Anonymous Tiger 3');
   });
 
   it('should support a custom prefix name', () => {

--- a/src/assets/wise5/components/discussion/Anonymizer.ts
+++ b/src/assets/wise5/components/discussion/Anonymizer.ts
@@ -1,0 +1,113 @@
+/**
+ * Generates an anonymous student name using a list of predefined names.
+ * Maps a specific ID against a list of IDs to consistently assign a name based on its index.
+ * If the number of IDs exceeds the available names, numeric suffixes are appended (e.g., "Student Tiger 1", "Student Tiger 2").
+ */
+export class Anonymizer {
+  private nameOptions = [
+    $localize`Tiger`,
+    $localize`Lion`,
+    $localize`Fox`,
+    $localize`Owl`,
+    $localize`Panda`,
+    $localize`Hawk`,
+    $localize`Mole`,
+    $localize`Falcon`,
+    $localize`Orca`,
+    $localize`Eagle`,
+    $localize`Manta`,
+    $localize`Otter`,
+    $localize`Cat`,
+    $localize`Zebra`,
+    $localize`Flea`,
+    $localize`Wolf`,
+    $localize`Dragon`,
+    $localize`Seal`,
+    $localize`Cobra`,
+    $localize`Bug`,
+    $localize`Gecko`,
+    $localize`Fish`,
+    $localize`Koala`,
+    $localize`Mouse`,
+    $localize`Wombat`,
+    $localize`Shark`,
+    $localize`Whale`,
+    $localize`Sloth`,
+    $localize`Slug`,
+    $localize`Ant`,
+    $localize`Mantis`,
+    $localize`Bat`,
+    $localize`Rhino`,
+    $localize`Gator`,
+    $localize`Monkey`,
+    $localize`Swan`,
+    $localize`Ray`,
+    $localize`Crow`,
+    $localize`Goat`,
+    $localize`Marmot`,
+    $localize`Dog`,
+    $localize`Finch`,
+    $localize`Puffin`,
+    $localize`Fly`,
+    $localize`Camel`,
+    $localize`Kiwi`,
+    $localize`Spider`,
+    $localize`Lizard`,
+    $localize`Robin`,
+    $localize`Bear`,
+    $localize`Boa`,
+    $localize`Cow`,
+    $localize`Crab`,
+    $localize`Mule`,
+    $localize`Moth`,
+    $localize`Lynx`,
+    $localize`Moose`,
+    $localize`Skunk`,
+    $localize`Mako`,
+    $localize`Liger`,
+    $localize`Llama`,
+    $localize`Shrimp`,
+    $localize`Parrot`,
+    $localize`Pig`,
+    $localize`Clam`,
+    $localize`Urchin`,
+    $localize`Toucan`,
+    $localize`Frog`,
+    $localize`Toad`,
+    $localize`Turtle`,
+    $localize`Viper`,
+    $localize`Trout`,
+    $localize`Hare`,
+    $localize`Bee`,
+    $localize`Krill`,
+    $localize`Dodo`,
+    $localize`Tuna`,
+    $localize`Loon`,
+    $localize`Leech`,
+    $localize`Python`,
+    $localize`Wasp`,
+    $localize`Yak`,
+    $localize`Snake`,
+    $localize`Duck`,
+    $localize`Worm`,
+    $localize`Yeti`
+  ];
+
+  constructor(
+    private id: number,
+    private ids: number[]
+  ) {}
+
+  getName(prefix: string = $localize`Student`): string {
+    let names = this.nameOptions;
+    if (this.ids.length > this.nameOptions.length) {
+      names = this.nameOptions.map((name) => name + ' ' + 1);
+      let i = 2;
+      while (this.ids.length > names.length) {
+        names = names.concat(this.nameOptions.map((name) => name + ' ' + i));
+        i++;
+      }
+    }
+    return `${prefix} ${names.at(this.ids.indexOf(this.id))}`;
+  }
+}

--- a/src/assets/wise5/components/discussion/Anonymizer.ts
+++ b/src/assets/wise5/components/discussion/Anonymizer.ts
@@ -98,7 +98,7 @@ export class Anonymizer {
     private ids: number[]
   ) {}
 
-  getName(prefix: string = $localize`Student`): string {
+  getName(prefix: string = $localize`Anonymous`): string {
     let names = this.nameOptions;
     if (this.ids.length > this.nameOptions.length) {
       names = this.nameOptions.map((name) => name + ' ' + 1);

--- a/src/assets/wise5/components/discussion/DiscussionInfo.ts
+++ b/src/assets/wise5/components/discussion/DiscussionInfo.ts
@@ -15,6 +15,7 @@ export class DiscussionInfo extends ComponentInfo {
         showSubmitButton: false,
         isStudentAttachmentEnabled: true,
         gateClassmateResponses: true,
+        anonymizeResponses: false,
         constraints: []
       }
     }

--- a/src/assets/wise5/components/discussion/discussion-authoring/discussion-authoring.component.html
+++ b/src/assets/wise5/components/discussion/discussion-authoring/discussion-authoring.component.html
@@ -24,5 +24,5 @@
   (ngModelChange)="componentChanged()"
   i18n
 >
-  Students cannot see classmates' names
+  Anonymize (students cannot see classmates' names)
 </mat-checkbox>

--- a/src/assets/wise5/components/discussion/discussion-authoring/discussion-authoring.component.html
+++ b/src/assets/wise5/components/discussion/discussion-authoring/discussion-authoring.component.html
@@ -18,3 +18,11 @@
 >
   Students must create a post before viewing classmates' posts
 </mat-checkbox>
+<mat-checkbox
+  color="primary"
+  [(ngModel)]="componentContent.anonymizeResponses"
+  (ngModelChange)="componentChanged()"
+  i18n
+>
+  Students cannot see classmates' names
+</mat-checkbox>

--- a/src/assets/wise5/components/discussion/discussion-show-work/discussion-show-work.component.ts
+++ b/src/assets/wise5/components/discussion/discussion-show-work/discussion-show-work.component.ts
@@ -78,6 +78,7 @@ export class DiscussionShowWorkComponent extends ComponentShowWorkDirective {
     const classResponses = this.discussionService.getClassResponses(
       componentStates,
       annotations,
+      this.workgroupId,
       isStudentMode
     );
     const isGradingMode = true;

--- a/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.ts
+++ b/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.ts
@@ -466,6 +466,7 @@ export class DiscussionStudent extends ComponentStudent {
     this.classResponses = this.discussionService.getClassResponses(
       componentStates,
       annotations,
+      this.workgroupId,
       isStudentMode,
       this.isAnonymizeResponses()
     );
@@ -480,7 +481,11 @@ export class DiscussionStudent extends ComponentStudent {
 
   addClassResponse(componentState: any): void {
     if (componentState.studentData.isSubmit) {
-      this.discussionService.setUsernames(componentState, this.isAnonymizeResponses());
+      this.discussionService.setUsernames(
+        componentState,
+        this.workgroupId,
+        this.isAnonymizeResponses()
+      );
       componentState.replies = [];
       this.classResponses.push(componentState);
       this.addResponseToResponsesMap(this.responsesMap, componentState);

--- a/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.ts
+++ b/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.ts
@@ -457,12 +457,17 @@ export class DiscussionStudent extends ComponentStudent {
     return this.componentContent.gateClassmateResponses;
   }
 
+  protected anonymizeResponses(): boolean {
+    return this.componentContent.anonymizeResponses;
+  }
+
   setClassResponses(componentStates: any[], annotations: any[] = []): void {
     const isStudentMode = true;
     this.classResponses = this.discussionService.getClassResponses(
       componentStates,
       annotations,
-      isStudentMode
+      isStudentMode,
+      this.anonymizeResponses()
     );
     this.responsesMap = this.discussionService.getResponsesMap(this.classResponses);
     this.topLevelResponses = this.discussionService.getLevel1Responses(
@@ -475,7 +480,7 @@ export class DiscussionStudent extends ComponentStudent {
 
   addClassResponse(componentState: any): void {
     if (componentState.studentData.isSubmit) {
-      this.discussionService.setUsernames(componentState);
+      this.discussionService.setUsernames(componentState, this.anonymizeResponses());
       componentState.replies = [];
       this.classResponses.push(componentState);
       this.addResponseToResponsesMap(this.responsesMap, componentState);

--- a/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.ts
+++ b/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.ts
@@ -457,7 +457,7 @@ export class DiscussionStudent extends ComponentStudent {
     return this.componentContent.gateClassmateResponses;
   }
 
-  protected anonymizeResponses(): boolean {
+  protected isAnonymizeResponses(): boolean {
     return this.componentContent.anonymizeResponses;
   }
 
@@ -467,7 +467,7 @@ export class DiscussionStudent extends ComponentStudent {
       componentStates,
       annotations,
       isStudentMode,
-      this.anonymizeResponses()
+      this.isAnonymizeResponses()
     );
     this.responsesMap = this.discussionService.getResponsesMap(this.classResponses);
     this.topLevelResponses = this.discussionService.getLevel1Responses(
@@ -480,7 +480,7 @@ export class DiscussionStudent extends ComponentStudent {
 
   addClassResponse(componentState: any): void {
     if (componentState.studentData.isSubmit) {
-      this.discussionService.setUsernames(componentState, this.anonymizeResponses());
+      this.discussionService.setUsernames(componentState, this.isAnonymizeResponses());
       componentState.replies = [];
       this.classResponses.push(componentState);
       this.addResponseToResponsesMap(this.responsesMap, componentState);

--- a/src/assets/wise5/components/discussion/discussion-teacher/discussion-teacher.component.ts
+++ b/src/assets/wise5/components/discussion/discussion-teacher/discussion-teacher.component.ts
@@ -55,4 +55,8 @@ export class DiscussionTeacherComponent extends DiscussionStudent {
   disableComponentIfNecessary(): void {
     // no need to disable the component for teacher
   }
+
+  protected anonymizeResponses(): boolean {
+    return false;
+  }
 }

--- a/src/assets/wise5/components/discussion/discussion-teacher/discussion-teacher.component.ts
+++ b/src/assets/wise5/components/discussion/discussion-teacher/discussion-teacher.component.ts
@@ -33,6 +33,7 @@ import { DiscussionStudent } from '../discussion-student/discussion-student.comp
 })
 export class DiscussionTeacherComponent extends DiscussionStudent {
   @Input() periodId: number;
+  @Input() anonymizeResponses: boolean;
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.component) {
@@ -56,7 +57,7 @@ export class DiscussionTeacherComponent extends DiscussionStudent {
     // no need to disable the component for teacher
   }
 
-  protected anonymizeResponses(): boolean {
-    return false;
+  protected isAnonymizeResponses(): boolean {
+    return this.anonymizeResponses;
   }
 }

--- a/src/assets/wise5/components/discussion/discussionService.ts
+++ b/src/assets/wise5/components/discussion/discussionService.ts
@@ -5,6 +5,7 @@ import { HttpClient } from '@angular/common/http';
 import { forkJoin, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { serverSaveTimeComparator } from '../../common/object/object';
+import { Anonymizer } from './Anonymizer';
 
 @Injectable()
 export class DiscussionService extends ComponentService {
@@ -25,6 +26,7 @@ export class DiscussionService extends ComponentService {
     component.prompt = '';
     component.isStudentAttachmentEnabled = true;
     component.gateClassmateResponses = true;
+    component.anonymizeResponses = false;
     return component;
   }
 
@@ -211,14 +213,15 @@ export class DiscussionService extends ComponentService {
   getClassResponses(
     componentStates: any[],
     annotations = [],
-    isStudentMode: boolean = false
+    isStudentMode: boolean = false,
+    anonymizeResponses: boolean = false
   ): any[] {
     const classResponses = [];
     componentStates = componentStates.sort(serverSaveTimeComparator);
     for (const componentState of componentStates) {
       if (componentState.studentData.isSubmit) {
         componentState.replies = [];
-        this.setUsernames(componentState);
+        this.setUsernames(componentState, anonymizeResponses);
         const latestInappropriateFlagAnnotation =
           this.getLatestInappropriateFlagAnnotationByStudentWorkId(annotations, componentState.id);
         if (isStudentMode) {
@@ -243,8 +246,17 @@ export class DiscussionService extends ComponentService {
     return annotation.data.action === 'Delete';
   }
 
-  setUsernames(componentState: any): void {
-    const workgroupId = componentState.workgroupId;
+  setUsernames(componentState: any, anonymizeResponses: boolean = false): void {
+    const { workgroupId, periodId } = componentState;
+    if (anonymizeResponses) {
+      const workgroupIds = this.configService
+        .getClassmateUserInfos()
+        .filter((userInfo) => userInfo.periodId === periodId)
+        .map((userInfo) => userInfo.workgroupId)
+        .concat(workgroupId);
+      componentState.usernames = new Anonymizer(workgroupId, workgroupIds).getName();
+      return;
+    }
     const usernames = this.configService.getUsernamesByWorkgroupId(workgroupId);
     if (usernames.length > 0) {
       componentState.usernames = this.configService.getUsernamesStringByWorkgroupId(workgroupId);

--- a/src/assets/wise5/components/discussion/discussionService.ts
+++ b/src/assets/wise5/components/discussion/discussionService.ts
@@ -213,6 +213,7 @@ export class DiscussionService extends ComponentService {
   getClassResponses(
     componentStates: any[],
     annotations = [],
+    myWorkgroupId: number,
     isStudentMode: boolean = false,
     anonymizeResponses: boolean = false
   ): any[] {
@@ -221,7 +222,7 @@ export class DiscussionService extends ComponentService {
     for (const componentState of componentStates) {
       if (componentState.studentData.isSubmit) {
         componentState.replies = [];
-        this.setUsernames(componentState, anonymizeResponses);
+        this.setUsernames(componentState, myWorkgroupId, anonymizeResponses);
         const latestInappropriateFlagAnnotation =
           this.getLatestInappropriateFlagAnnotationByStudentWorkId(annotations, componentState.id);
         if (isStudentMode) {
@@ -246,15 +247,14 @@ export class DiscussionService extends ComponentService {
     return annotation.data.action === 'Delete';
   }
 
-  setUsernames(componentState: any, anonymizeResponses: boolean = false): void {
-    const { workgroupId, periodId } = componentState;
-    if (anonymizeResponses) {
-      const workgroupIds = this.configService
-        .getClassmateUserInfos()
-        .filter((userInfo) => userInfo.periodId === periodId)
-        .map((userInfo) => userInfo.workgroupId)
-        .concat(workgroupId);
-      componentState.usernames = new Anonymizer(workgroupId, workgroupIds).getName();
+  setUsernames(
+    componentState: any,
+    myWorkgroupId: number,
+    anonymizeResponses: boolean = false
+  ): void {
+    const { workgroupId } = componentState;
+    if (anonymizeResponses && workgroupId !== myWorkgroupId) {
+      this.setAnonymousUsername(componentState);
       return;
     }
     const usernames = this.configService.getUsernamesByWorkgroupId(workgroupId);
@@ -269,6 +269,16 @@ export class DiscussionService extends ComponentService {
     } else {
       componentState.usernames = this.configService.getUserIdsStringByWorkgroupId(workgroupId);
     }
+  }
+
+  private setAnonymousUsername(componentState: any): void {
+    const { workgroupId, periodId } = componentState;
+    const workgroupIds = this.configService
+      .getClassmateUserInfos()
+      .filter((userInfo) => userInfo.periodId === periodId)
+      .map((userInfo) => userInfo.workgroupId)
+      .concat(workgroupId);
+    componentState.usernames = new Anonymizer(workgroupId, workgroupIds).getName();
   }
 
   getResponsesMap(componentStates: any[]): any {

--- a/src/assets/wise5/directives/teacher-summary-display/discussion-summary/discussion-summary.component.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/discussion-summary/discussion-summary.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Component as WISEComponent } from '../../../common/Component';
 import { TeacherSummaryDisplayComponent } from '../teacher-summary-display.component';
 import { ComponentFactory } from '../../../common/ComponentFactory';
@@ -13,16 +13,21 @@ import { FormsModule } from '@angular/forms';
   styleUrl: '../../summary-display/summary-display.component.scss',
   template: `
     <div [class.expanded]="expanded">
-      <span class="flex flex-row items-center">
-        <h2 class="mat-subtitle-1" i18n>Class Discussion</h2>
+      <h2 class="mat-subtitle-1" i18n>Class Discussion</h2>
+      <div class="mb-4 flex flex-wrap gap-4 justify-between items-center">
         <mat-slide-toggle
-          class="mat-primary account-menu__control mat-subtitle-1"
           [(ngModel)]="anonymizeResponses"
+          (change)="anonymizeResponsesChanged()"
           i18n
         >
-          Anonymize Responses
+          Hide student names
         </mat-slide-toggle>
-      </span>
+        @if (component.content.anonymizeResponses) {
+          <span class="mat-caption" i18n
+            >Note: Students do not see each other's names in this activity.</span
+          >
+        }
+      </div>
       <discussion-teacher
         class="max-h-160 block overflow-y-auto"
         [class.max-h-none]="expanded"
@@ -36,13 +41,18 @@ import { FormsModule } from '@angular/forms';
   `
 })
 export class DiscussionSummaryComponent extends TeacherSummaryDisplayComponent implements OnInit {
-  protected anonymizeResponses: boolean;
+  @Input() anonymizeResponses: boolean;
   protected component: WISEComponent;
   @Input() expanded: boolean;
+  @Output() anonymizeResponsesChange = new EventEmitter<boolean>();
 
   ngOnInit(): void {
     let content = this.projectService.getComponent(this.nodeId, this.componentId);
     content = this.projectService.injectAssetPaths(content);
     this.component = new ComponentFactory().getComponent(content, this.nodeId);
+  }
+
+  protected anonymizeResponsesChanged() {
+    this.anonymizeResponsesChange.emit(this.anonymizeResponses);
   }
 }

--- a/src/assets/wise5/directives/teacher-summary-display/discussion-summary/discussion-summary.component.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/discussion-summary/discussion-summary.component.ts
@@ -4,26 +4,39 @@ import { Component as WISEComponent } from '../../../common/Component';
 import { TeacherSummaryDisplayComponent } from '../teacher-summary-display.component';
 import { ComponentFactory } from '../../../common/ComponentFactory';
 import { DiscussionTeacherComponent } from '../../../components/discussion/discussion-teacher/discussion-teacher.component';
+import { MatSlideToggle } from '@angular/material/slide-toggle';
+import { FormsModule } from '@angular/forms';
 
 @Component({
-  imports: [CommonModule, DiscussionTeacherComponent],
+  imports: [CommonModule, DiscussionTeacherComponent, FormsModule, MatSlideToggle],
   selector: 'discussion-summary',
   styleUrl: '../../summary-display/summary-display.component.scss',
   template: `
     <div [class.expanded]="expanded">
-      <h2 class="mat-subtitle-1" i18n>Class Discussion</h2>
+      <span class="flex flex-row items-center">
+        <h2 class="mat-subtitle-1" i18n>Class Discussion</h2>
+        <mat-slide-toggle
+          class="mat-primary account-menu__control mat-subtitle-1"
+          [(ngModel)]="anonymizeResponses"
+          i18n
+        >
+          Anonymize Responses
+        </mat-slide-toggle>
+      </span>
       <discussion-teacher
         class="max-h-160 block overflow-y-auto"
         [class.max-h-none]="expanded"
         [nodeId]="nodeId"
         [component]="component"
         [periodId]="periodId"
+        [anonymizeResponses]="anonymizeResponses"
         [mode]="'summary'"
       />
     </div>
   `
 })
 export class DiscussionSummaryComponent extends TeacherSummaryDisplayComponent implements OnInit {
+  protected anonymizeResponses: boolean;
   protected component: WISEComponent;
   @Input() expanded: boolean;
 

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -3214,10 +3214,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts</context>
           <context context-type="linenumber">45</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
-          <context context-type="linenumber">101</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="7105610884619319408" datatype="html">
         <source>Look up username or reset password for a student account</source>
@@ -18730,6 +18726,13 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
           <context context-type="linenumber">93</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="358462242581945792" datatype="html">
+        <source>Anonymous</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1942410144330587547" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -3214,6 +3214,10 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts</context>
           <context context-type="linenumber">45</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">101</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="7105610884619319408" datatype="html">
         <source>Look up username or reset password for a student account</source>
@@ -18126,6 +18130,608 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">97,100</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="4348308606328932540" datatype="html">
+        <source>Tiger</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2137584686048358740" datatype="html">
+        <source>Lion</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7486534579624944939" datatype="html">
+        <source>Fox</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="183722403074487751" datatype="html">
+        <source>Owl</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1832905674524000038" datatype="html">
+        <source>Panda</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1379313477282267288" datatype="html">
+        <source>Hawk</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2157078139035509147" datatype="html">
+        <source>Mole</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4298289798791599054" datatype="html">
+        <source>Falcon</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2526182704547991221" datatype="html">
+        <source>Orca</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5307470187095677068" datatype="html">
+        <source>Eagle</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8326071933469281574" datatype="html">
+        <source>Manta</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2178389529107729193" datatype="html">
+        <source>Otter</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2744220263238810269" datatype="html">
+        <source>Cat</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3200103792034006827" datatype="html">
+        <source>Zebra</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6900335088391007475" datatype="html">
+        <source>Flea</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="10082399751312702" datatype="html">
+        <source>Wolf</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6211701622639397497" datatype="html">
+        <source>Dragon</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2401469399758214434" datatype="html">
+        <source>Seal</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5538207541160626311" datatype="html">
+        <source>Cobra</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="767733775493459640" datatype="html">
+        <source>Bug</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="783935118345982144" datatype="html">
+        <source>Gecko</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7385822291062024535" datatype="html">
+        <source>Fish</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5044568296955064366" datatype="html">
+        <source>Koala</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="728862926652618704" datatype="html">
+        <source>Mouse</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5444546332784355061" datatype="html">
+        <source>Wombat</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="264035644112677223" datatype="html">
+        <source>Shark</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="580222049558097084" datatype="html">
+        <source>Whale</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6343864594297771387" datatype="html">
+        <source>Sloth</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2861306361489095884" datatype="html">
+        <source>Slug</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1415422688193757492" datatype="html">
+        <source>Ant</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7922684197548836538" datatype="html">
+        <source>Mantis</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2852161332598570485" datatype="html">
+        <source>Bat</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="163344459050880069" datatype="html">
+        <source>Rhino</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1669656294000491884" datatype="html">
+        <source>Gator</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6280399625746050320" datatype="html">
+        <source>Monkey</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8704771054419799555" datatype="html">
+        <source>Swan</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1991891590478247822" datatype="html">
+        <source>Ray</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5934787643334855796" datatype="html">
+        <source>Crow</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5816117052837662269" datatype="html">
+        <source>Goat</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1456752184060161220" datatype="html">
+        <source>Marmot</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="990941812379234463" datatype="html">
+        <source>Dog</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5142714263134700591" datatype="html">
+        <source>Finch</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4259321622551969016" datatype="html">
+        <source>Puffin</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="382975474342332270" datatype="html">
+        <source>Fly</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">51</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8732990729917371187" datatype="html">
+        <source>Camel</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">52</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7401125251302544348" datatype="html">
+        <source>Kiwi</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="630998393861561995" datatype="html">
+        <source>Spider</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7355663318247890275" datatype="html">
+        <source>Lizard</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7813501590989435524" datatype="html">
+        <source>Robin</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">56</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3118414200599668885" datatype="html">
+        <source>Bear</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4765288601987353112" datatype="html">
+        <source>Boa</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4207787349175815190" datatype="html">
+        <source>Cow</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">59</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8993176983602435509" datatype="html">
+        <source>Crab</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="9125210069047747718" datatype="html">
+        <source>Mule</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6326589985711846411" datatype="html">
+        <source>Moth</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1113129284663451022" datatype="html">
+        <source>Lynx</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="9172859271696545318" datatype="html">
+        <source>Moose</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="677701704456307753" datatype="html">
+        <source>Skunk</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3332663286185310879" datatype="html">
+        <source>Mako</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="108662662041125128" datatype="html">
+        <source>Liger</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6917709011487497690" datatype="html">
+        <source>Llama</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="671489466765383179" datatype="html">
+        <source>Shrimp</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3673151339277085573" datatype="html">
+        <source>Parrot</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1552599557833207581" datatype="html">
+        <source>Pig</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">71</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6186153081460295348" datatype="html">
+        <source>Clam</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7114544732469166787" datatype="html">
+        <source>Urchin</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">73</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="359240374359300291" datatype="html">
+        <source>Toucan</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">74</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="487523319258823955" datatype="html">
+        <source>Frog</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8987134592708673447" datatype="html">
+        <source>Toad</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">76</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3210165342143580540" datatype="html">
+        <source>Turtle</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">77</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3307890034015174575" datatype="html">
+        <source>Viper</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5261448611357253284" datatype="html">
+        <source>Trout</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">79</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2449607567506927496" datatype="html">
+        <source>Hare</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">80</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8446069528116398373" datatype="html">
+        <source>Bee</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">81</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7779190411976611864" datatype="html">
+        <source>Krill</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5775073306832602563" datatype="html">
+        <source>Dodo</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3593620958227553513" datatype="html">
+        <source>Tuna</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">84</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7272317634035450738" datatype="html">
+        <source>Loon</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">85</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5556004893087681524" datatype="html">
+        <source>Leech</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">86</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7017719389022483276" datatype="html">
+        <source>Python</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">87</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3891973742293597607" datatype="html">
+        <source>Wasp</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">88</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7782865079768098569" datatype="html">
+        <source>Yak</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">89</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4104519939567221513" datatype="html">
+        <source>Snake</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="9039529742360603235" datatype="html">
+        <source>Duck</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">91</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7469393138243404348" datatype="html">
+        <source>Worm</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">92</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7449355324939813930" datatype="html">
+        <source>Yeti</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/Anonymizer.ts</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1942410144330587547" datatype="html">
         <source>Students post messages for the whole class to see and can reply to other students&apos; posts.</source>
         <context-group purpose="location">
@@ -18145,7 +18751,7 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/discussionService.ts</context>
-          <context context-type="linenumber">19</context>
+          <context context-type="linenumber">20</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3681514094143393882" datatype="html">
@@ -18254,7 +18860,15 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/discussion-authoring/discussion-authoring.component.html</context>
-          <context context-type="linenumber">19,21</context>
+          <context context-type="linenumber">19,23</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5302064367675209049" datatype="html">
+        <source> Students cannot see classmates&apos; names
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/discussion-authoring/discussion-authoring.component.html</context>
+          <context context-type="linenumber">27,29</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7695481917775533693" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -22555,7 +22555,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Class Discussion</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/discussion-summary/discussion-summary.component.ts</context>
-          <context context-type="linenumber">14,16</context>
+          <context context-type="linenumber">17,19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="53088066154549456" datatype="html">
+        <source> Anonymize Responses </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/discussion-summary/discussion-summary.component.ts</context>
+          <context context-type="linenumber">23,26</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3690771652722848805" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -18866,8 +18866,8 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">19,23</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="5302064367675209049" datatype="html">
-        <source> Students cannot see classmates&apos; names
+      <trans-unit id="6977775025631506852" datatype="html">
+        <source> Anonymize (students cannot see classmates&apos; names)
 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/discussion-authoring/discussion-authoring.component.html</context>
@@ -22558,14 +22558,21 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Class Discussion</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/discussion-summary/discussion-summary.component.ts</context>
-          <context context-type="linenumber">17,19</context>
+          <context context-type="linenumber">16,17</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="53088066154549456" datatype="html">
-        <source> Anonymize Responses </source>
+      <trans-unit id="6338860782944918625" datatype="html">
+        <source> Hide student names </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/discussion-summary/discussion-summary.component.ts</context>
-          <context context-type="linenumber">23,26</context>
+          <context context-type="linenumber">23,25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6793042667929328995" datatype="html">
+        <source>Note: Students do not see each other&apos;s names in this activity.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/discussion-summary/discussion-summary.component.ts</context>
+          <context context-type="linenumber">27,32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3690771652722848805" datatype="html">


### PR DESCRIPTION
## Changes
- Student responses in the Discussion activity can now be displayed with anonymous names instead of real names. The anonymous names are chosen from a list of animal names (Anonymous Lion, Anonymous Yeti, etc...)
- Add option to anonymize student responses in the authoring tool. By default, this option is disabled.
- Add option to toggle anonymizing student responses in the teacher tool > discussion summary view.

## Test
- Above works as described