### PR TITLE
feat(Step Icon): Improve default option

### DIFF
--- a/src/app/services/editBranchService.spec.ts
+++ b/src/app/services/editBranchService.spec.ts
@@ -58,6 +58,13 @@ function editBranch() {
         id: 'node2',
         title: 'Branch point',
         type: 'node',
+        icon: {
+          color: '#00B0FF',
+          type: 'font',
+          fontSet: 'material-icons',
+          fontName: 'school',
+          imgSrc: ''
+        },
         transitionLogic: {
           transitions: [
             {

--- a/src/assets/wise5/authoringTool/addNode/abstract-import-step/abstract-import-step.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/abstract-import-step/abstract-import-step.component.ts
@@ -6,6 +6,7 @@ import { InsertNodesService } from '../../../services/insertNodesService';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { InsertFirstNodeInBranchPathService } from '../../../services/insertFirstNodeInBranchPathService';
 import { AddStepTarget } from '../../../../../app/domain/addStepTarget';
+import { ensureDefaultIcon } from '../../../common/Node';
 
 @Directive()
 export abstract class AbstractImportStepComponent implements OnInit {
@@ -34,7 +35,7 @@ export abstract class AbstractImportStepComponent implements OnInit {
       .copyNodes(nodesToImport, this.importProjectId, this.configService.getProjectId())
       .subscribe((copiedNodesWithOldIds: any[]) => {
         const copiedNodes = this.replaceNodesWithNewIds(copiedNodesWithOldIds);
-        this.ensureDefaultIcon(copiedNodes);
+        ensureDefaultIcon(copiedNodes);
         if (this.target.type === 'firstStepInBranchPath') {
           this.insertFirstNodeInBranchPathService.insertNodes(
             copiedNodes,
@@ -57,26 +58,11 @@ export abstract class AbstractImportStepComponent implements OnInit {
     return nodes.map((node: any) => this.projectService.replaceOldIds(node, oldToNewIds));
   }
 
-  private ensureDefaultIcon(nodes: any[]): void {
-    nodes
-      .filter((node: any) => !node.icon)
-      .forEach(
-        (node: any) =>
-          (node.icon = {
-            color: '#00B0FF',
-            type: 'font',
-            fontSet: 'material-icons',
-            fontName: node.type === 'node' ? 'school' : 'dashboard',
-            imgSrc: ''
-          })
-      );
-  }
-
   private setColor(nodes: any[], nodeId: string): void {
     const nodeToMatchColor = this.projectService.isGroupNode(nodeId)
       ? this.projectService.getNodeById(nodeId)
       : this.projectService.getParentGroup(nodeId);
-    this.ensureDefaultIcon([nodeToMatchColor]);
+    ensureDefaultIcon([nodeToMatchColor]);
     nodes.forEach((node: any) => (node.icon.color = nodeToMatchColor.icon.color));
   }
 }

--- a/src/assets/wise5/authoringTool/addNode/abstract-import-step/abstract-import-step.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/abstract-import-step/abstract-import-step.component.ts
@@ -34,6 +34,7 @@ export abstract class AbstractImportStepComponent implements OnInit {
       .copyNodes(nodesToImport, this.importProjectId, this.configService.getProjectId())
       .subscribe((copiedNodesWithOldIds: any[]) => {
         const copiedNodes = this.replaceNodesWithNewIds(copiedNodesWithOldIds);
+        this.ensureDefaultIcon(copiedNodes);
         if (this.target.type === 'firstStepInBranchPath') {
           this.insertFirstNodeInBranchPathService.insertNodes(
             copiedNodes,
@@ -56,12 +57,26 @@ export abstract class AbstractImportStepComponent implements OnInit {
     return nodes.map((node: any) => this.projectService.replaceOldIds(node, oldToNewIds));
   }
 
+  private ensureDefaultIcon(nodes: any[]): void {
+    nodes
+      .filter((node: any) => !node.icon)
+      .forEach(
+        (node: any) =>
+          (node.icon = {
+            color: '#00B0FF',
+            type: 'font',
+            fontSet: 'material-icons',
+            fontName: node.type === 'node' ? 'school' : 'dashboard',
+            imgSrc: ''
+          })
+      );
+  }
+
   private setColor(nodes: any[], nodeId: string): void {
-    const color = (
-      this.projectService.isGroupNode(nodeId)
-        ? this.projectService.getNodeById(nodeId)
-        : this.projectService.getParentGroup(nodeId)
-    ).icon.color;
-    nodes.filter((node: any) => node.icon).forEach((node: any) => (node.icon.color = color));
+    const nodeToMatchColor = this.projectService.isGroupNode(nodeId)
+      ? this.projectService.getNodeById(nodeId)
+      : this.projectService.getParentGroup(nodeId);
+    this.ensureDefaultIcon([nodeToMatchColor]);
+    nodes.forEach((node: any) => (node.icon.color = nodeToMatchColor.icon.color));
   }
 }

--- a/src/assets/wise5/authoringTool/addNode/abstract-import-step/abstract-import-step.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/abstract-import-step/abstract-import-step.component.ts
@@ -32,21 +32,36 @@ export abstract class AbstractImportStepComponent implements OnInit {
     this.submitting = true;
     this.copyNodesService
       .copyNodes(nodesToImport, this.importProjectId, this.configService.getProjectId())
-      .subscribe((copiedNodes: any[]) => {
-        const nodesWithNewNodeIds = this.projectService.getNodesWithNewIds(copiedNodes);
+      .subscribe((copiedNodesWithOldIds: any[]) => {
+        const copiedNodes = this.replaceNodesWithNewIds(copiedNodesWithOldIds);
         if (this.target.type === 'firstStepInBranchPath') {
           this.insertFirstNodeInBranchPathService.insertNodes(
-            nodesWithNewNodeIds,
+            copiedNodes,
             this.target.branchNodeId,
             this.target.firstNodeIdInBranchPath
           );
         } else {
-          this.insertNodesService.insertNodes(nodesWithNewNodeIds, this.target.targetId);
+          this.setColor(copiedNodes, this.target.targetId);
+          this.insertNodesService.insertNodes(copiedNodes, this.target.targetId);
         }
         this.projectService.checkPotentialStartNodeIdChangeThenSaveProject().then(() => {
           this.projectService.refreshProject();
           this.router.navigate(['../../..'], { relativeTo: this.route });
         });
       });
+  }
+
+  private replaceNodesWithNewIds(nodes: any[]): any[] {
+    const oldToNewIds = this.projectService.getOldToNewIds(nodes);
+    return nodes.map((node: any) => this.projectService.replaceOldIds(node, oldToNewIds));
+  }
+
+  private setColor(nodes: any[], nodeId: string): void {
+    const color = (
+      this.projectService.isGroupNode(nodeId)
+        ? this.projectService.getNodeById(nodeId)
+        : this.projectService.getParentGroup(nodeId)
+    ).icon.color;
+    nodes.filter((node: any) => node.icon).forEach((node: any) => (node.icon.color = color));
   }
 }

--- a/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.ts
@@ -81,9 +81,11 @@ export class AddYourOwnNodeComponent {
     const newNode = this.projectService.createNode(this.addNodeFormGroup.controls['title'].value);
     switch (this.target.type) {
       case 'in':
+        newNode.icon.color = this.projectService.getNodeById(this.target.targetId).icon.color;
         this.projectService.createNodeInside(newNode, this.target.targetId);
         break;
       case 'after':
+        newNode.icon.color = this.projectService.getParentGroup(this.target.targetId).icon.color;
         this.projectService.createNodeAfter(newNode, this.target.targetId);
         break;
       case 'firstStepInBranchPath':
@@ -98,10 +100,6 @@ export class AddYourOwnNodeComponent {
     this.save().then(() => {
       this.router.navigate(['../..'], { relativeTo: this.route });
     });
-  }
-
-  protected isGroupNode(nodeId: string): boolean {
-    return this.projectService.isGroupNode(nodeId);
   }
 
   private addInitialComponents(nodeId: string, components: any[]): void {

--- a/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.ts
@@ -21,6 +21,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatInputModule } from '@angular/material/input';
 import { InsertFirstNodeInBranchPathService } from '../../../services/insertFirstNodeInBranchPathService';
 import { AddStepTarget } from '../../../../../app/domain/addStepTarget';
+import { ensureDefaultIcon } from '../../../common/Node';
 
 @Component({
   imports: [
@@ -79,13 +80,17 @@ export class AddYourOwnNodeComponent {
   protected submit(): void {
     this.submitting = true;
     const newNode = this.projectService.createNode(this.addNodeFormGroup.controls['title'].value);
+    const groupNode =
+      this.target.type === 'in'
+        ? this.projectService.getNodeById(this.target.targetId)
+        : this.projectService.getParentGroup(this.target.targetId);
+    ensureDefaultIcon([groupNode]);
+    newNode.icon.color = groupNode.icon.color;
     switch (this.target.type) {
       case 'in':
-        newNode.icon.color = this.projectService.getNodeById(this.target.targetId).icon.color;
         this.projectService.createNodeInside(newNode, this.target.targetId);
         break;
       case 'after':
-        newNode.icon.color = this.projectService.getParentGroup(this.target.targetId).icon.color;
         this.projectService.createNodeAfter(newNode, this.target.targetId);
         break;
       case 'firstStepInBranchPath':

--- a/src/assets/wise5/authoringTool/new-project-template.ts
+++ b/src/assets/wise5/authoringTool/new-project-template.ts
@@ -23,6 +23,13 @@ export const newProjectTemplate = {
       },
       transitionLogic: {
         transitions: []
+      },
+      icon: {
+        color: '#00B0FF',
+        type: 'font',
+        fontSet: 'material-icons',
+        fontName: 'dashboard',
+        imgSrc: ''
       }
     },
     {
@@ -35,6 +42,13 @@ export const newProjectTemplate = {
       showSubmitButton: false,
       transitionLogic: {
         transitions: []
+      },
+      icon: {
+        color: '#00B0FF',
+        type: 'font',
+        fontSet: 'material-icons',
+        fontName: 'school',
+        imgSrc: ''
       }
     }
   ],

--- a/src/assets/wise5/common/Node.ts
+++ b/src/assets/wise5/common/Node.ts
@@ -235,3 +235,18 @@ export class Node {
     return this.components.findIndex((component) => component.id === componentId);
   }
 }
+
+export function ensureDefaultIcon(nodes: Node[]): void {
+  nodes
+    .filter((node: Node) => !node.icon)
+    .forEach(
+      (node: Node) =>
+        (node.icon = {
+          color: '#00B0FF',
+          type: 'font',
+          fontSet: 'material-icons',
+          fontName: node.type === 'node' ? 'school' : 'dashboard',
+          imgSrc: ''
+        })
+    );
+}

--- a/src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.ts
+++ b/src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.ts
@@ -9,6 +9,7 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatButtonModule } from '@angular/material/button';
 import { RouterModule } from '@angular/router';
+import { NODE_ICON_COLORS } from '../../vle/node-icon/NodeIconColor';
 
 interface KIIcon {
   imgAlt: string;
@@ -32,20 +33,7 @@ interface KIIcon {
   templateUrl: 'node-icon-chooser-dialog.component.html'
 })
 export class NodeIconChooserDialogComponent {
-  protected colors = [
-    '#66BB6A',
-    '#009688',
-    '#00B0FF',
-    '#1565C0',
-    '#673AB7',
-    '#AB47BC',
-    '#E91E63',
-    '#D50000',
-    '#F57C00',
-    '#FBC02D',
-    '#795548',
-    '#757575'
-  ];
+  protected colors = NODE_ICON_COLORS;
 
   protected fontNames = [
     'access_time',

--- a/src/assets/wise5/services/authorBranchService.ts
+++ b/src/assets/wise5/services/authorBranchService.ts
@@ -22,6 +22,7 @@ export abstract class AuthorBranchService {
   ): void {
     const newNode = this.projectService.createNode($localize`Path ${pathIndex + 1}`);
     newNode.id = nodeId;
+    newNode.icon.color = this.projectService.getParentGroup(branchNode.id).icon.color;
     this.addTransitionFromBranchNodeToPathNode(params, branchNode, newNode, pathIndex);
     this.projectService.addNode(newNode);
     this.projectService.addApplicationNode(newNode);

--- a/src/assets/wise5/services/authorBranchService.ts
+++ b/src/assets/wise5/services/authorBranchService.ts
@@ -22,7 +22,7 @@ export abstract class AuthorBranchService {
   ): void {
     const newNode = this.projectService.createNode($localize`Path ${pathIndex + 1}`);
     newNode.id = nodeId;
-    newNode.icon.color = this.projectService.getParentGroup(branchNode.id).icon.color;
+    newNode.icon.color = this.projectService.getParentGroup(branchNode.id).icon?.color || '#00B0FF';
     this.addTransitionFromBranchNodeToPathNode(params, branchNode, newNode, pathIndex);
     this.projectService.addNode(newNode);
     this.projectService.addApplicationNode(newNode);

--- a/src/assets/wise5/services/createBranchService.ts
+++ b/src/assets/wise5/services/createBranchService.ts
@@ -53,7 +53,8 @@ export class CreateBranchService extends AuthorBranchService {
   ): any {
     const mergeStepNode = this.projectService.createNode($localize`Merge Step`);
     mergeStepNode.id = this.projectService.getNextAvailableNodeId(newNodeIds);
-    mergeStepNode.icon.color = this.projectService.getParentGroup(branchNodeId).icon.color;
+    mergeStepNode.icon.color =
+      this.projectService.getParentGroup(branchNodeId).icon?.color || '#00B0FF';
     if (nodeIdBranchNodeTransitionsTo !== '') {
       mergeStepNode.transitionLogic.transitions = [new Transition(nodeIdBranchNodeTransitionsTo)];
     }

--- a/src/assets/wise5/services/createBranchService.ts
+++ b/src/assets/wise5/services/createBranchService.ts
@@ -21,7 +21,7 @@ export class CreateBranchService extends AuthorBranchService {
     this.createPathSteps(params, branchNode, newNodeIds);
     const mergeStep: any =
       params.mergeStepId === ''
-        ? this.createMergeStep(newNodeIds, nodeIdBranchNodeTransitionsTo)
+        ? this.createMergeStep(newNodeIds, branchNode.id, nodeIdBranchNodeTransitionsTo)
         : this.projectService.getNode(params.mergeStepId);
     this.setPathStepTransitions(newNodeIds, mergeStep.id);
     this.setBranchNodeTransitionLogic(branchNode, params.criteria);
@@ -46,9 +46,14 @@ export class CreateBranchService extends AuthorBranchService {
     }
   }
 
-  private createMergeStep(newNodeIds: string[], nodeIdBranchNodeTransitionsTo: string): any {
+  private createMergeStep(
+    newNodeIds: string[],
+    branchNodeId: string,
+    nodeIdBranchNodeTransitionsTo: string
+  ): any {
     const mergeStepNode = this.projectService.createNode($localize`Merge Step`);
     mergeStepNode.id = this.projectService.getNextAvailableNodeId(newNodeIds);
+    mergeStepNode.icon.color = this.projectService.getParentGroup(branchNodeId).icon.color;
     if (nodeIdBranchNodeTransitionsTo !== '') {
       mergeStepNode.transitionLogic.transitions = [new Transition(nodeIdBranchNodeTransitionsTo)];
     }

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -111,13 +111,6 @@ export class TeacherProjectService extends ProjectService {
     };
   }
 
-  getNodesWithNewIds(nodes: any[]): any[] {
-    const oldToNewIds = this.getOldToNewIds(nodes);
-    return nodes.map((node: any) => {
-      return this.replaceOldIds(node, oldToNewIds);
-    });
-  }
-
   getOldToNewIds(nodes: any[]): Map<string, string> {
     const newNodeIds = [];
     const newComponentIds = [];

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -89,7 +89,7 @@ export class TeacherProjectService extends ProjectService {
    * @param title the title of the node
    * @returns the node object
    */
-  createNode(title: string) {
+  createNode(title: string): any {
     return {
       id: this.getNextAvailableNodeId(),
       title: title,
@@ -97,6 +97,13 @@ export class TeacherProjectService extends ProjectService {
       constraints: [],
       transitionLogic: {
         transitions: []
+      },
+      icon: {
+        color: '#00B0FF',
+        type: 'font',
+        fontSet: 'material-icons',
+        fontName: 'school',
+        imgSrc: ''
       },
       showSaveButton: false,
       showSubmitButton: false,

--- a/src/assets/wise5/services/teacherProjectService.ts
+++ b/src/assets/wise5/services/teacherProjectService.ts
@@ -13,6 +13,7 @@ import { branchPathBackgroundColors } from '../common/color/color';
 import { reduceByUniqueId } from '../common/array/array';
 import { NodeTypeSelected } from '../authoringTool/domain/node-type-selected';
 import { ComponentContent } from '../common/ComponentContent';
+import { getRandomNodeIconColor } from '../vle/node-icon/NodeIconColor';
 
 @Injectable()
 export class TeacherProjectService extends ProjectService {
@@ -72,7 +73,14 @@ export class TeacherProjectService extends ProjectService {
       transitionLogic: {
         transitions: []
       },
-      ids: []
+      ids: [],
+      icon: {
+        color: getRandomNodeIconColor(),
+        type: 'font',
+        fontSet: 'material-icons',
+        fontName: 'dashboard',
+        imgSrc: ''
+      }
     };
   }
 
@@ -81,7 +89,7 @@ export class TeacherProjectService extends ProjectService {
    * @param title the title of the node
    * @returns the node object
    */
-  createNode(title) {
+  createNode(title: string) {
     return {
       id: this.getNextAvailableNodeId(),
       title: title,

--- a/src/assets/wise5/vle/node-icon/NodeIconColor.ts
+++ b/src/assets/wise5/vle/node-icon/NodeIconColor.ts
@@ -1,0 +1,18 @@
+export const NODE_ICON_COLORS = [
+  '#66BB6A',
+  '#009688',
+  '#00B0FF',
+  '#1565C0',
+  '#673AB7',
+  '#AB47BC',
+  '#E91E63',
+  '#D50000',
+  '#F57C00',
+  '#FBC02D',
+  '#795548',
+  '#757575'
+];
+
+export function getRandomNodeIconColor(): string {
+  return NODE_ICON_COLORS[Math.floor(Math.random() * NODE_ICON_COLORS.length)];
+}

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10411,7 +10411,7 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
         <source>New Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.ts</context>
-          <context context-type="linenumber">44</context>
+          <context context-type="linenumber">45</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8293078288618811295" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -128,7 +128,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.ts</context>
-          <context context-type="linenumber">101</context>
+          <context context-type="linenumber">89</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6987978600862806678" datatype="html">
@@ -143,7 +143,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.ts</context>
-          <context context-type="linenumber">106</context>
+          <context context-type="linenumber">94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5003353968126431012" datatype="html">
@@ -162,7 +162,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.ts</context>
-          <context context-type="linenumber">111</context>
+          <context context-type="linenumber">99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7694452824674863458" datatype="html">
@@ -11916,7 +11916,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">94</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/milestone-report-button/milestone-report-button.component.html</context>
@@ -12192,14 +12192,14 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>First Step</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">38</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1384916903989385807" datatype="html">
         <source>Notebook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">70</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
@@ -12210,11 +12210,11 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>note</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">68</context>
+          <context context-type="linenumber">82</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">110</context>
+          <context context-type="linenumber">124</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
@@ -12225,11 +12225,11 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">69</context>
+          <context context-type="linenumber">83</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">111</context>
+          <context context-type="linenumber">125</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
@@ -12240,11 +12240,11 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>Notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">70</context>
+          <context context-type="linenumber">84</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">112</context>
+          <context context-type="linenumber">126</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/notebook/notebook-workgroup-grading/notebook-workgroup-grading.component.html</context>
@@ -12263,7 +12263,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>report</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">78</context>
+          <context context-type="linenumber">92</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
@@ -12274,7 +12274,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>reports</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">79</context>
+          <context context-type="linenumber">93</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/notebookService.ts</context>
@@ -12285,78 +12285,78 @@ The branches will be removed but the steps will remain in the unit.</source>
         <source>Final Report</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">87</context>
+          <context context-type="linenumber">101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8604167983715964004" datatype="html">
         <source>Final summary report of what you learned in this unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">88</context>
+          <context context-type="linenumber">102</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4419148705442508208" datatype="html">
         <source>Use this space to write your final report using evidence from your notebook.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">89</context>
+          <context context-type="linenumber">103</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2128364009265696768" datatype="html">
         <source>&lt;h3&gt;This is a heading&lt;/h3&gt;&lt;p&gt;This is a paragraph.&lt;/p&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">90</context>
+          <context context-type="linenumber">104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3712572360135341203" datatype="html">
         <source>Teacher Notebook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">98</context>
+          <context context-type="linenumber">112</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3422550137142657635" datatype="html">
         <source>teacher notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">134</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">135</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2558301014879118031" datatype="html">
         <source>Teacher Notes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">122</context>
+          <context context-type="linenumber">136</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">129</context>
+          <context context-type="linenumber">143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2841850575512700640" datatype="html">
         <source>Notes for the teacher as they&apos;re running the WISE unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">130</context>
+          <context context-type="linenumber">144</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4383493915104232758" datatype="html">
         <source>Use this space to take notes for this unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">131</context>
+          <context context-type="linenumber">145</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8373748870534083811" datatype="html">
         <source>&lt;p&gt;Use this space to take notes for this unit&lt;/p&gt;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/new-project-template.ts</context>
-          <context context-type="linenumber">132</context>
+          <context context-type="linenumber">146</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6005640251215534178" datatype="html">
@@ -13610,7 +13610,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/createBranchService.ts</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">54</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1686279380542079569" datatype="html">
@@ -16014,49 +16014,49 @@ Are you sure you want to proceed?</source>
         <source>Knowledge Integration elicit ideas</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.ts</context>
-          <context context-type="linenumber">100</context>
+          <context context-type="linenumber">88</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5060022891098618470" datatype="html">
         <source>Knowledge Integration discover ideas</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.ts</context>
-          <context context-type="linenumber">105</context>
+          <context context-type="linenumber">93</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6027324852341840147" datatype="html">
         <source>Knowledge Integration distinguish ideas</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.ts</context>
-          <context context-type="linenumber">110</context>
+          <context context-type="linenumber">98</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5284841868972566661" datatype="html">
         <source>Knowledge Integration connect ideas and reflect</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.ts</context>
-          <context context-type="linenumber">115</context>
+          <context context-type="linenumber">103</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1055307563609433839" datatype="html">
         <source>Connect Ideas &amp; Reflect</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.ts</context>
-          <context context-type="linenumber">116</context>
+          <context context-type="linenumber">104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1395167530251175410" datatype="html">
         <source>Knowledge Integration cycle</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.ts</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">108</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4840904011085648831" datatype="html">
         <source>KI Cycle</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/common/node-icon-chooser-dialog/node-icon-chooser-dialog.component.ts</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2692433425768915750" datatype="html">


### PR DESCRIPTION
Currently, we assign a gray hat icon for new steps and lessons. This makes the unit feel gray and dull. This PR tries to improve this by making the unit more colorful and organized. We do this by changing the following:

- New lesson icon will have a random color, grid icon ("dashboard" material icon)
- New step icon will have the same color as the lesson, hat icon ("school" material icon)
   - This includes branch path steps and the merge step 
- Imported step(s) icon(s) will have the same color as lesson they get imported into, same icon as before

## Test
- Above works as described

Closes #2286
