### PR TITLE
fix(Teacher Tools): Fix broken images

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading/node-grading.component.ts
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/nodeGrading/node-grading/node-grading.component.ts
@@ -102,7 +102,7 @@ export class NodeGradingComponent implements OnInit, OnDestroy, OnChanges {
       .filter((component) => this.projectService.componentHasWork(component))
       .map((component, index) => {
         component['displayIndex'] = index + 1;
-        return component;
+        return this.projectService.injectAssetPaths(component);
       });
     this.visibleComponents = [this.components[0]];
     this.numRubrics = this.node.getNumRubrics();

--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html
@@ -1,7 +1,7 @@
 <ng-template #bucketTemplate let-bucket="bucket" let-first="first">
   <div class="bucket" [ngClass]="{ 'selected-bg-bg': first, 'notice-bg-bg': !first }">
     <h3 class="mat-body-2">
-      {{ bucket.value }}
+      <span [innerHTML]="bucket.value"></span>
       @if (first) {
         (<span i18n>Source Bucket</span>)
       }

--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.spec.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.spec.ts
@@ -37,6 +37,9 @@ describe('MatchSummaryDisplayComponent', () => {
     spyOn(TestBed.inject(SummaryService), 'getLatestClassmateStudentWork').and.returnValue(
       of(getComponentStates())
     );
+    spyOn(TestBed.inject(ProjectService), 'injectAssetPaths').and.callFake((componentStates) => {
+      return componentStates;
+    });
     fixture = TestBed.createComponent(MatchSummaryDisplayComponent);
     component = fixture.componentInstance;
     component.nodeId = 'nId';

--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.ts
@@ -38,7 +38,9 @@ export class MatchSummaryDisplayComponent extends TeacherSummaryDisplayComponent
     this.getLatestWork().subscribe((componentStates) => {
       this.bucketData = [];
       this.bucketValues.clear();
-      this.matchSummaryData = new MatchSummaryData(componentStates);
+      this.matchSummaryData = new MatchSummaryData(
+        this.projectService.injectAssetPaths(componentStates)
+      );
       this.setBucketValues();
       this.setBucketData();
       this.setBucketShowMore();


### PR DESCRIPTION
## Changes in Teacher Tools
- Images in prompt for any activity don't appear
- Match images in buckets and choices don't appear

## Test
- Above is fixed

Closes #2250 
Closes #2285 
