### PR TITLE
fix(LabelService): Replace jQuery selector

### DIFF
--- a/src/assets/wise5/components/label/labelService.ts
+++ b/src/assets/wise5/components/label/labelService.ts
@@ -300,7 +300,10 @@ export class LabelService extends ComponentService {
     canvas.selection = false;
     canvas.hoverCursor = 'pointer';
     this.setCanvasDimension(canvas, width, height);
-    document.getElementById('canvasParent_' + canvasId).style.height = height + 2 + 'px';
+    const canvasParent = document.getElementById('canvasParent_' + canvasId);
+    if (canvasParent != null) {
+      canvasParent.style.height = height + 2 + 'px';
+    }
     return canvas;
   }
 

--- a/src/assets/wise5/components/label/labelService.ts
+++ b/src/assets/wise5/components/label/labelService.ts
@@ -300,7 +300,7 @@ export class LabelService extends ComponentService {
     canvas.selection = false;
     canvas.hoverCursor = 'pointer';
     this.setCanvasDimension(canvas, width, height);
-    $('#canvasParent_' + canvasId).css('height', height + 2);
+    document.getElementById('canvasParent_' + canvasId).style.height = height + 2 + 'px';
     return canvas;
   }
 


### PR DESCRIPTION
## Changes
Replace a jQuery selector with native js document selector. This was breaking the student work view for Label activities.

## Test
- Label activities work as before.
- You can view student work for Label activities in the Teacher Tools.
