### PR TITLE
fix(AIChat): Show student avatar when response is long

### DIFF
--- a/src/assets/wise5/components/aiChat/ai-chat-student-message/ai-chat-student-message.component.html
+++ b/src/assets/wise5/components/aiChat/ai-chat-student-message/ai-chat-student-message.component.html
@@ -6,7 +6,7 @@
     i18n-aria-label
     >account_circle</mat-icon
   >
-  <div class="flex justify-end flex-grow">
+  <div class="flex justify-end flex-1">
     <div class="response-text selected-bg-bg">
       <div class="mat-small secondary-text poster">{{ displayNames }}</div>
       <div [innerHtml]="message.content"></div>


### PR DESCRIPTION
## Changes
- Fixes display bug that was causing student avatar to be cut off for long student responses.

## Test
- Make sure student avatar is visible for long responses in AI Chat activities.

Closes #2294.
