### PR TITLE
feat(TeacherTools): Redesign Match summary to organize by choice

### DIFF
--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html
@@ -9,11 +9,13 @@
         @for (bucketDataPoint of choice.choiceDataPoints; track $index) {
           <li>
             <div class="bucket">
-              <mat-icon class="mat-18" aria-label="Bucket" i18n-aria-label>inventory_2</mat-icon>
-              <div [innerHTML]="bucketDataPoint.getBucketValue()"></div>
+              <mat-icon class="mat-18 shrink-0 mt-0.25" aria-label="Bucket" i18n-aria-label
+                >inventory_2</mat-icon
+              >
+              <div class="flex-1" [innerHTML]="bucketDataPoint.getBucketValue()"></div>
               <div class="shrink-0">
-                (<mat-icon class="mat-18 align-middle">person</mat-icon
-                >{{ bucketDataPoint.getCount() }})
+                <mat-icon class="mat-18 align-middle">person</mat-icon
+                >{{ bucketDataPoint.getCount() }}
               </div>
             </div>
           </li>

--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html
@@ -1,61 +1,49 @@
-<ng-template #bucketTemplate let-bucket="bucket" let-first="first">
-  <div class="bucket" [ngClass]="{ 'selected-bg-bg': first, 'notice-bg-bg': !first }">
+<ng-template #choiceTemplate let-choice="choice">
+  <div class="choice notice-bg-bg" [class.secondary-text]="choice.choiceDataPoints.length === 0">
     <h3 class="mat-body-2">
-      <span [innerHTML]="bucket.value"></span>
-      @if (first) {
-        (<span i18n>Source Bucket</span>)
-      }
+      <mat-icon class="mat-18 align-sub" aria-label="Item" i18n-aria-label>crop_16_9</mat-icon
+      >&nbsp;<span [innerHTML]="choice.choiceValue"></span>
     </h3>
-    <ul>
-      @for (choice of bucket.choices; track $index) {
-        @if ($index < 3 || getBucketShowMore(bucket.value)) {
+    @if (choice.choiceDataPoints.length > 0) {
+      <ul>
+        @for (bucketDataPoint of choice.choiceDataPoints; track $index) {
           <li>
-            <div class="choice">
-              <div [innerHTML]="choice.getId()"></div>
-              @if (!isChoiceReuseMatch || !first) {
-                <div class="shrink-0">
-                  (<mat-icon class="mat-18">person</mat-icon>{{ choice.getCount() }})
-                </div>
-              }
+            <div class="bucket">
+              <mat-icon class="mat-18" aria-label="Bucket" i18n-aria-label>inventory_2</mat-icon>
+              <div [innerHTML]="bucketDataPoint.getBucketValue()"></div>
+              <div class="shrink-0">
+                (<mat-icon class="mat-18 align-middle">person</mat-icon
+                >{{ bucketDataPoint.getCount() }})
+              </div>
             </div>
           </li>
         }
-      }
-      @if (bucket.choices.length > 3) {
-        <a href="#" class="text-sm px-1" (click)="toggleBucketShowMore(bucket.value, $event)">
-          @if (getBucketShowMore(bucket.value)) {
-            <span i18n>Show less</span>
-          } @else {
-            <span i18n>Show more</span>
-          }
-        </a>
-      }
-    </ul>
+      </ul>
+    } @else {
+      <div class="bucket">
+        <mat-icon class="mat-18" aria-label="Not moved" i18n-aria-label>do_not_disturb</mat-icon>
+        <div i18n>Not moved by any students</div>
+      </div>
+    }
   </div>
 </ng-template>
+
 <div [class.expanded]="expanded">
-  <h2 class="mat-subtitle-1" i18n>Choice Frequency</h2>
-  <div class="max-h-160 overflow-y-auto" [class.max-h-none]="expanded">
-    @if (bucketData.length > 0) {
-      <p i18n>
-        Number of teams that moved each item (choice) into the different buckets (categories).
+  <h2 class="mat-subtitle-1" i18n>Bucket Frequency</h2>
+  <div class="max-h-160 overflow-y-auto @container" [class.max-h-none]="expanded">
+    @if (choiceData.length > 0) {
+      <p class="!mt-0" i18n>
+        Number of times each item <mat-icon class="mat-18 align-sub">crop_16_9</mat-icon> was moved
+        into the different buckets <mat-icon class="mat-18 align-sub">inventory_2</mat-icon>.
       </p>
-      <div class="columns-3xs gap-2">
-        <div class="break-inside-avoid">
-          <ng-container
-            [ngTemplateOutlet]="bucketTemplate"
-            [ngTemplateOutletContext]="{ bucket: bucketData[0], first: true }"
-          />
-        </div>
-        @for (bucket of bucketData; track $index) {
-          @if ($index > 0) {
-            <div class="break-inside-avoid">
-              <ng-container
-                [ngTemplateOutlet]="bucketTemplate"
-                [ngTemplateOutletContext]="{ bucket: bucket, first: false }"
-              />
-            </div>
-          }
+      <div class="columns-1 @xl:columns-2 @4xl:columns-3 gap-2 mt-2">
+        @for (choice of choiceData; track $index) {
+          <div class="break-inside-avoid">
+            <ng-container
+              [ngTemplateOutlet]="choiceTemplate"
+              [ngTemplateOutletContext]="{ choice: choice }"
+            />
+          </div>
         }
       </div>
     } @else {

--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.scss
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.scss
@@ -11,7 +11,7 @@ h3,
 }
 
 .bucket {
-  @apply flex gap-1 px-2 py-1 mt-1 rounded-md bg-white border border-neutral-200 text-sm items-center;
+  @apply flex gap-1 px-2 py-1 mt-1 rounded-md bg-white border border-neutral-200 text-sm items-start justify-between;
 }
 
 ul {

--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.scss
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.scss
@@ -1,4 +1,4 @@
-@use "tailwindcss";
+@reference "tailwindcss";
 
 h3,
 .mat-subtitle-1 {
@@ -6,16 +6,12 @@ h3,
   margin-top: 0;
 }
 
-.bucket {
+.choice {
   @apply p-2 mb-2 rounded-md;
 }
 
-.choice {
-  @apply flex gap-1 px-2 py-1 mt-1 rounded-md bg-white border border-neutral-200 text-sm;
-}
-
-.mat-icon {
-  vertical-align: middle;
+.bucket {
+  @apply flex gap-1 px-2 py-1 mt-1 rounded-md bg-white border border-neutral-200 text-sm items-center;
 }
 
 ul {

--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.spec.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.spec.ts
@@ -51,45 +51,40 @@ describe('MatchSummaryDisplayComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should show the correct number of buckets and choices', () => {
-    expect(fixtureQueryAll(fixture, '.bucket').length).toEqual(3);
+  it('should display one card per unique choice', () => {
     expect(fixtureQueryAll(fixture, '.choice').length).toEqual(5);
-    fixture.nativeElement.querySelector('a').click();
-    fixture.detectChanges();
-    expect(fixtureQueryAll(fixture, '.choice').length).toEqual(6);
   });
 
-  it('should only show Show more button if more than 3 choices in bucket', () => {
-    expect(fixtureQueryAll(fixture, 'a').length).toEqual(1);
+  it('should order choices by total count descending then alphabetically', () => {
+    const cards = fixtureQueryAll(fixture, '.choice');
+    const labels = Array.from(cards).map((el) => el.querySelector('h3')?.textContent?.trim());
+    expect(labels[0]).toContain('Choice B');
+    expect(labels[1]).toContain('Choice D');
+    expect(labels[2]).toContain('Choice C');
+    expect(labels[3]).toContain('Choice E');
+    expect(labels[4]).toContain('Choice A');
   });
 
-  it('should display choices within bucket sorted by count', () => {
-    const choices = fixtureQueryAll(fixture, '.choice');
-    expect(choices[0].textContent.includes('Choice B'));
-    expect(choices[1].textContent.includes('Choice A'));
-    expect(choices[2].textContent.includes('Choice C'));
-    expect(choices[3].textContent.includes('Choice D'));
+  it('should show bucket rows sorted by count within each choice', () => {
+    const cards = fixtureQueryAll(fixture, '.choice');
+    const choiceDCard = cards[1];
+    const bucketRows = choiceDCard.querySelectorAll('.bucket');
+    expect(bucketRows.length).toEqual(2);
+    expect(bucketRows[0].textContent).toContain('Bucket 2');
+    expect(bucketRows[0].textContent).toContain('2');
   });
 
-  it('should show the correct count on each choice per bucket', () => {
-    const choices = fixtureQueryAll(fixture, '.choice');
-    expect(choices[0].textContent.includes('3'));
-    expect(choices[1].textContent.includes('2'));
-    expect(choices[2].textContent.includes('2'));
-    expect(choices[3].textContent.includes('1'));
+  it('should show the correct count for Choice B in Bucket 1', () => {
+    const cards = fixtureQueryAll(fixture, '.choice');
+    const choiceBCard = cards[0];
+    expect(choiceBCard.textContent).toContain('3');
   });
 
-  it('should change Show more to Show less when clicked', () => {
-    let button = fixture.nativeElement.querySelector('a');
-    expect(button.innerText).toEqual('Show more');
-    button.click();
-    fixture.detectChanges();
-    button = fixture.nativeElement.querySelector('a');
-    expect(button.innerText).toEqual('Show less');
-    button.click();
-    fixture.detectChanges();
-    button = fixture.nativeElement.querySelector('a');
-    expect(button.innerText).toEqual('Show more');
+  it('should show "Not moved by any students" for choices left in the source bucket', () => {
+    const cards = fixtureQueryAll(fixture, '.choice');
+    const choiceACard = cards[4];
+    expect(choiceACard.textContent).toContain('Not moved by any students');
+    expect(choiceACard.querySelectorAll('.bucket').length).toEqual(1);
   });
 });
 
@@ -114,17 +109,18 @@ function getComponentStates(): any {
             id: '0',
             type: 'bucket',
             value: 'Choices',
-            items: []
-          },
-          {
-            id: 'b1',
-            value: 'Bucket 1',
             items: [
               {
                 isIncorrectPosition: null,
                 id: 'a',
                 value: 'Choice A'
-              },
+              }
+            ]
+          },
+          {
+            id: 'b1',
+            value: 'Bucket 1',
+            items: [
               {
                 isIncorrectPosition: null,
                 id: 'b',
@@ -169,17 +165,18 @@ function getComponentStates(): any {
             id: '0',
             type: 'bucket',
             value: 'Choices',
-            items: []
-          },
-          {
-            id: 'b1',
-            value: 'Bucket 1',
             items: [
               {
                 isIncorrectPosition: null,
                 id: 'a',
                 value: 'Choice A'
-              },
+              }
+            ]
+          },
+          {
+            id: 'b1',
+            value: 'Bucket 1',
+            items: [
               {
                 isIncorrectPosition: null,
                 id: 'b',
@@ -240,7 +237,13 @@ function getComponentStates(): any {
           {
             id: 'b2',
             value: 'Bucket 2',
-            items: []
+            items: [
+              {
+                isIncorrectPosition: null,
+                id: 'b',
+                value: 'Choice D'
+              }
+            ]
           }
         ]
       },

--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, Input, OnInit } from '@angular/core';
-import { MatchContent } from '../../../components/match/MatchContent';
-import { MatchSummaryData } from '../summary-data/MatchSummaryData';
+import { ChoiceData, MatchSummaryData } from '../summary-data/MatchSummaryData';
 import { MatchSummaryDataPoint } from '../summary-data/MatchSummaryDataPoint';
 import { MatIconModule } from '@angular/material/icon';
 import { TeacherSummaryDisplayComponent } from '../teacher-summary-display.component';
@@ -16,71 +15,45 @@ import { TeacherSummaryDisplayComponent } from '../teacher-summary-display.compo
   templateUrl: './match-summary-display.component.html'
 })
 export class MatchSummaryDisplayComponent extends TeacherSummaryDisplayComponent implements OnInit {
-  protected bucketData: { value: string; choices: MatchSummaryDataPoint[] }[] = [];
-  private bucketsShowMore: Map<string, boolean> = new Map<string, boolean>();
-  private bucketValues: Set<string> = new Set<string>();
+  protected choiceData: ChoiceData[] = [];
   @Input() expanded: boolean;
-  protected isChoiceReuseMatch: boolean;
   private matchSummaryData: MatchSummaryData;
 
   ngOnInit(): void {
-    this.setIsChoiceReuseMatch();
     this.generateSummary();
-  }
-
-  private setIsChoiceReuseMatch(): void {
-    this.isChoiceReuseMatch = (
-      this.projectService.getComponent(this.nodeId, this.componentId) as MatchContent
-    ).choiceReuseEnabled;
   }
 
   private generateSummary(): void {
     this.getLatestWork().subscribe((componentStates) => {
-      this.bucketData = [];
-      this.bucketValues.clear();
+      this.choiceData = [];
       this.matchSummaryData = new MatchSummaryData(
         this.projectService.injectAssetPaths(componentStates)
       );
-      this.setBucketValues();
-      this.setBucketData();
-      this.setBucketShowMore();
+      this.setChoiceData();
     });
   }
 
-  protected setBucketValues(): void {
-    this.matchSummaryData
-      .getBucketsData()
-      .forEach((bucket) => this.bucketValues.add(bucket.bucketValue));
+  protected setChoiceData(): void {
+    this.matchSummaryData.getChoicesData().forEach((choice) => {
+      this.choiceData.push({
+        choiceValue: choice.choiceValue,
+        choiceDataPoints: choice.choiceDataPoints.sort(this.sortBuckets)
+      });
+    });
+    this.choiceData.sort(this.sortChoices);
   }
 
-  protected setBucketData(): void {
-    this.bucketValues.forEach((value) =>
-      this.bucketData.push({ value: value, choices: this.getBucketDataByValue(value) })
-    );
+  private getTotalCount(choice: ChoiceData): number {
+    return choice.choiceDataPoints.reduce((sum, dp) => sum + dp.getCount(), 0);
   }
 
-  private getBucketDataByValue(bucketValue: string): MatchSummaryDataPoint[] {
-    return this.matchSummaryData
-      .getBucketsData()
-      .find((bucket) => bucket.bucketValue === bucketValue)
-      .bucketDataPoints.sort(this.sortChoices);
-  }
+  private sortChoices = (a: ChoiceData, b: ChoiceData): number => {
+    const countDiff = this.getTotalCount(b) - this.getTotalCount(a);
+    return countDiff !== 0 ? countDiff : a.choiceValue.localeCompare(b.choiceValue);
+  };
 
-  private sortChoices(choiceA: MatchSummaryDataPoint, choiceB: MatchSummaryDataPoint): number {
-    return choiceB.getCount() - choiceA.getCount();
-  }
-
-  private setBucketShowMore(): void {
-    this.bucketValues.forEach((value) => this.bucketsShowMore.set(value, false));
-  }
-
-  protected getBucketShowMore(bucketValue: string): boolean {
-    return this.bucketsShowMore.get(bucketValue);
-  }
-
-  protected toggleBucketShowMore(bucketValue: string, event: Event): void {
-    event.preventDefault();
-    this.bucketsShowMore.set(bucketValue, !this.bucketsShowMore.get(bucketValue));
+  private sortBuckets(a: MatchSummaryDataPoint, b: MatchSummaryDataPoint): number {
+    return b.getCount() - a.getCount();
   }
 
   protected renderDisplay(): void {

--- a/src/assets/wise5/directives/teacher-summary-display/summary-data/MatchSummaryData.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/summary-data/MatchSummaryData.ts
@@ -2,84 +2,74 @@ import { ComponentState } from '../../../../../app/domain/componentState';
 import { MatchSummaryDataPoint } from './MatchSummaryDataPoint';
 import { SummaryData } from '../../summary-display/summary-data/SummaryData';
 
-type BucketData = { bucketValue: string; bucketDataPoints: MatchSummaryDataPoint[] };
+export type ChoiceData = { choiceValue: string; choiceDataPoints: MatchSummaryDataPoint[] };
 
 /**
- * Summary data for all choices in all buckets
+ * Summary data for all choices, each with a breakdown per bucket
  */
 export class MatchSummaryData extends SummaryData {
-  private isOrderedMatch: boolean;
-  protected bucketsData: BucketData[] = [];
+  protected choicesData: ChoiceData[] = [];
 
   constructor(componentStates: ComponentState[]) {
     super();
-    this.extractBucketData(componentStates);
+    this.extractChoiceData(componentStates);
   }
 
-  getBucketsData(): BucketData[] {
-    return this.bucketsData;
+  getChoicesData(): ChoiceData[] {
+    return this.choicesData;
   }
 
-  private extractBucketData(componentStates: ComponentState[]): void {
+  private extractChoiceData(componentStates: ComponentState[]): void {
     componentStates.forEach((componentState) => {
-      componentState.studentData.buckets.forEach((bucketStudentData) => {
-        const newBucketData = { bucketValue: bucketStudentData.value, bucketDataPoints: [] };
-        bucketStudentData.items.forEach((item) => {
-          this.extractChoiceDataPerBucket(item.value, bucketStudentData.value, newBucketData);
-          this.checkIsOrderedMatch(item.isIncorrectPosition);
-        });
-        this.addNewBucketDataToSummaryData(newBucketData);
+      componentState.studentData.buckets.forEach((bucketStudentData, index) => {
+        if (index === 0) {
+          bucketStudentData.items.forEach((item) => this.registerChoice(item.value));
+        } else {
+          bucketStudentData.items.forEach((item) => {
+            this.extractBucketDataPerChoice(item.value, bucketStudentData.value);
+          });
+        }
       });
     });
   }
 
-  private extractChoiceDataPerBucket(
-    itemValue: string,
-    bucketValue: string,
-    bucketData: BucketData
-  ): void {
-    const summaryDataPoint = this.findSummaryDataPoint(itemValue, bucketValue);
-    if (summaryDataPoint) {
-      summaryDataPoint.incrementCount(1);
+  private registerChoice(choiceValue: string): void {
+    if (!this.findChoiceByValue(choiceValue)) {
+      this.choicesData.push({ choiceValue, choiceDataPoints: [] });
+    }
+  }
+
+  private extractBucketDataPerChoice(choiceValue: string, bucketValue: string): void {
+    const dataPoint = this.findSummaryDataPoint(choiceValue, bucketValue);
+    if (dataPoint) {
+      dataPoint.incrementCount(1);
     } else {
-      const newDataPoint = new MatchSummaryDataPoint(itemValue, 1, bucketValue);
+      const newDataPoint = new MatchSummaryDataPoint(bucketValue, 1, choiceValue);
       this.summaryDataPoints.push(newDataPoint);
-      bucketData.bucketDataPoints.push(newDataPoint);
+      this.addDataPointToChoiceData(choiceValue, newDataPoint);
     }
   }
 
-  private addNewBucketDataToSummaryData(newBucketData: BucketData): void {
-    const bucketMatch = this.findBucketByValue(newBucketData.bucketValue);
-    if (bucketMatch) {
-      bucketMatch.bucketDataPoints = bucketMatch.bucketDataPoints.concat(
-        newBucketData.bucketDataPoints
-      );
+  private addDataPointToChoiceData(choiceValue: string, dataPoint: MatchSummaryDataPoint): void {
+    const choiceMatch = this.findChoiceByValue(choiceValue);
+    if (choiceMatch) {
+      choiceMatch.choiceDataPoints.push(dataPoint);
     } else {
-      this.bucketsData.push(newBucketData);
+      this.choicesData.push({ choiceValue, choiceDataPoints: [dataPoint] });
     }
   }
 
-  private findBucketByValue(bucketValue: string): BucketData {
-    return this.bucketsData.find((bucketData) => bucketData.bucketValue === bucketValue);
+  private findChoiceByValue(choiceValue: string): ChoiceData {
+    return this.choicesData.find((c) => c.choiceValue === choiceValue);
   }
 
-  private findSummaryDataPoint(itemValue: string, bucketValue: string): MatchSummaryDataPoint {
-    return this.bucketsData
-      .find((bucket) => bucket.bucketValue === bucketValue)
-      ?.bucketDataPoints.find((dataPoint) => dataPoint.getId() === itemValue);
-  }
-
-  private checkIsOrderedMatch(isIncorrectPosition: boolean): void {
-    if (!this.isOrderedMatch) {
-      this.isOrderedMatch = [true, false].includes(isIncorrectPosition);
-    }
+  private findSummaryDataPoint(choiceValue: string, bucketValue: string): MatchSummaryDataPoint {
+    return this.choicesData
+      .find((c) => c.choiceValue === choiceValue)
+      ?.choiceDataPoints.find((dp) => dp.getBucketValue() === bucketValue);
   }
 
   protected generateNewDataPoint(id: string | number): MatchSummaryDataPoint {
     return new MatchSummaryDataPoint(id);
-  }
-
-  getIsOrderedMatch(): boolean {
-    return this.isOrderedMatch;
   }
 }

--- a/src/assets/wise5/directives/teacher-summary-display/summary-data/MatchSummaryDataPoint.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/summary-data/MatchSummaryDataPoint.ts
@@ -4,14 +4,18 @@ import { SummaryDataPoint } from '../../summary-display/summary-data/SummaryData
  * Summary data for one choice in one bucket
  */
 export class MatchSummaryDataPoint extends SummaryDataPoint {
-  private bucketValue: string;
+  private choiceValue: string;
 
-  constructor(id: number | string, count?: number, bucketValue?: string) {
+  constructor(id: number | string, count?: number, choiceValue?: string) {
     super(id, count);
-    this.bucketValue = bucketValue;
+    this.choiceValue = choiceValue;
+  }
+
+  getChoiceValue(): string {
+    return this.choiceValue;
   }
 
   getBucketValue(): string {
-    return this.bucketValue;
+    return this.getId() as string;
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -15155,10 +15155,6 @@ Are you sure you want to proceed?</source>
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ideas-summary/ideas-summary.component.html</context>
           <context context-type="linenumber">74,77</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">29,35</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="4492261521538997006" datatype="html">
         <source> Team has not saved any work </source>
@@ -15877,6 +15873,10 @@ Are you sure you want to proceed?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/select-step-and-component-checkboxes/select-step-and-component-checkboxes.component.html</context>
           <context context-type="linenumber">61,63</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
+          <context context-type="linenumber">4,5</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8313145553257511938" datatype="html">
@@ -22704,10 +22704,6 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ideas-summary/ideas-summary.component.html</context>
           <context context-type="linenumber">72,74</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">27,30</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="4191006504398748947" datatype="html">
         <source>Your students&apos; ideas will show up here as they are detected in the activity.</source>
@@ -22716,32 +22712,46 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">77,81</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="5353710433603859763" datatype="html">
-        <source>Source Bucket</source>
+      <trans-unit id="8720332287407681000" datatype="html">
+        <source>Bucket</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">6,10</context>
+          <context context-type="linenumber">12,13</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="5731986766999662576" datatype="html">
-        <source>Choice Frequency</source>
+      <trans-unit id="3656239217373666781" datatype="html">
+        <source>Not moved</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">37,38</context>
+          <context context-type="linenumber">24,25</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7051463422291865328" datatype="html">
-        <source> Number of teams that moved each item (choice) into the different buckets (categories). </source>
+      <trans-unit id="6966354927154117696" datatype="html">
+        <source>Not moved by any students</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">41,44</context>
+          <context context-type="linenumber">25,31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3730845672011729296" datatype="html">
+        <source>Bucket Frequency</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
+          <context context-type="linenumber">32,33</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7095065065333948401" datatype="html">
+        <source> Number of times each item <x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon class=&quot;mat-18 align-sub&quot;&gt;"/>crop_16_9<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/> was moved into the different buckets <x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon class=&quot;mat-18 align-sub&quot;&gt;"/>inventory_2<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/>. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
+          <context context-type="linenumber">36,39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2004123481203797507" datatype="html">
         <source> Your students&apos; choices will show up here when they complete the activity. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">63,68</context>
+          <context context-type="linenumber">51,56</context>
         </context-group>
       </trans-unit>
       <trans-unit id="866753876041645935" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -22716,42 +22716,42 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Bucket</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">12,13</context>
+          <context context-type="linenumber">12,15</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3656239217373666781" datatype="html">
         <source>Not moved</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">24,25</context>
+          <context context-type="linenumber">26,27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6966354927154117696" datatype="html">
         <source>Not moved by any students</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">25,31</context>
+          <context context-type="linenumber">27,33</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3730845672011729296" datatype="html">
         <source>Bucket Frequency</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">32,33</context>
+          <context context-type="linenumber">34,35</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7095065065333948401" datatype="html">
         <source> Number of times each item <x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon class=&quot;mat-18 align-sub&quot;&gt;"/>crop_16_9<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/> was moved into the different buckets <x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon class=&quot;mat-18 align-sub&quot;&gt;"/>inventory_2<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/>. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">36,39</context>
+          <context context-type="linenumber">38,41</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2004123481203797507" datatype="html">
         <source> Your students&apos; choices will show up here when they complete the activity. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">51,56</context>
+          <context context-type="linenumber">53,58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="866753876041645935" datatype="html">


### PR DESCRIPTION
## Changes
- Instead of showing each bucket, Match summaries now show each choice with the number of times the choice was moved into different buckets.

<img width="1268" height="535" alt="Screenshot 2026-04-06 at 11 15 13 AM" src="https://github.com/user-attachments/assets/14027d7e-4678-40e3-9acb-3acc6641696f" />

## Test
- In the Teacher Tools, ensure that Match summaries now list all the choices instead of buckets, with the number of times the choice was moved to different buckets.
- Choices should be ordered by total number of times they were moved to any bucket, then alphabetically.
- Choices that were not moved by any students to any buckets should say so and have lighter gray text.
