### PR TITLE
feat(Idea Summary): Dialog to view more responses

### DIFF
--- a/src/assets/wise5/directives/teacher-summary-display/idea-summary-dialog/idea-summary-dialog.component.html
+++ b/src/assets/wise5/directives/teacher-summary-display/idea-summary-dialog/idea-summary-dialog.component.html
@@ -1,18 +1,18 @@
 <h2 mat-dialog-title>
-  <span i18n>Responses for "{{ data.idea.text }}"</span>
-  <span class="font-normal text-sm items-center">
-    <mat-icon class="mat-18">person</mat-icon>{{ data.idea.count }}
-  </span>
+  <span i18n>Responses for "{{ data.idea.text }}"</span> ({{ data.idea.count }})
 </h2>
-<mat-dialog-content class="dialog-content-scroll">
-  @for (response of data.responses; track response.timestamp) {
-    <p>
-      <span>{{ response.text }}</span>
-      <span class="font-normal text-sm flex items-center">
-        <mat-icon class="mat-18">person</mat-icon>{{ response.usernames }}
-      </span>
-    </p>
-  }
+<mat-dialog-content class="dialog-content-scroll @container">
+  <div class="@2xl:columns-2 @4xl:columns-3 gap-2">
+    @for (response of data.responses; track response.timestamp) {
+      <div class="rounded-md bg-white p-2 mb-2 break-inside-avoid-column">
+        <div class="font-normal flex gap-2 mb-2">
+          <mat-icon class="shrink-0" [style.color]="response.avatarColor">account_circle</mat-icon>
+          <span class="mt-0.5">{{ response.usernames }}</span>
+        </div>
+        <div>"{{ response.text }}"</div>
+      </div>
+    }
+  </div>
 </mat-dialog-content>
 <mat-dialog-actions align="end">
   <button mat-button mat-dialog-close cdkFocusRegionstart i18n>Close</button>

--- a/src/assets/wise5/directives/teacher-summary-display/idea-summary-dialog/idea-summary-dialog.component.html
+++ b/src/assets/wise5/directives/teacher-summary-display/idea-summary-dialog/idea-summary-dialog.component.html
@@ -1,0 +1,19 @@
+<h2 mat-dialog-title>
+  <span i18n>Responses for "{{ data.idea.text }}"</span>
+  <span class="font-normal text-sm items-center">
+    <mat-icon class="mat-18">person</mat-icon>{{ data.idea.count }}
+  </span>
+</h2>
+<mat-dialog-content class="dialog-content-scroll">
+  @for (response of data.responses; track response.timestamp) {
+    <p>
+      <span>{{ response.text }}</span>
+      <span class="font-normal text-sm flex items-center">
+        <mat-icon class="mat-18">person</mat-icon>{{ response.usernames }}
+      </span>
+    </p>
+  }
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close cdkFocusRegionstart i18n>Close</button>
+</mat-dialog-actions>

--- a/src/assets/wise5/directives/teacher-summary-display/idea-summary-dialog/idea-summary-dialog.component.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/idea-summary-dialog/idea-summary-dialog.component.ts
@@ -1,0 +1,12 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  imports: [MatButtonModule, MatDialogModule, MatIconModule],
+  templateUrl: './idea-summary-dialog.component.html'
+})
+export class IdeaSummaryDialogComponent {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: { idea: any; responses: any[] }) {}
+}

--- a/src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.html
+++ b/src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.html
@@ -15,9 +15,12 @@
     </mat-panel-description>
   </mat-expansion-panel-header>
   <div class="text-sm bg-white p-1 rounded">
-    <span i18n>Sample responses:</span>
+    <div class="flex">
+      <span i18n>Sample responses:</span><span class="flex-grow"></span
+      ><a (click)="showAllResponses()" i18n>View all</a><mat-icon>arrow_drop_down</mat-icon>
+    </div>
     <ul>
-      @for (response of responses; track response.timestamp) {
+      @for (response of sampleResponses; track response.timestamp) {
         <li i18n>"{{ response.text }}"</li>
       }
     </ul>

--- a/src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.html
+++ b/src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.html
@@ -15,13 +15,13 @@
     </mat-panel-description>
   </mat-expansion-panel-header>
   <div class="text-sm bg-white p-1 rounded">
-    <div class="flex">
-      <span i18n>Sample responses:</span><span class="flex-grow"></span
-      ><a (click)="showAllResponses()" i18n>View all</a><mat-icon>arrow_drop_down</mat-icon>
+    <div class="flex flex-wrap justify-between gap-2">
+      <span i18n>Sample responses:</span>
+      <a (click)="showAllResponses()" i18n>View all</a>
     </div>
     <ul>
       @for (response of sampleResponses; track response.timestamp) {
-        <li i18n>"{{ response.text }}"</li>
+        <li>"{{ response.text }}"</li>
       }
     </ul>
   </div>

--- a/src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.spec.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.spec.ts
@@ -59,6 +59,10 @@ describe('IdeaSummaryComponent', () => {
       count: 5,
       color: 'red'
     };
+    component['workgroups'] = [
+      { workgroupId: 1, displayNames: 'student1' },
+      { workgroupId: 2, displayNames: 'student2' }
+    ];
   });
 
   describe('initial state', () => {

--- a/src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.ts
@@ -6,6 +6,7 @@ import { ComponentState } from '../../../../../app/domain/componentState';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatDialog } from '@angular/material/dialog';
 import { IdeaSummaryDialogComponent } from '../idea-summary-dialog/idea-summary-dialog.component';
+import { getAvatarColorForWorkgroupId } from '../../../common/workgroup/workgroup';
 
 interface IdeaCategory {
   id: string;
@@ -78,6 +79,7 @@ export class IdeaSummaryComponent extends TeacherSummaryDisplayComponent {
           // which is before the computer response
           const studentResponse = responses[index - 1];
           studentResponse.usernames = this.getDisplayNames(state.workgroupId);
+          studentResponse.avatarColor = getAvatarColorForWorkgroupId(state.workgroupId);
           responsesWithIdea.push(studentResponse);
           workgroupsProcessed.push(state.workgroupId);
         }
@@ -97,7 +99,8 @@ export class IdeaSummaryComponent extends TeacherSummaryDisplayComponent {
       .map((state) => ({
         text: state.studentData.response,
         timestamp: state.clientSaveTime,
-        usernames: this.getDisplayNames(state.workgroupId)
+        usernames: this.getDisplayNames(state.workgroupId),
+        avatarColor: getAvatarColorForWorkgroupId(state.workgroupId)
       }));
   }
 

--- a/src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.ts
@@ -1,9 +1,11 @@
-import { Component, Input, ViewEncapsulation } from '@angular/core';
+import { Component, inject, Input, ViewEncapsulation } from '@angular/core';
 import { MatIcon } from '@angular/material/icon';
 import { TeacherSummaryDisplayComponent } from '../teacher-summary-display.component';
 import { firstValueFrom } from 'rxjs';
 import { ComponentState } from '../../../../../app/domain/componentState';
 import { MatExpansionModule } from '@angular/material/expansion';
+import { MatDialog } from '@angular/material/dialog';
+import { IdeaSummaryDialogComponent } from '../idea-summary-dialog/idea-summary-dialog.component';
 
 interface IdeaCategory {
   id: string;
@@ -15,6 +17,7 @@ interface IdeaCategory {
 interface Response {
   text: string;
   timestamp: number;
+  usernames: string;
 }
 
 @Component({
@@ -25,12 +28,21 @@ interface Response {
   templateUrl: './idea-summary.component.html'
 })
 export class IdeaSummaryComponent extends TeacherSummaryDisplayComponent {
+  private dialog = inject(MatDialog);
+
   @Input() componentId: string;
   @Input() idea: IdeaCategory;
   @Input() nodeId: string;
 
   protected expanded: boolean = false;
   protected responses: Response[] = [];
+  protected sampleResponses: Response[] = [];
+  private workgroups: any[] = [];
+
+  ngOnInit(): void {
+    super.ngOnInit();
+    this.workgroups = this.configService.getClassmateUserInfos();
+  }
 
   protected renderDisplay(): void {
     super.renderDisplay();
@@ -52,9 +64,7 @@ export class IdeaSummaryComponent extends TeacherSummaryDisplayComponent {
     } else if (component.type === 'OpenResponse') {
       this.responses = this.getORResponsesWithIdea(states, this.idea.id);
     }
-    if (this.responses.length > 2) {
-      this.responses = this.responses.slice(0, 2); // only show 2 responses max
-    }
+    this.sampleResponses = this.responses.slice(0, 2); // only show 2 responses max
   }
 
   private getDGResponsesWithIdea(states: ComponentState[], ideaId: string): Response[] {
@@ -66,7 +76,9 @@ export class IdeaSummaryComponent extends TeacherSummaryDisplayComponent {
         if (response?.ideas?.some((idea) => idea.detected && idea.name === ideaId)) {
           // computer responses contain ideas detected, but we want the actual student response
           // which is before the computer response
-          responsesWithIdea.push(responses[index - 1]);
+          const studentResponse = responses[index - 1];
+          studentResponse.usernames = this.getDisplayNames(state.workgroupId);
+          responsesWithIdea.push(studentResponse);
           workgroupsProcessed.push(state.workgroupId);
         }
       });
@@ -84,7 +96,22 @@ export class IdeaSummaryComponent extends TeacherSummaryDisplayComponent {
       .filter((state) => annotations.some((annotation) => annotation.studentWorkId === state.id))
       .map((state) => ({
         text: state.studentData.response,
-        timestamp: state.clientSaveTime
+        timestamp: state.clientSaveTime,
+        usernames: this.getDisplayNames(state.workgroupId)
       }));
+  }
+
+  private getDisplayNames(workgroupId: number): string {
+    return this.workgroups.find((workgroup) => workgroup.workgroupId === workgroupId).displayNames;
+  }
+
+  protected showAllResponses(): void {
+    this.dialog.open(IdeaSummaryDialogComponent, {
+      data: {
+        idea: this.idea,
+        responses: this.responses
+      },
+      panelClass: ['app-styles', 'dialog-lg']
+    });
   }
 }

--- a/src/assets/wise5/services/configService.ts
+++ b/src/assets/wise5/services/configService.ts
@@ -241,13 +241,10 @@ export class ConfigService {
     return null;
   }
 
-  setClassmateDisplayNames() {
-    let classmateUserInfos = this.getClassmateUserInfos();
-    if (classmateUserInfos) {
-      for (let workgroup of classmateUserInfos) {
-        workgroup.displayNames = this.getDisplayUsernamesByWorkgroupId(workgroup.workgroupId);
-      }
-    }
+  private setClassmateDisplayNames(): void {
+    this.getClassmateUserInfos()?.forEach((workgroup) => {
+      workgroup.displayNames = this.getDisplayUsernamesByWorkgroupId(workgroup.workgroupId);
+    });
   }
 
   /**

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -22685,14 +22685,14 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Responses for &quot;<x id="INTERPOLATION" equiv-text="{{ data.idea.text }}"/>&quot;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/idea-summary-dialog/idea-summary-dialog.component.html</context>
-          <context context-type="linenumber">2,3</context>
+          <context context-type="linenumber">2</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3690771652722848805" datatype="html">
         <source>Sample responses:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.html</context>
-          <context context-type="linenumber">19,20</context>
+          <context context-type="linenumber">19,21</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2734780694152757859" datatype="html">
@@ -22700,13 +22700,6 @@ If this problem continues, let your teacher know and move on to the next activit
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.html</context>
           <context context-type="linenumber">20,23</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4302009595680225393" datatype="html">
-        <source>&quot;<x id="INTERPOLATION" equiv-text="{{ response.text }}"/>&quot;</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.html</context>
-          <context context-type="linenumber">24,26</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1563518905064973119" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -350,6 +350,10 @@
           <context context-type="linenumber">13,19</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/idea-summary-dialog/idea-summary-dialog.component.html</context>
+          <context context-type="linenumber">18,20</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/vle/notifications-dialog/notifications-dialog.component.html</context>
           <context context-type="linenumber">74,76</context>
         </context-group>
@@ -14344,7 +14348,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/configService.ts</context>
-          <context context-type="linenumber">563</context>
+          <context context-type="linenumber">560</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5008745968518267369" datatype="html">
@@ -22677,18 +22681,32 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">27,32</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="7967732284579375900" datatype="html">
+        <source>Responses for &quot;<x id="INTERPOLATION" equiv-text="{{ data.idea.text }}"/>&quot;</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/idea-summary-dialog/idea-summary-dialog.component.html</context>
+          <context context-type="linenumber">2,3</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="3690771652722848805" datatype="html">
         <source>Sample responses:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.html</context>
-          <context context-type="linenumber">18,20</context>
+          <context context-type="linenumber">19,20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2734780694152757859" datatype="html">
+        <source>View all</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.html</context>
+          <context context-type="linenumber">20,23</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4302009595680225393" datatype="html">
         <source>&quot;<x id="INTERPOLATION" equiv-text="{{ response.text }}"/>&quot;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/idea-summary/idea-summary.component.html</context>
-          <context context-type="linenumber">21,23</context>
+          <context context-type="linenumber">24,26</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1563518905064973119" datatype="html">


### PR DESCRIPTION
Right now, the teacher can only see up to 2 responses in the Idea Summary for each idea. This change add a link that opens a dialog that allows the teacher to view all the responses that had that idea, along with the students' names.

![Screenshot 2026-04-09 at 4 00 50 PM](https://github.com/user-attachments/assets/17aec711-8aab-4c4b-90e6-a7b73a6e6d08)

## Notes
Please style as you see fit!

## Changes
- Add a "view more" link in each idea summary box. 
- Clicking on this link opens a dialog that shows all the responses that had that idea, along with the students' names.

## Test
- Above works as described, for both OR and DG activities