### PR TITLE
style(Component Selection): Group by function

### DIFF
--- a/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html
+++ b/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html
@@ -1,22 +1,18 @@
 <h2 mat-dialog-title i18n>Add New Activity</h2>
-<mat-dialog-content>
+<mat-dialog-content class="@container">
   <p class="flex flex-wrap justify-start items-center gap-2">
     <span i18n>Select the activity you want to add or</span>
     <button mat-raised-button color="primary" (click)="goToImportComponent()" i18n>
       import from another unit
     </button>
   </p>
-  <div class="flex flex-wrap justify-start items-center">
+  <div class="@lg:columns-2 @2xl:columns-3 @4xl:columns-4 gap-2">
     @for (componentGroup of componentGroups; track componentGroup.name) {
-      <div class="flex flex-col" style="border: 2px dotted">
-        <h3 class="mat-subheading-1">{{ componentGroup.name }}</h3>
-        @for (componentType of componentGroup.types; track componentType.type) {
-          <component-type-button
-            [componentType]="componentType.type"
-            (componentSelectedEvent)="selectComponent(componentType.type)"
-          />
-        }
-      </div>
+      <component-type-group
+        class="mb-2 block break-inside-avoid-column"
+        [componentGroup]="componentGroup"
+        (componentSelectedEvent)="selectComponent($event.type)"
+      />
     }
   </div>
 </mat-dialog-content>

--- a/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html
+++ b/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html
@@ -7,11 +7,16 @@
     </button>
   </p>
   <div class="flex flex-wrap justify-start items-center">
-    @for (componentType of componentTypes; track componentType.type) {
-      <component-type-button
-        [componentType]="componentType.type"
-        (componentSelectedEvent)="selectComponent(componentType.type)"
-      />
+    @for (componentGroup of componentGroups; track componentGroup.name) {
+      <div class="flex flex-col" style="border: 2px dotted">
+        <h3 class="mat-subheading-1">{{ componentGroup.name }}</h3>
+        @for (componentType of componentGroup.types; track componentType.type) {
+          <component-type-button
+            [componentType]="componentType.type"
+            (componentSelectedEvent)="selectComponent(componentType.type)"
+          />
+        }
+      </div>
     }
   </div>
 </mat-dialog-content>

--- a/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.ts
+++ b/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.ts
@@ -10,7 +10,7 @@ import { ComponentTypeService } from '../../../../assets/wise5/services/componen
   templateUrl: 'choose-new-component.component.html'
 })
 export class ChooseNewComponent {
-  protected componentTypes: any[];
+  protected componentGroups: any[];
 
   constructor(
     private componentTypeService: ComponentTypeService,
@@ -18,7 +18,7 @@ export class ChooseNewComponent {
   ) {}
 
   ngOnInit(): void {
-    this.componentTypes = this.componentTypeService.getComponentTypes();
+    this.componentGroups = this.componentTypeService.getComponentGroups();
   }
 
   protected goToImportComponent(): void {

--- a/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.ts
+++ b/src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.ts
@@ -1,11 +1,11 @@
 import { Component } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
-import { ComponentTypeButtonComponent } from '../../../../assets/wise5/authoringTool/components/component-type-button/component-type-button.component';
+import { ComponentTypeGroupComponent } from '../../component-type-group/component-type-group.component';
 import { ComponentTypeService } from '../../../../assets/wise5/services/componentTypeService';
 
 @Component({
-  imports: [ComponentTypeButtonComponent, MatButtonModule, MatDialogModule],
+  imports: [ComponentTypeGroupComponent, MatButtonModule, MatDialogModule],
   styles: ['component-type-button { width: 250px; padding: 4px; }'],
   templateUrl: 'choose-new-component.component.html'
 })

--- a/src/app/authoring-tool/component-type-group/component-type-group.component.html
+++ b/src/app/authoring-tool/component-type-group/component-type-group.component.html
@@ -1,0 +1,17 @@
+<mat-card appearance="filled">
+  <mat-card-header>
+    <mat-card-title class="pb-2">{{ componentGroup.name }}</mat-card-title>
+  </mat-card-header>
+  <mat-card-content>
+    <div class="@container">
+      <div class="grid @sm:grid-cols-2 gap-2">
+        @for (componentType of componentGroup.types; track componentType.type) {
+          <component-type-button
+            [componentType]="componentType.type"
+            (componentSelectedEvent)="componentSelectedEvent.emit(componentType)"
+          />
+        }
+      </div>
+    </div>
+  </mat-card-content>
+</mat-card>

--- a/src/app/authoring-tool/component-type-group/component-type-group.component.ts
+++ b/src/app/authoring-tool/component-type-group/component-type-group.component.ts
@@ -1,0 +1,32 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ComponentTypeButtonComponent } from '../../../assets/wise5/authoringTool/components/component-type-button/component-type-button.component';
+import { MatCardModule } from '@angular/material/card';
+
+@Component({
+  imports: [ComponentTypeButtonComponent, MatCardModule],
+  selector: 'component-type-group',
+  styles: `
+    @import 'tailwindcss';
+    :host {
+      --mat-card-filled-container-color: var(--color-gray-100);
+      --mat-card-title-text-size: var(--mat-sys-title-medium-font-size);
+      --mat-card-title-text-line-height: var(--mat-sys-title-medium-line-height);
+    }
+    .mat-mdc-card-header {
+      padding: 12px 12px 0;
+    }
+    .mat-mdc-card-content {
+      padding-left: 12px;
+      padding-right: 12px;
+
+      &:last-child {
+        padding-bottom: 12px;
+      }
+    }
+  `,
+  templateUrl: './component-type-group.component.html'
+})
+export class ComponentTypeGroupComponent {
+  @Input() componentGroup: any;
+  @Output() componentSelectedEvent = new EventEmitter<any>();
+}

--- a/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html
+++ b/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html
@@ -34,12 +34,17 @@
     </div>
     <div class="flex flex-col md:w-2/3 lg:w-3/4">
       <div class="flex flex-wrap justify-stretch items-center">
-        @for (componentType of componentTypes; track componentType.type) {
-          <div class="component-type">
-            <component-type-button
-              [componentType]="componentType.type"
-              (componentSelectedEvent)="addComponent(componentType)"
-            />
+        @for (componentGroup of componentGroups; track componentGroup.name) {
+          <div class="flex flex-col" style="border: 2px dotted">
+            <h3 class="mat-subheading-1">{{ componentGroup.name }}</h3>
+            @for (componentType of componentGroup.types; track componentType.type) {
+              <div class="component-type">
+                <component-type-button
+                  [componentType]="componentType.type"
+                  (componentSelectedEvent)="addComponent(componentType)"
+                />
+              </div>
+            }
           </div>
         }
       </div>

--- a/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html
+++ b/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html
@@ -1,4 +1,4 @@
-<form role="form" [formGroup]="addNodeFormGroup">
+<form role="form" [formGroup]="addNodeFormGroup" class="@container">
   <mat-form-field appearance="fill" class="title-field">
     <mat-label i18n>Step Title</mat-label>
     <input matInput type="text" id="title" name="title" formControlName="title" required />
@@ -7,8 +7,11 @@
     }
   </mat-form-field>
   <h5 i18n>Select activities to add to your new step (optional):</h5>
-  <div class="flex flex-col md:flex-row">
-    <div class="initial-components notice-bg-bg flex items-start md:w-1/3 lg:w-1/4">
+  <p class="info mat-small" i18n>
+    *Note: You can always add or remove content later by editing the step.
+  </p>
+  <div class="grid @lg:grid-cols-2 @2xl:grid-cols-3 gap-3">
+    <div class="initial-components flex items-start p-3">
       @if (initialComponents.length == 0) {
         <div class="mat-small" i18n>No activities added</div>
       }
@@ -32,25 +35,16 @@
         </div>
       }
     </div>
-    <div class="flex flex-col md:w-2/3 lg:w-3/4">
-      <div class="flex flex-wrap justify-stretch items-center">
+    <div class="flex flex-col @2xl:col-span-2 @container">
+      <div class="@2xl:columns-2 gap-2">
         @for (componentGroup of componentGroups; track componentGroup.name) {
-          <div class="flex flex-col" style="border: 2px dotted">
-            <h3 class="mat-subheading-1">{{ componentGroup.name }}</h3>
-            @for (componentType of componentGroup.types; track componentType.type) {
-              <div class="component-type">
-                <component-type-button
-                  [componentType]="componentType.type"
-                  (componentSelectedEvent)="addComponent(componentType)"
-                />
-              </div>
-            }
-          </div>
+          <component-type-group
+            class="mb-2 block break-inside-avoid-column"
+            [componentGroup]="componentGroup"
+            (componentSelectedEvent)="addComponent($event)"
+          />
         }
       </div>
-      <p class="info mat-small" i18n>
-        *Note: You can always add or remove content later by editing the step.
-      </p>
     </div>
   </div>
   <div class="nav-controls">

--- a/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.scss
+++ b/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.scss
@@ -1,4 +1,5 @@
 @use '@angular/material' as mat;
+@import 'tailwindcss';
 
 $border-color: #dddddd;
 $transform: transform 250ms cubic-bezier(0, 0, 0.2, 1);
@@ -10,8 +11,7 @@ $transform: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }
 
 .initial-components {
-  padding: 8px;
-  margin: 4px;
+  background-color: var(--color-gray-100);
 }
 
 .component-list {

--- a/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.ts
@@ -44,7 +44,7 @@ export class AddYourOwnNodeComponent {
   protected addNodeFormGroup: FormGroup = this.fb.group({
     title: new FormControl($localize`New Step`, [Validators.required])
   });
-  protected componentTypes: any[];
+  protected componentGroups: any[];
   protected initialComponents: string[] = [];
   protected submitting: boolean;
   protected target: AddStepTarget;
@@ -58,7 +58,7 @@ export class AddYourOwnNodeComponent {
     private route: ActivatedRoute,
     private router: Router
   ) {
-    this.componentTypes = this.componentTypeService.getComponentTypes();
+    this.componentGroups = this.componentTypeService.getComponentGroups();
   }
 
   ngOnInit(): void {

--- a/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.ts
+++ b/src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.ts
@@ -14,7 +14,7 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { TeacherProjectService } from '../../../services/teacherProjectService';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
-import { ComponentTypeButtonComponent } from '../../components/component-type-button/component-type-button.component';
+import { ComponentTypeGroupComponent } from '../../../../../app/authoring-tool/component-type-group/component-type-group.component';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
@@ -25,7 +25,7 @@ import { ensureDefaultIcon } from '../../../common/Node';
 
 @Component({
   imports: [
-    ComponentTypeButtonComponent,
+    ComponentTypeGroupComponent,
     DragDropModule,
     FormsModule,
     MatButtonModule,

--- a/src/assets/wise5/authoringTool/components/component-type-button/component-type-button.component.scss
+++ b/src/assets/wise5/authoringTool/components/component-type-button/component-type-button.component.scss
@@ -6,4 +6,6 @@ mat-card {
   width: 100%;
   justify-content: flex-start;
   text-transform: capitalize;
+  text-align: start;
+  padding: 0 8px;
 }

--- a/src/assets/wise5/components/dialogGuidance/DialogGuidanceInfo.ts
+++ b/src/assets/wise5/components/dialogGuidance/DialogGuidanceInfo.ts
@@ -2,10 +2,10 @@ import { ComponentInfo } from '../ComponentInfo';
 
 export class DialogGuidanceInfo extends ComponentInfo {
   protected description: string = $localize`Students chat with a computer avatar about a specific topic.`;
-  protected label: string = $localize`Dialog Guidance`;
+  protected label: string = $localize`Dialog`;
   protected previewExamples: any[] = [
     {
-      label: $localize`Dialog Guidance`,
+      label: $localize`Dialog`,
       content: {
         id: 'abcde12345',
         type: 'DialogGuidance',

--- a/src/assets/wise5/components/dialogGuidance/dialogGuidanceService.ts
+++ b/src/assets/wise5/components/dialogGuidance/dialogGuidanceService.ts
@@ -10,7 +10,7 @@ export class DialogGuidanceService extends ComponentService {
   }
 
   getComponentTypeLabel(): string {
-    return $localize`Dialog Guidance`;
+    return $localize`Dialog`;
   }
 
   createComponent() {

--- a/src/assets/wise5/components/embedded/EmbeddedInfo.ts
+++ b/src/assets/wise5/components/embedded/EmbeddedInfo.ts
@@ -2,10 +2,10 @@ import { ComponentInfo } from '../ComponentInfo';
 
 export class EmbeddedInfo extends ComponentInfo {
   protected description: string = $localize`Students interact with a custom applicatio, such as a model or simulation.`;
-  protected label: string = $localize`Embedded (Custom)`;
+  protected label: string = $localize`Custom`;
   protected previewExamples: any[] = [
     {
-      label: $localize`Embedded`,
+      label: $localize`Custom`,
       content: {
         id: 'abcde12345',
         type: 'Embedded',
@@ -13,8 +13,7 @@ export class EmbeddedInfo extends ComponentInfo {
         showSaveButton: false,
         showSubmitButton: false,
         showAddToNotebookButton: false,
-        url:
-          'https://wise.berkeley.edu/curriculum/shared/plate-tectonics-convection-explorer/v1/index.html?maxWidth=900',
+        url: 'https://wise.berkeley.edu/curriculum/shared/plate-tectonics-convection-explorer/v1/index.html?maxWidth=900',
         height: 600,
         constraints: []
       }

--- a/src/assets/wise5/components/embedded/embeddedService.ts
+++ b/src/assets/wise5/components/embedded/embeddedService.ts
@@ -27,7 +27,7 @@ export class EmbeddedService extends ComponentService {
   }
 
   getComponentTypeLabel(): string {
-    return $localize`Embedded (Custom)`;
+    return $localize`Custom`;
   }
 
   createComponent() {

--- a/src/assets/wise5/components/html/HtmlInfo.ts
+++ b/src/assets/wise5/components/html/HtmlInfo.ts
@@ -2,10 +2,10 @@ import { ComponentInfo } from '../ComponentInfo';
 
 export class HtmlInfo extends ComponentInfo {
   protected description: string = $localize`Students view rich text (HTML) content.`;
-  protected label: string = $localize`Rich Text (HTML)`;
+  protected label: string = $localize`Display Content`;
   protected previewExamples: any[] = [
     {
-      label: $localize`Rich Text (HTML)`,
+      label: $localize`Display Content`,
       content: {
         id: 'abcde12345',
         type: 'HTML',

--- a/src/assets/wise5/components/html/htmlService.ts
+++ b/src/assets/wise5/components/html/htmlService.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class HTMLService extends ComponentService {
   getComponentTypeLabel(): string {
-    return $localize`Rich Text (HTML)`;
+    return $localize`Display Content`;
   }
 
   createComponent() {

--- a/src/assets/wise5/components/match/MatchInfo.ts
+++ b/src/assets/wise5/components/match/MatchInfo.ts
@@ -2,10 +2,10 @@ import { ComponentInfo } from '../ComponentInfo';
 
 export class MatchInfo extends ComponentInfo {
   protected description: string = $localize`Students sort items into different buckets.`;
-  protected label: string = $localize`Match`;
+  protected label: string = $localize`Sort`;
   protected previewExamples: any[] = [
     {
-      label: $localize`Match`,
+      label: $localize`Sort`,
       content: {
         id: 'abcde12345',
         type: 'Match',

--- a/src/assets/wise5/components/match/matchService.ts
+++ b/src/assets/wise5/components/match/matchService.ts
@@ -5,7 +5,7 @@ import { MatchContent } from './MatchContent';
 @Injectable()
 export class MatchService extends ComponentService {
   getComponentTypeLabel(): string {
-    return $localize`Match`;
+    return $localize`Sort`;
   }
 
   createComponent() {

--- a/src/assets/wise5/components/showMyWork/ShowMyWorkInfo.ts
+++ b/src/assets/wise5/components/showMyWork/ShowMyWorkInfo.ts
@@ -2,10 +2,10 @@ import { ComponentInfo } from '../ComponentInfo';
 
 export class ShowMyWorkInfo extends ComponentInfo {
   protected description: string = $localize`Students are shown work that they submitted for a specific item.`;
-  protected label: string = $localize`Show My Work`;
+  protected label: string = $localize`Show Student Work`;
   protected previewExamples: any[] = [
     {
-      label: $localize`Show My Work`,
+      label: $localize`Show Student Work`,
       content: {
         id: 'abcde12345',
         type: 'ShowMyWork',

--- a/src/assets/wise5/components/summary/SummaryInfo.ts
+++ b/src/assets/wise5/components/summary/SummaryInfo.ts
@@ -2,10 +2,10 @@ import { ComponentInfo } from '../ComponentInfo';
 
 export class SummaryInfo extends ComponentInfo {
   protected description: string = $localize`Students are shown an aggregate graph summarizing data from the class.`;
-  protected label: string = $localize`Summary`;
+  protected label: string = $localize`Graph Summary`;
   protected previewExamples: any[] = [
     {
-      lable: $localize`Summary`,
+      lable: $localize`Graph Summary`,
       content: {
         id: 'abcde12345',
         type: 'Summary',

--- a/src/assets/wise5/components/summary/SummaryInfo.ts
+++ b/src/assets/wise5/components/summary/SummaryInfo.ts
@@ -2,10 +2,10 @@ import { ComponentInfo } from '../ComponentInfo';
 
 export class SummaryInfo extends ComponentInfo {
   protected description: string = $localize`Students are shown an aggregate graph summarizing data from the class.`;
-  protected label: string = $localize`Graph Summary`;
+  protected label: string = $localize`Summary Graph`;
   protected previewExamples: any[] = [
     {
-      lable: $localize`Graph Summary`,
+      lable: $localize`Summary Graph`,
       content: {
         id: 'abcde12345',
         type: 'Summary',

--- a/src/assets/wise5/components/summary/summaryService.ts
+++ b/src/assets/wise5/components/summary/summaryService.ts
@@ -37,7 +37,7 @@ export class SummaryService extends ComponentService {
   }
 
   getComponentTypeLabel(): string {
-    return $localize`Graph Summary`;
+    return $localize`Summary Graph`;
   }
 
   createComponent() {

--- a/src/assets/wise5/components/summary/summaryService.ts
+++ b/src/assets/wise5/components/summary/summaryService.ts
@@ -37,7 +37,7 @@ export class SummaryService extends ComponentService {
   }
 
   getComponentTypeLabel(): string {
-    return $localize`Summary`;
+    return $localize`Graph Summary`;
   }
 
   createComponent() {

--- a/src/assets/wise5/services/componentTypeService.ts
+++ b/src/assets/wise5/services/componentTypeService.ts
@@ -17,8 +17,8 @@ export class ComponentTypeService {
         name: $localize`View Information`,
         types: [
           { type: 'HTML', name: this.getComponentTypeLabel('HTML') },
-          { type: 'Summary', name: this.getComponentTypeLabel('Summary') },
-          { type: 'ShowMyWork', name: this.getComponentTypeLabel('ShowMyWork') }
+          { type: 'ShowMyWork', name: this.getComponentTypeLabel('ShowMyWork') },
+          { type: 'Summary', name: this.getComponentTypeLabel('Summary') }
         ]
       },
       {
@@ -33,16 +33,7 @@ export class ComponentTypeService {
         ]
       },
       {
-        name: $localize`Collaborate`,
-        types: [
-          { type: 'DialogGuidance', name: this.getComponentTypeLabel('DialogGuidance') },
-          { type: 'Discussion', name: this.getComponentTypeLabel('Discussion') },
-          { type: 'PeerChat', name: this.getComponentTypeLabel('PeerChat') },
-          { type: 'ShowGroupWork', name: this.getComponentTypeLabel('ShowGroupWork') }
-        ]
-      },
-      {
-        name: $localize`Experiment, Discover and Distinguish`,
+        name: $localize`Experiment, Discover, Distinguish`,
         types: [
           { type: 'Animation', name: this.getComponentTypeLabel('Animation') },
           { type: 'AudioOscillator', name: this.getComponentTypeLabel('AudioOscillator') },
@@ -50,6 +41,15 @@ export class ComponentTypeService {
           { type: 'Graph', name: this.getComponentTypeLabel('Graph') },
           { type: 'OutsideURL', name: this.getComponentTypeLabel('OutsideURL') },
           { type: 'Table', name: this.getComponentTypeLabel('Table') }
+        ]
+      },
+      {
+        name: $localize`Collaborate`,
+        types: [
+          { type: 'DialogGuidance', name: this.getComponentTypeLabel('DialogGuidance') },
+          { type: 'Discussion', name: this.getComponentTypeLabel('Discussion') },
+          { type: 'PeerChat', name: this.getComponentTypeLabel('PeerChat') },
+          { type: 'ShowGroupWork', name: this.getComponentTypeLabel('ShowGroupWork') }
         ]
       }
     ];

--- a/src/assets/wise5/services/componentTypeService.ts
+++ b/src/assets/wise5/services/componentTypeService.ts
@@ -11,32 +11,58 @@ export class ComponentTypeService {
     private userService: UserService
   ) {}
 
-  getComponentTypes(): any[] {
-    const componentTypes = [
-      { type: 'Animation', name: this.getComponentTypeLabel('Animation') },
-      { type: 'AudioOscillator', name: this.getComponentTypeLabel('AudioOscillator') },
-      { type: 'ConceptMap', name: this.getComponentTypeLabel('ConceptMap') },
-      { type: 'DialogGuidance', name: this.getComponentTypeLabel('DialogGuidance') },
-      { type: 'Discussion', name: this.getComponentTypeLabel('Discussion') },
-      { type: 'Draw', name: this.getComponentTypeLabel('Draw') },
-      { type: 'Embedded', name: this.getComponentTypeLabel('Embedded') },
-      { type: 'Graph', name: this.getComponentTypeLabel('Graph') },
-      { type: 'Label', name: this.getComponentTypeLabel('Label') },
-      { type: 'Match', name: this.getComponentTypeLabel('Match') },
-      { type: 'MultipleChoice', name: this.getComponentTypeLabel('MultipleChoice') },
-      { type: 'OpenResponse', name: this.getComponentTypeLabel('OpenResponse') },
-      { type: 'OutsideURL', name: this.getComponentTypeLabel('OutsideURL') },
-      { type: 'PeerChat', name: this.getComponentTypeLabel('PeerChat') },
-      { type: 'HTML', name: this.getComponentTypeLabel('HTML') },
-      { type: 'ShowGroupWork', name: this.getComponentTypeLabel('ShowGroupWork') },
-      { type: 'ShowMyWork', name: this.getComponentTypeLabel('ShowMyWork') },
-      { type: 'Summary', name: this.getComponentTypeLabel('Summary') },
-      { type: 'Table', name: this.getComponentTypeLabel('Table') }
+  getComponentGroups(): any[] {
+    const groups = [
+      {
+        name: $localize`View Information`,
+        types: [
+          { type: 'HTML', name: this.getComponentTypeLabel('HTML') },
+          { type: 'Summary', name: this.getComponentTypeLabel('Summary') },
+          { type: 'ShowMyWork', name: this.getComponentTypeLabel('ShowMyWork') }
+        ]
+      },
+      {
+        name: $localize`Explain and Assess`,
+        types: [
+          { type: 'ConceptMap', name: this.getComponentTypeLabel('ConceptMap') },
+          { type: 'Draw', name: this.getComponentTypeLabel('Draw') },
+          { type: 'Label', name: this.getComponentTypeLabel('Label') },
+          { type: 'MultipleChoice', name: this.getComponentTypeLabel('MultipleChoice') },
+          { type: 'OpenResponse', name: this.getComponentTypeLabel('OpenResponse') },
+          { type: 'Match', name: this.getComponentTypeLabel('Match') }
+        ]
+      },
+      {
+        name: $localize`Collaborate`,
+        types: [
+          { type: 'DialogGuidance', name: this.getComponentTypeLabel('DialogGuidance') },
+          { type: 'Discussion', name: this.getComponentTypeLabel('Discussion') },
+          { type: 'PeerChat', name: this.getComponentTypeLabel('PeerChat') },
+          { type: 'ShowGroupWork', name: this.getComponentTypeLabel('ShowGroupWork') }
+        ]
+      },
+      {
+        name: $localize`Experiment, Discover and Distinguish`,
+        types: [
+          { type: 'Animation', name: this.getComponentTypeLabel('Animation') },
+          { type: 'AudioOscillator', name: this.getComponentTypeLabel('AudioOscillator') },
+          { type: 'Embedded', name: this.getComponentTypeLabel('Embedded') },
+          { type: 'Graph', name: this.getComponentTypeLabel('Graph') },
+          { type: 'OutsideURL', name: this.getComponentTypeLabel('OutsideURL') },
+          { type: 'Table', name: this.getComponentTypeLabel('Table') }
+        ]
+      }
     ];
+
     if (this.isAiChatAllowed()) {
-      componentTypes.unshift({ type: 'AiChat', name: this.getComponentTypeLabel('AiChat') });
+      groups[2].types.unshift({ type: 'AiChat', name: this.getComponentTypeLabel('AiChat') });
     }
-    return componentTypes;
+
+    return groups;
+  }
+
+  getComponentTypes(): any[] {
+    return this.getComponentGroups().flatMap((group) => group.types);
   }
 
   getComponentTypeLabel(componentType: string): string {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -469,7 +469,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">61,65</context>
+          <context context-type="linenumber">63,67</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.html</context>
@@ -1594,7 +1594,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">58,61</context>
+          <context context-type="linenumber">60,63</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
@@ -1677,7 +1677,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">72,77</context>
+          <context context-type="linenumber">74,79</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.html</context>
@@ -10422,7 +10422,7 @@
         <source> *Note: You can always add or remove content later by editing the step. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">50,55</context>
+          <context context-type="linenumber">52,57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6009535360963985115" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -405,7 +405,7 @@
         <source>Cancel</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html</context>
-          <context context-type="linenumber">24,26</context>
+          <context context-type="linenumber">20,22</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
@@ -469,7 +469,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">63,67</context>
+          <context context-type="linenumber">57,61</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.html</context>
@@ -1594,7 +1594,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">60,63</context>
+          <context context-type="linenumber">54,57</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
@@ -1677,7 +1677,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">74,79</context>
+          <context context-type="linenumber">68,73</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.html</context>
@@ -10400,29 +10400,29 @@
           <context context-type="linenumber">9,11</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="4365227337792214829" datatype="html">
+        <source> *Note: You can always add or remove content later by editing the step. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
+          <context context-type="linenumber">11,14</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="287136474033183481" datatype="html">
         <source>No activities added</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">13,16</context>
+          <context context-type="linenumber">16,19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1057829402524211130" datatype="html">
         <source>Delete activity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">26,28</context>
+          <context context-type="linenumber">29,31</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
           <context context-type="linenumber">69,71</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4365227337792214829" datatype="html">
-        <source> *Note: You can always add or remove content later by editing the step. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">52,57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6009535360963985115" datatype="html">
@@ -22320,8 +22320,8 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8912044866093830565" datatype="html">
-        <source>Graph Summary</source>
+      <trans-unit id="5957336181991299942" datatype="html">
+        <source>Summary Graph</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/SummaryInfo.ts</context>
           <context context-type="linenumber">5</context>
@@ -23357,18 +23357,18 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8458375241882951939" datatype="html">
-        <source>Collaborate</source>
+      <trans-unit id="6733933997427278738" datatype="html">
+        <source>Experiment, Discover, Distinguish</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/componentTypeService.ts</context>
           <context context-type="linenumber">36</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4794322775979595681" datatype="html">
-        <source>Experiment, Discover and Distinguish</source>
+      <trans-unit id="8458375241882951939" datatype="html">
+        <source>Collaborate</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/componentTypeService.ts</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">47</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3570422532828875517" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -2403,18 +2403,6 @@
           <context context-type="sourcefile">src/app/contact/contact-form/contact-form.component.html</context>
           <context context-type="linenumber">77,78</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/summary/SummaryInfo.ts</context>
-          <context context-type="linenumber">5</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/summary/SummaryInfo.ts</context>
-          <context context-type="linenumber">8</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/summary/summaryService.ts</context>
-          <context context-type="linenumber">40</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="6416297464279464070" datatype="html">
         <source>Summary required</source>
@@ -18545,8 +18533,8 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4467968363873261907" datatype="html">
-        <source>Dialog Guidance</source>
+      <trans-unit id="4370054324502575963" datatype="html">
+        <source>Dialog</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/DialogGuidanceInfo.ts</context>
           <context context-type="linenumber">5</context>
@@ -19743,22 +19731,19 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6789418188453734195" datatype="html">
-        <source>Embedded (Custom)</source>
+      <trans-unit id="7590013429208346303" datatype="html">
+        <source>Custom</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/embedded/EmbeddedInfo.ts</context>
           <context context-type="linenumber">5</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/embedded/embeddedService.ts</context>
-          <context context-type="linenumber">30</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7120485563504644471" datatype="html">
-        <source>Embedded</source>
-        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/embedded/EmbeddedInfo.ts</context>
           <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/embedded/embeddedService.ts</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8965086816017582952" datatype="html">
@@ -20712,8 +20697,8 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1391027585017325946" datatype="html">
-        <source>Rich Text (HTML)</source>
+      <trans-unit id="3146182739118362727" datatype="html">
+        <source>Display Content</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/html/HtmlInfo.ts</context>
           <context context-type="linenumber">5</context>
@@ -20977,8 +20962,8 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6619869754055745168" datatype="html">
-        <source>Match</source>
+      <trans-unit id="5146398958364876914" datatype="html">
+        <source>Sort</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/match/MatchInfo.ts</context>
           <context context-type="linenumber">5</context>
@@ -22336,6 +22321,21 @@ If this problem continues, let your teacher know and move on to the next activit
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/summary/SummaryInfo.ts</context>
           <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8912044866093830565" datatype="html">
+        <source>Graph Summary</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/summary/SummaryInfo.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/summary/SummaryInfo.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/summary/summaryService.ts</context>
+          <context context-type="linenumber">40</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5609998247039115265" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -405,7 +405,7 @@
         <source>Cancel</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/add-component/choose-new-component/choose-new-component.component.html</context>
-          <context context-type="linenumber">19,21</context>
+          <context context-type="linenumber">24,26</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/import-step/choose-import-step/choose-import-step.component.html</context>
@@ -469,7 +469,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">58,62</context>
+          <context context-type="linenumber">61,65</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-new-node-template/choose-new-node-template.component.html</context>
@@ -1594,7 +1594,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">55,58</context>
+          <context context-type="linenumber">58,61</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-automated-assessment/choose-automated-assessment.component.html</context>
@@ -1677,7 +1677,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">69,74</context>
+          <context context-type="linenumber">72,77</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/choose-simulation/choose-simulation.component.html</context>
@@ -10422,7 +10422,7 @@
         <source> *Note: You can always add or remove content later by editing the step. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/addNode/add-your-own-node/add-your-own-node.component.html</context>
-          <context context-type="linenumber">47,52</context>
+          <context context-type="linenumber">50,55</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6009535360963985115" datatype="html">
@@ -22291,8 +22291,8 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8845548950803777715" datatype="html">
-        <source>Show My Work</source>
+      <trans-unit id="8147119602241675293" datatype="html">
+        <source>Show Student Work</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/showMyWork/ShowMyWorkInfo.ts</context>
           <context context-type="linenumber">5</context>
@@ -22301,19 +22301,16 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="sourcefile">src/assets/wise5/components/showMyWork/ShowMyWorkInfo.ts</context>
           <context context-type="linenumber">8</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/showMyWork/showMyWorkService.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="2326665523206278809" datatype="html">
         <source>(No response)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/showMyWork/show-my-work-student/show-my-work-student.component.html</context>
           <context context-type="linenumber">5,8</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8147119602241675293" datatype="html">
-        <source>Show Student Work</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/showMyWork/showMyWorkService.ts</context>
-          <context context-type="linenumber">7</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5536408973677447769" datatype="html">
@@ -23344,6 +23341,34 @@ If this problem continues, let your teacher know and move on to the next activit
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/services/authorBranchService.ts</context>
           <context context-type="linenumber">23</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4916034445624718726" datatype="html">
+        <source>View Information</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/services/componentTypeService.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8725153882939520386" datatype="html">
+        <source>Explain and Assess</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/services/componentTypeService.ts</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8458375241882951939" datatype="html">
+        <source>Collaborate</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/services/componentTypeService.ts</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4794322775979595681" datatype="html">
+        <source>Experiment, Discover and Distinguish</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/services/componentTypeService.ts</context>
+          <context context-type="linenumber">45</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3570422532828875517" datatype="html">


### PR DESCRIPTION
![Screenshot 2026-04-12 at 7 25 39 PM](https://github.com/user-attachments/assets/5131edfb-e33b-4cf0-9a19-190b67456a85)

## Notes
- Please style as you see fit!
- There is a lot of code overlap in the two places where we show this component groupings, but I also saw that they had some differences in styles, so I didn't extract a new component. Feel free to extract to a new component if you can and reduce duplication.

## Changes
- In AddYourOwnNode (creating a new blank step) and ChooseNewComponent (adding a component to an existing step) views, organize the components in groups based on function, as seen in the screenshot above.

## Test
- Test the two views and make sure they work as before
   - AddYourOwnNode (creating a new blank step)
   - ChooseNewComponent (adding a component to an existing step)
- The component select dropdown in the component info dialog works as before. Code that this feature uses was slightly updated in this PR.