### PR TITLE
style(Teacher Tools): Improve component summary layout

### DIFF
--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.html
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.html
@@ -9,7 +9,39 @@
     <mat-icon>fullscreen</mat-icon>
   </button>
 </ng-template>
-<div class="component-summary notice flex flex-col">
+<ng-template #scoreSummary>
+  @if (showScoreSummary) {
+    <div>
+      <teacher-summary-display
+        [nodeId]="node.id"
+        [componentId]="component.id"
+        [periodId]="periodId"
+        [studentDataType]="'scores'"
+        [source]="source"
+        [chartType]="'column'"
+        [doRender]="true"
+        class="summary"
+      />
+    </div>
+  }
+</ng-template>
+<ng-template #ideasSummary>
+  <ng-container
+    [ngTemplateOutlet]="expandSummaryTpl"
+    [ngTemplateOutletContext]="{ type: 'ideas' }"
+  />
+  <ideas-summary
+    [nodeId]="node.id"
+    [componentId]="component.id"
+    [periodId]="periodId"
+    [studentDataType]="'responses'"
+    [source]="source"
+    [doRender]="true"
+    [componentType]="component.type"
+    class="summary"
+  />
+</ng-template>
+<div class="component-summary notice flex flex-col @container">
   <div class="flex justify-between gap-4">
     <div>
       <div i18n>Prompt</div>
@@ -30,66 +62,58 @@
     <peer-group-button [node]="node" [component]="component" />
   </div>
   @if (showSummary) {
-    <div class="flex flex-col md:flex-row mt-3 gap-3">
-      @if (showScoreSummary) {
-        <div class="summary-graph">
-          <teacher-summary-display
-            [nodeId]="node.id"
-            [componentId]="component.id"
-            [periodId]="periodId"
-            [studentDataType]="'scores'"
-            [source]="source"
-            [chartType]="'column'"
-            [doRender]="true"
-            class="summary"
-          />
-        </div>
-      }
-      @if (hasIdeaRubricData) {
-        <div class="summary-content">
-          <ng-container
-            [ngTemplateOutlet]="expandSummaryTpl"
-            [ngTemplateOutletContext]="{ type: 'ideas' }"
-          />
-          <ideas-summary
-            [nodeId]="node.id"
-            [componentId]="component.id"
-            [periodId]="periodId"
-            [studentDataType]="'responses'"
-            [source]="source"
-            [doRender]="true"
-            [componentType]="component.type"
-            class="summary"
-          />
-        </div>
-      }
+    <div class="flex flex-col @2xl:grid @2xl:grid-cols-2 @5xl:grid-cols-3 mt-3 gap-3">
       @if (component.type === 'Discussion') {
-        <div class="summary-content flex flex-col gap-3">
-          @if (aiEnabled) {
+        @if (aiEnabled) {
+          <div class="col-span-full">
             <discussion-ai-summary
               [nodeId]="node.id"
               [componentId]="component.id"
               [periodId]="periodId"
               class="summary"
             />
-          }
-          <div class="relative">
-            <ng-container
-              [ngTemplateOutlet]="expandSummaryTpl"
-              [ngTemplateOutletContext]="{ type: 'discussion' }"
-            />
-            <discussion-summary
+          </div>
+        }
+        <ng-container [ngTemplateOutlet]="scoreSummary" />
+        <div class="summary-content" [class.!col-span-full]="!showScoreSummary">
+          <ng-container
+            [ngTemplateOutlet]="expandSummaryTpl"
+            [ngTemplateOutletContext]="{ type: 'discussion' }"
+          />
+          <discussion-summary
+            [nodeId]="node.id"
+            [componentId]="component.id"
+            [periodId]="periodId"
+            [source]="source"
+            [doRender]="true"
+            class="summary"
+          />
+        </div>
+      } @else if (component.type === 'OpenResponse') {
+        @if (aiEnabled) {
+          <div
+            class="flex"
+            [class.summary-content]="showScoreSummary && !hasIdeaRubricData"
+            [class.order-2]="showScoreSummary && !hasIdeaRubricData"
+            [class.!col-span-full]="!showScoreSummary || hasIdeaRubricData"
+          >
+            <open-response-ai-summary
               [nodeId]="node.id"
               [componentId]="component.id"
               [periodId]="periodId"
-              [source]="source"
-              [doRender]="true"
               class="summary"
             />
           </div>
-        </div>
+        }
+        <ng-container [ngTemplateOutlet]="scoreSummary" />
+        @if (hasIdeaRubricData) {
+          <div class="summary-content" [class.!col-span-full]="!showScoreSummary">
+            <ng-container [ngTemplateOutlet]="ideasSummary" />
+          </div>
+        }
       } @else if (component.type === 'Match') {
-        <div class="summary-content">
+        <ng-container [ngTemplateOutlet]="scoreSummary" />
+        <div class="summary-content" [class.!col-span-full]="!showScoreSummary">
           <ng-container
             [ngTemplateOutlet]="expandSummaryTpl"
             [ngTemplateOutletContext]="{ type: 'match' }"
@@ -104,7 +128,8 @@
           />
         </div>
       } @else if (component.type === 'MultipleChoice') {
-        <div class="summary-graph">
+        <ng-container [ngTemplateOutlet]="scoreSummary" />
+        <div>
           <teacher-summary-display
             [nodeId]="node.id"
             [componentId]="component.id"
@@ -117,13 +142,13 @@
             class="summary"
           />
         </div>
-      } @else if (component.type === 'OpenResponse' && aiEnabled) {
-        <open-response-ai-summary
-          [nodeId]="node.id"
-          [componentId]="component.id"
-          [periodId]="periodId"
-          class="summary"
-        />
+      } @else {
+        <ng-container [ngTemplateOutlet]="scoreSummary" />
+        @if (hasIdeaRubricData) {
+          <div class="summary-content" [class.!col-span-full]="!showScoreSummary">
+            <ng-container [ngTemplateOutlet]="ideasSummary" />
+          </div>
+        }
       }
     </div>
   }

--- a/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.scss
+++ b/src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.scss
@@ -30,11 +30,7 @@ peer-group-button > * {
   @apply rounded-md p-3 overflow-hidden bg-white flex flex-col grow;
 }
 
-.summary-graph {
-  @apply w-full md:w-1/2 lg:w-1/3;
-}
-
 .summary-content {
-  @apply w-full md:w-auto md:grow-2 relative;
+  @apply @5xl:col-span-2 relative;
 }
 

--- a/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.html
+++ b/src/assets/wise5/components/discussion/discussion-student/discussion-student.component.html
@@ -9,8 +9,8 @@
       [componentId]="componentId"
     />
   }
-  <div class="flex">
-    <div class="discussion-posts w-full md:w-1/2">
+  <div class="flex @container">
+    <div class="discussion-posts w-full @md:w-1/2">
       @if (mode === 'student' && !isDisabled) {
         <mat-card
           appearance="outlined"
@@ -89,7 +89,7 @@
           [(ngModel)]="newResponse"
         ></div>
       }
-      <div class="md:hidden">
+      <div class="@md:hidden">
         @for (componentState of topLevelResponses.all; track componentState) {
           <class-response
             [response]="componentState"
@@ -101,7 +101,7 @@
           />
         }
       </div>
-      <div class="hidden sm:block">
+      <div class="hidden @sm:block">
         @for (componentState of topLevelResponses.col2; track componentState) {
           <class-response
             [response]="componentState"
@@ -114,7 +114,7 @@
         }
       </div>
     </div>
-    <div class="discussion-posts hidden w-1/2 md:block">
+    <div class="discussion-posts hidden w-1/2 @md:block">
       @for (componentState of topLevelResponses.col1; track componentState) {
         <class-response
           [response]="componentState"

--- a/src/assets/wise5/components/discussion/discussion-teacher/discussion-teacher.component.html
+++ b/src/assets/wise5/components/discussion/discussion-teacher/discussion-teacher.component.html
@@ -1,7 +1,7 @@
-<div class="discussion-content">
+<div class="discussion-content @container">
   <div class="flex">
-    <div class="discussion-posts w-full md:w-1/2">
-      <div class="md:hidden">
+    <div class="discussion-posts w-full @3xl:w-1/2">
+      <div class="@3xl:hidden">
         @for (componentState of topLevelResponses.all; track componentState) {
           <class-response-teacher
             [response]="componentState"
@@ -15,7 +15,7 @@
           />
         }
       </div>
-      <div class="hidden sm:block">
+      <div class="hidden @3xl:block">
         @for (componentState of topLevelResponses.col2; track componentState) {
           <class-response-teacher
             [response]="componentState"
@@ -30,7 +30,7 @@
         }
       </div>
     </div>
-    <div class="discussion-posts hidden w-1/2 md:block">
+    <div class="discussion-posts hidden w-1/2 @3xl:block">
       @for (componentState of topLevelResponses.col1; track componentState) {
         <class-response-teacher
           [response]="componentState"
@@ -40,8 +40,7 @@
           (hidePostEvent)="hidePost($event)"
           (showPostEvent)="showPost($event)"
           [isDisabled]="isDisabled"
-          class="post"
-          style="display: block"
+          class="post block"
         />
       }
     </div>

--- a/src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html
+++ b/src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html
@@ -3,7 +3,7 @@
     class="gap-2"
     mat-stroked-button
     (click)="generateSummary()"
-    [disabled]="generatingSummary || !hasStudentResponses"
+    [disabled]="generatingSummary"
     color="primary"
   >
     <span i18n>Generate Summary</span><mat-icon>auto_awesome</mat-icon>
@@ -20,9 +20,7 @@
     <mat-spinner diameter="20" />
   }
 </div>
-@if (!hasStudentResponses) {
-  <p i18n>No student responses</p>
-} @else if (newSummaryAvailable) {
+@if (newSummaryAvailable) {
   <p class="info" i18n>*New responses since last summary</p>
 }
 @if (summary) {

--- a/src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html
+++ b/src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html
@@ -1,28 +1,30 @@
-<div class="flex gap-2 flex-wrap items-center mat-caption">
-  <div class="flex items-center gap-2">
-    <button
-      class="gap-2"
-      mat-button
-      (click)="generateSummary()"
-      [disabled]="generatingSummary || !hasStudentResponses"
-      color="primary"
-      matTooltip="Summarize class responses using AI"
-      matTooltipPosition="after"
-      i18n-matTooltip
-    >
-      <span i18n>Generate Summary</span><mat-icon>auto_awesome</mat-icon>
-    </button>
-    @if (!hasStudentResponses) {
-      <span i18n>No student responses</span>
-    }
-    @if (generatingSummary) {
-      <mat-spinner diameter="20" />
-    }
-  </div>
-  @if (newSummaryAvailable) {
-    <span class="info" i18n>*New responses since last summary</span>
+<div class="flex gap-2 items-center">
+  <button
+    class="gap-2"
+    mat-stroked-button
+    (click)="generateSummary()"
+    [disabled]="generatingSummary || !hasStudentResponses"
+    color="primary"
+  >
+    <span i18n>Generate Summary</span><mat-icon>auto_awesome</mat-icon>
+  </button>
+  <mat-icon
+    tabindex="0"
+    matTooltip="Summarize class responses using AI"
+    matTooltipPosition="above"
+    i18n-matTooltip
+  >
+    info
+  </mat-icon>
+  @if (generatingSummary) {
+    <mat-spinner diameter="20" />
   }
 </div>
+@if (!hasStudentResponses) {
+  <p i18n>No student responses</p>
+} @else if (newSummaryAvailable) {
+  <p class="info" i18n>*New responses since last summary</p>
+}
 @if (summary) {
   <markdown [data]="summary" />
   <div class="mat-caption text-secondary mt-1">{{ summaryCaption }}</div>

--- a/src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.ts
@@ -33,7 +33,6 @@ export abstract class AiSummaryComponent {
   protected projectService: TeacherProjectService = inject(TeacherProjectService);
 
   protected generatingSummary: boolean = false;
-  protected hasStudentResponses: boolean = false;
   protected latestComponentStates: any[] = [];
   protected newSummaryAvailable: boolean = false;
   protected summary: string;
@@ -42,13 +41,10 @@ export abstract class AiSummaryComponent {
   ngOnInit(): void {
     this.component = this.projectService.getComponent(this.nodeId, this.componentId);
     this.latestComponentStates = this.getLatestComponentStates();
-    this.hasStudentResponses = this.latestComponentStates.length > 0;
-    if (this.hasStudentResponses) {
-      this.summary = this.localStorageService.getItem(this.getSummaryKey()) || '';
-      const summaryTime = this.localStorageService.getItem(this.getSummaryTimeKey()) || 0;
-      this.summaryDate = new Date(summaryTime);
-      this.newSummaryAvailable = summaryTime > 0 && this.getLastResponseTime() > summaryTime;
-    }
+    this.summary = this.localStorageService.getItem(this.getSummaryKey()) || '';
+    const summaryTime = this.localStorageService.getItem(this.getSummaryTimeKey()) || 0;
+    this.summaryDate = new Date(summaryTime);
+    this.newSummaryAvailable = summaryTime > 0 && this.getLastResponseTime() > summaryTime;
   }
 
   protected getLatestComponentStates(): any[] {

--- a/src/assets/wise5/directives/teacher-summary-display/open-response-ai-summary/open-response-ai-summary.component.spec.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/open-response-ai-summary/open-response-ai-summary.component.spec.ts
@@ -69,20 +69,6 @@ describe('OpenResponseAiSummaryComponent', () => {
   });
 
   describe('ngOnInit', () => {
-    it('should set hasStudentResponses to false when no component states exist', () => {
-      spyOn(dataService, 'getComponentStatesByComponentId').and.returnValue([]);
-      component.ngOnInit();
-      fixture.detectChanges();
-      expect(component['hasStudentResponses']).toBe(false);
-    });
-
-    it('should set hasStudentResponses to true when component states exist', () => {
-      spyOn(dataService, 'getComponentStatesByComponentId').and.returnValue(getComponentStates());
-      component.ngOnInit();
-      fixture.detectChanges();
-      expect(component['hasStudentResponses']).toBe(true);
-    });
-
     it('should load summary from localStorage if it exists', () => {
       spyOn(dataService, 'getComponentStatesByComponentId').and.returnValue(getComponentStates());
       const savedSummary = 'This is a saved summary';
@@ -255,14 +241,6 @@ describe('OpenResponseAiSummaryComponent', () => {
   });
 
   describe('template rendering', () => {
-    it('should display "No student responses" when hasStudentResponses is false', () => {
-      spyOn(dataService, 'getComponentStatesByComponentId').and.returnValue([]);
-      component.ngOnInit();
-      fixture.detectChanges();
-      const compiled = fixture.nativeElement;
-      expect(compiled.textContent).toContain('No student responses');
-    });
-
     it('should display generate button when hasStudentResponses is true', () => {
       spyOn(dataService, 'getComponentStatesByComponentId').and.returnValue(getComponentStates());
       component.ngOnInit();

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -23137,41 +23137,26 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">13,18</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3421658563032484911" datatype="html">
-        <source>No student responses</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">24,26</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">24,26</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">24,26</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="2647230157856881985" datatype="html">
         <source>*New responses since last summary</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">26,30</context>
+          <context context-type="linenumber">24,28</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">26,30</context>
+          <context context-type="linenumber">24,28</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">26,30</context>
+          <context context-type="linenumber">24,28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3008190125112056008" datatype="html">
         <source>Summary generated <x id="PH" equiv-text="this.datePipe.transform(this.summaryDate, &apos;short&apos;)"/> from <x id="PH_1" equiv-text="this.latestComponentStates.length"/> responses</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.ts</context>
-          <context context-type="linenumber">105</context>
+          <context context-type="linenumber">101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2424618748979671937" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -953,7 +953,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.html</context>
-          <context context-type="linenumber">15,17</context>
+          <context context-type="linenumber">47,49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7561343662252105417" datatype="html">
@@ -23107,64 +23107,64 @@ If this problem continues, let your teacher know and move on to the next activit
           <context context-type="linenumber">401</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8864080509105680671" datatype="html">
-        <source>Summarize class responses using AI</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">9,13</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">9,13</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">9,13</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="273241930432839392" datatype="html">
         <source>Generate Summary</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">13,15</context>
+          <context context-type="linenumber">9,12</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">13,15</context>
+          <context context-type="linenumber">9,12</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">13,15</context>
+          <context context-type="linenumber">9,12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8864080509105680671" datatype="html">
+        <source>Summarize class responses using AI</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
+          <context context-type="linenumber">13,18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
+          <context context-type="linenumber">13,18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
+          <context context-type="linenumber">13,18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3421658563032484911" datatype="html">
         <source>No student responses</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">16,19</context>
+          <context context-type="linenumber">24,26</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">16,19</context>
+          <context context-type="linenumber">24,26</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">16,19</context>
+          <context context-type="linenumber">24,26</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2647230157856881985" datatype="html">
         <source>*New responses since last summary</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">23,28</context>
+          <context context-type="linenumber">26,30</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">23,28</context>
+          <context context-type="linenumber">26,30</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/ai-summary/ai-summary.component.html</context>
-          <context context-type="linenumber">23,28</context>
+          <context context-type="linenumber">26,30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3008190125112056008" datatype="html">


### PR DESCRIPTION
## Changes
- Improve layout when multiple activity summaries are visible at once and across different screen widths (see examples below).
- Move "Generate Summary" tooltip to an info icon for AI summary component.
- Refactor template.

Before:
<img height="300" alt="Screenshot 2026-04-12 at 3 29 51 PM" src="https://github.com/user-attachments/assets/2e4d240c-fde2-4792-8a7b-95a127370d75" />

After:
<img height="300" alt="Screenshot 2026-04-12 at 8 09 38 PM" src="https://github.com/user-attachments/assets/2b865ec2-c687-46c4-8339-85f0dccc0652" />

Before:
<img height="300" alt="Screenshot 2026-04-12 at 3 31 01 PM" src="https://github.com/user-attachments/assets/7005e7c8-b08d-45f4-ad1c-0818f9548a24" />

After:
<img height="300" alt="Screenshot 2026-04-12 at 3 26 22 PM" src="https://github.com/user-attachments/assets/326c2e5d-f333-4a66-9b48-17cf7fe781cd" />

Before:
<img height="300" alt="Screenshot 2026-04-12 at 8 19 28 PM" src="https://github.com/user-attachments/assets/e0c6379d-d74e-4a8e-967e-744f8091c178" />

After:
<img height="300" alt="Screenshot 2026-04-12 at 8 20 33 PM" src="https://github.com/user-attachments/assets/bba35f63-e518-49d7-a26f-e65a33c92d69" />

## Test
- Make sure component summaries work as before and layout adjusts based on different summaries shown.
- Make sure summary layout adjusts for small, medium, large screen widths.
