### PR TITLE
style(Authoring Tool): Organize Unit Info page using tabs

### DIFF
--- a/src/assets/wise5/authoringTool/advanced/advanced-project-authoring.component.html
+++ b/src/assets/wise5/authoringTool/advanced/advanced-project-authoring.component.html
@@ -3,25 +3,39 @@
     <ng-template mat-tab-label>
       <mat-icon>settings</mat-icon>&nbsp;<span i18n>General settings</span>
     </ng-template>
-    <div class="my-4">
-      <label id="navigation-type-label" i18n>Navigation mode:</label>
-      <mat-radio-group
-        aria-labelledby="navigation-type-label"
-        [(ngModel)]="navigationType"
-        (ngModelChange)="setNavigationType()"
-      >
-        <mat-radio-button color="primary" value="default" i18n
-          >Default (lessons appear in drop-down list and unit plan)</mat-radio-button
+    <div class="flex flex-col gap-5">
+      <div class="my-4">
+        <label id="navigation-type-label" i18n>Navigation mode:</label>
+        <mat-radio-group
+          aria-labelledby="navigation-type-label"
+          [(ngModel)]="navigationType"
+          (ngModelChange)="setNavigationType()"
         >
-        <mat-radio-button color="primary" value="tab" i18n
-          >Tabbed (lessons appear as tabs)
-        </mat-radio-button>
-      </mat-radio-group>
+          <mat-radio-button color="primary" value="default" i18n
+            >Default (lessons appear in drop-down list and unit plan)</mat-radio-button
+          >
+          <mat-radio-button color="primary" value="tab" i18n
+            >Tabbed (lessons appear as tabs)
+          </mat-radio-button>
+        </mat-radio-group>
+      </div>
+      <edit-unit-type [metadata]="metadata" />
+      <div class="flex gap-2">
+        <button mat-raised-button color="primary" class="topButton" (click)="downloadProject()">
+          <mat-icon>file_download</mat-icon>
+          <span i18n>Download unit</span>
+        </button>
+        @if (isMyUnit) {
+          <a href="{{ publishUnitUrl }}" class="share-button">
+            <button mat-flat-button color="primary">
+              <mat-icon>public</mat-icon>&nbsp;<ng-container i18n
+                >Submit to Public Unit Library</ng-container
+              >
+            </button>
+          </a>
+        }
+      </div>
     </div>
-    <button mat-raised-button color="primary" class="topButton" (click)="downloadProject()">
-      <mat-icon>file_download</mat-icon>
-      <span i18n>Download unit</span>
-    </button>
   </mat-tab>
   <mat-tab>
     <ng-template mat-tab-label>

--- a/src/assets/wise5/authoringTool/advanced/advanced-project-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/advanced/advanced-project-authoring.component.ts
@@ -14,10 +14,13 @@ import { TeacherProjectService } from '../../services/teacherProjectService';
 import { RubricAuthoringComponent } from '../rubric/rubric-authoring.component';
 import { MatTabChangeEvent, MatTabsModule } from '@angular/material/tabs';
 import { MilestonesAuthoringComponent } from '../milestones-authoring/milestones-authoring.component';
+import { EditUnitTypeComponent } from '../edit-unit-type/edit-unit-type.component';
+import { UserService } from '../../../../app/services/user.service';
 
 @Component({
   imports: [
     CdkTextareaAutosize,
+    EditUnitTypeComponent,
     FormsModule,
     MatButtonModule,
     MatFormFieldModule,
@@ -32,19 +35,31 @@ import { MilestonesAuthoringComponent } from '../milestones-authoring/milestones
   templateUrl: 'advanced-project-authoring.component.html'
 })
 export class AdvancedProjectAuthoringComponent {
+  protected isMyUnit: boolean;
+  protected metadata: any;
   protected navigationType: 'default' | 'tab';
   protected projectJSONString: string;
+  protected publishUnitUrl;
   protected selectedTab: number;
 
   constructor(
     private configService: ConfigService,
     private notificationService: NotificationService,
-    private projectService: TeacherProjectService
+    private projectService: TeacherProjectService,
+    private userService: UserService
   ) {}
 
   ngOnInit(): void {
+    this.metadata = this.projectService.getProjectMetadata();
+    if (this.metadata.unitType == null) {
+      this.metadata.unitType = 'Platform';
+    }
     this.navigationType = this.projectService.project.theme ?? 'default';
     this.projectJSONString = JSON.stringify(this.projectService.project, null, 4);
+    this.publishUnitUrl = `${this.configService.getContextPath()}/contact?projectId=${this.configService.getProjectId()}&publish=true`;
+    this.isMyUnit = this.metadata.authors.some(
+      (author) => author.id === this.userService.getUserId()
+    );
   }
 
   protected tabChanged(event: MatTabChangeEvent): void {

--- a/src/assets/wise5/authoringTool/edit-unit-resources/edit-unit-resources.component.html
+++ b/src/assets/wise5/authoringTool/edit-unit-resources/edit-unit-resources.component.html
@@ -16,6 +16,10 @@
     <ng-container *ngTemplateOutlet="addButton; context: { addToTop: true }" />
     <span class="flex-1"></span>
   </h5>
+  <p i18n>
+    Add additional resources for this unit. They will appear in the unit info page in the curriculum
+    library.
+  </p>
   <ul cdkDropList [cdkDropListData]="resources" (cdkDropListDropped)="drop($event)" cdkScrollable>
     @for (
       resource of resources;

--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html
@@ -1,109 +1,82 @@
-@if (isMyUnit) {
-  <a href="{{ publishUnitUrl }}" class="share-button">
-    <button mat-flat-button color="primary">
-      <mat-icon>public</mat-icon>&nbsp;<ng-container i18n>Publish</ng-container>
-    </button>
-  </a>
-}
-<div class="project-icon-label flex gap-5">
-  <span i18n>Unit Icon</span>
-  <button mat-raised-button color="primary" (click)="toggleEditProjectIconMode()" i18n>Edit</button>
-</div>
-<div class="project-icon-container">
-  @if (isShowProjectIcon) {
-    <div>
-      <img [src]="projectIcon" class="project-icon" />
-    </div>
-  }
-  @if (isShowProjectIconError) {
-    <div class="project-icon-error">
-      <p class="red margin-bottom-20" i18n>This unit does not have a unit icon.</p>
-      <p class="red" i18n>Click the edit button to set one.</p>
-    </div>
-  }
-  @if (isShowProjectIconLoading) {
-    <div>
-      <mat-spinner />
-    </div>
-  }
-</div>
-@if (isEditingProjectIcon) {
-  <div>
-    <div class="choose-project-icon-message flex gap-5">
-      <span i18n
-        >Choose a new Unit Icon by clicking on one below or upload your own custom icon.</span
-      >
-      <button mat-raised-button color="primary" (click)="chooseCustomProjectIcon()" i18n>
-        Upload
-      </button>
-    </div>
-    <div class="flex flex-wrap">
-      @for (projectIcon of projectIcons; track projectIcon) {
-        <img
-          class="project-icon-to-choose"
-          src="/projectIcons/{{ projectIcon }}"
-          (click)="setFeaturedProjectIcon(projectIcon)"
-        />
-      }
-    </div>
-    <br />
-  </div>
-}
-<br />
-@for (metadataField of metadataAuthoring.fields; track metadataField) {
-  <div>
-    @if (metadataField.type === 'textarea') {
-      <translatable-textarea
-        [content]="metadata"
-        [key]="metadataField.key"
-        [label]="metadataField.name"
-        (defaultLanguageTextChanged)="metadataChanged.next()"
-        class="textarea"
-      />
-    }
-    @if (metadataField.type === 'input') {
-      <translatable-input
-        [content]="metadata"
-        [key]="metadataField.key"
-        [label]="metadataField.name"
-        (defaultLanguageTextChanged)="metadataChanged.next()"
-        class="input"
-      />
-    }
-    @if (metadataField.name === 'Language') {
-      <edit-project-language-setting />
-    }
-    @if (metadataField.type === 'radio' && metadataField.name !== 'Language') {
-      <label class="bold">{{ metadataField.name }}:</label>
-      <mat-radio-group class="radio-group margin-bottom-20 flex flex-col">
-        @for (choice of metadataField.choices; track choice) {
-          <mat-radio-button
-            type="radio"
-            color="primary"
-            [value]="choice"
-            [checked]="metadataChoiceIsChecked(metadataField, choice)"
-            (click)="metadataRadioClicked(metadataField, choice)"
-          >
-            {{ getMetadataChoiceText(choice) }}
-          </mat-radio-button>
-        }
-      </mat-radio-group>
-    }
-    @if (metadataField.type === 'checkbox') {
-      <label class="bold">{{ metadataField.name }}:</label>
-      <div class="flex flex-col">
-        @for (choice of metadataField.choices; track choice) {
-          <mat-checkbox
-            color="primary"
-            [(ngModel)]="metadataField.choicesMapping[choice]"
-            (click)="metadataCheckboxClicked(metadataField)"
-          >
-            {{ getMetadataChoiceText(choice) }}
-          </mat-checkbox>
+<mat-tab-group animationDuration="0ms">
+  <mat-tab>
+    <ng-template mat-tab-label>
+      <mat-icon>settings</mat-icon>&nbsp;<span i18n>General</span>
+    </ng-template>
+    <div class="flex flex-col gap-5" style="margin-top: 20px">
+      <div>
+        @for (metadataField of metadataAuthoring.fields; track metadataField) {
+          @if (metadataField.key === 'title' || metadataField.key === 'summary') {
+            <translatable-input
+              [content]="metadata"
+              [key]="metadataField.key"
+              [label]="metadataField.name"
+              (defaultLanguageTextChanged)="metadataChanged.next()"
+              class="input"
+            />
+          }
         }
       </div>
-    }
-  </div>
-}
-<edit-unit-type [metadata]="metadata" />
-<edit-unit-resources [resources]="metadata.resources" />
+      <div class="flex flex-col gap-5" style="border: 2px dotted; padding: 10px">
+        <div class="project-icon-label flex flex-row gap-5">
+          <span i18n>Unit Icon</span>
+          <button mat-raised-button color="primary" (click)="toggleEditProjectIconMode()" i18n>
+            Edit
+          </button>
+        </div>
+        @if (isShowProjectIcon) {
+          <div>
+            <img [src]="projectIcon" class="project-icon" />
+          </div>
+        } @else if (isShowProjectIconError) {
+          <div class="project-icon-error">
+            <p class="red margin-bottom-20" i18n>This unit does not have a unit icon.</p>
+            <p class="red" i18n>Click the edit button to set one.</p>
+          </div>
+        } @else if (isShowProjectIconLoading) {
+          <div>
+            <mat-spinner />
+          </div>
+        }
+        @if (isEditingProjectIcon) {
+          <div>
+            <div class="choose-project-icon-message flex gap-5">
+              <span i18n
+                >Choose a new Unit Icon by clicking on one below or upload your own custom
+                icon.</span
+              >
+              <button mat-raised-button color="primary" (click)="chooseCustomProjectIcon()" i18n>
+                Upload
+              </button>
+            </div>
+            <div class="flex flex-wrap">
+              @for (projectIcon of projectIcons; track projectIcon) {
+                <img
+                  class="project-icon-to-choose"
+                  src="/projectIcons/{{ projectIcon }}"
+                  (click)="setFeaturedProjectIcon(projectIcon)"
+                />
+              }
+            </div>
+            <br />
+          </div>
+        }
+      </div>
+    </div>
+  </mat-tab>
+  <mat-tab>
+    <ng-template mat-tab-label>
+      <mat-icon>translate</mat-icon>&nbsp;<span i18n>Language</span>
+    </ng-template>
+    <div style="min-height: 800px; margin-top: 20px">
+      <!-- min-height is set to 800px to show all language options without outer scrollbar -->
+      <edit-project-language-setting />
+    </div>
+  </mat-tab>
+  <mat-tab>
+    <ng-template mat-tab-label>
+      <mat-icon>folder</mat-icon>&nbsp;<span i18n>Resources</span>
+    </ng-template>
+    <edit-unit-resources [resources]="metadata.resources" />
+  </mat-tab>
+</mat-tab-group>

--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html
@@ -1,82 +1,96 @@
-<mat-tab-group animationDuration="0ms">
-  <mat-tab>
-    <ng-template mat-tab-label>
-      <mat-icon>settings</mat-icon>&nbsp;<span i18n>General</span>
-    </ng-template>
-    <div class="flex flex-col gap-5" style="margin-top: 20px">
-      <div>
-        @for (metadataField of metadataAuthoring.fields; track metadataField) {
-          @if (metadataField.key === 'title' || metadataField.key === 'summary') {
-            <translatable-input
-              [content]="metadata"
-              [key]="metadataField.key"
-              [label]="metadataField.name"
-              (defaultLanguageTextChanged)="metadataChanged.next()"
-              class="input"
-            />
+<div class="project-info-authoring">
+  <mat-tab-group animationDuration="0ms">
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <mat-icon>settings</mat-icon>&nbsp;<span i18n>General</span>
+      </ng-template>
+      <div class="flex flex-col gap-5 mt-4">
+        <div>
+          @for (metadataField of metadataAuthoring.fields; track metadataField) {
+            @if (metadataField.key === 'title') {
+              <translatable-input
+                [content]="metadata"
+                [key]="metadataField.key"
+                [label]="metadataField.name"
+                (defaultLanguageTextChanged)="metadataChanged.next()"
+              />
+            }
+            @if (metadataField.key === 'summary') {
+              <translatable-textarea
+                [content]="metadata"
+                [key]="metadataField.key"
+                [label]="metadataField.name"
+                (defaultLanguageTextChanged)="metadataChanged.next()"
+              />
+            }
           }
-        }
-      </div>
-      <div class="flex flex-col gap-5" style="border: 2px dotted; padding: 10px">
-        <div class="project-icon-label flex flex-row gap-5">
-          <span i18n>Unit Icon</span>
-          <button mat-raised-button color="primary" (click)="toggleEditProjectIconMode()" i18n>
-            Edit
-          </button>
         </div>
-        @if (isShowProjectIcon) {
-          <div>
-            <img [src]="projectIcon" class="project-icon" />
+        <div class="flex flex-col gap-4 p-3">
+          <div class="project-icon-label flex flex-row items-center gap-4">
+            <span i18n>Unit Icon</span>
+            <button mat-raised-button color="primary" (click)="toggleEditProjectIconMode()" i18n>
+              Edit
+            </button>
           </div>
-        } @else if (isShowProjectIconError) {
-          <div class="project-icon-error">
-            <p class="red margin-bottom-20" i18n>This unit does not have a unit icon.</p>
-            <p class="red" i18n>Click the edit button to set one.</p>
-          </div>
-        } @else if (isShowProjectIconLoading) {
-          <div>
-            <mat-spinner />
-          </div>
-        }
-        @if (isEditingProjectIcon) {
-          <div>
-            <div class="choose-project-icon-message flex gap-5">
-              <span i18n
-                >Choose a new Unit Icon by clicking on one below or upload your own custom
-                icon.</span
-              >
-              <button mat-raised-button color="primary" (click)="chooseCustomProjectIcon()" i18n>
-                Upload
-              </button>
+          @if (isShowProjectIcon) {
+            <div>
+              <img [src]="projectIcon" class="project-icon" />
             </div>
-            <div class="flex flex-wrap">
-              @for (projectIcon of projectIcons; track projectIcon) {
-                <img
-                  class="project-icon-to-choose"
-                  src="/projectIcons/{{ projectIcon }}"
-                  (click)="setFeaturedProjectIcon(projectIcon)"
-                />
-              }
+          } @else if (isShowProjectIconError) {
+            <div class="project-icon-error">
+              <p class="red mb-4" i18n>This unit does not have a unit icon.</p>
+              <p class="red" i18n>Click the edit button to set one.</p>
             </div>
-            <br />
-          </div>
-        }
+          } @else if (isShowProjectIconLoading) {
+            <div>
+              <mat-spinner />
+            </div>
+          }
+          @if (isEditingProjectIcon) {
+            <div>
+              <div class="flex items-center gap-4 mb-4">
+                <span i18n
+                  >Choose a new Unit Icon by clicking on one below or upload your own custom
+                  icon.</span
+                >
+                <button mat-raised-button color="primary" (click)="chooseCustomProjectIcon()" i18n>
+                  Upload
+                </button>
+              </div>
+              <div class="flex flex-wrap">
+                @for (projectIcon of projectIcons; track projectIcon) {
+                  <img
+                    role="button"
+                    tabindex="0"
+                    class="project-icon-to-choose"
+                    src="/projectIcons/{{ projectIcon }}"
+                    (click)="setFeaturedProjectIcon(projectIcon)"
+                    (keydown.enter)="setFeaturedProjectIcon(projectIcon)"
+                    aria-label="Choose this project icon"
+                    i18n-aria-label
+                  />
+                }
+              </div>
+              <br />
+            </div>
+          }
+        </div>
       </div>
-    </div>
-  </mat-tab>
-  <mat-tab>
-    <ng-template mat-tab-label>
-      <mat-icon>translate</mat-icon>&nbsp;<span i18n>Language</span>
-    </ng-template>
-    <div style="min-height: 800px; margin-top: 20px">
-      <!-- min-height is set to 800px to show all language options without outer scrollbar -->
-      <edit-project-language-setting />
-    </div>
-  </mat-tab>
-  <mat-tab>
-    <ng-template mat-tab-label>
-      <mat-icon>folder</mat-icon>&nbsp;<span i18n>Resources</span>
-    </ng-template>
-    <edit-unit-resources [resources]="metadata.resources" />
-  </mat-tab>
-</mat-tab-group>
+    </mat-tab>
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <mat-icon>translate</mat-icon>&nbsp;<span i18n>Language</span>
+      </ng-template>
+      <div class="mt-4" style="min-height: 800px">
+        <!-- min-height is set to 800px to show all language options without outer scrollbar -->
+        <edit-project-language-setting />
+      </div>
+    </mat-tab>
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <mat-icon>folder</mat-icon>&nbsp;<span i18n>Resources</span>
+      </ng-template>
+      <edit-unit-resources [resources]="metadata.resources" class="block mt-4" />
+    </mat-tab>
+  </mat-tab-group>
+</div>

--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.scss
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.scss
@@ -1,52 +1,30 @@
-.project-icon-label {
-  margin-bottom: 10px;
-}
+.project-info-authoring {
+  .project-icon-label {
+    margin-bottom: 10px;
+  }
 
-.project-icon-container {
-  width: 200px;
-  height: 200px;
-  display: flex;
-  align-items: center;
-  justify-content: center
-}
+  .project-icon-container {
+    width: 200px;
+    height: 200px;
+    display: flex;
+    align-items: center;
+    justify-content: center
+  }
 
-.project-icon {
-  width: 200px;
-}
+  .project-icon {
+    width: 200px;
+  }
 
-.project-icon-error {
-  border: 1px solid black;
-  padding: 20px;
-}
+  .project-icon-error {
+    border: 1px solid black;
+    padding: 20px;
+  }
 
-.choose-project-icon-message {
-  margin-bottom: 20px;
-}
+  .project-icon-to-choose {
+    cursor: pointer;
+  }
 
-.project-icon-to-choose {
-  cursor: pointer;
-}
-
-.bold {
-  font-weight: bold;
-}
-
-.red {
-  color: red;
-}
-
-.margin-bottom-20 {
-  margin-bottom: 20px;
-}
-
-.textarea {
-  width: 100%;
-}
-
-.input {
-  width: 50%;
-}
-
-.share-button {
-  float: right;
+  .mat-mdc-tab-header {
+    margin: 0 -16px;
+  }
 }

--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.spec.ts
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.spec.ts
@@ -4,7 +4,8 @@ import { TeacherProjectService } from '../../services/teacherProjectService';
 import { ConfigService } from '../../services/configService';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { UserService } from '../../../../app/services/user.service';
-import { MockProviders } from 'ng-mocks';
+import { MockComponent, MockProviders } from 'ng-mocks';
+import { EditProjectLanguageSettingComponent } from '../project-info/edit-project-language-setting/edit-project-language-setting.component';
 
 describe('ProjectInfoAuthoringComponent', () => {
   let component: ProjectInfoAuthoringComponent;
@@ -12,7 +13,7 @@ describe('ProjectInfoAuthoringComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ProjectInfoAuthoringComponent],
+      imports: [ProjectInfoAuthoringComponent, MockComponent(EditProjectLanguageSettingComponent)],
       providers: [
         MockProviders(ConfigService, TeacherProjectService, UserService),
         provideHttpClient(withInterceptorsFromDi())

--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.ts
@@ -5,25 +5,26 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatRadioModule } from '@angular/material/radio';
 import { Subject, debounceTime } from 'rxjs';
-import { UserService } from '../../../../app/services/user.service';
 import { ConfigService } from '../../services/configService';
 import { TeacherProjectService } from '../../services/teacherProjectService';
 import { TranslatableInputComponent } from '../components/translatable-input/translatable-input.component';
 import { TranslatableTextareaComponent } from '../components/translatable-textarea/translatable-textarea.component';
 import { EditUnitResourcesComponent } from '../edit-unit-resources/edit-unit-resources.component';
-import { EditUnitTypeComponent } from '../edit-unit-type/edit-unit-type.component';
 import { AssetChooser } from '../project-asset-authoring/asset-chooser';
 import { EditProjectLanguageSettingComponent } from '../project-info/edit-project-language-setting/edit-project-language-setting.component';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   imports: [
     EditProjectLanguageSettingComponent,
     EditUnitResourcesComponent,
-    EditUnitTypeComponent,
     MatButtonModule,
     MatCheckboxModule,
+    MatIconModule,
     MatProgressSpinnerModule,
     MatRadioModule,
+    MatTabsModule,
     TranslatableInputComponent,
     TranslatableTextareaComponent
   ],
@@ -32,22 +33,19 @@ import { EditProjectLanguageSettingComponent } from '../project-info/edit-projec
 })
 export class ProjectInfoAuthoringComponent {
   isEditingProjectIcon: boolean = false;
-  protected isMyUnit: boolean;
   isShowProjectIcon: boolean = false;
   isShowProjectIconError: boolean = false;
   isShowProjectIconLoading: boolean = false;
-  metadata: any;
+  protected metadata: any;
   metadataAuthoring: any;
   metadataChanged: Subject<void> = new Subject<void>();
   projectIcon: string = '';
   projectIcons: any = [];
-  protected publishUnitUrl;
 
   constructor(
     private configService: ConfigService,
     private dialog: MatDialog,
-    private projectService: TeacherProjectService,
-    private userService: UserService
+    private projectService: TeacherProjectService
   ) {}
 
   ngOnInit(): void {
@@ -55,16 +53,9 @@ export class ProjectInfoAuthoringComponent {
     if (this.metadata.resources == null) {
       this.metadata.resources = [];
     }
-    if (this.metadata.unitType == null) {
-      this.metadata.unitType = 'Platform';
-    }
     this.metadataAuthoring = JSON.parse(
       this.configService.getConfigParam('projectMetadataSettings')
     );
-    this.isMyUnit = this.metadata.authors.some(
-      (author) => author.id === this.userService.getUserId()
-    );
-    this.publishUnitUrl = `${this.configService.getContextPath()}/contact?projectId=${this.configService.getProjectId()}&publish=true`;
     this.loadProjectIcon();
     this.processMetadata();
     this.metadataChanged.pipe(debounceTime(1000)).subscribe(() => {

--- a/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialog } from '@angular/material/dialog';
@@ -16,6 +16,7 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
+  encapsulation: ViewEncapsulation.None,
   imports: [
     EditProjectLanguageSettingComponent,
     EditUnitResourcesComponent,

--- a/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.html
+++ b/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.html
@@ -1,4 +1,7 @@
-<h3 i18n>Language</h3>
+<p i18n style="margin-bottom: 10px">
+  WISE units support multiple languages. After you've added additional languages, use the language
+  toggle as you're authoring to translate content for additional supported languages.
+</p>
 <span i18n>Default language:</span>
 <ng-select
   [items]="availableLanguages"

--- a/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.html
+++ b/src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.html
@@ -1,6 +1,6 @@
 <p i18n style="margin-bottom: 10px">
   WISE units support multiple languages. After you've added additional languages, use the language
-  toggle as you're authoring to translate content for additional supported languages.
+  toggle as you're authoring to translate content for other languages.
 </p>
 <span i18n>Default language:</span>
 <ng-select

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -905,7 +905,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/advanced/advanced-project-authoring.component.html</context>
-          <context context-type="linenumber">49,53</context>
+          <context context-type="linenumber">63,67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8880132687084463323" datatype="html">
@@ -1223,7 +1223,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/edit-unit-resources/edit-unit-resources.component.html</context>
-          <context context-type="linenumber">30,32</context>
+          <context context-type="linenumber">34,36</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
@@ -1284,7 +1284,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/edit-unit-resources/edit-unit-resources.component.html</context>
-          <context context-type="linenumber">68,69</context>
+          <context context-type="linenumber">72,73</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
@@ -1315,7 +1315,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/edit-unit-resources/edit-unit-resources.component.html</context>
-          <context context-type="linenumber">77,79</context>
+          <context context-type="linenumber">81,83</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/node/node-authoring/node-authoring.component.html</context>
@@ -6464,10 +6464,6 @@
           <context context-type="linenumber">10,13</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
-          <context context-type="linenumber">10,13</context>
-        </context-group>
-        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/edit-component-annotations/edit-component-annotations.component.html</context>
           <context context-type="linenumber">132,135</context>
         </context-group>
@@ -6488,10 +6484,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/library/library-project-menu/library-project-menu.component.html</context>
           <context context-type="linenumber">25,28</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
-          <context context-type="linenumber">4,8</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6770769801335635194" datatype="html">
@@ -8307,8 +8299,8 @@
           <context context-type="linenumber">105,107</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.html</context>
-          <context context-type="linenumber">1,4</context>
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
+          <context context-type="linenumber">69,71</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7320027445219108849" datatype="html">
@@ -10632,35 +10624,42 @@
         <source>Navigation mode:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/advanced/advanced-project-authoring.component.html</context>
-          <context context-type="linenumber">7,9</context>
+          <context context-type="linenumber">8,10</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8555748708121198389" datatype="html">
         <source>Default (lessons appear in drop-down list and unit plan)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/advanced/advanced-project-authoring.component.html</context>
-          <context context-type="linenumber">14,16</context>
+          <context context-type="linenumber">15,17</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1890075437242835278" datatype="html">
         <source>Tabbed (lessons appear as tabs) </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/advanced/advanced-project-authoring.component.html</context>
-          <context context-type="linenumber">17,21</context>
+          <context context-type="linenumber">18,22</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1653435262796372065" datatype="html">
         <source>Download unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/advanced/advanced-project-authoring.component.html</context>
-          <context context-type="linenumber">23,27</context>
+          <context context-type="linenumber">26,29</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3673512239719163589" datatype="html">
+        <source>Submit to Public Unit Library</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/advanced/advanced-project-authoring.component.html</context>
+          <context context-type="linenumber">32,36</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8129802372590365244" datatype="html">
         <source>Rubric</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/advanced/advanced-project-authoring.component.html</context>
-          <context context-type="linenumber">28,31</context>
+          <context context-type="linenumber">42,45</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/aiChat/edit-ai-chat-advanced/edit-ai-chat-advanced.component.html</context>
@@ -10751,7 +10750,7 @@
         <source>Milestones</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/advanced/advanced-project-authoring.component.html</context>
-          <context context-type="linenumber">37,40</context>
+          <context context-type="linenumber">51,54</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/shared/authoring-tool-bar/authoring-tool-bar.component.ts</context>
@@ -10770,7 +10769,7 @@
         <source>JSON</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/advanced/advanced-project-authoring.component.html</context>
-          <context context-type="linenumber">44,47</context>
+          <context context-type="linenumber">58,61</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/aiChat/edit-ai-chat-advanced/edit-ai-chat-advanced.component.html</context>
@@ -10857,7 +10856,7 @@
         <source>Edit Unit JSON</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/advanced/advanced-project-authoring.component.html</context>
-          <context context-type="linenumber">54,57</context>
+          <context context-type="linenumber">68,71</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/recovery-authoring/recovery-authoring.component.html</context>
@@ -10870,7 +10869,7 @@ Click &quot;OK&quot; to revert back to the last valid JSON.
 Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/advanced/advanced-project-authoring.component.ts</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="82388219829106287" datatype="html">
@@ -11966,26 +11965,37 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="sourcefile">src/assets/wise5/authoringTool/edit-unit-resources/edit-unit-resources.component.html</context>
           <context context-type="linenumber">15,16</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
+          <context context-type="linenumber">78,80</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5263249600886629291" datatype="html">
+        <source> Add additional resources for this unit. They will appear in the unit info page in the curriculum library. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/edit-unit-resources/edit-unit-resources.component.html</context>
+          <context context-type="linenumber">20,23</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="6813396031694137692" datatype="html">
         <source>Resource Name</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/edit-unit-resources/edit-unit-resources.component.html</context>
-          <context context-type="linenumber">34,37</context>
+          <context context-type="linenumber">38,41</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5646644722959423444" datatype="html">
         <source>Resource URL</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/edit-unit-resources/edit-unit-resources.component.html</context>
-          <context context-type="linenumber">42,45</context>
+          <context context-type="linenumber">46,49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4749936818577754995" datatype="html">
         <source>Delete resource</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/edit-unit-resources/edit-unit-resources.component.html</context>
-          <context context-type="linenumber">56,58</context>
+          <context context-type="linenumber">60,62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8736780065388669223" datatype="html">
@@ -13689,53 +13699,143 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">116</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="6439365426343089851" datatype="html">
+        <source>General</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
+          <context context-type="linenumber">4,6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/aiChat/edit-ai-chat-advanced/edit-ai-chat-advanced.component.html</context>
+          <context context-type="linenumber">4,7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/animation/edit-animation-advanced/edit-animation-advanced.component.html</context>
+          <context context-type="linenumber">4,6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/edit-audio-oscillator-advanced/edit-audio-oscillator-advanced.component.html</context>
+          <context context-type="linenumber">4,6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.html</context>
+          <context context-type="linenumber">4,7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-advanced/edit-dialog-guidance-advanced.component.html</context>
+          <context context-type="linenumber">4,6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/edit-discussion-advanced/edit-discussion-advanced.component.html</context>
+          <context context-type="linenumber">4,7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/draw/edit-draw-advanced/edit-draw-advanced.component.html</context>
+          <context context-type="linenumber">4,8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/embedded/edit-embedded-advanced/edit-embedded-advanced.component.html</context>
+          <context context-type="linenumber">4,7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.html</context>
+          <context context-type="linenumber">4,7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/html/edit-html-advanced/edit-html-advanced.component.html</context>
+          <context context-type="linenumber">4,6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/label/edit-label-advanced/edit-label-advanced.component.html</context>
+          <context context-type="linenumber">4,8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/match/edit-match-advanced/edit-match-advanced.component.html</context>
+          <context context-type="linenumber">4,8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/edit-multiple-choice-advanced/edit-multiple-choice-advanced.component.html</context>
+          <context context-type="linenumber">4,7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
+          <context context-type="linenumber">4,7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/outsideURL/edit-outside-url-advanced/edit-outside-url-advanced.component.ts</context>
+          <context context-type="linenumber">11,14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/summary/edit-summary-advanced/edit-summary-advanced.component.ts</context>
+          <context context-type="linenumber">11,14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html</context>
+          <context context-type="linenumber">4,6</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="5051388252985578877" datatype="html">
         <source>Unit Icon</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
-          <context context-type="linenumber">9,10</context>
+          <context context-type="linenumber">22,23</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5377078063439833222" datatype="html">
+        <source> Edit </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
+          <context context-type="linenumber">24,27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6612727015582273891" datatype="html">
         <source>This unit does not have a unit icon.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
-          <context context-type="linenumber">20,22</context>
+          <context context-type="linenumber">33,34</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8401624672824530115" datatype="html">
         <source>Click the edit button to set one.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
-          <context context-type="linenumber">21,26</context>
+          <context context-type="linenumber">34,37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8945986900727189150" datatype="html">
         <source>Choose a new Unit Icon by clicking on one below or upload your own custom icon.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
-          <context context-type="linenumber">34,36</context>
+          <context context-type="linenumber">45,48</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4842432534148275616" datatype="html">
         <source> Upload </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info-authoring/project-info-authoring.component.html</context>
-          <context context-type="linenumber">37,41</context>
+          <context context-type="linenumber">49,52</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4814068849928280629" datatype="html">
+        <source> WISE units support multiple languages. After you&apos;ve added additional languages, use the language toggle as you&apos;re authoring to translate content for additional supported languages.
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.html</context>
+          <context context-type="linenumber">2,7</context>
         </context-group>
       </trans-unit>
       <trans-unit id="955279821105592607" datatype="html">
         <source>Default language:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.html</context>
-          <context context-type="linenumber">2,6</context>
+          <context context-type="linenumber">5,9</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6950367361975708984" datatype="html">
         <source>Additional languages:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/project-info/edit-project-language-setting/edit-project-language-setting.component.html</context>
-          <context context-type="linenumber">10,14</context>
+          <context context-type="linenumber">13,17</context>
         </context-group>
       </trans-unit>
       <trans-unit id="87418722412836884" datatype="html">
@@ -16612,77 +16712,6 @@ Are you sure you want to proceed?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/aiChat/ai-chat-student/ai-chat-student.component.ts</context>
           <context context-type="linenumber">114</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6439365426343089851" datatype="html">
-        <source>General</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/aiChat/edit-ai-chat-advanced/edit-ai-chat-advanced.component.html</context>
-          <context context-type="linenumber">4,7</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/animation/edit-animation-advanced/edit-animation-advanced.component.html</context>
-          <context context-type="linenumber">4,6</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/audioOscillator/edit-audio-oscillator-advanced/edit-audio-oscillator-advanced.component.html</context>
-          <context context-type="linenumber">4,6</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/conceptMap/edit-concept-map-advanced/edit-concept-map-advanced.component.html</context>
-          <context context-type="linenumber">4,7</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/dialogGuidance/edit-dialog-guidance-advanced/edit-dialog-guidance-advanced.component.html</context>
-          <context context-type="linenumber">4,6</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/discussion/edit-discussion-advanced/edit-discussion-advanced.component.html</context>
-          <context context-type="linenumber">4,7</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/draw/edit-draw-advanced/edit-draw-advanced.component.html</context>
-          <context context-type="linenumber">4,8</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/embedded/edit-embedded-advanced/edit-embedded-advanced.component.html</context>
-          <context context-type="linenumber">4,7</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/graph/edit-graph-advanced/edit-graph-advanced.component.html</context>
-          <context context-type="linenumber">4,7</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/html/edit-html-advanced/edit-html-advanced.component.html</context>
-          <context context-type="linenumber">4,6</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/label/edit-label-advanced/edit-label-advanced.component.html</context>
-          <context context-type="linenumber">4,8</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/match/edit-match-advanced/edit-match-advanced.component.html</context>
-          <context context-type="linenumber">4,8</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/multipleChoice/edit-multiple-choice-advanced/edit-multiple-choice-advanced.component.html</context>
-          <context context-type="linenumber">4,7</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/openResponse/edit-open-response-advanced/edit-open-response-advanced.component.html</context>
-          <context context-type="linenumber">4,7</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/outsideURL/edit-outside-url-advanced/edit-outside-url-advanced.component.ts</context>
-          <context context-type="linenumber">11,14</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/summary/edit-summary-advanced/edit-summary-advanced.component.ts</context>
-          <context context-type="linenumber">11,14</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/components/table/edit-table-advanced/edit-table-advanced.component.html</context>
-          <context context-type="linenumber">4,6</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1141886420788473147" datatype="html">


### PR DESCRIPTION
In the Unit Info page, we had everything on one page without any organization, which made it difficult to read and change. This PR introduces tabs to organize the different sections. You can see the mockups here: https://balsamiq.cloud/s8brvqj/p9j1not/r26E6

## Changes
- Split unit info into three tabs
   - General (title, summary, icons)
   - Language
   - Resources 
- Moved these options to Advanced > General Settings tab
   - "Unit Type" ("WISE Platform" vs "Other Platform")
   - "Submit to Public Unit Library" button. This button used to say "Public Publish"

## Test
- You should be able to view and edit the unit info settings in the new layout.