### PR TITLE
style(Export): Improve page design using material cards for export type

### DIFF
--- a/src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html
+++ b/src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html
@@ -1,116 +1,182 @@
 <div class="view-content view-content--with-sidemenu">
   <div class="l-constrained flex flex-col">
-    <div class="flex flex-col gap-2">
-      <div>
-        <button
-          mat-raised-button
-          (click)="goToExportOneWorkgroupPerRowPage()"
-          aria-label="Export One Workgroup Per Row"
-          i18n-aria-label
-          i18n
+    <div class="flex flex-row flex-wrap justify-center md:justify-start gap-2">
+      <mat-card appearance="outlined">
+        <mat-card-title>
+          <h6 class="center"><strong>One Workgroup Per Row</strong></h6>
+        </mat-card-title>
+        <mat-card-content class="center" i18n
+          >Each workgroup gets their own row with all their work</mat-card-content
         >
-          Export One Workgroup Per Row
-        </button>
-      </div>
-      <div>
-        <button
-          mat-raised-button
-          (click)="goToExportStudentWorkPage()"
-          aria-label="Export Student Work"
-          i18n-aria-label
-          i18n
+        <mat-card-actions>
+          <button
+            mat-flat-button
+            color="primary"
+            class="w-full"
+            (click)="goToExportOneWorkgroupPerRowPage()"
+            i18n
+          >
+            Select
+          </button>
+        </mat-card-actions>
+      </mat-card>
+      <mat-card appearance="outlined">
+        <mat-card-title>
+          <h6 class="center"><strong>Student Work</strong></h6>
+        </mat-card-title>
+        <mat-card-content class="center" i18n>All student work and annotations</mat-card-content>
+        <mat-card-actions>
+          <button
+            mat-flat-button
+            color="primary"
+            class="w-full"
+            (click)="goToExportStudentWorkPage()"
+            i18n
+          >
+            Select
+          </button>
+        </mat-card-actions>
+      </mat-card>
+      <mat-card appearance="outlined">
+        <mat-card-title>
+          <h6 class="center"><strong>Events</strong></h6>
+        </mat-card-title>
+        <mat-card-content class="center" i18n
+          >All events that were logged during the classroom
+        </mat-card-content>
+        <mat-card-actions>
+          <button
+            mat-flat-button
+            color="primary"
+            class="w-full"
+            (click)="goToExportEventsPage()"
+            i18n
+          >
+            Select
+          </button>
+        </mat-card-actions>
+      </mat-card>
+      <mat-card appearance="outlined">
+        <mat-card-title>
+          <h6 class="center"><strong>Item Data</strong></h6>
+        </mat-card-title>
+        <mat-card-content class="center" i18n>Custom data for certain activities</mat-card-content>
+        <mat-card-actions>
+          <button
+            mat-flat-button
+            color="primary"
+            class="w-full"
+            (click)="goToExportItemPage()"
+            i18n
+          >
+            Select
+          </button>
+        </mat-card-actions>
+      </mat-card>
+      <mat-card appearance="outlined">
+        <mat-card-title>
+          <h6 class="center"><strong>Raw Data</strong></h6>
+        </mat-card-title>
+        <mat-card-content class="center" i18n>All data logged by activities</mat-card-content>
+        <mat-card-actions>
+          <button
+            mat-flat-button
+            color="primary"
+            class="w-full"
+            (click)="goToExportRawDataPage()"
+            i18n
+          >
+            Select
+          </button>
+        </mat-card-actions>
+      </mat-card>
+      <mat-card appearance="outlined">
+        <mat-card-title>
+          <h6 class="center"><strong>Step Visits</strong></h6>
+        </mat-card-title>
+        <mat-card-content class="center" i18n>Time spent on each step in the unit</mat-card-content>
+        <mat-card-actions>
+          <button
+            mat-flat-button
+            color="primary"
+            class="w-full"
+            (click)="exportVisitsClicked()"
+            i18n
+          >
+            Select
+          </button>
+        </mat-card-actions>
+      </mat-card>
+      <mat-card appearance="outlined">
+        <mat-card-title>
+          <h6 class="center"><strong>Latest Notebook Items</strong></h6>
+        </mat-card-title>
+        <mat-card-content class="center" i18n>Latest notebook items and reports</mat-card-content>
+        <mat-card-actions>
+          <button
+            mat-flat-button
+            color="primary"
+            class="w-full"
+            (click)="export('latestNotebookItems')"
+            i18n
+          >
+            Download
+          </button>
+        </mat-card-actions>
+      </mat-card>
+      <mat-card appearance="outlined">
+        <mat-card-title>
+          <h6 class="center"><strong>All Notebook Items</strong></h6>
+        </mat-card-title>
+        <mat-card-content class="center" i18n>All notebook items and reports</mat-card-content>
+        <mat-card-actions>
+          <button
+            mat-flat-button
+            color="primary"
+            class="w-full"
+            (click)="export('allNotebookItems')"
+            i18n
+          >
+            Download
+          </button>
+        </mat-card-actions>
+      </mat-card>
+      <mat-card appearance="outlined">
+        <mat-card-title>
+          <h6 class="center"><strong>Notifications</strong></h6>
+        </mat-card-title>
+        <mat-card-content class="center" i18n
+          >Notifications sent to student and teachers</mat-card-content
         >
-          Export Student Work
-        </button>
-      </div>
-      <div>
-        <button
-          mat-raised-button
-          (click)="goToExportEventsPage()"
-          aria-label="Export Events"
-          i18n-aria-label
-          i18n
-        >
-          Export Events
-        </button>
-      </div>
-      <div>
-        <button
-          mat-raised-button
-          (click)="export('latestNotebookItems')"
-          aria-label="Export Latest Notebook Items"
-          i18n-aria-label
-          i18n
-        >
-          Export Latest Notebook Items
-        </button>
-      </div>
-      <div>
-        <button
-          mat-raised-button
-          (click)="export('allNotebookItems')"
-          aria-label="Export All Notebook Items"
-          i18n-aria-label
-          i18n
-        >
-          Export All Notebook Items
-        </button>
-      </div>
-      <div>
-        <button
-          mat-raised-button
-          (click)="export('notifications')"
-          aria-label="Export Notifications"
-          i18n-aria-label
-          i18n
-        >
-          Export Notifications
-        </button>
-      </div>
-      <div>
-        <button
-          mat-raised-button
-          (click)="export('studentAssets')"
-          aria-label="Export Student Assets"
-          i18n-aria-label
-          i18n
-        >
-          Export Student Assets
-        </button>
-      </div>
-      <div>
-        <button
-          mat-raised-button
-          (click)="goToExportItemPage()"
-          aria-label="Export Item Data"
-          i18n-aria-label
-          i18n
-        >
-          Export Item Data
-        </button>
-      </div>
-      <div>
-        <button
-          mat-raised-button
-          (click)="goToExportRawDataPage()"
-          aria-label="Export Raw Data"
-          i18n-aria-label
-          i18n
-        >
-          Export Raw Data
-        </button>
-      </div>
-      <div>
-        <button
-          mat-raised-button
-          (click)="exportVisitsClicked()"
-          aria-label="Export Step Visits"
-          i18n-aria-label
-          i18n
-        >
-          Export Step Visits
-        </button>
-      </div>
+        <mat-card-actions>
+          <button
+            mat-flat-button
+            color="primary"
+            class="w-full"
+            (click)="export('notifications')"
+            i18n
+          >
+            Download
+          </button>
+        </mat-card-actions>
+      </mat-card>
+      <mat-card appearance="outlined">
+        <mat-card-title>
+          <h6 class="center"><strong>Student Assets</strong></h6>
+        </mat-card-title>
+        <mat-card-content class="center" i18n>Student uploaded files</mat-card-content>
+        <mat-card-actions>
+          <button
+            mat-flat-button
+            color="primary"
+            class="w-full"
+            (click)="export('studentAssets')"
+            i18n
+          >
+            Download
+          </button>
+        </mat-card-actions>
+      </mat-card>
     </div>
   </div>
 </div>

--- a/src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html
+++ b/src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html
@@ -1,12 +1,12 @@
 <div class="view-content view-content--with-sidemenu">
   <div class="l-constrained flex flex-col">
-    <div class="flex flex-row flex-wrap justify-center md:justify-start gap-2">
+    <div class="grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-2">
       <mat-card appearance="outlined">
         <mat-card-title>
           <h6 class="center"><strong>One Workgroup Per Row</strong></h6>
         </mat-card-title>
         <mat-card-content class="center" i18n
-          >Each workgroup gets their own row with all their work</mat-card-content
+          >Each workgroup gets one row with all their work</mat-card-content
         >
         <mat-card-actions>
           <button
@@ -42,7 +42,7 @@
           <h6 class="center"><strong>Events</strong></h6>
         </mat-card-title>
         <mat-card-content class="center" i18n
-          >All events that were logged during the classroom
+          >All events that were logged during the unit
         </mat-card-content>
         <mat-card-actions>
           <button
@@ -60,7 +60,9 @@
         <mat-card-title>
           <h6 class="center"><strong>Item Data</strong></h6>
         </mat-card-title>
-        <mat-card-content class="center" i18n>Custom data for certain activities</mat-card-content>
+        <mat-card-content class="center" i18n
+          >Custom data for certain activity types</mat-card-content
+        >
         <mat-card-actions>
           <button
             mat-flat-button
@@ -77,7 +79,7 @@
         <mat-card-title>
           <h6 class="center"><strong>Raw Data</strong></h6>
         </mat-card-title>
-        <mat-card-content class="center" i18n>All data logged by activities</mat-card-content>
+        <mat-card-content class="center" i18n>All data logged during the unit</mat-card-content>
         <mat-card-actions>
           <button
             mat-flat-button
@@ -146,7 +148,7 @@
           <h6 class="center"><strong>Notifications</strong></h6>
         </mat-card-title>
         <mat-card-content class="center" i18n
-          >Notifications sent to student and teachers</mat-card-content
+          >Notifications sent to students and teachers</mat-card-content
         >
         <mat-card-actions>
           <button

--- a/src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts
@@ -14,9 +14,10 @@ import { MatDialog } from '@angular/material/dialog';
 import { DialogWithSpinnerComponent } from '../../../directives/dialog-with-spinner/dialog-with-spinner.component';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatButton } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
 
 @Component({
-  imports: [MatButton],
+  imports: [MatButton, MatCardModule],
   styles: ['.button-div { margin-top: 10px; margin-bottom: 10px; }'],
   templateUrl: './data-export.component.html'
 })

--- a/src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts
+++ b/src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts
@@ -18,7 +18,15 @@ import { MatCardModule } from '@angular/material/card';
 
 @Component({
   imports: [MatButton, MatCardModule],
-  styles: ['.button-div { margin-top: 10px; margin-bottom: 10px; }'],
+  styles: `
+    .button-div {
+      margin-top: 10px;
+      margin-bottom: 10px;
+    }
+    mat-card {
+      justify-content: space-between;
+    }
+  `,
   templateUrl: './data-export.component.html'
 })
 export class DataExportComponent {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10295,6 +10295,30 @@
           <context context-type="linenumber">17,20</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
+          <context context-type="linenumber">19,22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
+          <context context-type="linenumber">36,39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
+          <context context-type="linenumber">55,58</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
+          <context context-type="linenumber">72,75</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
+          <context context-type="linenumber">89,92</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
+          <context context-type="linenumber">106,109</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component.html</context>
           <context context-type="linenumber">123,126</context>
         </context-group>
@@ -15480,159 +15504,96 @@ Are you sure you want to proceed?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">133</context>
+          <context context-type="linenumber">134</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4009582044773611629" datatype="html">
-        <source>Export One Workgroup Per Row</source>
+      <trans-unit id="6364952943066153285" datatype="html">
+        <source>Each workgroup gets their own row with all their work</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">8,12</context>
+          <context context-type="linenumber">9,13</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="99210463776863844" datatype="html">
-        <source> Export One Workgroup Per Row </source>
+      <trans-unit id="4383335737663852693" datatype="html">
+        <source>All student work and annotations</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">12,17</context>
+          <context context-type="linenumber">27,30</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8627212084022526759" datatype="html">
-        <source>Export Student Work</source>
+      <trans-unit id="2640124895962658475" datatype="html">
+        <source>All events that were logged during the classroom </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">19,23</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-student-work/export-student-work.component.html</context>
-          <context context-type="linenumber">12,14</context>
+          <context context-type="linenumber">45,49</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3130756363008167999" datatype="html">
-        <source> Export Student Work </source>
+      <trans-unit id="7552541928494851698" datatype="html">
+        <source>Custom data for certain activities</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">23,28</context>
+          <context context-type="linenumber">63,66</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1056262710520491167" datatype="html">
-        <source>Export Events</source>
+      <trans-unit id="8242202711576251313" datatype="html">
+        <source>All data logged by activities</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">30,34</context>
+          <context context-type="linenumber">80,83</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3464747096413677262" datatype="html">
-        <source> Export Events </source>
+      <trans-unit id="3253707906330253061" datatype="html">
+        <source>Time spent on each step in the unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">34,39</context>
+          <context context-type="linenumber">97,100</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3222708296650718137" datatype="html">
-        <source>Export Latest Notebook Items</source>
+      <trans-unit id="5690683917392408412" datatype="html">
+        <source>Latest notebook items and reports</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">41,45</context>
+          <context context-type="linenumber">114,117</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="9216266550266384434" datatype="html">
-        <source> Export Latest Notebook Items </source>
+      <trans-unit id="2256581797902573217" datatype="html">
+        <source> Download </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">45,50</context>
+          <context context-type="linenumber">123,126</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
+          <context context-type="linenumber">140,143</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
+          <context context-type="linenumber">159,162</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
+          <context context-type="linenumber">176,179</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="342569927114816782" datatype="html">
-        <source>Export All Notebook Items</source>
+      <trans-unit id="4094569276452991996" datatype="html">
+        <source>All notebook items and reports</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">52,56</context>
+          <context context-type="linenumber">131,134</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="706688436553016926" datatype="html">
-        <source> Export All Notebook Items </source>
+      <trans-unit id="460956048109139675" datatype="html">
+        <source>Notifications sent to student and teachers</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">56,61</context>
+          <context context-type="linenumber">149,152</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="5267193792474009113" datatype="html">
-        <source>Export Notifications</source>
+      <trans-unit id="8059351239761064349" datatype="html">
+        <source>Student uploaded files</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">63,67</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3536334464503182721" datatype="html">
-        <source> Export Notifications </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">67,72</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7571640881541679292" datatype="html">
-        <source>Export Student Assets</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">74,78</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2537295102137947130" datatype="html">
-        <source> Export Student Assets </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">78,83</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="259717233331409481" datatype="html">
-        <source>Export Item Data</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">85,89</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-item/export-item.component.html</context>
-          <context context-type="linenumber">12,14</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8213799124339286184" datatype="html">
-        <source> Export Item Data </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">89,94</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6559411860777314278" datatype="html">
-        <source>Export Raw Data</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">96,100</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-raw-data/export-raw-data.component.html</context>
-          <context context-type="linenumber">12,14</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6931126388549221785" datatype="html">
-        <source> Export Raw Data </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">100,105</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1967289956440236551" datatype="html">
-        <source>Export Step Visits</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">107,111</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4435133180728589193" datatype="html">
-        <source> Export Step Visits </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">111,117</context>
+          <context context-type="linenumber">167,170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1943268732247200427" datatype="html">
@@ -15665,6 +15626,13 @@ Are you sure you want to proceed?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-student-work/export-student-work.component.html</context>
           <context context-type="linenumber">38,42</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="259717233331409481" datatype="html">
+        <source>Export Item Data</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-item/export-item.component.html</context>
+          <context context-type="linenumber">12,14</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4491785516188965027" datatype="html">
@@ -15844,6 +15812,13 @@ Are you sure you want to proceed?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-student-work/export-student-work.component.html</context>
           <context context-type="linenumber">35,40</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6559411860777314278" datatype="html">
+        <source>Export Raw Data</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-raw-data/export-raw-data.component.html</context>
+          <context context-type="linenumber">12,14</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7689081267731130533" datatype="html">
@@ -16136,6 +16111,13 @@ Are you sure you want to proceed?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-step-visits/export-step-visits.component.ts</context>
           <context context-type="linenumber">199</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8627212084022526759" datatype="html">
+        <source>Export Student Work</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/export-student-work/export-student-work.component.html</context>
+          <context context-type="linenumber">12,14</context>
         </context-group>
       </trans-unit>
       <trans-unit id="123041415701394466" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -10308,15 +10308,15 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">72,75</context>
+          <context context-type="linenumber">74,77</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">89,92</context>
+          <context context-type="linenumber">91,94</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">106,109</context>
+          <context context-type="linenumber">108,111</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/outsideURL/outside-url-authoring/outside-url-authoring.component.html</context>
@@ -15504,11 +15504,11 @@ Are you sure you want to proceed?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.ts</context>
-          <context context-type="linenumber">134</context>
+          <context context-type="linenumber">142</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6364952943066153285" datatype="html">
-        <source>Each workgroup gets their own row with all their work</source>
+      <trans-unit id="4748233234614035480" datatype="html">
+        <source>Each workgroup gets one row with all their work</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
           <context context-type="linenumber">9,13</context>
@@ -15521,79 +15521,79 @@ Are you sure you want to proceed?</source>
           <context context-type="linenumber">27,30</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2640124895962658475" datatype="html">
-        <source>All events that were logged during the classroom </source>
+      <trans-unit id="4412122591105803180" datatype="html">
+        <source>All events that were logged during the unit </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
           <context context-type="linenumber">45,49</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7552541928494851698" datatype="html">
-        <source>Custom data for certain activities</source>
+      <trans-unit id="1568593262681697846" datatype="html">
+        <source>Custom data for certain activity types</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">63,66</context>
+          <context context-type="linenumber">64,68</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8242202711576251313" datatype="html">
-        <source>All data logged by activities</source>
+      <trans-unit id="7422054710486820948" datatype="html">
+        <source>All data logged during the unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">80,83</context>
+          <context context-type="linenumber">82,85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3253707906330253061" datatype="html">
         <source>Time spent on each step in the unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">97,100</context>
+          <context context-type="linenumber">99,102</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5690683917392408412" datatype="html">
         <source>Latest notebook items and reports</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">114,117</context>
+          <context context-type="linenumber">116,119</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2256581797902573217" datatype="html">
         <source> Download </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">123,126</context>
+          <context context-type="linenumber">125,128</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">140,143</context>
+          <context context-type="linenumber">142,145</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">159,162</context>
+          <context context-type="linenumber">161,164</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">176,179</context>
+          <context context-type="linenumber">178,181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4094569276452991996" datatype="html">
         <source>All notebook items and reports</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">131,134</context>
+          <context context-type="linenumber">133,136</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="460956048109139675" datatype="html">
-        <source>Notifications sent to student and teachers</source>
+      <trans-unit id="214289689725549211" datatype="html">
+        <source>Notifications sent to students and teachers</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">149,152</context>
+          <context context-type="linenumber">151,154</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8059351239761064349" datatype="html">
         <source>Student uploaded files</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/dataExport/data-export/data-export.component.html</context>
-          <context context-type="linenumber">167,170</context>
+          <context context-type="linenumber">169,172</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1943268732247200427" datatype="html">


### PR DESCRIPTION
## Notes

Please style and reword as you see fit

## Changes
- Use material cards to represent exportable items. 
   - Some of the items need further configuration, and their buttons say "Select". 
   - Others can be download immediately without configuration, and their buttons say "Download".

## Test
- Export page works as before