### PR TITLE
feat(Discussion): Hide hidden response content in teacher summary

### DIFF
--- a/src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html
+++ b/src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html
@@ -20,7 +20,7 @@
     </details>
   } @else {
     <ng-container *ngTemplateOutlet="postContent; context: { $implicit: true }" />
-    <ng-container *ngTemplateOutlet="commentsSection; context: { $implicit: false }" />
+    <ng-container *ngTemplateOutlet="commentsSection" />
   }
 </mat-card>
 

--- a/src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html
+++ b/src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html
@@ -1,4 +1,30 @@
 <mat-card appearance="outlined" class="class-response">
+  @if (isHidden(response)) {
+    <details>
+      <summary class="secondary-text notice-bg-bg">
+        <span class="flex-grow" i18n>This post is hidden from students.</span>
+        <span class="details-closed" i18n>(tap to view)</span>
+        <span class="details-open hidden" i18n>(tap to hide)</span>
+        <button
+          matIconButton
+          (click)="showPost(response); $event.preventDefault()"
+          matTooltip="Show to students"
+          matTooltipPosition="above"
+          i18n-matTooltip
+        >
+          <mat-icon color="warn">visibility_off</mat-icon>
+        </button>
+      </summary>
+      <ng-container *ngTemplateOutlet="postContent" />
+      <ng-container *ngTemplateOutlet="commentsSection; context: { $implicit: true }" />
+    </details>
+  } @else {
+    <ng-container *ngTemplateOutlet="postContent; context: { $implicit: true }" />
+    <ng-container *ngTemplateOutlet="commentsSection; context: { $implicit: false }" />
+  }
+</mat-card>
+
+<ng-template #postContent let-showHideButton>
   <div class="p-2 w-full">
     <div class="flex flex-row items-center gap-2">
       <mat-icon
@@ -17,12 +43,8 @@
           />
         </div>
       </div>
-      <span class="flex-grow"></span>
-      @if (
-        response.latestInappropriateFlagAnnotation == null ||
-        response.latestInappropriateFlagAnnotation.data == null ||
-        response.latestInappropriateFlagAnnotation.data.action != 'Delete'
-      ) {
+      @if (showHideButton) {
+        <span class="flex-grow"></span>
         <button
           matIconButton
           (click)="hidePost(response)"
@@ -32,19 +54,6 @@
         >
           <mat-icon>visibility_on</mat-icon>
         </button>
-      } @else if (
-        response.latestInappropriateFlagAnnotation != null &&
-        response.latestInappropriateFlagAnnotation.data.action === 'Delete'
-      ) {
-        <button
-          matIconButton
-          (click)="showPost(response)"
-          matTooltip="Show to students"
-          matTooltipPosition="above"
-          i18n-matTooltip
-        >
-          <mat-icon color="warn">visibility_off</mat-icon>
-        </button>
       }
     </div>
     <div class="post" [innerHTML]="response.studentData.responseTextHTML"></div>
@@ -52,11 +61,12 @@
       <img [src]="attachment.iconURL" i18n-alt alt="Post attachment" class="attachment" />
     }
   </div>
+</ng-template>
+
+<ng-template #commentsSection let-parentHidden>
   @if (response.replies.length > 0) {
     <div class="notice-bg-bg">
-      @if (mode === 'student' || response.replies.length > 0) {
-        <mat-divider class="comment-divider" />
-      }
+      <mat-divider class="comment-divider" />
       <div class="comments-header" matSubheader>
         @if (response.replies.length === 1) {
           <span i18n> Comments ({{ response.replies.length }}) </span>
@@ -71,69 +81,78 @@
       <div class="comments">
         @for (reply of repliesToShow; track reply) {
           <div class="comment" [ngClass]="{ 'animate-show': !isLast }">
-            <div class="flex flex-row items-center gap-2">
-              <mat-icon
-                matListAvatar
-                class="mat-40"
-                style="color: {{ getAvatarColorForWorkgroupId(reply.workgroupId) }}"
+            @if (parentHidden || isHidden(reply)) {
+              <details
+                class="reply-details rounded-md notice-bg-border border-1 open:border-transparent open:pb-2"
               >
-                account_circle
-              </mat-icon>
-              <div class="flex flex-wrap gap-2 items-center">
-                <span class="strong">{{ reply.usernames }}</span>
-                <save-time-message
-                  [saveTime]="adjustClientSaveTime(reply.serverSaveTime)"
-                  [timeOnly]="true"
-                  tooltipPosition="after"
-                />
-              </div>
-              <span class="flex-grow"></span>
-              @if (
-                (response.latestInappropriateFlagAnnotation == null ||
-                  response.latestInappropriateFlagAnnotation.data.action !== 'Delete') &&
-                (reply.latestInappropriateFlagAnnotation == null ||
-                  reply.latestInappropriateFlagAnnotation.data.action != 'Delete')
-              ) {
-                <button
-                  matIconButton
-                  (click)="hidePost(reply)"
-                  matTooltip="Hide from students"
-                  matTooltipPosition="above"
-                  i18n-matTooltip
-                >
-                  <mat-icon>visibility_on</mat-icon>
-                </button>
-              } @else if (
-                response.latestInappropriateFlagAnnotation != null &&
-                response.latestInappropriateFlagAnnotation.data.action === 'Delete'
-              ) {
-                <mat-icon
-                  tabindex="0"
-                  color="warn"
-                  matTooltip="Parent post is hidden, so this comment is also hidden"
-                  matTooltipPosition="above"
-                  i18n-matTooltip
-                  >visibility_off</mat-icon
-                >
-              } @else if (
-                reply.latestInappropriateFlagAnnotation != null &&
-                reply.latestInappropriateFlagAnnotation.data.action === 'Delete'
-              ) {
-                <button
-                  matIconButton
-                  (click)="showPost(reply)"
-                  matTooltip="Show to students"
-                  matTooltipPosition="above"
-                  i18n-matTooltip
-                >
-                  <mat-icon color="warn">visibility_off</mat-icon>
-                </button>
-              }
-            </div>
-            <div class="pt-1" [innerHTML]="reply.studentData.responseHTML"></div>
+                <summary class="secondary-text notice-bg-bg rounded-md" [class.py-2]="parentHidden">
+                  @if (parentHidden) {
+                    <span class="flex-grow" i18n
+                      >Comment hidden because parent post is hidden.</span
+                    >
+                  } @else {
+                    <span class="flex-grow" i18n>This comment is hidden from students.</span>
+                  }
+                  <span class="details-closed" i18n>(tap to view)</span>
+                  <span class="details-open hidden" i18n>(tap to hide)</span>
+                  @if (!parentHidden && isHidden(reply)) {
+                    <button
+                      matIconButton
+                      (click)="showPost(reply); $event.preventDefault()"
+                      matTooltip="Show to students"
+                      matTooltipPosition="above"
+                      i18n-matTooltip
+                    >
+                      <mat-icon color="warn">visibility_off</mat-icon>
+                    </button>
+                  }
+                </summary>
+                <ng-container *ngTemplateOutlet="replyContent; context: { $implicit: reply }" />
+              </details>
+            } @else {
+              <ng-container
+                *ngTemplateOutlet="
+                  replyContent;
+                  context: { $implicit: reply, showHideButton: true }
+                "
+              />
+            }
           </div>
         }
       </div>
     </div>
   }
-</mat-card>
+</ng-template>
+
+<ng-template #replyContent let-reply let-showHideButton="showHideButton">
+  <div class="flex flex-row items-center gap-2 pt-1">
+    <mat-icon
+      matListAvatar
+      class="mat-40"
+      style="color: {{ getAvatarColorForWorkgroupId(reply.workgroupId) }}"
+    >
+      account_circle
+    </mat-icon>
+    <div class="flex flex-wrap gap-2 items-center">
+      <span class="strong">{{ reply.usernames }}</span>
+      <save-time-message
+        [saveTime]="adjustClientSaveTime(reply.serverSaveTime)"
+        [timeOnly]="true"
+        tooltipPosition="after"
+      />
+    </div>
+    @if (showHideButton) {
+      <span class="flex-grow"></span>
+      <button
+        matIconButton
+        (click)="hidePost(reply)"
+        matTooltip="Hide from students"
+        matTooltipPosition="above"
+        i18n-matTooltip
+      >
+        <mat-icon>visibility_on</mat-icon>
+      </button>
+    }
+  </div>
+  <div class="pt-1" [innerHTML]="reply.studentData.responseHTML"></div>
+</ng-template>

--- a/src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.spec.ts
+++ b/src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.spec.ts
@@ -1,0 +1,251 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ClassResponseTeacherComponent } from './class-response-teacher.component';
+import { MockComponent, MockProvider } from 'ng-mocks';
+import { SaveTimeMessageComponent } from '../../../common/save-time-message/save-time-message.component';
+import { ConfigService } from '../../../services/configService';
+import { provideRouter } from '@angular/router';
+
+let fixture: ComponentFixture<ClassResponseTeacherComponent>;
+let component: ClassResponseTeacherComponent;
+
+describe('ClassResponseTeacherComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ClassResponseTeacherComponent, MockComponent(SaveTimeMessageComponent)],
+      providers: [MockProvider(ConfigService), provideRouter([])]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ClassResponseTeacherComponent);
+    component = fixture.componentInstance;
+    component.response = createResponse('Hello World');
+    fixture.detectChanges();
+  });
+
+  isHidden();
+  visiblePost();
+  hiddenPost();
+  visibleReply();
+  hiddenReply();
+  hiddenParentReply();
+  hidePost();
+  showPost();
+});
+
+function createResponse(text: string = '', replies: any[] = []): any {
+  return {
+    workgroupId: 1,
+    usernames: 'Student A',
+    serverSaveTime: Date.now(),
+    studentData: { response: text, responseTextHTML: text, attachments: [] },
+    replies,
+    latestInappropriateFlagAnnotation: null
+  };
+}
+
+function createReply(text: string = ''): any {
+  return {
+    workgroupId: 2,
+    usernames: 'Student B',
+    serverSaveTime: Date.now(),
+    studentData: { response: text, responseHTML: text },
+    latestInappropriateFlagAnnotation: null
+  };
+}
+
+function hiddenAnnotation(): any {
+  return { data: { action: 'Delete' } };
+}
+
+function queryText(selector: string): string {
+  return fixture.nativeElement.querySelector(selector)?.textContent?.trim() ?? '';
+}
+
+function query(selector: string): HTMLElement | null {
+  return fixture.nativeElement.querySelector(selector);
+}
+
+function isHidden() {
+  describe('isHidden', () => {
+    it('returns false when latestInappropriateFlagAnnotation is null', () => {
+      const post = createResponse();
+      expect(component['isHidden'](post)).toBe(false);
+    });
+
+    it('returns false when latestInappropriateFlagAnnotation data is null', () => {
+      const post = createResponse();
+      post.latestInappropriateFlagAnnotation = { data: null };
+      expect(component['isHidden'](post)).toBe(false);
+    });
+
+    it('returns false when action is not Delete', () => {
+      const post = createResponse();
+      post.latestInappropriateFlagAnnotation = { data: { action: 'Flag' } };
+      expect(component['isHidden'](post)).toBe(false);
+    });
+
+    it('returns true when latestInappropriateFlagAnnotation action is Delete', () => {
+      const post = createResponse();
+      post.latestInappropriateFlagAnnotation = hiddenAnnotation();
+      expect(component['isHidden'](post)).toBe(true);
+    });
+  });
+}
+
+function visiblePost() {
+  describe('visible post', () => {
+    it('renders post content', () => {
+      expect(queryText('.post')).toBe('Hello World');
+    });
+
+    it('includes a hide button', () => {
+      const btn = query('button[mattooltip="Hide from students"]');
+      expect(btn).not.toBeNull();
+    });
+
+    it('does not wrap the post in a <details> element', () => {
+      expect(query('details')).toBeNull();
+    });
+  });
+}
+
+function hiddenPost() {
+  describe('hidden post', () => {
+    beforeEach(() => {
+      component.response = createResponse('Hidden content');
+      component.response.latestInappropriateFlagAnnotation = hiddenAnnotation();
+      fixture.detectChanges();
+    });
+
+    it('wraps the post in a <details> element', () => {
+      expect(query('details')).not.toBeNull();
+    });
+
+    it('shows hidden post message', () => {
+      expect(queryText('summary')).toContain('This post is hidden from students.');
+    });
+
+    it('includes a show button', () => {
+      const btn = query('button[mattooltip="Show to students"]');
+      expect(btn).not.toBeNull();
+    });
+  });
+}
+
+function visibleReply() {
+  describe('visible reply on a visible post', () => {
+    let reply: any;
+
+    beforeEach(() => {
+      reply = createReply('Reply text');
+      component.response.replies = [reply];
+      component['repliesToShow'] = [reply];
+      fixture.detectChanges();
+    });
+
+    it('shows reply content without a <details> wrapper', () => {
+      expect(query('.comment details')).toBeNull();
+    });
+
+    it('renders the reply content', () => {
+      expect(queryText('.comment')).toContain('Reply text');
+    });
+
+    it('includes a hide button', () => {
+      const btn = query('.comment button[mattooltip="Hide from students"]');
+      expect(btn).not.toBeNull();
+    });
+  });
+}
+
+function hiddenReply() {
+  describe('hidden reply on a visible post', () => {
+    let reply: any;
+
+    beforeEach(() => {
+      reply = createReply('Hidden reply');
+      reply.latestInappropriateFlagAnnotation = hiddenAnnotation();
+      component.response.replies = [reply];
+      component['repliesToShow'] = [reply];
+      fixture.detectChanges();
+    });
+
+    it('wraps the reply in a <details> element', () => {
+      expect(query('.comment details')).not.toBeNull();
+    });
+
+    it('shows comment hidden message', () => {
+      expect(queryText('.comment summary')).toContain('This comment is hidden from students.');
+    });
+
+    it('includes a show button', () => {
+      const btn = query('.comment button[mattooltip="Show to students"]');
+      expect(btn).not.toBeNull();
+    });
+  });
+}
+
+function hiddenParentReply() {
+  describe('hidden parent post', () => {
+    let reply: any;
+
+    beforeEach(() => {
+      reply = createReply('Reply on hidden post');
+      component.response = createResponse('Hidden post content', [reply]);
+      component.response.latestInappropriateFlagAnnotation = hiddenAnnotation();
+      component['repliesToShow'] = [reply];
+      fixture.detectChanges();
+    });
+
+    it('wraps replies in a <details> element', () => {
+      const detailsEls = fixture.nativeElement.querySelectorAll('.comment details');
+      expect(detailsEls.length).toBeGreaterThan(0);
+    });
+
+    it('shows parent hidden message on replies', () => {
+      expect(queryText('.comment summary')).toContain(
+        'Comment hidden because parent post is hidden.'
+      );
+    });
+
+    it('does not include a show button on replies', () => {
+      const btn = query('.comment button[mattooltip="Show to students"]');
+      expect(btn).toBeNull();
+    });
+  });
+}
+
+function hidePost() {
+  describe('hidePost', () => {
+    it('emits hidePostEvent after confirmation', () => {
+      spyOn(window, 'confirm').and.returnValue(true);
+      const spy = spyOn(component.hidePostEvent, 'emit');
+      component['hidePost'](component.response);
+      expect(spy).toHaveBeenCalledWith(component.response);
+    });
+
+    it('does not emit hidePostEvent when confirmation is cancelled', () => {
+      spyOn(window, 'confirm').and.returnValue(false);
+      const spy = spyOn(component.hidePostEvent, 'emit');
+      component['hidePost'](component.response);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+}
+
+function showPost() {
+  describe('showPost', () => {
+    it('emits showPostEvent after confirmation', () => {
+      spyOn(window, 'confirm').and.returnValue(true);
+      const spy = spyOn(component.showPostEvent, 'emit');
+      component['showPost'](component.response);
+      expect(spy).toHaveBeenCalledWith(component.response);
+    });
+
+    it('does not emit showPostEvent when confirmation is cancelled', () => {
+      spyOn(window, 'confirm').and.returnValue(false);
+      const spy = spyOn(component.showPostEvent, 'emit');
+      component['showPost'](component.response);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+}

--- a/src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.ts
+++ b/src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.ts
@@ -29,6 +29,35 @@ import { ClassResponse } from '../class-response/class-response.component';
   ],
   selector: 'class-response-teacher',
   styleUrl: '../class-response/class-response.component.scss',
+  styles: `
+    @reference "tailwindcss";
+
+    details:open > summary {
+      .details-closed {
+        @apply hidden;
+      }
+
+      .details-open {
+        @apply flex;
+      }
+    }
+
+    .reply-details:open {
+      @apply px-2;
+
+      > summary {
+        @apply -mx-2 mb-1 rounded-b-none;
+      }
+    }
+
+    summary {
+      @apply italic cursor-pointer px-2 flex items-center gap-2;
+
+      &::-webkit-details-marker {
+        display: none;
+      }
+    }
+  `,
   templateUrl: './class-response-teacher.component.html'
 })
 export class ClassResponseTeacherComponent extends ClassResponse {
@@ -47,6 +76,10 @@ export class ClassResponseTeacherComponent extends ClassResponse {
     if (confirm($localize`Are you sure you want to hide this content?`)) {
       this.hidePostEvent.emit(componentState);
     }
+  }
+
+  protected isHidden(post: any): boolean {
+    return post.latestInappropriateFlagAnnotation?.data?.action === 'Delete';
   }
 
   protected showPost(componentState: any): void {

--- a/src/assets/wise5/components/discussion/class-response/class-response.component.ts
+++ b/src/assets/wise5/components/discussion/class-response/class-response.component.ts
@@ -82,6 +82,7 @@ export class ClassResponse {
   }
 
   private injectLinks(response: string): string {
+    if (response == null) return '';
     return response.replace(this.urlMatcher, (match) => {
       let matchUrl = match;
       if (!match.startsWith('http')) {

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -19336,33 +19336,62 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
           <context context-type="linenumber">20</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6159543550097070213" datatype="html">
-        <source>Hide from students</source>
+      <trans-unit id="1412436253746963115" datatype="html">
+        <source>This post is hidden from students.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html</context>
-          <context context-type="linenumber">29,32</context>
+          <context context-type="linenumber">5,7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5681541379200816319" datatype="html">
+        <source>(tap to view)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html</context>
+          <context context-type="linenumber">6,7</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html</context>
-          <context context-type="linenumber">100,102</context>
+          <context context-type="linenumber">96,97</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3308519205068715103" datatype="html">
+        <source>(tap to hide)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html</context>
+          <context context-type="linenumber">7,10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html</context>
+          <context context-type="linenumber">97,99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6724243278406717774" datatype="html">
         <source>Show to students</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html</context>
-          <context context-type="linenumber">42,45</context>
+          <context context-type="linenumber">11,14</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html</context>
-          <context context-type="linenumber">125,127</context>
+          <context context-type="linenumber">102,104</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6159543550097070213" datatype="html">
+        <source>Hide from students</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html</context>
+          <context context-type="linenumber">51,54</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html</context>
+          <context context-type="linenumber">149,153</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3681514094143393882" datatype="html">
         <source>Post attachment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html</context>
-          <context context-type="linenumber">52,55</context>
+          <context context-type="linenumber">61,66</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response/class-response.component.html</context>
@@ -19373,7 +19402,7 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source> Comments (<x id="INTERPOLATION" equiv-text="{{ response.replies.length }}"/>) </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html</context>
-          <context context-type="linenumber">62,63</context>
+          <context context-type="linenumber">72,73</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response/class-response.component.html</context>
@@ -19384,32 +19413,39 @@ Category Name: <x id="PH_1" equiv-text="categoryName"/></source>
         <source>Comments (<x id="INTERPOLATION" equiv-text="{{ response.replies.length }}"/>)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html</context>
-          <context context-type="linenumber">66,67</context>
+          <context context-type="linenumber">76,77</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response/class-response.component.html</context>
           <context context-type="linenumber">37,38</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3587038731559112650" datatype="html">
-        <source>Parent post is hidden, so this comment is also hidden</source>
+      <trans-unit id="1410061077038345346" datatype="html">
+        <source>Comment hidden because parent post is hidden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html</context>
-          <context context-type="linenumber">113,115</context>
+          <context context-type="linenumber">91,94</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3208793939943994267" datatype="html">
+        <source>This comment is hidden from students.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.html</context>
+          <context context-type="linenumber">94,96</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1877738603549884080" datatype="html">
         <source>Are you sure you want to hide this content?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.ts</context>
-          <context context-type="linenumber">47</context>
+          <context context-type="linenumber">76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8186667027058635380" datatype="html">
         <source>Are you sure you want to show this content?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/discussion/class-response-teacher/class-response-teacher.component.ts</context>
-          <context context-type="linenumber">53</context>
+          <context context-type="linenumber">86</context>
         </context-group>
       </trans-unit>
       <trans-unit id="189861158609674899" datatype="html">


### PR DESCRIPTION
## Changes
- Hide the content of Discussion posts and replies (comments) that have been hidden for students by teacher in the Discussion summary view in the Teacher Tools.
- Teachers can click/tap to view and hide hidden response content.
- Add tests for ClassResponseTeacherComponent.

## Test
- Make sure posts and comments that have been marked as hidden by teacher are hidden by default in teacher summary view.
- Teachers can show and hide hidden response content by clicking/tapping. 
- Hiding/showing posts and comments via the "Hide from students" and "Show to students" buttons works as before. 