### PR TITLE
feat(Authoring): Use slider to set activity width

### DIFF
--- a/src/app/authoring-tool/edit-component-width/edit-component-width.component.ts
+++ b/src/app/authoring-tool/edit-component-width/edit-component-width.component.ts
@@ -6,7 +6,7 @@ import { MatSliderModule } from '@angular/material/slider';
 @Component({
   imports: [FormsModule, MatSliderModule],
   selector: 'edit-component-width',
-  template: `<span i18n>Activity width:</span>
+  template: `<span i18n>Activity width:</span>&nbsp;
     <mat-slider
       min="0"
       [max]="possibleValues.length - 1"
@@ -14,18 +14,18 @@ import { MatSliderModule } from '@angular/material/slider';
       discrete
       showTickMarks
       [displayWith]="formatLabel"
-      style="min-width: 300px;"
+      style="min-width: 240px;"
     >
       <input matSliderThumb (input)="onSliderChange($event)" [value]="selectedIndex" />
     </mat-slider>
     <span>{{ selectedValue }}%</span>
     <p i18n>
-      *Setting the activities' widths determines how they appear on the screen. For example, if two
-      adjacent activities' widths are both set to 50%, they will appear side-by-side.
+      *Setting the activity's width determines how it appears on the screen. If two adjacent
+      activities are set to 50% each (or 67% and 33%, for example), they will appear side-by-side.
     </p>`
 })
 export class EditComponentWidthComponent extends EditComponentFieldComponent {
-  protected possibleValues = [25, 33, 50, 66, 75, 100];
+  protected possibleValues = [25, 33, 50, 67, 75, 100];
   protected selectedIndex = 0;
   protected selectedValue = this.possibleValues[0];
 

--- a/src/app/authoring-tool/edit-component-width/edit-component-width.component.ts
+++ b/src/app/authoring-tool/edit-component-width/edit-component-width.component.ts
@@ -1,45 +1,42 @@
 import { Component } from '@angular/core';
-import { EditComponentFieldComponent } from '../edit-component-field.component';
 import { FormsModule } from '@angular/forms';
-import { MatSliderModule } from '@angular/material/slider';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { EditComponentFieldComponent } from '../edit-component-field.component';
 
 @Component({
-  imports: [FormsModule, MatSliderModule],
+  imports: [FormsModule, MatButtonToggleModule, MatIconModule, MatTooltipModule],
   selector: 'edit-component-width',
-  template: `<span i18n>Activity width:</span>&nbsp;
-    <mat-slider
-      min="0"
-      [max]="possibleValues.length - 1"
-      step="1"
-      discrete
-      showTickMarks
-      [displayWith]="formatLabel"
-      style="min-width: 240px;"
+  template: `<span i18n>Activity width</span
+    ><mat-icon
+      matTooltip="*Setting the activity's width determines how it appears on the screen. If two adjacent
+      activities are set to 50% each (or 67% and 33%, for example), they will appear side-by-side."
+      i18n-matTooltip
+      >help</mat-icon
+    ><br />
+    <mat-button-toggle-group
+      [(ngModel)]="selectedValue"
+      (change)="onWidthChange()"
+      aria-label="Activity width"
+      hideSingleSelectionIndicator="true"
     >
-      <input matSliderThumb (input)="onSliderChange($event)" [value]="selectedIndex" />
-    </mat-slider>
-    <span>{{ selectedValue }}%</span>
-    <p i18n>
-      *Setting the activity's width determines how it appears on the screen. If two adjacent
-      activities are set to 50% each (or 67% and 33%, for example), they will appear side-by-side.
-    </p>`
+      @for (value of possibleValues; track $index) {
+        <mat-button-toggle value="{{ value }}">{{ value }}%</mat-button-toggle>
+      }
+    </mat-button-toggle-group>`
 })
 export class EditComponentWidthComponent extends EditComponentFieldComponent {
   protected possibleValues = [25, 33, 50, 67, 75, 100];
-  protected selectedIndex = 0;
-  protected selectedValue = this.possibleValues[0];
+  protected selectedValue = '100';
 
   public override ngOnInit(): void {
     super.ngOnInit();
-    this.selectedValue = this.componentContent.componentWidth ?? 100;
-    this.selectedIndex = this.possibleValues.indexOf(this.selectedValue);
+    this.selectedValue = String(this.componentContent.componentWidth ?? 100);
   }
 
-  protected formatLabel = (index: number): string => `${this.possibleValues[index]}%`;
-
-  protected onSliderChange(event: any): void {
-    this.selectedValue = this.possibleValues[event.target.value];
-    this.componentContent.componentWidth = this.selectedValue;
-    this.inputChanged.next(this.selectedValue);
+  protected onWidthChange(): void {
+    this.componentContent.componentWidth = Number(this.selectedValue);
+    this.inputChanged.next(Number(this.selectedValue));
   }
 }

--- a/src/app/authoring-tool/edit-component-width/edit-component-width.component.ts
+++ b/src/app/authoring-tool/edit-component-width/edit-component-width.component.ts
@@ -1,20 +1,45 @@
 import { Component } from '@angular/core';
 import { EditComponentFieldComponent } from '../edit-component-field.component';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
 import { FormsModule } from '@angular/forms';
+import { MatSliderModule } from '@angular/material/slider';
 
 @Component({
-  imports: [FormsModule, MatFormFieldModule, MatInputModule],
+  imports: [FormsModule, MatSliderModule],
   selector: 'edit-component-width',
-  template: `<mat-form-field>
-    <mat-label i18n>Activity Width</mat-label>
-    <input
-      matInput
-      type="number"
-      [(ngModel)]="componentContent.componentWidth"
-      (ngModelChange)="inputChanged.next($event)"
-    />
-  </mat-form-field> `
+  template: `<span i18n>Activity width:</span>
+    <mat-slider
+      min="0"
+      [max]="possibleValues.length - 1"
+      step="1"
+      discrete
+      showTickMarks
+      [displayWith]="formatLabel"
+      style="min-width: 300px;"
+    >
+      <input matSliderThumb (input)="onSliderChange($event)" [value]="selectedIndex" />
+    </mat-slider>
+    <span>{{ selectedValue }}%</span>
+    <p i18n>
+      *Setting the activities' widths determines how they appear on the screen. For example, if two
+      adjacent activities' widths are both set to 50%, they will appear side-by-side.
+    </p>`
 })
-export class EditComponentWidthComponent extends EditComponentFieldComponent {}
+export class EditComponentWidthComponent extends EditComponentFieldComponent {
+  protected possibleValues = [25, 33, 50, 66, 75, 100];
+  protected selectedIndex = 0;
+  protected selectedValue = this.possibleValues[0];
+
+  public override ngOnInit(): void {
+    super.ngOnInit();
+    this.selectedValue = this.componentContent.componentWidth ?? 100;
+    this.selectedIndex = this.possibleValues.indexOf(this.selectedValue);
+  }
+
+  protected formatLabel = (index: number): string => `${this.possibleValues[index]}%`;
+
+  protected onSliderChange(event: any): void {
+    this.selectedValue = this.possibleValues[event.target.value];
+    this.componentContent.componentWidth = this.selectedValue;
+    this.inputChanged.next(this.selectedValue);
+  }
+}

--- a/src/app/authoring-tool/edit-component-width/edit-component-width.component.ts
+++ b/src/app/authoring-tool/edit-component-width/edit-component-width.component.ts
@@ -8,13 +8,17 @@ import { EditComponentFieldComponent } from '../edit-component-field.component';
 @Component({
   imports: [FormsModule, MatButtonToggleModule, MatIconModule, MatTooltipModule],
   selector: 'edit-component-width',
-  template: `<span i18n>Activity width</span
-    ><mat-icon
-      matTooltip="*Setting the activity's width determines how it appears on the screen. If two adjacent
-      activities are set to 50% each (or 67% and 33%, for example), they will appear side-by-side."
-      i18n-matTooltip
-      >help</mat-icon
-    ><br />
+  template: `<div class="flex items-center gap-2 my-2">
+      <span i18n>Activity width</span>
+      <mat-icon
+        tabindex="0"
+        matTooltip="The activity's width determines how it appears on the screen. If two adjacent
+        activities are set to 50% each (or 67% and 33%, for example), they will appear side-by-side."
+        matTooltipPosition="above"
+        i18n-matTooltip
+        >help</mat-icon
+      >
+    </div>
     <mat-button-toggle-group
       [(ngModel)]="selectedValue"
       (change)="onWidthChange()"

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1100,15 +1100,15 @@
         <source>Activity width</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-component-width/edit-component-width.component.ts</context>
-          <context context-type="linenumber">11,13</context>
+          <context context-type="linenumber">12,15</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1982615447291140386" datatype="html">
-        <source>*Setting the activity&apos;s width determines how it appears on the screen. If two adjacent
-      activities are set to 50% each (or 67% and 33%, for example), they will appear side-by-side.</source>
+      <trans-unit id="6520102811746443451" datatype="html">
+        <source>The activity&apos;s width determines how it appears on the screen. If two adjacent
+        activities are set to 50% each (or 67% and 33%, for example), they will appear side-by-side.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-component-width/edit-component-width.component.ts</context>
-          <context context-type="linenumber">13,18</context>
+          <context context-type="linenumber">15,19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8650499415827640724" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1096,18 +1096,19 @@
           <context context-type="linenumber">85</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7007219426980695734" datatype="html">
-        <source>Activity width:</source>
+      <trans-unit id="8084155234460667951" datatype="html">
+        <source>Activity width</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-component-width/edit-component-width.component.ts</context>
-          <context context-type="linenumber">9,12</context>
+          <context context-type="linenumber">11,13</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2306241230244820439" datatype="html">
-        <source> *Setting the activity&apos;s width determines how it appears on the screen. If two adjacent activities are set to 50% each (or 67% and 33%, for example), they will appear side-by-side. </source>
+      <trans-unit id="1982615447291140386" datatype="html">
+        <source>*Setting the activity&apos;s width determines how it appears on the screen. If two adjacent
+      activities are set to 50% each (or 67% and 33%, for example), they will appear side-by-side.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-component-width/edit-component-width.component.ts</context>
-          <context context-type="linenumber">23,27</context>
+          <context context-type="linenumber">13,18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8650499415827640724" datatype="html">

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1103,8 +1103,8 @@
           <context context-type="linenumber">9,12</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1197041381998976714" datatype="html">
-        <source> *Setting the activities&apos; widths determines how they appear on the screen. For example, if two adjacent activities&apos; widths are both set to 50%, they will appear side-by-side. </source>
+      <trans-unit id="2306241230244820439" datatype="html">
+        <source> *Setting the activity&apos;s width determines how it appears on the screen. If two adjacent activities are set to 50% each (or 67% and 33%, for example), they will appear side-by-side. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-component-width/edit-component-width.component.ts</context>
           <context context-type="linenumber">23,27</context>

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -1096,11 +1096,18 @@
           <context context-type="linenumber">85</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2810375050239191789" datatype="html">
-        <source>Activity Width</source>
+      <trans-unit id="7007219426980695734" datatype="html">
+        <source>Activity width:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authoring-tool/edit-component-width/edit-component-width.component.ts</context>
-          <context context-type="linenumber">11,15</context>
+          <context context-type="linenumber">9,12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1197041381998976714" datatype="html">
+        <source> *Setting the activities&apos; widths determines how they appear on the screen. For example, if two adjacent activities&apos; widths are both set to 50%, they will appear side-by-side. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/authoring-tool/edit-component-width/edit-component-width.component.ts</context>
+          <context context-type="linenumber">23,27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8650499415827640724" datatype="html">


### PR DESCRIPTION
<img width="800" height="133" alt="Screenshot 2026-05-06 at 4 43 24 PM" src="https://github.com/user-attachments/assets/1ccdd87f-6877-493b-80e3-ef1f48234305" />

## Notes
Please style as you see fit. It might be better to hide the explanation text in an info tooltip instead of always displaying it.

## Changes
- In the activity advanced authoring > general tab, use a ```mat-slider``` to set the activity's width, in percentages. Possible values are 25, 33, 50, 66, 75, and 100. The default is 100.
- Add a blurb about what setting the activity width means in terms of display layout.

Before, we just displayed a input without any instructions, which was confusing for most people.

## Test
- Existing activities show 100 (which is the default value).
- You can change the activity width to any of the possible values.
- Changes are saved.