### PR TITLE
build(GitHub Actions): Update Node version to 24

### DIFF
--- a/.github/workflows/code-build.yml
+++ b/.github/workflows/code-build.yml
@@ -8,18 +8,15 @@ on:
         required: true
   push:
     branches: [gh-actions-update-node-version-24]
-      secrets:
-        aws_key: ${{secrets.AWS_ACCESS_KEY_ID}}
-        aws_secret_key: ${{secrets.AWS_SECRET_ACCESS_KEY}}
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.aws_key}}
-          aws-secret-access-key: ${{ secrets.aws_secret_key}}
+          aws-access-key-id: ${{ secrets.aws_key || secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.aws_secret_key || secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
       - name: Run CodeBuild
         id: code-build

--- a/.github/workflows/code-build.yml
+++ b/.github/workflows/code-build.yml
@@ -8,6 +8,9 @@ on:
         required: true
   push:
     branches: [gh-actions-update-node-version-24]
+      secrets:
+        aws_key: ${{secrets.AWS_ACCESS_KEY_ID}}
+        aws_secret_key: ${{secrets.AWS_SECRET_ACCESS_KEY}}
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-build.yml
+++ b/.github/workflows/code-build.yml
@@ -6,8 +6,6 @@ on:
         required: true
       aws_secret_key:
         required: true
-  push:
-    branches: [gh-actions-update-node-version-24]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,8 +13,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.aws_key || secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.aws_secret_key || secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.aws_key}}
+          aws-secret-access-key: ${{ secrets.aws_secret_key }}
           aws-region: us-west-1
       - name: Run CodeBuild
         id: code-build

--- a/.github/workflows/code-build.yml
+++ b/.github/workflows/code-build.yml
@@ -6,6 +6,8 @@ on:
         required: true
       aws_secret_key:
         required: true
+  push:
+    branches: [gh-actions-update-node-version-24]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-messages.yml
+++ b/.github/workflows/generate-messages.yml
@@ -9,15 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-versions: [20.x]
+        node-versions: [24.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           fetch-depth: 0
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/.github/workflows/generate-messages.yml
+++ b/.github/workflows/generate-messages.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           fetch-depth: 0
-      - uses: actions/checkout@6
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/generate-messages.yml
+++ b/.github/workflows/generate-messages.yml
@@ -4,6 +4,8 @@ on:
     secrets:
       token:
         required: true
+  push:
+    branches: [gh-actions-update-node-version-24]
 jobs:
   generate-messages:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-messages.yml
+++ b/.github/workflows/generate-messages.yml
@@ -4,8 +4,6 @@ on:
     secrets:
       token:
         required: true
-  push:
-    branches: [gh-actions-update-node-version-24]
 jobs:
   generate-messages:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-docker-image-prod.yml
+++ b/.github/workflows/publish-docker-image-prod.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -11,7 +11,7 @@ jobs:
         node-version: [24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -3,8 +3,6 @@ permissions:
   id-token: write
 on:
   workflow_call:
-  push:
-    branches: [gh-actions-update-node-version-24]
 jobs:
   test-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -3,6 +3,8 @@ permissions:
   id-token: write
 on:
   workflow_call:
+  push:
+    branches: [gh-actions-update-node-version-24]
 jobs:
   test-coverage:
     runs-on: ubuntu-latest
@@ -13,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: |

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Changes
- Update Node version to 24.
- Update checkout actions version to 6

## Test
- GitHub actions work as before with these new settings