### PR TITLE
style(Authoring): Organize notebook authoring using tabs

### DIFF
--- a/src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html
+++ b/src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html
@@ -1,285 +1,294 @@
-<div>
-  <h4 i18n>Notebook Settings</h4>
-</div>
-<div>
-  <mat-slide-toggle
-    color="primary"
-    class="toggle"
-    [(ngModel)]="project.notebook.enabled"
-    (ngModelChange)="contentChanged()"
-    i18n
-  >
-    Student Notebook
-  </mat-slide-toggle>
-</div>
-@if (project.notebook.enabled) {
-  <div class="notebook-div">
-    <div class="notebook-input">
-      <translatable-input
-        [content]="project.notebook"
-        key="label"
-        label="Notebook Label"
-        i18n-label
-        (defaultLanguageTextChanged)="contentChanged()"
-      />
-    </div>
-    <div>
-      <mat-slide-toggle
-        color="primary"
-        class="toggle"
-        [(ngModel)]="project.notebook.itemTypes.note.enabled"
-        (ngModelChange)="contentChanged()"
-        i18n
-      >
-        Enable Note
-      </mat-slide-toggle>
-    </div>
-    @if (project.notebook.itemTypes.note.enabled) {
-      <div class="notebook-child-div">
-        <div class="flex flex-wrap gap-5">
-          <translatable-input
-            [content]="project.notebook.itemTypes.note.label"
-            key="singular"
-            label="Label (Singular)"
-            i18n-label
-            (defaultLanguageTextChanged)="contentChanged()"
-            class="notebook-input"
-          />
-          <translatable-input
-            [content]="project.notebook.itemTypes.note.label"
-            key="plural"
-            label="Label (Plural)"
-            i18n-label
-            (defaultLanguageTextChanged)="contentChanged()"
-            class="notebook-input"
-          />
-          <translatable-input
-            [content]="project.notebook.itemTypes.note.label"
-            key="link"
-            label="Label (Link)"
-            i18n-label
-            (defaultLanguageTextChanged)="contentChanged()"
-            class="notebook-input"
-          />
-        </div>
-        <mat-checkbox
-          color="primary"
-          [(ngModel)]="project.notebook.itemTypes.note.enableAddNote"
-          (ngModelChange)="contentChanged()"
-          i18n
-        >
-          Enable Add Note Button
-        </mat-checkbox>
-        <br />
-        <mat-checkbox
-          color="primary"
-          [(ngModel)]="project.notebook.itemTypes.note.enableDeleteNote"
-          [(ngModel)]="project.notebook.itemTypes.note.requireTextOnEveryNote"
-          (ngModelChange)="contentChanged()"
-          i18n
-        >
-          Require students to write text on every note
-        </mat-checkbox>
-        <br />
-        <mat-checkbox
-          color="primary"
-          [(ngModel)]="project.notebook.itemTypes.note.enableClipping"
-          (ngModelChange)="contentChanged()"
-          i18n
-        >
-          Enable Clipping
-        </mat-checkbox>
-        <br />
-        <mat-checkbox
-          color="primary"
-          [(ngModel)]="project.notebook.itemTypes.note.enableStudentUploads"
-          (ngModelChange)="contentChanged()"
-          i18n
-        >
-          Enable Student Uploads
-        </mat-checkbox>
-      </div>
-    }
+<mat-tab-group animationDuration="0ms">
+  <mat-tab>
+    <ng-template mat-tab-label>
+      <span i18n>Student</span>
+    </ng-template>
     <mat-slide-toggle
       color="primary"
       class="toggle"
-      [(ngModel)]="project.notebook.itemTypes.report.enabled"
+      [(ngModel)]="project.notebook.enabled"
       (ngModelChange)="contentChanged()"
       i18n
     >
-      Enable Report
+      Enable Student Notebook
     </mat-slide-toggle>
-    @if (project.notebook.itemTypes.report.enabled) {
-      <div class="notebook-child-div">
-        <div class="flex flex-wrap gap-5">
+    @if (project.notebook.enabled) {
+      <div class="notebook-div">
+        <div class="notebook-input">
           <translatable-input
-            [content]="project.notebook.itemTypes.report.label"
-            key="singular"
-            label="Label (Singular)"
-            i18n-label
-            (defaultLanguageTextChanged)="contentChanged()"
-            class="notebook-input"
-          />
-          <translatable-input
-            [content]="project.notebook.itemTypes.report.label"
-            key="plural"
-            label="Label (Plural)"
-            i18n-label
-            (defaultLanguageTextChanged)="contentChanged()"
-            class="notebook-input"
-          />
-          <translatable-input
-            [content]="project.notebook.itemTypes.report.label"
-            key="link"
-            label="Label (Link)"
+            [content]="project.notebook"
+            key="label"
+            label="Notebook Label"
             i18n-label
             (defaultLanguageTextChanged)="contentChanged()"
           />
         </div>
-        @for (reportNote of project.notebook.itemTypes.report.notes; track reportNote) {
-          <div>
-            <div class="notebook-input">
+        <div>
+          <mat-slide-toggle
+            color="primary"
+            class="toggle"
+            [(ngModel)]="project.notebook.itemTypes.note.enabled"
+            (ngModelChange)="contentChanged()"
+            i18n
+          >
+            Enable Note
+          </mat-slide-toggle>
+        </div>
+        @if (project.notebook.itemTypes.note.enabled) {
+          <div class="notebook-child-div">
+            <div class="flex flex-wrap gap-5">
               <translatable-input
-                [content]="reportNote"
-                key="title"
-                label="Title"
+                [content]="project.notebook.itemTypes.note.label"
+                key="singular"
+                label="Label (Singular)"
+                i18n-label
+                (defaultLanguageTextChanged)="contentChanged()"
+                class="notebook-input"
+              />
+              <translatable-input
+                [content]="project.notebook.itemTypes.note.label"
+                key="plural"
+                label="Label (Plural)"
+                i18n-label
+                (defaultLanguageTextChanged)="contentChanged()"
+                class="notebook-input"
+              />
+              <translatable-input
+                [content]="project.notebook.itemTypes.note.label"
+                key="link"
+                label="Label (Link)"
+                i18n-label
+                (defaultLanguageTextChanged)="contentChanged()"
+                class="notebook-input"
+              />
+            </div>
+            <mat-checkbox
+              color="primary"
+              [(ngModel)]="project.notebook.itemTypes.note.enableAddNote"
+              (ngModelChange)="contentChanged()"
+              i18n
+            >
+              Enable Add Note Button
+            </mat-checkbox>
+            <br />
+            <mat-checkbox
+              color="primary"
+              [(ngModel)]="project.notebook.itemTypes.note.enableDeleteNote"
+              [(ngModel)]="project.notebook.itemTypes.note.requireTextOnEveryNote"
+              (ngModelChange)="contentChanged()"
+              i18n
+            >
+              Require students to write text on every note
+            </mat-checkbox>
+            <br />
+            <mat-checkbox
+              color="primary"
+              [(ngModel)]="project.notebook.itemTypes.note.enableClipping"
+              (ngModelChange)="contentChanged()"
+              i18n
+            >
+              Enable Clipping
+            </mat-checkbox>
+            <br />
+            <mat-checkbox
+              color="primary"
+              [(ngModel)]="project.notebook.itemTypes.note.enableStudentUploads"
+              (ngModelChange)="contentChanged()"
+              i18n
+            >
+              Enable Student Uploads
+            </mat-checkbox>
+          </div>
+        }
+        <mat-slide-toggle
+          color="primary"
+          class="toggle"
+          [(ngModel)]="project.notebook.itemTypes.report.enabled"
+          (ngModelChange)="contentChanged()"
+          i18n
+        >
+          Enable Report
+        </mat-slide-toggle>
+        @if (project.notebook.itemTypes.report.enabled) {
+          <div class="notebook-child-div">
+            <div class="flex flex-wrap gap-5">
+              <translatable-input
+                [content]="project.notebook.itemTypes.report.label"
+                key="singular"
+                label="Label (Singular)"
+                i18n-label
+                (defaultLanguageTextChanged)="contentChanged()"
+                class="notebook-input"
+              />
+              <translatable-input
+                [content]="project.notebook.itemTypes.report.label"
+                key="plural"
+                label="Label (Plural)"
+                i18n-label
+                (defaultLanguageTextChanged)="contentChanged()"
+                class="notebook-input"
+              />
+              <translatable-input
+                [content]="project.notebook.itemTypes.report.label"
+                key="link"
+                label="Label (Link)"
                 i18n-label
                 (defaultLanguageTextChanged)="contentChanged()"
               />
             </div>
-            <div>
-              <mat-form-field>
-                <mat-label i18n>Max Score</mat-label>
-                <input
-                  matInput
-                  [(ngModel)]="reportNote.maxScore"
-                  type="number"
-                  (ngModelChange)="contentChanged()"
+            @for (reportNote of project.notebook.itemTypes.report.notes; track reportNote) {
+              <div>
+                <div class="notebook-input">
+                  <translatable-input
+                    [content]="reportNote"
+                    key="title"
+                    label="Title"
+                    i18n-label
+                    (defaultLanguageTextChanged)="contentChanged()"
+                  />
+                </div>
+                <div>
+                  <mat-form-field>
+                    <mat-label i18n>Max Score</mat-label>
+                    <input
+                      matInput
+                      [(ngModel)]="reportNote.maxScore"
+                      type="number"
+                      (ngModelChange)="contentChanged()"
+                    />
+                  </mat-form-field>
+                </div>
+                <translatable-textarea
+                  [content]="reportNote"
+                  key="description"
+                  label="Description"
+                  i18n-label
+                  (defaultLanguageTextChanged)="contentChanged()"
                 />
-              </mat-form-field>
-            </div>
-            <translatable-textarea
-              [content]="reportNote"
-              key="description"
-              label="Description"
-              i18n-label
-              (defaultLanguageTextChanged)="contentChanged()"
-            />
-            <translatable-textarea
-              [content]="reportNote"
-              key="prompt"
-              label="Prompt"
-              i18n-label
-              (defaultLanguageTextChanged)="contentChanged()"
-            />
-            <mat-label i18n>Starter Text</mat-label>
-            <translatable-rich-text-editor
-              [content]="reportNote"
-              key="content"
-              (defaultLanguageTextChanged)="save()"
-            />
+                <translatable-textarea
+                  [content]="reportNote"
+                  key="prompt"
+                  label="Prompt"
+                  i18n-label
+                  (defaultLanguageTextChanged)="contentChanged()"
+                />
+                <mat-label i18n>Starter Text</mat-label>
+                <translatable-rich-text-editor
+                  [content]="reportNote"
+                  key="content"
+                  (defaultLanguageTextChanged)="save()"
+                />
+              </div>
+            }
           </div>
         }
       </div>
     }
-  </div>
-}
-<div>
-  <mat-slide-toggle
-    color="primary"
-    class="toggle"
-    [(ngModel)]="project.teacherNotebook.enabled"
-    (ngModelChange)="contentChanged()"
-    i18n
-  >
-    Teacher Notebook
-  </mat-slide-toggle>
-</div>
-@if (project.teacherNotebook.enabled) {
-  <div class="notebook-div">
-    <div>
-      <mat-form-field>
-        <mat-label i18n>Notebook Label</mat-label>
-        <input
-          matInput
-          [(ngModel)]="project.teacherNotebook.label"
-          (ngModelChange)="contentChanged()"
-        />
-      </mat-form-field>
-    </div>
+  </mat-tab>
+  <mat-tab>
+    <ng-template mat-tab-label>
+      <span i18n>Teacher</span>
+    </ng-template>
     <mat-slide-toggle
       color="primary"
       class="toggle"
-      [(ngModel)]="project.teacherNotebook.itemTypes.report.enabled"
+      [(ngModel)]="project.teacherNotebook.enabled"
       (ngModelChange)="contentChanged()"
       i18n
     >
-      Enable Report
+      Enable Teacher Notebook
     </mat-slide-toggle>
-    @if (project.teacherNotebook.itemTypes.report.enabled) {
-      <div class="notebook-child-div">
-        <div class="flex gap-5">
+    @if (project.teacherNotebook.enabled) {
+      <div class="notebook-div">
+        <div>
           <mat-form-field>
-            <mat-label i18n>Label (Singular)</mat-label>
+            <mat-label i18n>Notebook Label</mat-label>
             <input
               matInput
-              [(ngModel)]="project.teacherNotebook.itemTypes.report.label.singular"
-              (ngModelChange)="contentChanged()"
-            />
-          </mat-form-field>
-          <mat-form-field>
-            <mat-label i18n>Label (Plural)</mat-label>
-            <input
-              matInput
-              [(ngModel)]="project.teacherNotebook.itemTypes.report.label.plural"
-              (ngModelChange)="contentChanged()"
-            />
-          </mat-form-field>
-          <mat-form-field>
-            <mat-label i18n>Label (Link)</mat-label>
-            <input
-              matInput
-              [(ngModel)]="project.teacherNotebook.itemTypes.report.label.link"
+              [(ngModel)]="project.teacherNotebook.label"
               (ngModelChange)="contentChanged()"
             />
           </mat-form-field>
         </div>
-        @for (reportNote of project.teacherNotebook.itemTypes.report.notes; track reportNote) {
-          <div>
-            <mat-form-field>
-              <mat-label i18n>Title</mat-label>
-              <input matInput [(ngModel)]="reportNote.title" (ngModelChange)="contentChanged()" />
-            </mat-form-field>
-            <br />
-            <mat-form-field class="textarea">
-              <mat-label i18n>Description</mat-label>
-              <textarea
-                matInput
-                cdkTextareaAutosize
-                [(ngModel)]="reportNote.description"
-                (ngModelChange)="contentChanged()"
-              ></textarea>
-            </mat-form-field>
-            <br />
-            <mat-form-field class="textarea">
-              <mat-label i18n>Prompt</mat-label>
-              <textarea
-                matInput
-                cdkTextareaAutosize
-                [(ngModel)]="reportNote.prompt"
-                (ngModelChange)="contentChanged()"
-              ></textarea>
-            </mat-form-field>
-            <br />
-            <mat-label i18n>Starter Text</mat-label>
-            <wise-authoring-tinymce-editor
-              [(model)]="reportIdToAuthoringNote[reportNote.reportId].html"
-              (modelChange)="reportStarterTextChanged(reportNote.reportId)"
-              [disabled]="reportStarterTextDisabled()"
-            />
+        <mat-slide-toggle
+          color="primary"
+          class="toggle"
+          [(ngModel)]="project.teacherNotebook.itemTypes.report.enabled"
+          (ngModelChange)="contentChanged()"
+          i18n
+        >
+          Enable Report
+        </mat-slide-toggle>
+        @if (project.teacherNotebook.itemTypes.report.enabled) {
+          <div class="notebook-child-div">
+            <div class="flex gap-5">
+              <mat-form-field>
+                <mat-label i18n>Label (Singular)</mat-label>
+                <input
+                  matInput
+                  [(ngModel)]="project.teacherNotebook.itemTypes.report.label.singular"
+                  (ngModelChange)="contentChanged()"
+                />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label i18n>Label (Plural)</mat-label>
+                <input
+                  matInput
+                  [(ngModel)]="project.teacherNotebook.itemTypes.report.label.plural"
+                  (ngModelChange)="contentChanged()"
+                />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label i18n>Label (Link)</mat-label>
+                <input
+                  matInput
+                  [(ngModel)]="project.teacherNotebook.itemTypes.report.label.link"
+                  (ngModelChange)="contentChanged()"
+                />
+              </mat-form-field>
+            </div>
+            @for (reportNote of project.teacherNotebook.itemTypes.report.notes; track reportNote) {
+              <div>
+                <mat-form-field>
+                  <mat-label i18n>Title</mat-label>
+                  <input
+                    matInput
+                    [(ngModel)]="reportNote.title"
+                    (ngModelChange)="contentChanged()"
+                  />
+                </mat-form-field>
+                <br />
+                <mat-form-field class="textarea">
+                  <mat-label i18n>Description</mat-label>
+                  <textarea
+                    matInput
+                    cdkTextareaAutosize
+                    [(ngModel)]="reportNote.description"
+                    (ngModelChange)="contentChanged()"
+                  ></textarea>
+                </mat-form-field>
+                <br />
+                <mat-form-field class="textarea">
+                  <mat-label i18n>Prompt</mat-label>
+                  <textarea
+                    matInput
+                    cdkTextareaAutosize
+                    [(ngModel)]="reportNote.prompt"
+                    (ngModelChange)="contentChanged()"
+                  ></textarea>
+                </mat-form-field>
+                <br />
+                <mat-label i18n>Starter Text</mat-label>
+                <wise-authoring-tinymce-editor
+                  [(model)]="reportIdToAuthoringNote[reportNote.reportId].html"
+                  (modelChange)="reportStarterTextChanged(reportNote.reportId)"
+                  [disabled]="reportStarterTextDisabled()"
+                />
+              </div>
+            }
           </div>
         }
       </div>
     }
-  </div>
-}
+  </mat-tab>
+</mat-tab-group>

--- a/src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.ts
+++ b/src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.ts
@@ -15,6 +15,7 @@ import { MatInputModule } from '@angular/material/input';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { WiseAuthoringTinymceEditorComponent } from '../../directives/wise-tinymce-editor/wise-authoring-tinymce-editor.component';
+import { MatTabsModule } from '@angular/material/tabs';
 
 @Component({
   imports: [
@@ -24,6 +25,7 @@ import { WiseAuthoringTinymceEditorComponent } from '../../directives/wise-tinym
     MatFormFieldModule,
     MatInputModule,
     MatSlideToggleModule,
+    MatTabsModule,
     TranslatableInputComponent,
     TranslatableRichTextEditorComponent,
     TranslatableTextareaComponent,

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -941,7 +941,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">265,268</context>
+          <context context-type="linenumber">272,275</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/classroomMonitorComponents/component-summary/component-summary.component.html</context>
@@ -2369,6 +2369,10 @@
           <context context-type="linenumber">28,29</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
+          <context context-type="linenumber">190,194</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/peerChat/peerChatService.ts</context>
           <context context-type="linenumber">65</context>
         </context-group>
@@ -2431,7 +2435,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">255,258</context>
+          <context context-type="linenumber">262,265</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/common/cRater/crater-rubric/crater-rubric.component.html</context>
@@ -3239,6 +3243,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/register/register-home/register-home.component.html</context>
           <context context-type="linenumber">18,19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
+          <context context-type="linenumber">4,8</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/classroomMonitor/student-progress/student-progress.component.ts</context>
@@ -10920,10 +10928,6 @@ Click &quot;Cancel&quot; to keep the invalid JSON open so you can fix it.</sourc
           <context context-type="sourcefile">src/assets/wise5/authoringTool/components/shared/authoring-tool-bar/authoring-tool-bar.component.ts</context>
           <context context-type="linenumber">75</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">2,7</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="8360107325291301836" datatype="html">
         <source>Advanced Settings</source>
@@ -13046,11 +13050,11 @@ The branches will be removed but the steps will remain in the unit.</source>
           <context context-type="linenumber">170</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8956408262591847852" datatype="html">
-        <source> Student Notebook </source>
+      <trans-unit id="5662379156935763798" datatype="html">
+        <source> Enable Student Notebook </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">12,16</context>
+          <context context-type="linenumber">13,16</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4080836711065708122" datatype="html">
@@ -13061,7 +13065,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">202,205</context>
+          <context context-type="linenumber">205,208</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4018591944568764632" datatype="html">
@@ -13083,7 +13087,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">223,226</context>
+          <context context-type="linenumber">226,229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1555938427850288052" datatype="html">
@@ -13098,7 +13102,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">231,234</context>
+          <context context-type="linenumber">234,237</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2424689480379208844" datatype="html">
@@ -13113,28 +13117,28 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">239,242</context>
+          <context context-type="linenumber">242,245</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8882938764098391051" datatype="html">
         <source> Enable Add Note Button </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">71,75</context>
+          <context context-type="linenumber">71,74</context>
         </context-group>
       </trans-unit>
       <trans-unit id="524921195084743379" datatype="html">
         <source> Require students to write text on every note </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">81,85</context>
+          <context context-type="linenumber">81,84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5714542547925487783" datatype="html">
         <source> Enable Clipping </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">90,94</context>
+          <context context-type="linenumber">90,93</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1123785272686478751" datatype="html">
@@ -13152,7 +13156,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">217,219</context>
+          <context context-type="linenumber">220,222</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5701618810648052610" datatype="html">
@@ -13163,7 +13167,7 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">250,251</context>
+          <context context-type="linenumber">253,256</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/components/graph/graph-authoring/graph-authoring.component.html</context>
@@ -13186,14 +13190,14 @@ The branches will be removed but the steps will remain in the unit.</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">274,276</context>
+          <context context-type="linenumber">281,283</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="5642130327490278395" datatype="html">
-        <source> Teacher Notebook </source>
+      <trans-unit id="8813126972024269116" datatype="html">
+        <source> Enable Teacher Notebook </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/authoringTool/notebook-authoring/notebook-authoring.component.html</context>
-          <context context-type="linenumber">195,199</context>
+          <context context-type="linenumber">199,202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4199930238964775542" datatype="html">


### PR DESCRIPTION
## Changes
- Use tabs to separate student and teacher notebook settings. Before, we were showing them all in one page, which made the page long.

## Test
- Notebook editing works as before