### PR TITLE
feat(TeacherTools): Show workgroups in tooltip for Sort summary

### DIFF
--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html
@@ -15,7 +15,7 @@
             @if (!isChoiceReuseMatch) {
               <span
                 class="shrink-0 cursor-pointer"
-                [matTooltip]="getWorkgroupNames(choice)"
+                [matTooltip]="workgroupNamesTooltips.get(choice)"
                 matTooltipClass="multiline-tooltip"
                 matTooltipPosition="above"
                 tabindex="0"
@@ -50,7 +50,7 @@
               <span class="flex-1" [innerHTML]="bucketDataPoint.getBucketValue()"></span>
               <span
                 class="shrink-0 cursor-pointer"
-                [matTooltip]="getWorkgroupNames(bucketDataPoint)"
+                [matTooltip]="workgroupNamesTooltips.get(bucketDataPoint)"
                 matTooltipClass="multiline-tooltip"
                 matTooltipPosition="above"
                 tabindex="0"

--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html
@@ -13,7 +13,13 @@
             >
             <span class="flex-1" [innerHTML]="choice.getChoiceValue()"></span>
             @if (!isChoiceReuseMatch) {
-              <span class="shrink-0">
+              <span
+                class="shrink-0 cursor-pointer"
+                [matTooltip]="getWorkgroupNames(choice)"
+                matTooltipClass="multiline-tooltip"
+                matTooltipPosition="above"
+                tabindex="0"
+              >
                 <mat-icon class="mat-18 align-middle">person</mat-icon>{{ choice.getCount() }}
               </span>
             }
@@ -42,7 +48,13 @@
                 >inventory_2</mat-icon
               >
               <span class="flex-1" [innerHTML]="bucketDataPoint.getBucketValue()"></span>
-              <span class="shrink-0">
+              <span
+                class="shrink-0 cursor-pointer"
+                [matTooltip]="getWorkgroupNames(bucketDataPoint)"
+                matTooltipClass="multiline-tooltip"
+                matTooltipPosition="above"
+                tabindex="0"
+              >
                 <mat-icon class="mat-18 align-middle">person</mat-icon
                 >{{ bucketDataPoint.getCount() }}
               </span>

--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.ts
@@ -27,6 +27,7 @@ export class MatchSummaryDisplayComponent extends TeacherSummaryDisplayComponent
   protected isChoiceReuseMatch: boolean;
   private matchSummaryData: MatchSummaryData;
   viewMode: SummaryViewMode = 'bucket';
+  protected workgroupNamesTooltips = new Map<MatchSummaryDataPoint, string>();
 
   ngOnInit(): void {
     this.setIsChoiceReuseMatch();
@@ -43,11 +44,13 @@ export class MatchSummaryDisplayComponent extends TeacherSummaryDisplayComponent
     this.getLatestWork().subscribe((componentStates) => {
       this.bucketData = [];
       this.choiceData = [];
+      this.workgroupNamesTooltips = new Map();
       this.matchSummaryData = new MatchSummaryData(
         this.projectService.injectAssetPaths(componentStates)
       );
       this.setChoiceData();
       this.setBucketData();
+      this.setWorkgroupNamesTooltips();
     });
   }
 
@@ -83,11 +86,17 @@ export class MatchSummaryDisplayComponent extends TeacherSummaryDisplayComponent
     return b.getCount() - a.getCount();
   }
 
-  protected getWorkgroupNames(dataPoint: MatchSummaryDataPoint): string {
-    return dataPoint
-      .getWorkgroupIds()
-      .map((id) => this.configService.getDisplayUsernamesByWorkgroupId(id))
-      .join('\n');
+  private setWorkgroupNamesTooltips(): void {
+    const allDataPoints = this.matchSummaryData.getChoicesData().flatMap((c) => c.choiceDataPoints);
+    for (const dp of allDataPoints) {
+      this.workgroupNamesTooltips.set(
+        dp,
+        dp
+          .getWorkgroupIds()
+          .map((id) => this.configService.getDisplayUsernamesByWorkgroupId(id))
+          .join('\n')
+      );
+    }
   }
 
   protected renderDisplay(): void {

--- a/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.ts
@@ -5,12 +5,14 @@ import { BucketData, ChoiceData, MatchSummaryData } from '../summary-data/MatchS
 import { MatchSummaryDataPoint } from '../summary-data/MatchSummaryDataPoint';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { TeacherSummaryDisplayComponent } from '../teacher-summary-display.component';
+import { ConfigService } from '../../../services/configService';
 
 export type SummaryViewMode = 'choice' | 'bucket';
 
 @Component({
-  imports: [CommonModule, MatButtonToggleModule, MatIconModule],
+  imports: [CommonModule, MatButtonToggleModule, MatIconModule, MatTooltipModule],
   selector: 'match-summary-display',
   styleUrls: [
     './match-summary-display.component.scss',
@@ -79,6 +81,13 @@ export class MatchSummaryDisplayComponent extends TeacherSummaryDisplayComponent
 
   private sortByCount(a: MatchSummaryDataPoint, b: MatchSummaryDataPoint): number {
     return b.getCount() - a.getCount();
+  }
+
+  protected getWorkgroupNames(dataPoint: MatchSummaryDataPoint): string {
+    return dataPoint
+      .getWorkgroupIds()
+      .map((id) => this.configService.getDisplayUsernamesByWorkgroupId(id))
+      .join('\n');
   }
 
   protected renderDisplay(): void {

--- a/src/assets/wise5/directives/teacher-summary-display/summary-data/MatchSummaryData.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/summary-data/MatchSummaryData.ts
@@ -47,7 +47,11 @@ export class MatchSummaryData extends SummaryData {
           bucketStudentData.items.forEach((choice) => this.registerChoice(choice.value));
         } else {
           bucketStudentData.items.forEach((choice) => {
-            this.extractBucketDataPerChoice(choice.value, bucketStudentData.value);
+            this.extractBucketDataPerChoice(
+              choice.value,
+              bucketStudentData.value,
+              componentState.workgroupId
+            );
           });
         }
       });
@@ -60,12 +64,18 @@ export class MatchSummaryData extends SummaryData {
     }
   }
 
-  private extractBucketDataPerChoice(choiceValue: string, bucketValue: string): void {
+  private extractBucketDataPerChoice(
+    choiceValue: string,
+    bucketValue: string,
+    workgroupId: number
+  ): void {
     const dataPoint = this.findSummaryDataPoint(choiceValue, bucketValue);
     if (dataPoint) {
       dataPoint.incrementCount(1);
+      dataPoint.addWorkgroupId(workgroupId);
     } else {
       const newDataPoint = new MatchSummaryDataPoint(bucketValue, 1, choiceValue);
+      newDataPoint.addWorkgroupId(workgroupId);
       this.summaryDataPoints.push(newDataPoint);
       this.addDataPointToChoiceData(choiceValue, newDataPoint);
     }

--- a/src/assets/wise5/directives/teacher-summary-display/summary-data/MatchSummaryDataPoint.ts
+++ b/src/assets/wise5/directives/teacher-summary-display/summary-data/MatchSummaryDataPoint.ts
@@ -5,6 +5,7 @@ import { SummaryDataPoint } from '../../summary-display/summary-data/SummaryData
  */
 export class MatchSummaryDataPoint extends SummaryDataPoint {
   private choiceValue: string;
+  private workgroupIds: number[] = [];
 
   constructor(id: number | string, count?: number, choiceValue?: string) {
     super(id, count);
@@ -17,5 +18,15 @@ export class MatchSummaryDataPoint extends SummaryDataPoint {
 
   getBucketValue(): string {
     return this.getId() as string;
+  }
+
+  addWorkgroupId(workgroupId: number): void {
+    if (!this.workgroupIds.includes(workgroupId)) {
+      this.workgroupIds.push(workgroupId);
+    }
+  }
+
+  getWorkgroupIds(): number[] {
+    return this.workgroupIds;
   }
 }

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -16275,11 +16275,11 @@ Are you sure you want to proceed?</source>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">33,34</context>
+          <context context-type="linenumber">39,40</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">85,88</context>
+          <context context-type="linenumber">97,100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8313145553257511938" datatype="html">
@@ -23320,67 +23320,67 @@ If this problem continues, let your teacher know and move on to the next activit
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">41,44</context>
+          <context context-type="linenumber">47,50</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">81,83</context>
+          <context context-type="linenumber">93,95</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6966354927154117696" datatype="html">
         <source>Not moved by any students</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">56,62</context>
+          <context context-type="linenumber">68,74</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5731986766999662576" datatype="html">
         <source>Choice Frequency</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">63,65</context>
+          <context context-type="linenumber">75,77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7095065065333948401" datatype="html">
         <source> Number of times each item <x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon class=&quot;mat-18 align-sub&quot;&gt;"/>crop_16_9<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/> was moved into the different buckets <x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon class=&quot;mat-18 align-sub&quot;&gt;"/>inventory_2<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/>. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">67,70</context>
+          <context context-type="linenumber">79,82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2604441497936252366" datatype="html">
         <source>Organize by:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">71,73</context>
+          <context context-type="linenumber">83,85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6609121112482902764" datatype="html">
         <source>Organize by</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">76,79</context>
+          <context context-type="linenumber">88,91</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3328715450847929611" datatype="html">
         <source>Organize by bucket</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">79,80</context>
+          <context context-type="linenumber">91,92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8820191890545506313" datatype="html">
         <source>Organize by choice</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">83,84</context>
+          <context context-type="linenumber">95,96</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2004123481203797507" datatype="html">
         <source> Your students&apos; choices will show up here when they complete the activity. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/teacher-summary-display/match-summary-display/match-summary-display.component.html</context>
-          <context context-type="linenumber">115,119</context>
+          <context context-type="linenumber">127,131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="866753876041645935" datatype="html">


### PR DESCRIPTION
## Changes
- Show a list of workgroup names in a tooltip when hovering over each item or bucket in Sort (Match) summary view in the teacher tools.

## Test
- Go to Grade by Step in the Teacher Tools for a run with a step that includes a Sort activity. Select the step and then the question summary for the Sort activity.
- In Bucket view, make sure that when you mouse over (or Tab to using keyboard) the person icon + count for each item that a tooltip appears showing the names for the workgroups that moved that item into the bucket.
- In Item view, make sure that when you mouse over (or Tab to using keyboard) the person icon + count for each bucket that a tooltip appears showing the names for the workgroups that moved the item into that bucket.
