### PR TITLE
fix(HTML Authoring): Disable pasting images

### DIFF
--- a/src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts
+++ b/src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts
@@ -158,6 +158,7 @@ export class WiseTinymceEditorComponent {
         }
       },
       paste_block_drop: true,
+      paste_data_images: false,
       skin_url: '/assets/tinymce/wise',
       promotion: false
     };

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -23426,21 +23426,21 @@ If this problem continues, let your teacher know and move on to the next activit
         <source>Insert from Notebook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts</context>
-          <context context-type="linenumber">171</context>
+          <context context-type="linenumber">172</context>
         </context-group>
       </trans-unit>
       <trans-unit id="535405804327281099" datatype="html">
         <source>Insert note +</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts</context>
-          <context context-type="linenumber">172</context>
+          <context context-type="linenumber">173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7138428925866529608" datatype="html">
         <source>Image from notebook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/assets/wise5/directives/wise-tinymce-editor/wise-tinymce-editor.component.ts</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">199</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7206782115156099663" datatype="html">


### PR DESCRIPTION
## Changes
- Set TinyMCE's ```paste_data_images``` option to false to disallow authors from pasting images. This was creating images to be converted to base64 strings, which made the unit large.

## Test
Try pasting images in:
- Display content authoring
- Student notebook report