### PR TITLE
style(Authoring Tool): Disable tab animation in unit list

### DIFF
--- a/src/app/curriculum/curriculum.component.html
+++ b/src/app/curriculum/curriculum.component.html
@@ -33,6 +33,7 @@
               i18n-aria-label
               aria-label="Unit library navigation"
               [tabPanel]="tabPanel"
+              animationDuration="0ms"
             >
               <a mat-tab-link routerLink="/curriculum/public" [active]="isPublicRoute()">
                 {{ getPublicTabLabel() }}

--- a/src/messages.xlf
+++ b/src/messages.xlf
@@ -2656,7 +2656,7 @@
         <source>Unit library navigation</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/curriculum/curriculum.component.html</context>
-          <context context-type="linenumber">34,37</context>
+          <context context-type="linenumber">34,36</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1326396148114021147" datatype="html">


### PR DESCRIPTION
## Changes
- Disabled the Unit Library tab switching animation.

## Test
- Switching tabs should not trigger the animation.

Closes #2322
